### PR TITLE
Fix filename and .desktop reference for appdata.xml.

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -7,7 +7,7 @@ bashcompletion_DATA = wxmaxima
 EXTRA_DIST = wxmaxima tips.txt wxmathml.lisp wxmaxima.png wxmaxima.svg Info.plist.in PkgInfo autocomplete.txt wxmaxima.manifest
 
 appdatadir = $(datarootdir)/appdata
-dist_appdata_DATA = wxmaxima.appdata.xml
+dist_appdata_DATA = wxMaxima.appdata.xml
 
 appicondir = $(datarootdir)/pixmaps
 dist_appicon_DATA = wxmaxima.svg wxmaxima.png text-x-wxmaxima-batch.svg text-x-wxmathml.svg wxmaxima-16.xpm wxmaxima-32.xpm

--- a/data/wxMaxima.appdata.xml
+++ b/data/wxMaxima.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
- <id>wxmaxima.desktop</id>
+ <id>wxMaxima.desktop</id>
  <metadata_license>CC0-1.0</metadata_license>
  <project_license>GPL-2.0+</project_license>
  <name>wxMaxima</name>


### PR DESCRIPTION
* Change appdata filename to be consistent with .desktop file name
* The reference to the .desktop file in appdata.xml was to
  wxmaxima.desktop, while the installed .desktop file was
  called wxMaxima.desktop, fix this.

The renaming of the appdata file is not strictly required but recommended for distro-specific package managers to pick up the appdata file consistently [see http://dominique.leuenberger.net/blog/2016/07/how-to-fix-my-application-does-not-show-up-in-software-centers/]. Comments welcome.

Thanks!