### PR TITLE
Autodetection for the pngcairo terminal of gnuplot.

### DIFF
--- a/data/wxmathml.lisp
+++ b/data/wxmathml.lisp
@@ -1242,7 +1242,7 @@
   (cond
    ((like (simplify
 	   (mfunction-call $system
-			   '"(gnuplot -e 'set term pngcairo')"))
+			   '"(gnuplot -e 'set term pngcairo dashed')"))
 	  0.)
     (setq $wxplot_pngcairo t)))
   )

--- a/data/wxmathml.lisp
+++ b/data/wxmathml.lisp
@@ -1238,7 +1238,7 @@
 (defmvar $wxplot_pngcairo nil)
 
 (catch
-   (setq $wxplot_pngcairo t)
+   (setq $wxplot_pngcairo nil)
   (cond
    ((like (simplify
 	   (mfunction-call $system

--- a/data/wxmathml.lisp
+++ b/data/wxmathml.lisp
@@ -1236,15 +1236,16 @@
 (defmvar $wxplot_size '((mlist simp) 500 300))
 (defmvar $wxplot_old_gnuplot nil)
 (defmvar $wxplot_pngcairo nil)
-(cond
-  ((like (simplify
-             (MFUNCTION-CALL $SYSTEM
-                 '"(gnuplot -e 'set term pngcairo')"))
-         0.)
-   (IF (NOT (BOUNDP '$WXPLOT_PNGCAIRO))
-       (ADD2LNC '$WXPLOT_PNGCAIRO $VALUES))
-   (SETQ $WXPLOT_PNGCAIRO T)))
- 
+
+(catch
+   (setq $wxplot_pngcairo t)
+  (cond
+   ((like (simplify
+	   (mfunction-call $system
+			   '"(gnuplot -e 'set term pngcairo')"))
+	  0.)
+    (setq $wxplot_pngcairo t)))
+  )
 
 (defvar *image-counter* 0)
 

--- a/data/wxmathml.lisp
+++ b/data/wxmathml.lisp
@@ -1236,6 +1236,15 @@
 (defmvar $wxplot_size '((mlist simp) 500 300))
 (defmvar $wxplot_old_gnuplot nil)
 (defmvar $wxplot_pngcairo nil)
+(cond
+  ((like (simplify
+             (MFUNCTION-CALL $SYSTEM
+                 '"(gnuplot -e 'set term pngcairo')"))
+         0.)
+   (IF (NOT (BOUNDP '$WXPLOT_PNGCAIRO))
+       (ADD2LNC '$WXPLOT_PNGCAIRO $VALUES))
+   (SETQ $WXPLOT_PNGCAIRO T)))
+ 
 
 (defvar *image-counter* 0)
 


### PR DESCRIPTION
Closes #322.
This patch  adds an autodetection if we can use gnuplot's pngcairo terminal (produces much better graphics than the ordinary png terminal, supports the linestyles dashes and dash_dots from the current version of maxima and all linestyles the next maxima version will).

This autodetection is quite fast (50 miliseconds on my laptop). And I have updated it to fail silently (for example in the case there is still a gnuplot version out there that doesn't support pngcairo) falling back to the png terminal wxmaxima used from the beginning. 
In theory in the future we could adding a cache mechanism for the autodetection's result so it is kept for the next run of wxMaxima. But that would mean we would have to deal with cases like: "What happens if a system change exchanges a gnuplot with wxmaxima by a version without" or ""What happens if an user uses the same home directory on two computers only one of which supports pngcairo." Not making any assumptions about the system should IMHO be the better option.

---
Compatibility: Other than the increased graphics quality an users that don't try to use other linestyles than "solid" or "dots" (the png terminal ignored all other line styles) won't see any difference when my patches are applied.