### PR TITLE
Use wxChoice instead of wxComboBox with wxCB_DROPDOWN | wxCB_READONLY for drop-down list.

### DIFF
--- a/src/ConfigDialogue.cpp
+++ b/src/ConfigDialogue.cpp
@@ -474,7 +474,7 @@ wxPanel* ConfigDialogue::CreateOptionsPanel()
       _("Turkish"),
       _("Ukrainian")
     };
-  m_language = new wxComboBox(panel, language_id, wxEmptyString, wxDefaultPosition, wxSize(230, -1), LANGUAGE_NUMBER, m_language_choices, wxCB_DROPDOWN | wxCB_READONLY);
+  m_language = new wxChoice(panel, language_id, wxDefaultPosition, wxSize(230, -1), LANGUAGE_NUMBER, m_language_choices);
   grid_sizer->Add(lang, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
   grid_sizer->Add(m_language, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
   

--- a/src/ConfigDialogue.h
+++ b/src/ConfigDialogue.h
@@ -165,7 +165,7 @@ protected:
   wxSpinCtrl* m_autoSaveInterval;
   wxButton* m_mpBrowse;
   wxTextCtrl* m_additionalParameters;
-  wxComboBox* m_language;
+  wxChoice* m_language;
   wxCheckBox* m_saveSize;
   wxCheckBox* m_abortOnError;
   wxCheckBox* m_pollStdOut;

--- a/src/IntegrateWiz.cpp
+++ b/src/IntegrateWiz.cpp
@@ -45,8 +45,8 @@ IntegrateWiz::IntegrateWiz(wxWindow* parent, int id,
   checkbox_2 = new wxCheckBox(this, numeric_id, _("&Numerical integration"));
   label_6 = new wxStaticText(this, -1, _("Method:"));
   wxString numeric_methods[] = { wxT("quadpack"), wxT("romberg") };
-  combobox_1 = new wxComboBox(this, -1, wxEmptyString, wxDefaultPosition, wxDefaultSize,
-                              2, numeric_methods, wxCB_DROPDOWN | wxCB_READONLY);
+  choice_1 = new wxChoice(this, -1, wxDefaultPosition, wxDefaultSize,
+                          2, numeric_methods);
   static_line_1 = new wxStaticLine(this, -1);
 #if defined __WXMSW__
   button_1 = new wxButton(this, wxID_OK, _("OK"));
@@ -75,11 +75,11 @@ void IntegrateWiz::set_properties()
   text_ctrl_4->Enable(false);
   button_4->Enable(false);
   checkbox_2->Enable(false);
-  combobox_1->Enable(false);
+  choice_1->Enable(false);
 
   int num_sel = 0;
   wxConfig::Get()->Read(wxT("Wiz/Int/numericSelection"), &num_sel);
-  combobox_1->SetSelection(num_sel);
+  choice_1->SetSelection(num_sel);
 
   text_ctrl_1->SetFocus();
 }
@@ -111,7 +111,7 @@ void IntegrateWiz::do_layout()
   grid_sizer_4->Add(20, 20, 0, 0);
   grid_sizer_4->Add(checkbox_2, 0, wxALL, 5);
   grid_sizer_4->Add(label_6, 0, wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL | wxALL, 5);
-  grid_sizer_4->Add(combobox_1, 0, wxALL, 5);
+  grid_sizer_4->Add(choice_1, 0, wxALL, 5);
   grid_sizer_3->Add(grid_sizer_4, 1, wxEXPAND, 0);
   grid_sizer_3->Add(static_line_1, 0, wxEXPAND | wxLEFT | wxRIGHT, 2);
   sizer_3->Add(button_1, 0, wxALL, 5);
@@ -129,7 +129,7 @@ wxString IntegrateWiz::GetValue()
   wxString s;
   if (checkbox_2->GetValue())
   {
-    if (combobox_1->GetValue() == wxT("romberg"))
+    if (choice_1->GetSelection() == 1)
     {
       wxConfig::Get()->Write(wxT("Wiz/Int/numericSelection"), 1);
       s = wxT("romberg(") +
@@ -198,7 +198,7 @@ void IntegrateWiz::OnCheckbox(wxCommandEvent& event)
   checkbox_2->Enable(enable);
 
   enable = enable && checkbox_2->GetValue();
-  combobox_1->Enable(enable);
+  choice_1->Enable(enable);
 }
 
 void IntegrateWiz::OnButton(wxCommandEvent& event)

--- a/src/IntegrateWiz.h
+++ b/src/IntegrateWiz.h
@@ -69,7 +69,7 @@ private:
   wxButton* button_2;
   wxCheckBox* checkbox_2;
   wxStaticText* label_6;
-  wxComboBox* combobox_1;
+  wxChoice* choice_1;
   DECLARE_EVENT_TABLE()
 };
 

--- a/src/LimitWiz.cpp
+++ b/src/LimitWiz.cpp
@@ -35,15 +35,14 @@ LimitWiz::LimitWiz(wxWindow* parent, int id, const wxString& title,
                               wxSize(110, -1));
   button_1 = new wxButton(this, special, _("Special"));
   label_5 = new wxStaticText(this, -1, _("Direction:"));
-  const wxString combo_box_1_choices[] =
+  const wxString choice_1_choices[] =
     {
       _("both sides"),
       _("left"),
       _("right")
     };
-  combo_box_1 = new wxComboBox(this, -1, wxEmptyString, wxDefaultPosition,
-                               wxSize(130, -1), 3,
-                               combo_box_1_choices, wxCB_DROPDOWN | wxCB_READONLY);
+  choice_1 = new wxChoice(this, -1, wxDefaultPosition, wxSize(130, -1),
+                          3, choice_1_choices);
   checkbox_1 = new wxCheckBox(this, -1, _("&Taylor series"));
   static_line_1 = new wxStaticLine(this, -1);
 
@@ -65,7 +64,7 @@ LimitWiz::LimitWiz(wxWindow* parent, int id, const wxString& title,
 void LimitWiz::set_properties()
 {
   SetTitle(_("Limit"));
-  combo_box_1->SetSelection(0);
+  choice_1->SetSelection(0);
 #if defined __WXMSW__
   button_2->SetDefault();
 #else
@@ -91,7 +90,7 @@ void LimitWiz::do_layout()
   sizer_1->Add(button_1, 0, wxALL, 5);
   grid_sizer_2->Add(sizer_1, 1, 0, 0);
   grid_sizer_2->Add(label_5, 0, wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL | wxALL, 5);
-  grid_sizer_2->Add(combo_box_1, 0, wxALL, 5);
+  grid_sizer_2->Add(choice_1, 0, wxALL, 5);
   grid_sizer_2->Add(20, 20, 0, wxALL, 5);
   grid_sizer_2->Add(checkbox_1, 9, wxALL, 5);
   grid_sizer_1->Add(grid_sizer_2, 1, wxEXPAND, 0);
@@ -118,11 +117,14 @@ wxString LimitWiz::GetValue()
   s += text_ctrl_2->GetValue();
   s += wxT(", ");
   s += text_ctrl_3->GetValue();
-  wxString f = combo_box_1->GetValue();
-  if (f == _("left"))
-    s += wxT(", minus");
-  else if (f == _("right"))
-    s += wxT(", plus");
+  if (choice_1->IsEnabled())
+  {
+    int f = choice_1->GetSelection();
+    if (f == 1)
+      s += wxT(", minus");
+    else if (f == 2)
+      s += wxT(", plus");
+  }
   s += wxT(");");
 
   return s;
@@ -154,14 +156,11 @@ void LimitWiz::OnIdle(wxIdleEvent& ev)
   if (point == wxT("inf") || point == wxT("-inf") || point == wxT("+inf") ||
       point == wxT("minf") || point == wxT("-minf") || point == wxT("+minf"))
   {
-    combo_box_1->SetValue(wxEmptyString);
-    combo_box_1->Enable(false);
+    choice_1->Enable(false);
   }
-  else if (combo_box_1->IsEnabled() == false)
+  else if (choice_1->IsEnabled() == false)
   {
-    combo_box_1->Enable(true);
-    if (combo_box_1->GetValue() == wxEmptyString)
-      combo_box_1->SetValue(_("both sides"));
+    choice_1->Enable(true);
   }
 }
 

--- a/src/LimitWiz.h
+++ b/src/LimitWiz.h
@@ -58,7 +58,7 @@ protected:
   BTextCtrl* text_ctrl_3;
   wxButton* button_1;
   wxStaticText* label_5;
-  wxComboBox* combo_box_1;
+  wxChoice* choice_1;
   wxCheckBox* checkbox_1;
   wxStaticLine* static_line_1;
   wxButton* button_2;

--- a/src/MatWiz.cpp
+++ b/src/MatWiz.cpp
@@ -169,17 +169,15 @@ MatDim::MatDim(wxWindow* parent, int id, const wxString& title,
   text_ctrl_2 = new BTextCtrl(this, -1, wxT("3"), wxDefaultPosition,
                               wxSize(150, -1));
   label_4 = new wxStaticText(this, -1, _("Type:"));
-  const wxString combo_box_1_choices[] =
+  const wxString choice_1_choices[] =
     {
       _("general"),
       _("diagonal"),
       _("symmetric"),
       _("antisymmetric")
     };
-  combo_box_1 = new wxComboBox(this, -1, wxEmptyString, wxDefaultPosition,
-                               wxSize(150, -1), 4,
-                               combo_box_1_choices,
-                               wxCB_DROPDOWN | wxCB_READONLY);
+  choice_1 = new wxChoice(this, -1, wxDefaultPosition,
+                          wxSize(150, -1), 4, choice_1_choices);
   label_0 = new wxStaticText(this, -1, _("Name:"));
   text_ctrl_0 = new BTextCtrl(this, -1, wxEmptyString, wxDefaultPosition,
                               wxSize(70, -1));
@@ -205,7 +203,7 @@ void MatDim::set_properties()
   button_2->SetDefault();
 #endif
 
-  combo_box_1->SetSelection(0);
+  choice_1->SetSelection(0);
   text_ctrl_1->SetFocus();
   text_ctrl_1->SetSelection(-1, -1);
 }
@@ -221,7 +219,7 @@ void MatDim::do_layout()
   grid_sizer_2->Add(label_3, 0, wxALL | wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL, 5);
   grid_sizer_2->Add(text_ctrl_2, 0, wxALL, 5);
   grid_sizer_2->Add(label_4, 0, wxALL | wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL, 5);
-  grid_sizer_2->Add(combo_box_1, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+  grid_sizer_2->Add(choice_1, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
   grid_sizer_2->Add(label_0, 0, wxALL | wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL, 5);
   grid_sizer_2->Add(text_ctrl_0, 0, wxALL, 5);
   grid_sizer_1->Add(grid_sizer_2, 1, wxEXPAND, 0);
@@ -238,7 +236,7 @@ void MatDim::do_layout()
 
 int MatDim::GetMatrixType()
 {
-  int type = combo_box_1->GetSelection();
+  int type = choice_1->GetSelection();
   if (type == 0)
     return MatWiz::MATRIX_GENERAL;
   if (type == 1)

--- a/src/MatWiz.h
+++ b/src/MatWiz.h
@@ -86,7 +86,7 @@ protected:
   wxStaticText* label_3;
   BTextCtrl* text_ctrl_2;
   wxStaticText* label_4;
-  wxComboBox* combo_box_1;
+  wxChoice* choice_1;
   wxStaticLine* static_line_1;
   wxButton* button_1;
   wxButton* button_2;


### PR DESCRIPTION
This PR replaces the use of `wxComboBox` as drop-down list by `wxChoice`.

On OS X and GTK+, a `wxChoice` and a `wxComboBox` with `wxCB_DROPDOWN | wxCB_READONLY` are different.  The former is preferable because the user can click anywhere on the control to show the list, not limited to the button on the right.