### PR TITLE
Enable better translation of "save changes" dialog

### DIFF
--- a/locales/ca.po
+++ b/locales/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ca\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-07 21:42+0200\n"
+"POT-Creation-Date: 2016-10-16 17:47+0900\n"
 "PO-Revision-Date: 2016-04-28 18:51+0200\n"
 "Last-Translator: Innocent De Marchi <tangram.peces@gmail.com>\n"
 "Language-Team: Innocent De Marchi <tangram.peces@gmail.com>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.7.6\n"
 
-#: ../src/wxMaxima.cpp:4519
+#: ../src/wxMaxima.cpp:4531
 #, c-format
 msgid ""
 "\n"
@@ -30,7 +30,7 @@ msgstr ""
 "wxWidgets: %d.%d.%d\n"
 "Soport unicode: %s"
 
-#: ../src/wxMaxima.cpp:4532
+#: ../src/wxMaxima.cpp:4544
 msgid ""
 "\n"
 "Lisp: "
@@ -38,7 +38,7 @@ msgstr ""
 "\n"
 "Lisp: "
 
-#: ../src/wxMaxima.cpp:4528
+#: ../src/wxMaxima.cpp:4540
 msgid ""
 "\n"
 "Maxima version: "
@@ -46,7 +46,7 @@ msgstr ""
 "\n"
 "Versió de Maxima: "
 
-#: ../src/wxMaxima.cpp:5381
+#: ../src/wxMaxima.cpp:5397
 msgid ""
 "\n"
 "Not connected to Maxima!\n"
@@ -54,7 +54,7 @@ msgstr ""
 "\n"
 "No connectat a Maxima!\n"
 
-#: ../src/wxMaxima.cpp:4530
+#: ../src/wxMaxima.cpp:4542
 msgid ""
 "\n"
 "Not connected."
@@ -74,7 +74,7 @@ msgstr ""
 msgid " (Graphics) "
 msgstr "(Gràfics)"
 
-#: ../src/EditorCell.cpp:3045 ../src/EditorCell.cpp:3227
+#: ../src/EditorCell.cpp:3088 ../src/EditorCell.cpp:3270
 #, c-format
 msgid " ... + %i hidden lines"
 msgstr ""
@@ -83,7 +83,7 @@ msgstr ""
 msgid " << Expression longer than allowed by the configuration setting! >>"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1673
+#: ../src/wxMaxima.cpp:1678
 msgid ""
 " was saved using a newer version of wxMaxima so it may not load correctly. "
 "Please update your wxMaxima."
@@ -91,7 +91,7 @@ msgstr ""
 " es va desar amb una versió més actualitzada de wxMaxima; és possible que no "
 "es carregui correctament. Si us plau, actualitzeu wxMaxima."
 
-#: ../src/wxMaxima.cpp:1665
+#: ../src/wxMaxima.cpp:1670
 msgid ""
 " was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr ""
@@ -106,64 +106,64 @@ msgstr ""
 msgid "\"implies\" symbol"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:101
+#: ../src/wxMaximaFrame.cpp:100
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:773
+#: ../src/wxMaximaFrame.cpp:772
 msgid "&Algebra"
 msgstr "Àl&gebra"
 
-#: ../src/wxMaximaFrame.cpp:767
+#: ../src/wxMaximaFrame.cpp:766
 msgid "&Apply to List..."
 msgstr "&Aplicar a llista"
 
-#: ../src/wxMaximaFrame.cpp:964
+#: ../src/wxMaximaFrame.cpp:963
 msgid "&Apropos..."
 msgstr "&Quant a"
 
-#: ../src/wxMaximaFrame.cpp:478
+#: ../src/wxMaximaFrame.cpp:477
 msgid "&Batch File...\tCtrl-B"
 msgstr "Arxiu per &Batch\tCtrl-B"
 
-#: ../src/wxMaximaFrame.cpp:724
+#: ../src/wxMaximaFrame.cpp:723
 msgid "&Boundary Value Problem..."
 msgstr "Pro&blema de contorn"
 
-#: ../src/wxMaximaFrame.cpp:975
+#: ../src/wxMaximaFrame.cpp:974
 msgid "&Bug Report"
 msgstr "Informar d'e&rror"
 
-#: ../src/wxMaximaFrame.cpp:825
+#: ../src/wxMaximaFrame.cpp:824
 msgid "&Calculus"
 msgstr "A&nàlisi"
 
-#: ../src/wxMaximaFrame.cpp:876
+#: ../src/wxMaximaFrame.cpp:875
 msgid "&Canonical Form"
 msgstr "Forma &canònica"
 
-#: ../src/wxMaximaFrame.cpp:749
+#: ../src/wxMaximaFrame.cpp:748
 msgid "&Characteristic Polynomial..."
 msgstr "Polinomi &caracteristic"
 
-#: ../src/wxMaximaFrame.cpp:654
+#: ../src/wxMaximaFrame.cpp:653
 msgid "&Clear Memory"
 msgstr "&Netejar memòria"
 
-#: ../src/wxMaximaFrame.cpp:859
+#: ../src/wxMaximaFrame.cpp:858
 msgid "&Combine Factorials"
 msgstr "&Combinar factorials"
 
-#: ../src/wxMaximaFrame.cpp:902
+#: ../src/wxMaximaFrame.cpp:901
 msgid "&Complex Simplification"
 msgstr "Simplificació &complexa"
 
-#: ../src/wxMaximaFrame.cpp:822
+#: ../src/wxMaximaFrame.cpp:821
 msgid "&Continued Fraction"
 msgstr "Fracció contín&ua"
 
-#: ../src/wxMaximaFrame.cpp:502
+#: ../src/wxMaximaFrame.cpp:501
 msgid "&Copy\tCtrl-C"
 msgstr "&Copiar\tCtrl-C"
 
@@ -171,108 +171,108 @@ msgstr "&Copiar\tCtrl-C"
 msgid "&Definite integration"
 msgstr "Integració &definida"
 
-#: ../src/wxMaximaFrame.cpp:896
+#: ../src/wxMaximaFrame.cpp:895
 msgid "&Demoivre"
 msgstr "&Demoivre"
 
-#: ../src/wxMaximaFrame.cpp:752
+#: ../src/wxMaximaFrame.cpp:751
 msgid "&Determinant"
 msgstr "&Determinant"
 
-#: ../src/wxMaximaFrame.cpp:785
+#: ../src/wxMaximaFrame.cpp:784
 msgid "&Differentiate..."
 msgstr "&Derivar"
 
-#: ../src/wxMaximaFrame.cpp:543
+#: ../src/wxMaximaFrame.cpp:542
 msgid "&Edit"
 msgstr "&Editar"
 
-#: ../src/wxMaximaFrame.cpp:709
+#: ../src/wxMaximaFrame.cpp:708
 msgid "&Eliminate Variable..."
 msgstr "Eliminar &variable"
 
-#: ../src/wxMaximaFrame.cpp:744
+#: ../src/wxMaximaFrame.cpp:743
 msgid "&Enter Matrix..."
 msgstr "&Introduir matriu"
 
-#: ../src/wxMaximaFrame.cpp:961
+#: ../src/wxMaximaFrame.cpp:960
 msgid "&Example..."
 msgstr "&Exemple"
 
-#: ../src/wxMaximaFrame.cpp:839
+#: ../src/wxMaximaFrame.cpp:838
 msgid "&Expand Expression"
 msgstr "&﻿Expandeix expressió"
 
-#: ../src/wxMaximaFrame.cpp:873
+#: ../src/wxMaximaFrame.cpp:872
 msgid "&Expand Trigonometric"
 msgstr "﻿Expandeix &trigonometría"
 
-#: ../src/wxMaximaFrame.cpp:899
+#: ../src/wxMaximaFrame.cpp:898
 msgid "&Exponentialize"
 msgstr "Expo&nencialitzar"
 
-#: ../src/wxMaximaFrame.cpp:480
+#: ../src/wxMaximaFrame.cpp:479
 msgid "&Export..."
 msgstr "&Exportar"
 
-#: ../src/wxMaximaFrame.cpp:834
+#: ../src/wxMaximaFrame.cpp:833
 msgid "&Factor Expression"
 msgstr "&Factoritza expressió"
 
-#: ../src/wxMaximaFrame.cpp:489
+#: ../src/wxMaximaFrame.cpp:488
 msgid "&File"
 msgstr "&Arxiu"
 
-#: ../src/wxMaximaFrame.cpp:692
+#: ../src/wxMaximaFrame.cpp:691
 msgid "&Find Root..."
 msgstr "C&alcula arrel"
 
-#: ../src/wxMaximaFrame.cpp:738
+#: ../src/wxMaximaFrame.cpp:737
 msgid "&Generate Matrix..."
 msgstr "&Genera matriu"
 
-#: ../src/wxMaximaFrame.cpp:809
+#: ../src/wxMaximaFrame.cpp:808
 msgid "&Greatest Common Divisor..."
 msgstr "Mà&xim comú divisor"
 
-#: ../src/wxMaximaFrame.cpp:994
+#: ../src/wxMaximaFrame.cpp:993
 msgid "&Help"
 msgstr "A&juda"
 
-#: ../src/wxMaximaFrame.cpp:777
+#: ../src/wxMaximaFrame.cpp:776
 msgid "&Integrate..."
 msgstr "&Integrar"
 
-#: ../src/wxMaximaFrame.cpp:645
+#: ../src/wxMaximaFrame.cpp:644
 msgid "&Interrupt\tCtrl-."
 msgstr "&﻿Interrupció\tCtrl-."
 
-#: ../src/wxMaximaFrame.cpp:649
+#: ../src/wxMaximaFrame.cpp:648
 msgid "&Interrupt\tCtrl-G"
 msgstr "&﻿Interrupció\tCtrl-G"
 
-#: ../src/wxMaximaFrame.cpp:746
+#: ../src/wxMaximaFrame.cpp:745
 msgid "&Invert Matrix"
 msgstr "In&verteix matriu"
 
-#: ../src/wxMaximaFrame.cpp:476
+#: ../src/wxMaximaFrame.cpp:475
 msgid "&Load Package...\tCtrl-L"
 msgstr "Carrega &paquet\tCtrl-L"
 
-#: ../src/wxMaximaFrame.cpp:769
+#: ../src/wxMaximaFrame.cpp:768
 #, fuzzy
 msgid "&Map to List(s)..."
 msgstr "Distribui&r sobre lista"
 
-#: ../src/wxMaximaFrame.cpp:684
+#: ../src/wxMaximaFrame.cpp:683
 msgid "&Maxima"
 msgstr "&Maxima"
 
-#: ../src/wxMaximaFrame.cpp:958
+#: ../src/wxMaximaFrame.cpp:957
 msgid "&Maxima help"
 msgstr "Ajuda de &Maxima"
 
-#: ../src/wxMaximaFrame.cpp:917
+#: ../src/wxMaximaFrame.cpp:916
 msgid "&Modulus Computation..."
 msgstr "Càlcul del &mòdul"
 
@@ -280,7 +280,7 @@ msgstr "Càlcul del &mòdul"
 msgid "&New\tCtrl-N"
 msgstr "&Nou\tCtrl-N"
 
-#: ../src/wxMaximaFrame.cpp:947
+#: ../src/wxMaximaFrame.cpp:946
 msgid "&Numeric"
 msgstr "N&umèric"
 
@@ -296,11 +296,11 @@ msgstr "&Nusum"
 msgid "&Open\tCtrl-O"
 msgstr "&Obre\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:463
+#: ../src/wxMaximaFrame.cpp:462
 msgid "&Open...\tCtrl-O"
 msgstr "&Obre...\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:929
+#: ../src/wxMaximaFrame.cpp:928
 msgid "&Plot"
 msgstr "&Gràfics"
 
@@ -308,7 +308,7 @@ msgstr "&Gràfics"
 msgid "&Power series"
 msgstr "Sèrie de &potències"
 
-#: ../src/wxMaximaFrame.cpp:483
+#: ../src/wxMaximaFrame.cpp:482
 msgid "&Print...\tCtrl-P"
 msgstr "&Imprimir...\tCtrl-P"
 
@@ -316,39 +316,39 @@ msgstr "&Imprimir...\tCtrl-P"
 msgid "&Rational"
 msgstr "&Racional"
 
-#: ../src/wxMaximaFrame.cpp:870
+#: ../src/wxMaximaFrame.cpp:869
 msgid "&Reduce Trigonometric"
 msgstr "R&eduir trigonometria"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "&Restart Maxima"
 msgstr "&Reiniciar Maxima"
 
-#: ../src/wxMaximaFrame.cpp:700
+#: ../src/wxMaximaFrame.cpp:699
 msgid "&Roots of Polynomial (Real)"
 msgstr "Arrels reals d'un polino&mi"
 
-#: ../src/wxMaximaFrame.cpp:472
+#: ../src/wxMaximaFrame.cpp:471
 msgid "&Save\tCtrl-S"
 msgstr "&Desa\tCtrl-S"
 
-#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:919
+#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:918
 msgid "&Simplify"
 msgstr "&Simplifica"
 
-#: ../src/wxMaximaFrame.cpp:829
+#: ../src/wxMaximaFrame.cpp:828
 msgid "&Simplify Expression"
 msgstr "&Simplifica expressió"
 
-#: ../src/wxMaximaFrame.cpp:856
+#: ../src/wxMaximaFrame.cpp:855
 msgid "&Simplify Factorials"
 msgstr "&Simplifica factorials"
 
-#: ../src/wxMaximaFrame.cpp:867
+#: ../src/wxMaximaFrame.cpp:866
 msgid "&Simplify Trigonometric"
 msgstr "&Simplifica trigonometria"
 
-#: ../src/wxMaximaFrame.cpp:688
+#: ../src/wxMaximaFrame.cpp:687
 msgid "&Solve..."
 msgstr "&Resol"
 
@@ -360,11 +360,11 @@ msgstr "Especial"
 msgid "&Taylor series"
 msgstr "Sèrie de Taylor"
 
-#: ../src/wxMaximaFrame.cpp:762
+#: ../src/wxMaximaFrame.cpp:761
 msgid "&Transpose Matrix"
 msgstr "&Matriu transporta"
 
-#: ../src/wxMaximaFrame.cpp:879
+#: ../src/wxMaximaFrame.cpp:878
 msgid "&Trigonometric Simplification"
 msgstr "Simplificació &trigonomètrica"
 
@@ -382,7 +382,7 @@ msgstr "(Fer servir l'idioma predeterminat)"
 msgid "- Infinity"
 msgstr "- Infinit"
 
-#: ../src/wxMaxima.cpp:351
+#: ../src/wxMaxima.cpp:356
 msgid ""
 "... [suppressed additional lines since the output is longer than allowed in "
 "the configuration] "
@@ -392,16 +392,16 @@ msgstr ""
 msgid "1/2"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:103
+#: ../src/wxMaximaFrame.cpp:102
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4601
+#: ../src/wxMaxima.cpp:4613
 msgid "<br>Lisp: "
 msgstr "<br>Lisp: "
 
-#: ../src/wxMaxima.cpp:5487
+#: ../src/wxMaxima.cpp:5503
 msgid ""
 "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
@@ -433,11 +433,11 @@ msgid ""
 "\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1472
+#: ../src/wxMaximaFrame.cpp:1495
 msgid "A symbol from the configuration dialogue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:731
+#: ../src/wxMaximaFrame.cpp:730
 msgid "A&t Value..."
 msgstr "&Condició inicial"
 
@@ -445,12 +445,12 @@ msgstr "&Condició inicial"
 msgid "Abort evaluation on error"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaxima.cpp:4603
+#: ../src/wxMaxima.cpp:4615 ../src/wxMaximaFrame.cpp:985
 msgid "About"
 msgstr "&Quant a..."
 
-#: ../src/wxMaximaFrame.cpp:987 ../src/wxMaximaFrame.cpp:990
-#: ../src/wxMaximaFrame.cpp:991
+#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaximaFrame.cpp:989
+#: ../src/wxMaximaFrame.cpp:990
 msgid "About wxMaxima"
 msgstr "Quant a wxMaxima"
 
@@ -458,23 +458,23 @@ msgstr "Quant a wxMaxima"
 msgid "Active cell bracket"
 msgstr "﻿Claudàtor de cel·la activa"
 
-#: ../src/wxMaximaFrame.cpp:760
+#: ../src/wxMaximaFrame.cpp:759
 msgid "Ad&joint Matrix"
 msgstr "Matriu ad&junta"
 
-#: ../src/wxMaximaFrame.cpp:914
+#: ../src/wxMaximaFrame.cpp:913
 msgid "Add Algebraic E&quality..."
 msgstr "Afegir &igualtat algebraica"
 
-#: ../src/wxMaximaFrame.cpp:657
+#: ../src/wxMaximaFrame.cpp:656
 msgid "Add a directory to search path"
 msgstr "Afegir un directori a la ruta de recerca"
 
-#: ../src/wxMaxima.cpp:3353
+#: ../src/wxMaxima.cpp:3365
 msgid "Add dir to path:"
 msgstr "Afegir directori a la ruta:"
 
-#: ../src/wxMaximaFrame.cpp:915
+#: ../src/wxMaximaFrame.cpp:914
 msgid "Add equality to the rational simplifier"
 msgstr "Afegir igualtat al simplificador racional"
 
@@ -482,7 +482,7 @@ msgstr "Afegir igualtat al simplificador racional"
 msgid "Add the .wxmx file to the HTML export"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:656
+#: ../src/wxMaximaFrame.cpp:655
 msgid "Add to &Path..."
 msgstr "Afe&gir a la ruta"
 
@@ -526,27 +526,27 @@ msgstr "Variable anterior:"
 msgid "All|*"
 msgstr "Tots|*"
 
-#: ../src/wxMaximaFrame.cpp:1364
+#: ../src/wxMaximaFrame.cpp:1363
 msgid "Alpha"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3838
+#: ../src/wxMaxima.cpp:3850
 msgid "Apply"
 msgstr "Aplicar"
 
-#: ../src/wxMaximaFrame.cpp:768
+#: ../src/wxMaximaFrame.cpp:767
 msgid "Apply function to a list"
 msgstr "Aplicar funció a llista"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Apropos"
 msgstr "A propòsit"
 
-#: ../src/wxMaxima.cpp:3764
+#: ../src/wxMaxima.cpp:3776
 msgid "Array:"
 msgstr "Vector:"
 
-#: ../src/wxMaxima.cpp:4462
+#: ../src/wxMaxima.cpp:4474
 msgid "Artwork by"
 msgstr "Il·lustració de"
 
@@ -554,7 +554,7 @@ msgstr "Il·lustració de"
 msgid "Ask to save untitled documents"
 msgstr "Demanar per a desar documents sense títol"
 
-#: ../src/wxMaxima.cpp:3650
+#: ../src/wxMaxima.cpp:3662
 msgid "At value"
 msgstr "Condició inicial"
 
@@ -581,11 +581,11 @@ msgstr ""
 msgid "Autosave interval (minutes, 0 means: off):"
 msgstr "Interval per desar automàticament (minuts, 0 per desactivar)"
 
-#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3557
+#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3569
 msgid "BC2"
 msgstr "BC2"
 
-#: ../src/wxMaximaFrame.cpp:1272
+#: ../src/wxMaximaFrame.cpp:1271
 msgid "Barsplot..."
 msgstr "Diagrama de barres..."
 
@@ -593,7 +593,7 @@ msgstr "Diagrama de barres..."
 msgid "Bat files (*.bat)|*.bat|All|*"
 msgstr "Arxius bat (*.bat)|*.bat|Tots|*"
 
-#: ../src/wxMaxima.cpp:2943
+#: ../src/wxMaxima.cpp:2951
 msgid "Batch File"
 msgstr "Arxiu per lots"
 
@@ -606,7 +606,7 @@ msgid ""
 "cells."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1365
+#: ../src/wxMaximaFrame.cpp:1364
 msgid "Beta"
 msgstr ""
 
@@ -619,11 +619,11 @@ msgstr "Escala del mapa de bits per a l'exportació"
 msgid "Bold"
 msgstr "Negreta"
 
-#: ../src/wxMaxima.cpp:2359
+#: ../src/wxMaxima.cpp:2366
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1274
+#: ../src/wxMaximaFrame.cpp:1273
 msgid "Boxplot..."
 msgstr "Diagrama de caixes..."
 
@@ -635,15 +635,15 @@ msgstr "Navegar"
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr "Error: es requereix l'auto completat per un tipus d'ítem desconegut."
 
-#: ../src/MathCtrl.cpp:2080
+#: ../src/MathCtrl.cpp:2127
 msgid "Bug: Cell left but not entered."
 msgstr "Error: cel·la esquerra sense entrada."
 
-#: ../src/wxMaxima.cpp:1178
+#: ../src/wxMaxima.cpp:1183
 msgid "Bug: Found a math end marker without any start marker."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1222
+#: ../src/wxMaxima.cpp:1227
 msgid "Bug: Found the end of autocompletion symbols but no beginning"
 msgstr ""
 
@@ -655,11 +655,11 @@ msgstr ""
 msgid "Bug: Fraction without enumerator"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2312
+#: ../src/MathCtrl.cpp:2359
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5839
+#: ../src/MathCtrl.cpp:5891
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of "
 "the worksheet."
@@ -667,14 +667,14 @@ msgstr ""
 "Error: hi ha una petició de canviar el contingut d'una cel·la situada abans "
 "de l'inici del full de càlcul."
 
-#: ../src/MathCtrl.cpp:5913
+#: ../src/MathCtrl.cpp:5965
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 "Error: hi ha una petició d'eliminar una cel·la situada abans de l'inici del "
 "full de càlcul."
 
-#: ../src/MathCtrl.cpp:5882
+#: ../src/MathCtrl.cpp:5934
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
@@ -686,43 +686,43 @@ msgstr ""
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
 msgstr ""
 
-#: ../src/GroupCell.cpp:780 ../src/GroupCell.cpp:951
+#: ../src/GroupCell.cpp:781 ../src/GroupCell.cpp:952
 msgid "Bug: No image counter to write to!"
 msgstr ""
 
-#: ../src/AbsCell.cpp:193
+#: ../src/AbsCell.cpp:199
 msgid "Bug: No last cell in an absCell!"
 msgstr ""
 
-#: ../src/ConjugateCell.cpp:185
+#: ../src/ConjugateCell.cpp:194
 msgid "Bug: No last cell in an conjugateCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:471
+#: ../src/FracCell.cpp:472
 msgid "Bug: No last cell in an denominator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:267
+#: ../src/ExptCell.cpp:270
 msgid "Bug: No last cell in an exponent of an exptCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:459
+#: ../src/FracCell.cpp:460
 msgid "Bug: No last cell in an numerator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:257
+#: ../src/ExptCell.cpp:260
 msgid "Bug: No last cell in the base of an exptCell!"
 msgstr ""
 
-#: ../src/ParenCell.cpp:534
+#: ../src/ParenCell.cpp:535
 msgid "Bug: No last cell inside a parenthesis!"
 msgstr ""
 
-#: ../src/SqrtCell.cpp:312
+#: ../src/SqrtCell.cpp:317
 msgid "Bug: No last cell inside a square root!"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2123
+#: ../src/MathCtrl.cpp:2170
 msgid ""
 "Bug: Start or end of merging of subsequent editing actions was requested two "
 "times in a row."
@@ -730,7 +730,7 @@ msgstr ""
 "Error: s'ha sol·licitat la fusió de l'inici o final d'accions d'edició "
 "encadenades dues vegades en una fila."
 
-#: ../src/MathCtrl.cpp:2090
+#: ../src/MathCtrl.cpp:2137
 msgid "Bug: Text changed, but no active cell."
 msgstr "Error: ha canviat el text però no hi ha cap cel·la activa."
 
@@ -741,13 +741,13 @@ msgstr ""
 "Error: s'està intentant registrar els canvis de contingut de la cel·la que "
 "no existeix."
 
-#: ../src/MathCtrl.cpp:555
+#: ../src/MathCtrl.cpp:600
 msgid "Bug: Trying to append maxima's output to a cell outside the worksheet."
 msgstr ""
 "Error: s'està intentant afegir la sortida de Maxima a una cel·la situada "
 "fora del full de càlcul."
 
-#: ../src/MathCtrl.cpp:2014
+#: ../src/MathCtrl.cpp:2061
 msgid ""
 "Bug: Trying to merge individual cell adds to a region in the undo buffer but "
 "there are other cells between them."
@@ -755,38 +755,38 @@ msgstr ""
 "Error: s'està intentant combinar addicions de cel·les individuals a una "
 "regió a la coa de desfer accions però hi ha altres cel·les entre elles."
 
-#: ../src/MathCtrl.cpp:6522
+#: ../src/MathCtrl.cpp:6577
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2092
+#: ../src/MathCtrl.cpp:2139
 msgid "Bug: Trying to record a cell contents change without a cell."
 msgstr ""
 "Error: s'està intentant registrar els canvis de contingut de la cel·la que "
 "no existeix."
 
-#: ../src/MathCtrl.cpp:1495
+#: ../src/MathCtrl.cpp:1540
 #, fuzzy
 msgid "Bug: Trying to select inside a cell without having a current cell"
 msgstr ""
 "Error: s'està intentant registrar els canvis de contingut de la cel·la que "
 "no existeix."
 
-#: ../src/MathCtrl.cpp:5883
+#: ../src/MathCtrl.cpp:5935
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
 "Error: desfer acció amb canvi del contingut de la cel·la i addició de la "
 "cel·la."
 
-#: ../src/MathCtrl.cpp:5844 ../src/MathCtrl.cpp:5918 ../src/MathCtrl.cpp:5952
+#: ../src/MathCtrl.cpp:5896 ../src/MathCtrl.cpp:5970 ../src/MathCtrl.cpp:6004
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
 "Error: s'està intentant desfer una acció a una cel·la situada fora del full "
 "de càlcul."
 
-#: ../src/wxMaximaFrame.cpp:973
+#: ../src/wxMaximaFrame.cpp:972
 msgid "Build &Info"
 msgstr "&Informació de compilació"
 
@@ -803,51 +803,51 @@ msgstr ""
 "«Editar->Preferències» seleccionant «Tecla retorn avalua cel·les», "
 "intercanviant la funcionalitat de les tecles."
 
-#: ../src/wxMaximaFrame.cpp:782
+#: ../src/wxMaximaFrame.cpp:781
 msgid "C&hange Variable..."
 msgstr "C&anviar variable"
 
-#: ../src/wxMaximaFrame.cpp:540
+#: ../src/wxMaximaFrame.cpp:539
 msgid "C&onfigure"
 msgstr "&Preferències"
 
-#: ../src/wxMaximaFrame.cpp:801
+#: ../src/wxMaximaFrame.cpp:800
 msgid "Calculate &Product..."
 msgstr "&Calcular producte"
 
-#: ../src/wxMaximaFrame.cpp:799
+#: ../src/wxMaximaFrame.cpp:798
 msgid "Calculate Su&m..."
 msgstr "Calcular su&ma"
 
-#: ../src/wxMaximaFrame.cpp:939
+#: ../src/wxMaximaFrame.cpp:938
 msgid "Calculate bigfloat value of the last result"
 msgstr "Format real gran de la darrera expressió"
 
-#: ../src/wxMaximaFrame.cpp:936
+#: ../src/wxMaximaFrame.cpp:935
 msgid "Calculate float value of the last result"
 msgstr "Format real de la darrera expressió"
 
-#: ../src/wxMaxima.cpp:3971
+#: ../src/wxMaxima.cpp:3983
 msgid "Calculate modulus:"
 msgstr "Calcular mòdul:"
 
-#: ../src/wxMaximaFrame.cpp:942
+#: ../src/wxMaximaFrame.cpp:941
 msgid "Calculate numeric value of the last result"
 msgstr "Calcular el valor numèric del darrer resultat"
 
-#: ../src/wxMaximaFrame.cpp:802
+#: ../src/wxMaximaFrame.cpp:801
 msgid "Calculate products"
 msgstr "Calcular productes"
 
-#: ../src/wxMaximaFrame.cpp:800
+#: ../src/wxMaximaFrame.cpp:799
 msgid "Calculate sums"
 msgstr "Calcular sumes"
 
-#: ../src/wxMaxima.cpp:5830
+#: ../src/wxMaxima.cpp:5845
 msgid "Can not connect to the web server."
 msgstr "No és possible connectar amb el servidor web."
 
-#: ../src/wxMaxima.cpp:5881
+#: ../src/wxMaxima.cpp:5896
 msgid "Can not download version info."
 msgstr "No es pot baixar la informació de la versió."
 
@@ -863,15 +863,15 @@ msgstr "No es pot baixar la informació de la versió."
 #: ../src/PlotFormatWiz.cpp:48 ../src/SeriesWiz.cpp:49 ../src/SeriesWiz.cpp:51
 #: ../src/SubstituteWiz.cpp:41 ../src/SubstituteWiz.cpp:43 ../src/SumWiz.cpp:44
 #: ../src/SumWiz.cpp:46 ../src/SystemWiz.cpp:38 ../src/SystemWiz.cpp:40
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Cancel"
 msgstr "﻿Cancel·lar"
 
-#: ../src/wxMaximaFrame.cpp:126 ../src/wxMaxima.cpp:932
+#: ../src/wxMaxima.cpp:937 ../src/wxMaximaFrame.cpp:125
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1217
+#: ../src/wxMaximaFrame.cpp:1216
 msgid "Canonical (tr)"
 msgstr "Canònic (tr)"
 
@@ -879,7 +879,7 @@ msgstr "Canònic (tr)"
 msgid "Catalan"
 msgstr "Català"
 
-#: ../src/wxMaximaFrame.cpp:638
+#: ../src/wxMaximaFrame.cpp:637
 msgid "Ce&ll"
 msgstr "Ce&l·la"
 
@@ -887,41 +887,41 @@ msgstr "Ce&l·la"
 msgid "Cell bracket"
 msgstr "Claudàtor de cel·la"
 
-#: ../src/wxMaxima.cpp:5261
+#: ../src/wxMaxima.cpp:5273
 msgid "Cell ends in a backslash"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:676
+#: ../src/wxMaximaFrame.cpp:675
 msgid "Change &2d Display"
 msgstr "Canviar pantalla &2D"
 
-#: ../src/wxMaximaFrame.cpp:677
+#: ../src/wxMaximaFrame.cpp:676
 msgid "Change the 2d display algorithm used to display math output"
 msgstr ""
 "Canviar l'algoritme fet servir per mostrar la sortida matemàtica a la "
 "pantalla 2D."
 
-#: ../src/wxMaxima.cpp:3995
+#: ../src/wxMaxima.cpp:4007
 msgid "Change variable"
 msgstr "Canviar variable"
 
-#: ../src/wxMaximaFrame.cpp:783
+#: ../src/wxMaximaFrame.cpp:782
 msgid "Change variable in integral or sum"
 msgstr "Canviar variable a la integral o suma"
 
-#: ../src/wxMaxima.cpp:3751
+#: ../src/wxMaxima.cpp:3763
 msgid "Char poly"
 msgstr "Polinomi característic"
 
-#: ../src/wxMaximaFrame.cpp:978
+#: ../src/wxMaximaFrame.cpp:977
 msgid "Check for Updates"
 msgstr "Comprovar actualitzacions"
 
-#: ../src/wxMaximaFrame.cpp:979
+#: ../src/wxMaximaFrame.cpp:978
 msgid "Check if a newer version of wxMaxima/Maxima exist."
 msgstr "Comprovar si hi ha disponible una nova versió de wxMaxima/Maxima."
 
-#: ../src/wxMaximaFrame.cpp:1385
+#: ../src/wxMaximaFrame.cpp:1384
 msgid "Chi"
 msgstr ""
 
@@ -942,15 +942,15 @@ msgstr "Seleccionar font"
 msgid "Choose new plot format:"
 msgstr "Seleccionau un nuo format de gràfics:"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710
 msgid "Classes:"
 msgstr "Classes:"
 
-#: ../src/wxMaximaFrame.cpp:469
+#: ../src/wxMaximaFrame.cpp:468
 msgid "Close\tCtrl-W"
 msgstr "Tanca\tCtrl-W"
 
-#: ../src/wxMaximaFrame.cpp:470
+#: ../src/wxMaximaFrame.cpp:469
 msgid "Close window"
 msgstr "Tanca la finestra"
 
@@ -982,19 +982,19 @@ msgstr ""
 msgid "Code highlighting: Variables"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4806
+#: ../src/wxMaxima.cpp:4818
 msgid "Col. names:"
 msgstr "Noms col.:"
 
-#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Columns:"
 msgstr "Columnes:"
 
-#: ../src/wxMaximaFrame.cpp:860
+#: ../src/wxMaximaFrame.cpp:859
 msgid "Combine factorials in an expression"
 msgstr "Combinar factorials a una expressió"
 
-#: ../src/wxMaxima.cpp:5293
+#: ../src/wxMaxima.cpp:5305
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
@@ -1006,24 +1006,24 @@ msgstr "Coordenades x separades per comes."
 msgid "Comma separated y coordinates"
 msgstr "Coordenades y separades per comes."
 
-#: ../src/MathCtrl.cpp:1030
+#: ../src/MathCtrl.cpp:1072
 msgid "Comment Selection"
 msgstr "Comentar selecció"
 
-#: ../src/wxMaximaFrame.cpp:533
+#: ../src/wxMaximaFrame.cpp:532
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:532
+#: ../src/wxMaximaFrame.cpp:531
 #, fuzzy
 msgid "Comment selection\tCtrl-/"
 msgstr "Comentar selecció"
 
-#: ../src/wxMaximaFrame.cpp:601
+#: ../src/wxMaximaFrame.cpp:600
 msgid "Complete Word\tCtrl-K"
 msgstr "&Autocompletar\tCtrl-K"
 
-#: ../src/wxMaximaFrame.cpp:602
+#: ../src/wxMaximaFrame.cpp:601
 msgid "Complete word"
 msgstr "Autocompletar"
 
@@ -1031,36 +1031,36 @@ msgstr "Autocompletar"
 msgid "Completely stop maxima and restart it"
 msgstr "Aturar completament Maxima i reiniciar"
 
-#: ../src/wxMaximaFrame.cpp:823
+#: ../src/wxMaximaFrame.cpp:822
 msgid "Compute continued fraction of a value"
 msgstr "Calcular la fracció continua d'un valor"
 
-#: ../src/wxMaximaFrame.cpp:761
+#: ../src/wxMaximaFrame.cpp:760
 msgid "Compute the adjoint matrix"
 msgstr "Calcula la matriu adjunta"
 
-#: ../src/wxMaximaFrame.cpp:750
+#: ../src/wxMaximaFrame.cpp:749
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr "Calcula el polinomi característic d'una matriu"
 
-#: ../src/wxMaximaFrame.cpp:753
+#: ../src/wxMaximaFrame.cpp:752
 msgid "Compute the determinant of a matrix"
 msgstr "Calcular el determinant d'una matriu"
 
-#: ../src/wxMaximaFrame.cpp:810
+#: ../src/wxMaximaFrame.cpp:809
 msgid "Compute the greatest common divisor"
 msgstr "Calcular el màxim divisor comú"
 
-#: ../src/wxMaximaFrame.cpp:747
+#: ../src/wxMaximaFrame.cpp:746
 msgid "Compute the inverse of a matrix"
 msgstr "Calcular la inversa d'una matriu"
 
-#: ../src/wxMaximaFrame.cpp:813
+#: ../src/wxMaximaFrame.cpp:812
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
 "Calcular el mínim comú múltiple (executar «load(functs)» abans de fer servir)"
 
-#: ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4868
 msgid "Condition:"
 msgstr "Condició"
 
@@ -1072,8 +1072,8 @@ msgstr "Arxius de configuració (*.ini)|*.ini"
 msgid "Configuration warning"
 msgstr "Advertència sobre configuració"
 
-#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:538
-#: ../src/wxMaximaFrame.cpp:541
+#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:540
 msgid "Configure wxMaxima"
 msgstr "Configurar wxMaxima"
 
@@ -1082,130 +1082,132 @@ msgstr "Configurar wxMaxima"
 msgid "Constant"
 msgstr "Constant"
 
-#: ../src/wxMaximaFrame.cpp:844
+#: ../src/wxMaximaFrame.cpp:843
 msgid "Contract Logarithms"
 msgstr "C&ontreure logaritmes"
 
-#: ../src/wxMaximaFrame.cpp:851
+#: ../src/wxMaximaFrame.cpp:850
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr "Convertir binomials, funcions beta i gamma a factorials"
 
-#: ../src/wxMaximaFrame.cpp:854
+#: ../src/wxMaximaFrame.cpp:853
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr "Convertir binomials, funcions factorials i beta a funció gamma"
 
-#: ../src/wxMaximaFrame.cpp:888
+#: ../src/wxMaximaFrame.cpp:887
 msgid "Convert complex expression to polar form"
 msgstr "Convertir expressió complexa a forma polar"
 
-#: ../src/wxMaximaFrame.cpp:885
+#: ../src/wxMaximaFrame.cpp:884
 msgid "Convert complex expression to rect form"
 msgstr "Convertir expressió complexa a forma cartesiana"
 
-#: ../src/wxMaximaFrame.cpp:897
+#: ../src/wxMaximaFrame.cpp:896
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
 "Convertir funció exponencial d'argument imaginari a forma trigonomètrica"
 
-#: ../src/wxMaximaFrame.cpp:842
+#: ../src/wxMaximaFrame.cpp:841
 msgid "Convert logarithm of product to sum of logarithms"
 msgstr "Convertir logaritme d'un producte en suma de logaritmes"
 
-#: ../src/wxMaximaFrame.cpp:845
+#: ../src/wxMaximaFrame.cpp:844
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "Convertir suma de logaritmes en logaritme d'un producte"
 
-#: ../src/wxMaximaFrame.cpp:850
+#: ../src/wxMaximaFrame.cpp:849
 msgid "Convert to &Factorials"
 msgstr "Convertir a &factorials"
 
-#: ../src/wxMaximaFrame.cpp:853
+#: ../src/wxMaximaFrame.cpp:852
 msgid "Convert to &Gamma"
 msgstr "Convertir a &gamma"
 
-#: ../src/wxMaximaFrame.cpp:887
+#: ../src/wxMaximaFrame.cpp:886
 msgid "Convert to &Polarform"
 msgstr "Convertir a forma &polar"
 
-#: ../src/wxMaximaFrame.cpp:884
+#: ../src/wxMaximaFrame.cpp:883
 msgid "Convert to &Rectform"
 msgstr "Convertir a forma &cartesiana"
 
-#: ../src/wxMaximaFrame.cpp:877
+#: ../src/wxMaximaFrame.cpp:876
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr "Convertir expressió trigonomètrica a forma canònica quasi lineal"
 
-#: ../src/wxMaximaFrame.cpp:900
+#: ../src/wxMaximaFrame.cpp:899
 msgid "Convert trigonometric functions to exponential form"
 msgstr "Convertir funcions trigonomètriques a forma exponencial"
 
-#: ../src/ToolBar.cpp:140 ../src/MathCtrl.cpp:918 ../src/MathCtrl.cpp:931
-#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1024
+#: ../src/MathCtrl.cpp:960 ../src/MathCtrl.cpp:973 ../src/MathCtrl.cpp:1019
+#: ../src/MathCtrl.cpp:1066 ../src/ToolBar.cpp:140
 msgid "Copy"
 msgstr "Copiar"
 
-#: ../src/wxMaximaFrame.cpp:597
+#: ../src/wxMaximaFrame.cpp:596
 msgid "Copy Previous Input\tCtrl-I"
 msgstr "&Copiar entrada anterior\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:599
+#: ../src/wxMaximaFrame.cpp:598
 msgid "Copy Previous Output\tCtrl-U"
 msgstr "Copiar resultat anterior\tCtrl-U"
 
-#: ../src/wxMaximaFrame.cpp:514 ../src/MathCtrl.cpp:936 ../src/MathCtrl.cpp:982
+#: ../src/MathCtrl.cpp:978 ../src/MathCtrl.cpp:1024
+#: ../src/wxMaximaFrame.cpp:513
 msgid "Copy as Image"
 msgstr "Copiar com a imatge"
 
-#: ../src/wxMaximaFrame.cpp:507 ../src/MathCtrl.cpp:932 ../src/MathCtrl.cpp:978
+#: ../src/MathCtrl.cpp:974 ../src/MathCtrl.cpp:1020
+#: ../src/wxMaximaFrame.cpp:506
 msgid "Copy as LaTeX"
 msgstr "Copiar com a &LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:510
+#: ../src/wxMaximaFrame.cpp:509
 #, fuzzy
 msgid "Copy as MathML"
 msgstr "Copiar com a imatge"
 
-#: ../src/MathCtrl.cpp:935 ../src/MathCtrl.cpp:980
+#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1022
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:504
+#: ../src/wxMaximaFrame.cpp:503
 msgid "Copy as Text\tCtrl-Shift-C"
 msgstr "Copiar com a &text\tCtrl-Shift-C"
 
-#: ../src/MathCtrl.cpp:933 ../src/MathCtrl.cpp:979
+#: ../src/MathCtrl.cpp:975 ../src/MathCtrl.cpp:1021
 #, fuzzy
 msgid "Copy as plain text"
 msgstr "Copiar com a imatge"
 
-#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:503
+#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:502
 msgid "Copy selection"
 msgstr "Copiar selecció"
 
-#: ../src/wxMaximaFrame.cpp:515
+#: ../src/wxMaximaFrame.cpp:514
 msgid "Copy selection from document as an image"
 msgstr "Copiar selecció del document com a imatge"
 
-#: ../src/wxMaximaFrame.cpp:505
+#: ../src/wxMaximaFrame.cpp:504
 msgid "Copy selection from document as text"
 msgstr "Copiar selecció del document en format text"
 
-#: ../src/wxMaximaFrame.cpp:508
+#: ../src/wxMaximaFrame.cpp:507
 msgid "Copy selection from document in LaTeX format"
 msgstr "Copiar selecció del document en format LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:511
+#: ../src/wxMaximaFrame.cpp:510
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:598
+#: ../src/wxMaximaFrame.cpp:597
 msgid "Create a new cell with previous input"
 msgstr "Crea una nova cel·la con l'entrada anterior"
 
-#: ../src/wxMaximaFrame.cpp:600
+#: ../src/wxMaximaFrame.cpp:599
 msgid "Create a new cell with previous output"
 msgstr "Crea una nova cel·la amb el resultat anterior"
 
@@ -1213,15 +1215,15 @@ msgstr "Crea una nova cel·la amb el resultat anterior"
 msgid "Cursor"
 msgstr "Cursor"
 
-#: ../src/ToolBar.cpp:137 ../src/MathCtrl.cpp:1023
+#: ../src/MathCtrl.cpp:1065 ../src/ToolBar.cpp:137
 msgid "Cut"
 msgstr "Talla"
 
-#: ../src/wxMaximaFrame.cpp:499
+#: ../src/wxMaximaFrame.cpp:498
 msgid "Cut\tCtrl-X"
 msgstr "&Talla\tCtrl-X"
 
-#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:500
+#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:499
 msgid "Cut selection"
 msgstr "Talla selecció"
 
@@ -1233,18 +1235,18 @@ msgstr "Txec"
 msgid "Danish"
 msgstr "Danès"
 
-#: ../src/wxMaxima.cpp:4799 ../src/wxMaxima.cpp:4806 ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4811 ../src/wxMaxima.cpp:4818 ../src/wxMaxima.cpp:4868
 msgid "Data Matrix:"
 msgstr "Matriu de dades:"
 
-#: ../src/wxMaxima.cpp:4826
+#: ../src/wxMaxima.cpp:4838
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr "Arxiu de dades (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698 ../src/wxMaxima.cpp:4712
-#: ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726 ../src/wxMaxima.cpp:4734
-#: ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748 ../src/wxMaxima.cpp:4755
-#: ../src/wxMaxima.cpp:4791
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710 ../src/wxMaxima.cpp:4724
+#: ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738 ../src/wxMaxima.cpp:4746
+#: ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760 ../src/wxMaxima.cpp:4767
+#: ../src/wxMaxima.cpp:4803
 msgid "Data:"
 msgstr "Dades:"
 
@@ -1252,7 +1254,7 @@ msgstr "Dades:"
 msgid "Debug: watch maxima's stdout stream"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:820
+#: ../src/wxMaximaFrame.cpp:819
 msgid "Decompose rational function to partial fractions"
 msgstr "Descompondre funció racional en fraccions simples"
 
@@ -1287,47 +1289,47 @@ msgstr ""
 "Defineix la velocitat predeterminada (en fotogrames per segon) de "
 "reproducció de les animacions."
 
-#: ../src/wxMaxima.cpp:3403 ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3415 ../src/wxMaxima.cpp:3424
 msgid "Delete"
 msgstr "Suprimeix"
 
-#: ../src/wxMaximaFrame.cpp:667
+#: ../src/wxMaximaFrame.cpp:666
 msgid "Delete F&unction..."
 msgstr "Suprimeix f&unció"
 
-#: ../src/MathCtrl.cpp:939 ../src/MathCtrl.cpp:985
+#: ../src/MathCtrl.cpp:981 ../src/MathCtrl.cpp:1027
 msgid "Delete Selection"
 msgstr "Suprimeix selecció"
 
-#: ../src/wxMaximaFrame.cpp:669
+#: ../src/wxMaximaFrame.cpp:668
 msgid "Delete V&ariable..."
 msgstr "Suprimeix v&ariable"
 
-#: ../src/wxMaximaFrame.cpp:668
+#: ../src/wxMaximaFrame.cpp:667
 msgid "Delete a function"
 msgstr "Suprimeix una funció"
 
-#: ../src/wxMaximaFrame.cpp:670
+#: ../src/wxMaximaFrame.cpp:669
 msgid "Delete a variable"
 msgstr "Suprimeix una variable"
 
-#: ../src/wxMaximaFrame.cpp:655
+#: ../src/wxMaximaFrame.cpp:654
 msgid "Delete all values from memory"
 msgstr "Suprimeix totes les variables de la memòria"
 
-#: ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3424
 msgid "Delete function(s):"
 msgstr "Suprimeix funció(ns):"
 
-#: ../src/wxMaxima.cpp:3403
+#: ../src/wxMaxima.cpp:3415
 msgid "Delete variable(s):"
 msgstr "Suprimeix variable(s):"
 
-#: ../src/wxMaximaFrame.cpp:1367
+#: ../src/wxMaximaFrame.cpp:1366
 msgid "Delta"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4011
+#: ../src/wxMaxima.cpp:4023
 msgid "Denom. deg:"
 msgstr "Denom. deg:"
 
@@ -1335,35 +1337,35 @@ msgstr "Denom. deg:"
 msgid "Depth:"
 msgstr "Fondària:"
 
-#: ../src/wxMaxima.cpp:3541
+#: ../src/wxMaxima.cpp:3553
 msgid "Derivative:"
 msgstr "Derivada:"
 
-#: ../src/wxMaximaFrame.cpp:1258
+#: ../src/wxMaximaFrame.cpp:1257
 msgid "Deviation..."
 msgstr "Desviació..."
 
-#: ../src/wxMaximaFrame.cpp:816
+#: ../src/wxMaximaFrame.cpp:815
 msgid "Di&vide Polynomials..."
 msgstr "Di&vidir polinomis"
 
-#: ../src/wxMaximaFrame.cpp:1223
+#: ../src/wxMaximaFrame.cpp:1222
 msgid "Diff..."
 msgstr "Derivar"
 
-#: ../src/wxMaxima.cpp:4154 ../src/wxMaxima.cpp:5066
+#: ../src/wxMaxima.cpp:4166 ../src/wxMaxima.cpp:5078
 msgid "Differentiate"
 msgstr "Diferenciar"
 
-#: ../src/wxMaximaFrame.cpp:786
+#: ../src/wxMaximaFrame.cpp:785
 msgid "Differentiate expression"
 msgstr "Diferenciar expressió"
 
-#: ../src/MathCtrl.cpp:1001
+#: ../src/MathCtrl.cpp:1043
 msgid "Differentiate..."
 msgstr "Derivar"
 
-#: ../src/LimitWiz.cpp:37 ../src/FindReplacePane.cpp:76
+#: ../src/FindReplacePane.cpp:76 ../src/LimitWiz.cpp:37
 msgid "Direction:"
 msgstr "Direcció:"
 
@@ -1371,48 +1373,49 @@ msgstr "Direcció:"
 msgid "Discrete plot"
 msgstr "Gràfic discret"
 
-#: ../src/wxMaximaFrame.cpp:679
+#: ../src/wxMaximaFrame.cpp:678
 msgid "Display Te&X Form"
 msgstr "Mostrar format Te&X"
 
-#: ../src/wxMaxima.cpp:3320
+#: ../src/wxMaxima.cpp:3332
 msgid "Display algorithm"
 msgstr "Mostra algoritme"
 
-#: ../src/wxMaximaFrame.cpp:680
+#: ../src/wxMaximaFrame.cpp:679
 msgid "Display last result in TeX form"
 msgstr "Mostra el darrer resultat en format TeX"
 
-#: ../src/wxMaximaFrame.cpp:674
+#: ../src/wxMaximaFrame.cpp:673
 msgid "Display time used for evaluation"
 msgstr "Mostra el temps de l'avaluació"
 
-#: ../src/wxMaxima.cpp:4061
+#: ../src/wxMaxima.cpp:4073
 msgid "Divide"
 msgstr "Dividir"
 
-#: ../src/MathCtrl.cpp:1032
+#: ../src/MathCtrl.cpp:1074
 msgid "Divide Cell"
 msgstr "Dividir cel·la"
 
-#: ../src/wxMaximaFrame.cpp:635
+#: ../src/wxMaximaFrame.cpp:634
 #, fuzzy
 msgid "Divide Cell\tCtrl-D"
 msgstr "Dividir cel·la"
 
-#: ../src/wxMaximaFrame.cpp:817
+#: ../src/wxMaximaFrame.cpp:816
 msgid "Divide numbers or polynomials"
 msgstr "Dividir números o polinomis"
 
-#: ../src/wxMaximaFrame.cpp:636
+#: ../src/wxMaximaFrame.cpp:635
 msgid "Divide this input cell into two cells"
 msgstr "Divideix aquesta cel·la d'entrada en dues cel·les"
 
-#: ../src/wxMaxima.cpp:5917
-msgid "Do you want to save the changes you made in the document \""
+#: ../src/wxMaxima.cpp:5932
+#, fuzzy, c-format
+msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr "Voleu desar els canvis que realitzats al document \""
 
-#: ../src/wxMaxima.cpp:1664 ../src/wxMaxima.cpp:1672
+#: ../src/wxMaxima.cpp:1669 ../src/wxMaxima.cpp:1677
 msgid "Document "
 msgstr "Document"
 
@@ -1434,7 +1437,7 @@ msgstr ""
 "individualment: aquesta acció permet que els sistemes de control de versions "
 "com a git i svn puguin detectar els canvis amb eficàcia."
 
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Don't save"
 msgstr "No desis"
 
@@ -1442,27 +1445,27 @@ msgstr "No desis"
 msgid "Down"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:734
+#: ../src/wxMaximaFrame.cpp:733
 msgid "E&quations"
 msgstr "E&quacions"
 
-#: ../src/wxMaximaFrame.cpp:487
+#: ../src/wxMaximaFrame.cpp:486
 msgid "E&xit\tCtrl-Q"
 msgstr "&Surt\tCtrl-Q"
 
-#: ../src/wxMaximaFrame.cpp:757
+#: ../src/wxMaximaFrame.cpp:756
 msgid "Eige&nvectors"
 msgstr "Vectors &propis"
 
-#: ../src/wxMaximaFrame.cpp:755
+#: ../src/wxMaximaFrame.cpp:754
 msgid "Eigen&values"
 msgstr "Va&lors propis"
 
-#: ../src/wxMaxima.cpp:3572
+#: ../src/wxMaxima.cpp:3584
 msgid "Eliminate"
 msgstr "Suprimeix"
 
-#: ../src/wxMaximaFrame.cpp:710
+#: ../src/wxMaximaFrame.cpp:709
 msgid "Eliminate a variable from a system of equations"
 msgstr "Suprimeix una variable d'un sistema d'equacions"
 
@@ -1474,21 +1477,21 @@ msgstr "Final de la demostració"
 msgid "English"
 msgstr "Anglès"
 
-#: ../src/wxMaxima.cpp:4712 ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726
-#: ../src/wxMaxima.cpp:4734 ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748
-#: ../src/wxMaxima.cpp:4755 ../src/wxMaxima.cpp:4791 ../src/wxMaxima.cpp:4799
+#: ../src/wxMaxima.cpp:4724 ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738
+#: ../src/wxMaxima.cpp:4746 ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760
+#: ../src/wxMaxima.cpp:4767 ../src/wxMaxima.cpp:4803 ../src/wxMaxima.cpp:4811
 msgid "Enter Data"
 msgstr "Introduïu les dades"
 
-#: ../src/wxMaximaFrame.cpp:1279
+#: ../src/wxMaximaFrame.cpp:1278
 msgid "Enter Matrix..."
 msgstr "Introduir matriu"
 
-#: ../src/wxMaximaFrame.cpp:745
+#: ../src/wxMaximaFrame.cpp:744
 msgid "Enter a matrix"
 msgstr "Introduir una matriu"
 
-#: ../src/wxMaxima.cpp:3962
+#: ../src/wxMaxima.cpp:3974
 msgid "Enter an equation for rational simplification:"
 msgstr "Introduir una equació per a simplificació racional:"
 
@@ -1500,11 +1503,11 @@ msgstr "Introduir una llista de variables separades per comes."
 msgid "Enter evaluates cells"
 msgstr "Tecla retorn avalua cel·les"
 
-#: ../src/wxMaxima.cpp:3734
+#: ../src/wxMaxima.cpp:3746
 msgid "Enter matrix"
 msgstr "Introduir matriu"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 #, fuzzy
 msgid "Enter new precision for bigfloats:"
 msgstr "Introduir nova precisió:"
@@ -1513,12 +1516,12 @@ msgstr "Introduir nova precisió:"
 msgid "Enter the path to the Maxima executable."
 msgstr "Introduir la ruta a l'executable Maxima."
 
-#: ../src/wxMaximaFrame.cpp:1368
+#: ../src/wxMaximaFrame.cpp:1367
 #, fuzzy
 msgid "Epsilon"
 msgstr "Epsilon:"
 
-#: ../src/wxMaxima.cpp:4208
+#: ../src/wxMaxima.cpp:4220
 msgid "Epsilon:"
 msgstr "Epsilon:"
 
@@ -1527,13 +1530,13 @@ msgstr "Epsilon:"
 msgid "Equation %d:"
 msgstr "Equació %d:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:3633
-#: ../src/wxMaxima.cpp:5019
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:3645
+#: ../src/wxMaxima.cpp:5031
 msgid "Equation(s):"
 msgstr "Equació(ns):"
 
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3993
-#: ../src/wxMaxima.cpp:4807 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:4005
+#: ../src/wxMaxima.cpp:4819 ../src/wxMaxima.cpp:5045
 msgid "Equation:"
 msgstr "Equació:"
 
@@ -1544,81 +1547,81 @@ msgid ""
 "be introduced one into another. Also they are always printed out as 2D maths."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3570
+#: ../src/wxMaxima.cpp:3582
 msgid "Equations:"
 msgstr "Equacions:"
 
-#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1455
-#: ../src/wxMaxima.cpp:1469 ../src/wxMaxima.cpp:1620 ../src/wxMaxima.cpp:1633
-#: ../src/wxMaxima.cpp:1643 ../src/wxMaxima.cpp:1666 ../src/wxMaxima.cpp:2034
-#: ../src/wxMaxima.cpp:2206 ../src/wxMaxima.cpp:5381 ../src/wxMaxima.cpp:5830
-#: ../src/wxMaxima.cpp:5881
+#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1460
+#: ../src/wxMaxima.cpp:1474 ../src/wxMaxima.cpp:1625 ../src/wxMaxima.cpp:1638
+#: ../src/wxMaxima.cpp:1648 ../src/wxMaxima.cpp:1671 ../src/wxMaxima.cpp:2039
+#: ../src/wxMaxima.cpp:2211 ../src/wxMaxima.cpp:5397 ../src/wxMaxima.cpp:5845
+#: ../src/wxMaxima.cpp:5896
 msgid "Error"
 msgstr "Error"
 
-#: ../src/wxMaxima.cpp:2886 ../src/wxMaxima.cpp:2900 ../src/wxMaxima.cpp:2913
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617 ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:2894 ../src/wxMaxima.cpp:2908 ../src/wxMaxima.cpp:2921
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629 ../src/wxMaxima.cpp:3740
 msgid "Error!"
 msgstr "Error!"
 
-#: ../src/wxMaximaFrame.cpp:1370
+#: ../src/wxMaximaFrame.cpp:1369
 msgid "Eta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:909
+#: ../src/wxMaximaFrame.cpp:908
 msgid "Evaluate &Noun Forms"
 msgstr "Avaluar formes &nominals"
 
-#: ../src/wxMaximaFrame.cpp:589
+#: ../src/wxMaximaFrame.cpp:588
 msgid "Evaluate All Cells\tCtrl-Shift-R"
 msgstr "Avaluar totes les cel·les\tCtrl-Shift-R"
 
-#: ../src/wxMaximaFrame.cpp:587
+#: ../src/wxMaximaFrame.cpp:586
 msgid "Evaluate All Visible Cells\tCtrl-R"
 msgstr "Avaluar totes les cel·les visibles\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:585 ../src/MathCtrl.cpp:942
+#: ../src/MathCtrl.cpp:984 ../src/wxMaximaFrame.cpp:584
 msgid "Evaluate Cell(s)"
 msgstr "A&valuar cel·la(es)"
 
-#: ../src/wxMaximaFrame.cpp:591
+#: ../src/wxMaximaFrame.cpp:590
 #, fuzzy
 msgid "Evaluate Cells Above\tCtrl-Shift-P"
 msgstr "Avaluar les cel·les anteriors\tCtrl-Shift-P"
 
-#: ../src/MathCtrl.cpp:956 ../src/MathCtrl.cpp:1051
+#: ../src/MathCtrl.cpp:998 ../src/MathCtrl.cpp:1093
 #, fuzzy
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr "Evaluar celda\tShift-Enter"
 
-#: ../src/MathCtrl.cpp:961 ../src/MathCtrl.cpp:1053
+#: ../src/MathCtrl.cpp:1003 ../src/MathCtrl.cpp:1095
 #, fuzzy
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr "Evaluar celda\tShift-Enter"
 
-#: ../src/MathCtrl.cpp:971 ../src/MathCtrl.cpp:1057
+#: ../src/MathCtrl.cpp:1013 ../src/MathCtrl.cpp:1099
 #, fuzzy
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr "Evaluar celda\tShift-Enter"
 
-#: ../src/MathCtrl.cpp:966 ../src/MathCtrl.cpp:1055
+#: ../src/MathCtrl.cpp:1008 ../src/MathCtrl.cpp:1097
 #, fuzzy
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr "Evaluar celda\tShift-Enter"
 
-#: ../src/wxMaximaFrame.cpp:586
+#: ../src/wxMaximaFrame.cpp:585
 msgid "Evaluate active or selected cell(s)"
 msgstr "Avaluar cel·les actives o seleccionades"
 
-#: ../src/wxMaximaFrame.cpp:590
+#: ../src/wxMaximaFrame.cpp:589
 msgid "Evaluate all cells in the document"
 msgstr "Avaluar totes les cel·les del document"
 
-#: ../src/wxMaximaFrame.cpp:910
+#: ../src/wxMaximaFrame.cpp:909
 msgid "Evaluate all noun forms in expression"
 msgstr "Avaluar totes les formes nominals en una expressió"
 
-#: ../src/wxMaximaFrame.cpp:588
+#: ../src/wxMaximaFrame.cpp:587
 msgid "Evaluate all visible cells in the document"
 msgstr "Avaluar totes les cel·les visibles en el document"
 
@@ -1631,7 +1634,7 @@ msgstr ""
 msgid "Evaluate to point"
 msgstr "Avaluar formes &nominals"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Example"
 msgstr "Exemple"
 
@@ -1644,31 +1647,31 @@ msgstr "Text d'exemple"
 msgid "Examples:"
 msgstr "Exemple"
 
-#: ../src/wxMaximaFrame.cpp:488
+#: ../src/wxMaximaFrame.cpp:487
 msgid "Exit wxMaxima"
 msgstr "Sortir de wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:1214
+#: ../src/wxMaximaFrame.cpp:1213
 msgid "Expand"
 msgstr "Expandir"
 
-#: ../src/wxMaximaFrame.cpp:1219
+#: ../src/wxMaximaFrame.cpp:1218
 msgid "Expand (tr)"
 msgstr "Expandir (tr)"
 
-#: ../src/MathCtrl.cpp:997
+#: ../src/MathCtrl.cpp:1039
 msgid "Expand Expression"
 msgstr "Expandir expressió"
 
-#: ../src/wxMaximaFrame.cpp:841
+#: ../src/wxMaximaFrame.cpp:840
 msgid "Expand Logarithms"
 msgstr "Ex&pandir logaritmes"
 
-#: ../src/wxMaximaFrame.cpp:840
+#: ../src/wxMaximaFrame.cpp:839
 msgid "Expand an expression"
 msgstr "Expandir una expressió"
 
-#: ../src/wxMaximaFrame.cpp:874
+#: ../src/wxMaximaFrame.cpp:873
 msgid "Expand trigonometric expression"
 msgstr "Expandir expressió trigonomètrica"
 
@@ -1676,7 +1679,7 @@ msgstr "Expandir expressió trigonomètrica"
 msgid "Expected the icon files to be found at"
 msgstr ""
 
-#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2834
+#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2842
 msgid "Export"
 msgstr "&Exporta"
 
@@ -1687,32 +1690,32 @@ msgstr ""
 "Exportar les animacions a TeX (l'animació d'imatges només serà possible si "
 "el visor de PDF ho permet)"
 
-#: ../src/wxMaximaFrame.cpp:481
+#: ../src/wxMaximaFrame.cpp:480
 msgid "Export document to a HTML or pdfLaTeX file"
 msgstr "Exportar document a arxiu HTML o pdfLaTeX"
 
-#: ../src/wxMaximaFrame.cpp:253
+#: ../src/wxMaximaFrame.cpp:252
 msgid "Export failed."
 msgstr "Ha fallat l'exportació."
 
-#: ../src/wxMaximaFrame.cpp:239
+#: ../src/wxMaximaFrame.cpp:238
 msgid "Export successful."
 msgstr "Exportació reeixida."
 
-#: ../src/wxMaxima.cpp:2913
+#: ../src/wxMaxima.cpp:2921
 msgid "Exporting to HTML failed!"
 msgstr "Ha fallat l'exportació a HTML!"
 
-#: ../src/wxMaxima.cpp:2886
+#: ../src/wxMaxima.cpp:2894
 msgid "Exporting to TeX failed!"
 msgstr "Ha fallat l'exportació a TeX!"
 
-#: ../src/wxMaxima.cpp:2900
+#: ../src/wxMaxima.cpp:2908
 #, fuzzy
 msgid "Exporting to maxima batch file failed!"
 msgstr "Ha fallat l'exportació a TeX!"
 
-#: ../src/wxMaximaFrame.cpp:229
+#: ../src/wxMaximaFrame.cpp:228
 msgid "Exporting..."
 msgstr "Exportant..."
 
@@ -1725,42 +1728,42 @@ msgid "Expression(s):"
 msgstr "Expressió(ns):"
 
 #: ../src/IntegrateWiz.cpp:30 ../src/LimitWiz.cpp:27 ../src/SeriesWiz.cpp:33
-#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3648
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:4205 ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5064
+#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3660
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:4217 ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5076
 msgid "Expression:"
 msgstr "Expressió:"
 
-#: ../src/wxMaximaFrame.cpp:1213
+#: ../src/wxMaximaFrame.cpp:1212
 msgid "Factor"
 msgstr "Factoritzar"
 
-#: ../src/wxMaximaFrame.cpp:836
+#: ../src/wxMaximaFrame.cpp:835
 msgid "Factor Complex"
 msgstr "Factorització comple&xe"
 
-#: ../src/MathCtrl.cpp:996
+#: ../src/MathCtrl.cpp:1038
 msgid "Factor Expression"
 msgstr "Factoritzar expresió"
 
-#: ../src/wxMaximaFrame.cpp:835
+#: ../src/wxMaximaFrame.cpp:834
 msgid "Factor an expression"
 msgstr "Factoritzar una expressió"
 
-#: ../src/wxMaximaFrame.cpp:837
+#: ../src/wxMaximaFrame.cpp:836
 msgid "Factor an expression in Gaussian numbers"
 msgstr "Factoritzar una expressió en números gaussians"
 
-#: ../src/wxMaximaFrame.cpp:862
+#: ../src/wxMaximaFrame.cpp:861
 msgid "Factorials and &Gamma"
 msgstr "Factorials i &gamma"
 
-#: ../src/wxMaxima.cpp:285
+#: ../src/wxMaxima.cpp:286
 msgid "Fatal error"
 msgstr "Error fatal"
 
-#: ../src/GroupCell.cpp:1571
+#: ../src/GroupCell.cpp:1572
 #, c-format
 msgid "Figure %d:"
 msgstr "Figura %d:"
@@ -1769,22 +1772,22 @@ msgstr "Figura %d:"
 msgid "File"
 msgstr "Arxiu"
 
-#: ../src/wxMaxima.cpp:1457 ../src/wxMaxima.cpp:1623 ../src/wxMaxima.cpp:1636
-#: ../src/wxMaxima.cpp:1646 ../src/wxMaxima.cpp:1668
+#: ../src/wxMaxima.cpp:1462 ../src/wxMaxima.cpp:1628 ../src/wxMaxima.cpp:1641
+#: ../src/wxMaxima.cpp:1651 ../src/wxMaxima.cpp:1673
 #, fuzzy
 msgid "File could not be opened"
 msgstr "No es troba l'arxiu"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File not found"
 msgstr "No es troba l'arxiu"
 
-#: ../src/wxMaxima.cpp:1511 ../src/wxMaxima.cpp:1729
+#: ../src/wxMaxima.cpp:1516 ../src/wxMaxima.cpp:1734
 #, fuzzy
 msgid "File opened"
 msgstr "No es troba l'arxiu"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File you tried to open does not exist."
 msgstr "No existeix l'arxiu  que cal carregar"
 
@@ -1796,67 +1799,67 @@ msgstr "Arxiu"
 msgid "Find"
 msgstr "Buscar"
 
-#: ../src/wxMaximaFrame.cpp:523
+#: ../src/wxMaximaFrame.cpp:522
 msgid "Find\tCtrl-F"
 msgstr "&Buscar\tCtrl-F"
 
-#: ../src/wxMaximaFrame.cpp:787
+#: ../src/wxMaximaFrame.cpp:786
 msgid "Find &Limit..."
 msgstr "Calcula &límit"
 
-#: ../src/wxMaximaFrame.cpp:790
+#: ../src/wxMaximaFrame.cpp:789
 msgid "Find Minimum..."
 msgstr "Calcula mínim"
 
-#: ../src/MathCtrl.cpp:993
+#: ../src/MathCtrl.cpp:1035
 msgid "Find Root..."
 msgstr "Calcula arrel..."
 
-#: ../src/wxMaximaFrame.cpp:791
+#: ../src/wxMaximaFrame.cpp:790
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr "Calcula el mínim (sense restriccions) d'una expressió"
 
-#: ../src/wxMaximaFrame.cpp:788
+#: ../src/wxMaximaFrame.cpp:787
 msgid "Find a limit of an expression"
 msgstr "Calcula el límit d'una expressió"
 
-#: ../src/wxMaximaFrame.cpp:693
+#: ../src/wxMaximaFrame.cpp:692
 msgid "Find a root of an equation on an interval"
 msgstr "Calcula una arrel d'una equació en un interval"
 
-#: ../src/wxMaximaFrame.cpp:695
+#: ../src/wxMaximaFrame.cpp:694
 msgid "Find all roots of a polynomial"
 msgstr "Calcular totes les arrels d'un polinomi"
 
-#: ../src/wxMaximaFrame.cpp:698
+#: ../src/wxMaximaFrame.cpp:697
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr "Calcular totes les arrels reals d'un polinomi"
 
-#: ../src/wxMaxima.cpp:3220
+#: ../src/wxMaxima.cpp:3215
 msgid "Find and Replace"
 msgstr "Cercar i substituir"
 
-#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:523
+#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:522
 msgid "Find and replace"
 msgstr "Cercar i substituir"
 
-#: ../src/wxMaximaFrame.cpp:756
+#: ../src/wxMaximaFrame.cpp:755
 msgid "Find eigenvalues of a matrix"
 msgstr "Calcular els valors propis d'una matriu"
 
-#: ../src/wxMaximaFrame.cpp:758
+#: ../src/wxMaximaFrame.cpp:757
 msgid "Find eigenvectors of a matrix"
 msgstr "Calcular els vectors propis d'una matriu"
 
-#: ../src/wxMaxima.cpp:4210
+#: ../src/wxMaxima.cpp:4222
 msgid "Find minimum"
 msgstr "Calcular mínim"
 
-#: ../src/wxMaximaFrame.cpp:701
+#: ../src/wxMaximaFrame.cpp:700
 msgid "Find real roots of a polynomial"
 msgstr "Calcular les arrels reals d'un polinomi"
 
-#: ../src/wxMaxima.cpp:3493 ../src/wxMaxima.cpp:5036
+#: ../src/wxMaxima.cpp:3505 ../src/wxMaxima.cpp:5048
 msgid "Find root"
 msgstr "Calcular arrel"
 
@@ -1880,11 +1883,11 @@ msgstr ""
 msgid "Fixed font in text controls"
 msgstr "Font proporcional en controls de text"
 
-#: ../src/wxMaximaFrame.cpp:623
+#: ../src/wxMaximaFrame.cpp:622
 msgid "Fold All\tCtrl-Alt-["
 msgstr "Plegar tot\tCtrl-A"
 
-#: ../src/wxMaximaFrame.cpp:624
+#: ../src/wxMaximaFrame.cpp:623
 msgid "Fold all sections"
 msgstr "Duplicar totes les seccions"
 
@@ -1892,25 +1895,25 @@ msgstr "Duplicar totes les seccions"
 msgid "Follow"
 msgstr "Segueix"
 
-#: ../src/ParenCell.cpp:319
+#: ../src/ParenCell.cpp:320
 msgid "Font issue: The Parenthesis sign is too small!"
 msgstr ""
 
-#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:381
+#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:382
 msgid ""
 "Font issue: The char height is too small! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:199
+#: ../src/SqrtCell.cpp:202
 msgid ""
 "Font issue: The sqrt() sign has the size 0! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:198
+#: ../src/SqrtCell.cpp:201
 msgid "Font issue? The contents of a sqrt() has the size 0."
 msgstr ""
 
@@ -1941,15 +1944,15 @@ msgstr "Francès"
 
 #: ../src/IntegrateWiz.cpp:37 ../src/Plot2dWiz.cpp:37 ../src/Plot2dWiz.cpp:47
 #: ../src/Plot2dWiz.cpp:536 ../src/Plot3dWiz.cpp:36 ../src/Plot3dWiz.cpp:45
-#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4240
+#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4252
 msgid "From:"
 msgstr "Des de:"
 
-#: ../src/wxMaximaFrame.cpp:576
+#: ../src/wxMaximaFrame.cpp:575
 msgid "Full Screen\tAlt-Enter"
 msgstr "P&antalla completa\tAlt-Retorn"
 
-#: ../src/wxMaxima.cpp:3342
+#: ../src/wxMaxima.cpp:3354
 msgid "Function"
 msgstr "Funció"
 
@@ -1957,32 +1960,32 @@ msgstr "Funció"
 msgid "Function names"
 msgstr "Noms de funcions"
 
-#: ../src/wxMaxima.cpp:3633
+#: ../src/wxMaxima.cpp:3645
 msgid "Function(s):"
 msgstr "Funció(ns):"
 
-#: ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3803
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3815
+#: ../src/wxMaxima.cpp:3848
 msgid "Function:"
 msgstr "Funció:"
 
-#: ../src/wxMaximaFrame.cpp:904
+#: ../src/wxMaximaFrame.cpp:903
 msgid "Functions for complex simplification"
 msgstr "Funcions per a la simplificació complexa"
 
-#: ../src/wxMaximaFrame.cpp:864
+#: ../src/wxMaximaFrame.cpp:863
 msgid "Functions for simplifying factorials and gamma function"
 msgstr "Funcions per a simplificar factorials i funció gamma"
 
-#: ../src/wxMaximaFrame.cpp:881
+#: ../src/wxMaximaFrame.cpp:880
 msgid "Functions for simplifying trigonometric expressions"
 msgstr "Funcions per a simplificar expressions trigonomètriques"
 
-#: ../src/wxMaxima.cpp:4046
+#: ../src/wxMaxima.cpp:4058
 msgid "GCD"
 msgstr "MCD"
 
-#: ../src/wxMaxima.cpp:5152
+#: ../src/wxMaxima.cpp:5164
 msgid "GIF image (*.gif)|*.gif"
 msgstr "Imatges gif (*.gif)|*.gif"
 
@@ -1990,31 +1993,31 @@ msgstr "Imatges gif (*.gif)|*.gif"
 msgid "Galician"
 msgstr "Galleg"
 
-#: ../src/wxMaximaFrame.cpp:1366
+#: ../src/wxMaximaFrame.cpp:1365
 msgid "Gamma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:391
+#: ../src/wxMaximaFrame.cpp:390
 msgid "General Math"
 msgstr "Matemàtiques generals"
 
-#: ../src/wxMaximaFrame.cpp:549
+#: ../src/wxMaximaFrame.cpp:548
 msgid "General Math\tAlt-Shift-M"
 msgstr "&Matemàtiques generals\tAlt-Shift-M"
 
-#: ../src/wxMaxima.cpp:3766 ../src/wxMaxima.cpp:3785
+#: ../src/wxMaxima.cpp:3778 ../src/wxMaxima.cpp:3797
 msgid "Generate Matrix"
 msgstr "Genera matriu"
 
-#: ../src/wxMaximaFrame.cpp:741
+#: ../src/wxMaximaFrame.cpp:740
 msgid "Generate Matrix from Expression..."
 msgstr "&Genera matriu a partir d'expressió"
 
-#: ../src/wxMaximaFrame.cpp:739
+#: ../src/wxMaximaFrame.cpp:738
 msgid "Generate a matrix from a 2-dimensional array"
 msgstr "Genera matriu a partir d'una taula de 2 dimensions"
 
-#: ../src/wxMaximaFrame.cpp:742
+#: ../src/wxMaximaFrame.cpp:741
 msgid "Generate a matrix from a lambda expression"
 msgstr "Genera matriu a partir d'una expressió lambda"
 
@@ -2022,40 +2025,40 @@ msgstr "Genera matriu a partir d'una expressió lambda"
 msgid "German"
 msgstr "Alemany"
 
-#: ../src/wxMaximaFrame.cpp:893
+#: ../src/wxMaximaFrame.cpp:892
 msgid "Get &Imaginary Part"
 msgstr "Calcula part &imaginària"
 
-#: ../src/wxMaximaFrame.cpp:793
+#: ../src/wxMaximaFrame.cpp:792
 msgid "Get &Series..."
 msgstr "Calcula &sèrie"
 
-#: ../src/wxMaximaFrame.cpp:804
+#: ../src/wxMaximaFrame.cpp:803
 msgid "Get Laplace transformation of an expression"
 msgstr "Calcula la transformada de Laplace d'una expressió"
 
-#: ../src/wxMaximaFrame.cpp:890
+#: ../src/wxMaximaFrame.cpp:889
 msgid "Get Real P&art"
 msgstr "Calcula part &real"
 
-#: ../src/wxMaximaFrame.cpp:807
+#: ../src/wxMaximaFrame.cpp:806
 msgid "Get inverse Laplace transformation of an expression"
 msgstr "Calcula la transformada inversa de Laplace d'una expressió"
 
-#: ../src/wxMaximaFrame.cpp:794
+#: ../src/wxMaximaFrame.cpp:793
 msgid "Get the Taylor or power series of expression"
 msgstr ""
 "Calcula el desenvolupament de Taylor o sèrie de potències de l'expresió"
 
-#: ../src/wxMaximaFrame.cpp:894
+#: ../src/wxMaximaFrame.cpp:893
 msgid "Get the imaginary part of complex expression"
 msgstr "Calcula la part imaginària d'una expressió complexa"
 
-#: ../src/wxMaximaFrame.cpp:891
+#: ../src/wxMaximaFrame.cpp:890
 msgid "Get the real part of complex expression"
 msgstr "Calcula la part real d'una expressió complexa"
 
-#: ../src/MathCtrl.cpp:5932
+#: ../src/MathCtrl.cpp:5984
 msgid ""
 "Got a request to undo an action that involves an delete which isn't possible "
 "at this moment."
@@ -2067,12 +2070,12 @@ msgstr ""
 msgid "Greek"
 msgstr "Grec"
 
-#: ../src/wxMaximaFrame.cpp:356
+#: ../src/wxMaximaFrame.cpp:355
 #, fuzzy
 msgid "Greek Letters"
 msgstr "Constants gregues"
 
-#: ../src/wxMaximaFrame.cpp:552
+#: ../src/wxMaximaFrame.cpp:551
 #, fuzzy
 msgid "Greek Letters\tAlt-Shift-G"
 msgstr "&Matemàtiques generals\tAlt-Shift-M"
@@ -2085,7 +2088,7 @@ msgstr "Constants gregues"
 msgid "Grid:"
 msgstr "Quadrícula:"
 
-#: ../src/wxMaxima.cpp:2836
+#: ../src/wxMaxima.cpp:2844
 #, fuzzy
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|pdfLaTeX file (*."
@@ -2100,12 +2103,12 @@ msgstr "HTML/Text de les cel·les: exportar els retorns de línia"
 msgid "Help"
 msgstr "Ajuda"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 #, fuzzy
 msgid "Hide All Toolbars\tAlt-Shift--"
 msgstr "&Amaga tot\tAlt-Shift--"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide all panes"
 msgstr "Amaga tots els panells"
 
@@ -2113,19 +2116,19 @@ msgstr "Amaga tots els panells"
 msgid "Highlight (dpart)"
 msgstr "Resaltat"
 
-#: ../src/wxMaxima.cpp:4685
+#: ../src/wxMaxima.cpp:4697
 msgid "Histogram"
 msgstr "Histograma"
 
-#: ../src/wxMaximaFrame.cpp:1270
+#: ../src/wxMaximaFrame.cpp:1269
 msgid "Histogram..."
 msgstr "Histograma..."
 
-#: ../src/wxMaximaFrame.cpp:309
+#: ../src/wxMaximaFrame.cpp:308
 msgid "History"
 msgstr "Història"
 
-#: ../src/wxMaximaFrame.cpp:555
+#: ../src/wxMaximaFrame.cpp:554
 #, fuzzy
 msgid "History\tAlt-Shift-I"
 msgstr "&Història\tAlt-Shift-H"
@@ -2146,11 +2149,11 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Hongarès"
 
-#: ../src/wxMaxima.cpp:3527
+#: ../src/wxMaxima.cpp:3539
 msgid "IC1"
 msgstr "IC1"
 
-#: ../src/wxMaxima.cpp:3543
+#: ../src/wxMaxima.cpp:3555
 msgid "IC2"
 msgstr "IC2"
 
@@ -2166,7 +2169,7 @@ msgid ""
 "same output cell."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:683
+#: ../src/wxMaximaFrame.cpp:682
 msgid ""
 "If maxima ever finishes evaluating without wxMaxima realizing this this menu "
 "item can force wxMaxima to try to send commands to maxima again."
@@ -2238,11 +2241,11 @@ msgstr ""
 "Si es torba molt a realitzar-se un càlcul, és possible aturar-ho "
 "seleccionant 'Maxima->atura' o 'Maxima->Reinicia Maxima' en el menú."
 
-#: ../src/wxMaximaFrame.cpp:1499
+#: ../src/wxMaximaFrame.cpp:1518
 msgid "Image"
 msgstr "Imatge"
 
-#: ../src/wxMaxima.cpp:5644
+#: ../src/wxMaxima.cpp:5659
 msgid "Image files (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 msgstr "Arxius gràfics (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 
@@ -2272,7 +2275,7 @@ msgstr ""
 "sobre d'ell. Això poc millorar la llegibilitat d'algunes fonts o subíndex "
 "curts."
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Include columns:"
 msgstr "Incloure columnes:"
 
@@ -2291,19 +2294,19 @@ msgstr ""
 msgid "Infinity"
 msgstr "Infinit"
 
-#: ../src/wxMaximaFrame.cpp:974
+#: ../src/wxMaximaFrame.cpp:973
 msgid "Info about Maxima build"
 msgstr "Informació sobre la compilació de Maxima"
 
-#: ../src/wxMaxima.cpp:4207
+#: ../src/wxMaxima.cpp:4219
 msgid "Initial Estimates:"
 msgstr "Estimadors inicials:"
 
-#: ../src/wxMaximaFrame.cpp:718
+#: ../src/wxMaximaFrame.cpp:717
 msgid "Initial Value Problem (&1)..."
 msgstr "Problema de valor inicial (&1)"
 
-#: ../src/wxMaximaFrame.cpp:721
+#: ../src/wxMaximaFrame.cpp:720
 msgid "Initial Value Problem (&2)..."
 msgstr "Problema de valor inicial (&2)"
 
@@ -2311,7 +2314,7 @@ msgstr "Problema de valor inicial (&2)"
 msgid "Input labels"
 msgstr "Introduir etiquetes"
 
-#: ../src/wxMaximaFrame.cpp:403
+#: ../src/wxMaximaFrame.cpp:402
 msgid "Insert"
 msgstr "Insereix"
 
@@ -2319,98 +2322,98 @@ msgstr "Insereix"
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr "Inserir % abans d'un operador a l'inici d'una cel·la"
 
-#: ../src/wxMaximaFrame.cpp:612
+#: ../src/wxMaximaFrame.cpp:611
 msgid "Insert &Section Cell\tCtrl-3"
 msgstr "Nova cel·la de &secció\tCtrl-3"
 
-#: ../src/wxMaximaFrame.cpp:608
+#: ../src/wxMaximaFrame.cpp:607
 msgid "Insert &Text Cell\tCtrl-1"
 msgstr "Nova cel·la de te&xt\tCtrl-1"
 
-#: ../src/wxMaximaFrame.cpp:558
+#: ../src/wxMaximaFrame.cpp:557
 msgid "Insert Cell\tAlt-Shift-C"
 msgstr "In&serta cel·la\tAlt-Shift-C"
 
-#: ../src/wxMaxima.cpp:5642
+#: ../src/wxMaxima.cpp:5657
 msgid "Insert Image"
 msgstr "Insereix imatge"
 
-#: ../src/wxMaximaFrame.cpp:620
+#: ../src/wxMaximaFrame.cpp:619
 msgid "Insert Image..."
 msgstr "I&nsereix imatge"
 
-#: ../src/wxMaximaFrame.cpp:606
+#: ../src/wxMaximaFrame.cpp:605
 msgid "Insert Input &Cell"
 msgstr "Nova cel·la d'&entrada"
 
-#: ../src/wxMaximaFrame.cpp:618
+#: ../src/wxMaximaFrame.cpp:617
 msgid "Insert Page Break"
 msgstr "Insereix un salt de pàgina"
 
-#: ../src/wxMaximaFrame.cpp:614
+#: ../src/wxMaximaFrame.cpp:613
 msgid "Insert S&ubsection Cell\tCtrl-4"
 msgstr "Insereix cel·la de s&ubsecció\tCtrl-4"
 
-#: ../src/wxMaximaFrame.cpp:616
+#: ../src/wxMaximaFrame.cpp:615
 #, fuzzy
 msgid "Insert S&ubsubsection Cell\tCtrl-5"
 msgstr "Insereix cel·la de s&ubsecció\tCtrl-4"
 
-#: ../src/MathCtrl.cpp:1015
+#: ../src/MathCtrl.cpp:1057
 msgid "Insert Section Cell"
 msgstr "Insereix cel·la de secció"
 
-#: ../src/MathCtrl.cpp:1016
+#: ../src/MathCtrl.cpp:1058
 msgid "Insert Subsection Cell"
 msgstr "Insereix cel·la de subsecció"
 
-#: ../src/MathCtrl.cpp:1017
+#: ../src/MathCtrl.cpp:1059
 #, fuzzy
 msgid "Insert Subsubsection Cell"
 msgstr "Insereix cel·la de subsecció"
 
-#: ../src/wxMaximaFrame.cpp:610
+#: ../src/wxMaximaFrame.cpp:609
 msgid "Insert T&itle Cell\tCtrl-2"
 msgstr "Insereix cel·la de &títol\tCtrl-2"
 
-#: ../src/MathCtrl.cpp:1013
+#: ../src/MathCtrl.cpp:1055
 msgid "Insert Text Cell"
 msgstr "Insereix cel·la de text"
 
-#: ../src/MathCtrl.cpp:1014
+#: ../src/MathCtrl.cpp:1056
 msgid "Insert Title Cell"
 msgstr "Insereix cel·la de títol"
 
-#: ../src/wxMaximaFrame.cpp:607
+#: ../src/wxMaximaFrame.cpp:606
 msgid "Insert a new input cell"
 msgstr "Insereix nova cel·la d'entrada"
 
-#: ../src/wxMaximaFrame.cpp:613
+#: ../src/wxMaximaFrame.cpp:612
 msgid "Insert a new section cell"
 msgstr "Insereix nova cel·la de secció"
 
-#: ../src/wxMaximaFrame.cpp:615
+#: ../src/wxMaximaFrame.cpp:614
 msgid "Insert a new subsection cell"
 msgstr "Insereix nova cel·la de subsecció"
 
-#: ../src/wxMaximaFrame.cpp:617
+#: ../src/wxMaximaFrame.cpp:616
 #, fuzzy
 msgid "Insert a new subsubsection cell"
 msgstr "Insereix nova cel·la de subsecció"
 
-#: ../src/wxMaximaFrame.cpp:609
+#: ../src/wxMaximaFrame.cpp:608
 msgid "Insert a new text cell"
 msgstr "Insereix nova cel·la de text"
 
-#: ../src/wxMaximaFrame.cpp:611
+#: ../src/wxMaximaFrame.cpp:610
 msgid "Insert a new title cell"
 msgstr "Insereix nova cel·la de títol"
 
-#: ../src/wxMaximaFrame.cpp:619
+#: ../src/wxMaximaFrame.cpp:618
 msgid "Insert a page break"
 msgstr "Insereix nova pàgina"
 
-#: ../src/wxMaximaFrame.cpp:621
+#: ../src/wxMaximaFrame.cpp:620
 msgid "Insert image"
 msgstr "Insereix imatge"
 
@@ -2423,27 +2426,27 @@ msgstr ""
 msgid "Integral sign"
 msgstr "Integra expressió"
 
-#: ../src/wxMaxima.cpp:3992
+#: ../src/wxMaxima.cpp:4004
 msgid "Integral/Sum:"
 msgstr "Integral/suma:"
 
-#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4105 ../src/wxMaxima.cpp:5051
+#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4117 ../src/wxMaxima.cpp:5063
 msgid "Integrate"
 msgstr "Integra"
 
-#: ../src/wxMaxima.cpp:4091
+#: ../src/wxMaxima.cpp:4103
 msgid "Integrate (risch)"
 msgstr "Integra (risch)"
 
-#: ../src/wxMaximaFrame.cpp:778
+#: ../src/wxMaximaFrame.cpp:777
 msgid "Integrate expression"
 msgstr "Integra expressió"
 
-#: ../src/wxMaximaFrame.cpp:780
+#: ../src/wxMaximaFrame.cpp:779
 msgid "Integrate expression with Risch algorithm"
 msgstr "Integra expressió amb algoritme Risch"
 
-#: ../src/wxMaximaFrame.cpp:1224 ../src/MathCtrl.cpp:1000
+#: ../src/MathCtrl.cpp:1042 ../src/wxMaximaFrame.cpp:1223
 msgid "Integrate..."
 msgstr "Integra..."
 
@@ -2451,7 +2454,7 @@ msgstr "Integra..."
 msgid "Interrupt"
 msgstr "Atura"
 
-#: ../src/wxMaximaFrame.cpp:646 ../src/wxMaximaFrame.cpp:650
+#: ../src/wxMaximaFrame.cpp:645 ../src/wxMaximaFrame.cpp:649
 msgid "Interrupt current computation"
 msgstr "Atura el càlcul actual"
 
@@ -2473,15 +2476,15 @@ msgstr ""
 "\n"
 "Si us plau, introduïu novament la ruta al programa Maxima."
 
-#: ../src/wxMaxima.cpp:4137
+#: ../src/wxMaxima.cpp:4149
 msgid "Inverse Laplace"
 msgstr "Laplace inversa"
 
-#: ../src/wxMaximaFrame.cpp:806
+#: ../src/wxMaximaFrame.cpp:805
 msgid "Inverse Laplace T&ransform..."
 msgstr "Trans&formada inversa de Laplace"
 
-#: ../src/wxMaximaFrame.cpp:1372
+#: ../src/wxMaximaFrame.cpp:1371
 msgid "Iota"
 msgstr ""
 
@@ -2515,7 +2518,7 @@ msgstr "Japonés"
 msgid "Kabyle"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1373
+#: ../src/wxMaximaFrame.cpp:1372
 msgid "Kappa"
 msgstr ""
 
@@ -2524,7 +2527,7 @@ msgstr ""
 msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr "Mantenir el signe de percentatge per a símbols especials: %e, %i, etc."
 
-#: ../src/wxMaxima.cpp:4031
+#: ../src/wxMaxima.cpp:4043
 msgid "LCM"
 msgstr "MCM"
 
@@ -2540,7 +2543,7 @@ msgstr ""
 msgid "Label width:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1374
+#: ../src/wxMaximaFrame.cpp:1373
 msgid "Lambda"
 msgstr ""
 
@@ -2552,11 +2555,11 @@ msgstr "Idioma de la interfície d'usuari de wxMaxima."
 msgid "Language:"
 msgstr "Idioma:"
 
-#: ../src/wxMaxima.cpp:4120
+#: ../src/wxMaxima.cpp:4132
 msgid "Laplace"
 msgstr "Laplace"
 
-#: ../src/wxMaximaFrame.cpp:803
+#: ../src/wxMaximaFrame.cpp:802
 msgid "Laplace &Transform..."
 msgstr "&Transformada de Laplace"
 
@@ -2565,15 +2568,15 @@ msgstr "&Transformada de Laplace"
 msgid "Leads to"
 msgstr "tiende a:"
 
-#: ../src/wxMaximaFrame.cpp:812
+#: ../src/wxMaximaFrame.cpp:811
 msgid "Least Common Multiple..."
 msgstr "Mí&nim comú múltiple"
 
-#: ../src/wxMaxima.cpp:4809
+#: ../src/wxMaxima.cpp:4821
 msgid "Least Squares Fit"
 msgstr "﻿Ajust per mínims quadrats"
 
-#: ../src/wxMaximaFrame.cpp:1266
+#: ../src/wxMaximaFrame.cpp:1265
 msgid "Least Squares Fit..."
 msgstr "﻿Ajust per mínims quadrats..."
 
@@ -2584,24 +2587,24 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4192
+#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4204
 msgid "Limit"
 msgstr "Límit"
 
-#: ../src/wxMaximaFrame.cpp:1225
+#: ../src/wxMaximaFrame.cpp:1224
 msgid "Limit..."
 msgstr "Límit..."
 
-#: ../src/wxMaximaFrame.cpp:1265
+#: ../src/wxMaximaFrame.cpp:1264
 msgid "Linear Regression..."
 msgstr "Regressió lineal..."
 
-#: ../src/wxMaxima.cpp:3803
+#: ../src/wxMaxima.cpp:3815
 #, fuzzy
 msgid "List(s):"
 msgstr "Llista:"
 
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3848
 msgid "List:"
 msgstr "Llista:"
 
@@ -2609,15 +2612,15 @@ msgstr "Llista:"
 msgid "Load"
 msgstr "Carrega"
 
-#: ../src/wxMaxima.cpp:2932
+#: ../src/wxMaxima.cpp:2940
 msgid "Load Package"
 msgstr "Carrega paquet"
 
-#: ../src/wxMaximaFrame.cpp:479
+#: ../src/wxMaximaFrame.cpp:478
 msgid "Load a Maxima file using the batch command"
 msgstr "Carrega un arxiu Maxima fent servir l'ordre batch"
 
-#: ../src/wxMaximaFrame.cpp:477
+#: ../src/wxMaximaFrame.cpp:476
 msgid "Load a Maxima package file"
 msgstr "Carrega un paquet Maxima"
 
@@ -2629,49 +2632,49 @@ msgstr "Llegir estil des d'un arxiu"
 msgid "Long Right arrow"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Lower bound:"
 msgstr "Cota inferior:"
 
-#: ../src/wxMaximaFrame.cpp:771
+#: ../src/wxMaximaFrame.cpp:770
 msgid "Ma&p to Matrix..."
 msgstr "Distribuir sobre &matriu..."
 
-#: ../src/wxMaximaFrame.cpp:547
+#: ../src/wxMaximaFrame.cpp:546
 #, fuzzy
 msgid "Main Toolbar\tAlt-Shift-B"
 msgstr "&Barra d'eines\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:765
+#: ../src/wxMaximaFrame.cpp:764
 msgid "Make &List..."
 msgstr "Construir &llista..."
 
-#: ../src/wxMaxima.cpp:3821
+#: ../src/wxMaxima.cpp:3833
 msgid "Make list"
 msgstr "Construir llista"
 
-#: ../src/wxMaximaFrame.cpp:766
+#: ../src/wxMaximaFrame.cpp:765
 msgid "Make list from expression"
 msgstr "Construir una llista a partir d'una expressió"
 
-#: ../src/wxMaximaFrame.cpp:907
+#: ../src/wxMaximaFrame.cpp:906
 msgid "Make substitution in expression"
 msgstr "Fer una substitució en una expressió"
 
-#: ../src/wxMaximaFrame.cpp:682
+#: ../src/wxMaximaFrame.cpp:681
 #, fuzzy
 msgid "Manually Trigger Evaluation"
 msgstr "Mostra el temps de l'avaluació"
 
-#: ../src/wxMaxima.cpp:3805
+#: ../src/wxMaxima.cpp:3817
 msgid "Map"
 msgstr "Aplicar"
 
-#: ../src/wxMaximaFrame.cpp:770
+#: ../src/wxMaximaFrame.cpp:769
 msgid "Map function to a list"
 msgstr "Aplica funció a una llista"
 
-#: ../src/wxMaximaFrame.cpp:772
+#: ../src/wxMaximaFrame.cpp:771
 msgid "Map function to a matrix"
 msgstr "Aplica una funció a una matriu"
 
@@ -2688,23 +2691,23 @@ msgstr "Fer coincidir parèntesi en els controle de text"
 msgid "Math font:"
 msgstr "Font matemàtica:"
 
-#: ../src/wxMaximaFrame.cpp:374
+#: ../src/wxMaximaFrame.cpp:373
 msgid "Mathematical Symbols"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3716
+#: ../src/wxMaxima.cpp:3728
 msgid "Matrix"
 msgstr "Matriu"
 
-#: ../src/wxMaxima.cpp:3702
+#: ../src/wxMaxima.cpp:3714
 msgid "Matrix map"
 msgstr "Aplica rmatriu"
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Matrix name:"
 msgstr "Nom de matriu:"
 
-#: ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3749
+#: ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3761
 msgid "Matrix:"
 msgstr "Matriu:"
 
@@ -2712,7 +2715,7 @@ msgstr "Matriu:"
 msgid "Maxima"
 msgstr "Maxima"
 
-#: ../src/wxMaximaFrame.cpp:137
+#: ../src/wxMaximaFrame.cpp:136
 #, fuzzy
 msgid "Maxima has a question"
 msgstr "Preguntes de Maxima"
@@ -2721,24 +2724,24 @@ msgstr "Preguntes de Maxima"
 msgid "Maxima input"
 msgstr "Entrada Maxima"
 
-#: ../src/wxMaximaFrame.cpp:166
+#: ../src/wxMaximaFrame.cpp:165
 msgid "Maxima is calculating"
 msgstr "Maxima està calculant"
 
-#: ../src/wxMaximaFrame.cpp:111
+#: ../src/wxMaximaFrame.cpp:110
 #, fuzzy
 msgid "Maxima is ready for input."
 msgstr "Entrada Maxima"
 
-#: ../src/wxMaxima.cpp:2945
+#: ../src/wxMaxima.cpp:2953
 msgid "Maxima package (*.mac)|*.mac"
 msgstr "Paquet de Maxima (*.mac)|*.mac"
 
-#: ../src/wxMaxima.cpp:2934
+#: ../src/wxMaxima.cpp:2942
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr "Paquet Maxima (*.mac)|*.mac|Paquet Lisp (*.lisp)|*.lisp|Tots|*"
 
-#: ../src/wxMaxima.cpp:1014
+#: ../src/wxMaxima.cpp:1019
 msgid "Maxima process terminated."
 msgstr "Procés de Maxima finalitzat."
 
@@ -2750,7 +2753,7 @@ msgstr "Programa Maxima:"
 msgid "Maxima questions"
 msgstr "Preguntes de Maxima"
 
-#: ../src/wxMaxima.cpp:942
+#: ../src/wxMaxima.cpp:947
 msgid "Maxima started. Waiting for connection..."
 msgstr "Maxima iniciat. Esperant la connexió..."
 
@@ -2782,7 +2785,7 @@ msgstr ""
 "Maxima fa servir ':' per assignar un valor a una variable ('a : 3;') i ':=' "
 "per definir funcions ('f(x) := x^2;')."
 
-#: ../src/wxMaxima.cpp:4597
+#: ../src/wxMaxima.cpp:4609
 msgid "Maxima version: "
 msgstr "Versió de Maxima: "
 
@@ -2819,41 +2822,41 @@ msgstr ""
 msgid "Maximum displayed number of digits:"
 msgstr "Nombre màxim de dígits per mostrar:"
 
-#: ../src/wxMaximaFrame.cpp:1263
+#: ../src/wxMaximaFrame.cpp:1262
 msgid "Mean Difference Test..."
 msgstr "Test diferència de mitjanes"
 
-#: ../src/wxMaximaFrame.cpp:1262
+#: ../src/wxMaximaFrame.cpp:1261
 msgid "Mean Test..."
 msgstr "Test mitjanes..."
 
-#: ../src/wxMaximaFrame.cpp:1255
+#: ../src/wxMaximaFrame.cpp:1254
 msgid "Mean..."
 msgstr "Aplicar..."
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Mean:"
 msgstr "Mitjana:"
 
-#: ../src/wxMaximaFrame.cpp:1256
+#: ../src/wxMaximaFrame.cpp:1255
 msgid "Median..."
 msgstr "Mediana..."
 
-#: ../src/MathCtrl.cpp:945
+#: ../src/MathCtrl.cpp:987
 msgid "Merge Cells"
 msgstr "Unir cel·les"
 
-#: ../src/wxMaximaFrame.cpp:633
+#: ../src/wxMaximaFrame.cpp:632
 #, fuzzy
 msgid "Merge Cells\tCtrl-M"
 msgstr "Unir cel·les"
 
-#: ../src/wxMaximaFrame.cpp:634
+#: ../src/wxMaximaFrame.cpp:633
 msgid "Merge the text from two input cells into one"
 msgstr ""
 "Combinar el text a partir de l'entrada de dues cel·les per produir una cadena"
 
-#: ../src/wxMaxima.cpp:2668
+#: ../src/wxMaxima.cpp:2676
 msgid "Message from the stdout of Maxima: "
 msgstr ""
 
@@ -2861,19 +2864,19 @@ msgstr ""
 msgid "Method:"
 msgstr "Mètode:"
 
-#: ../src/wxMaxima.cpp:5289
+#: ../src/wxMaxima.cpp:5301
 msgid "Mismatched parenthesis"
 msgstr "No coincideixen els parèntisi"
 
-#: ../src/wxMaxima.cpp:3972
+#: ../src/wxMaxima.cpp:3984
 msgid "Modulus"
 msgstr "Mòdul"
 
-#: ../src/wxMaximaFrame.cpp:1375
+#: ../src/wxMaximaFrame.cpp:1374
 msgid "Mu"
 msgstr ""
 
-#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Name:"
 msgstr "Nom:"
 
@@ -2881,7 +2884,7 @@ msgstr "Nom:"
 msgid "New"
 msgstr "Nou"
 
-#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
+#: ../src/wxMaximaFrame.cpp:456 ../src/wxMaximaFrame.cpp:459
 msgid "New\tCtrl-N"
 msgstr "Nou\tCtrl-N"
 
@@ -2897,11 +2900,11 @@ msgstr ""
 msgid "New value:"
 msgstr "Nuo valor:"
 
-#: ../src/wxMaxima.cpp:3993 ../src/wxMaxima.cpp:4119 ../src/wxMaxima.cpp:4136
+#: ../src/wxMaxima.cpp:4005 ../src/wxMaxima.cpp:4131 ../src/wxMaxima.cpp:4148
 msgid "New variable:"
 msgstr "Nova variable:"
 
-#: ../src/wxMaximaFrame.cpp:630
+#: ../src/wxMaximaFrame.cpp:629
 msgid "Next Command\tAlt-Down"
 msgstr "Següent ordre\tAlt-Down"
 
@@ -2909,15 +2912,15 @@ msgstr "Següent ordre\tAlt-Down"
 msgid "No"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5362
+#: ../src/wxMaxima.cpp:5378
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3249 ../src/wxMaxima.cpp:3271
+#: ../src/wxMaxima.cpp:3260 ../src/wxMaxima.cpp:3283
 msgid "No matches found!"
 msgstr "No s'han trobat coincidències!"
 
-#: ../src/wxMaximaFrame.cpp:1264
+#: ../src/wxMaximaFrame.cpp:1263
 msgid "Normality Test..."
 msgstr "Test de normalitat..."
 
@@ -2948,34 +2951,34 @@ msgstr ""
 msgid "Norwegian"
 msgstr "Noruec"
 
-#: ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:3740
 msgid "Not a valid matrix dimension!"
 msgstr "La dimensió de la matriu no és vàlida!"
 
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629
 msgid "Not a valid number of equations!"
 msgstr "El nombre d'equacions és incorrecte!"
 
-#: ../src/wxMaximaFrame.cpp:197
+#: ../src/wxMaximaFrame.cpp:196
 #, fuzzy
 msgid "Not connected to maxima"
 msgstr ""
 "\n"
 "No connectat a Maxima!\n"
 
-#: ../src/wxMaxima.cpp:4599
+#: ../src/wxMaxima.cpp:4611
 msgid "Not connected."
 msgstr "No conectat."
 
-#: ../src/wxMaximaFrame.cpp:1376
+#: ../src/wxMaximaFrame.cpp:1375
 msgid "Nu"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Num. deg:"
 msgstr "num deg:"
 
-#: ../src/wxMaxima.cpp:3585 ../src/wxMaxima.cpp:3609
+#: ../src/wxMaxima.cpp:3597 ../src/wxMaxima.cpp:3621
 msgid "Number of equations:"
 msgstr "Nombre d'equacions:"
 
@@ -3002,15 +3005,15 @@ msgstr "d'Acord"
 msgid "Old value:"
 msgstr "Valor anterior:"
 
-#: ../src/wxMaxima.cpp:3992 ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135
+#: ../src/wxMaxima.cpp:4004 ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147
 msgid "Old variable:"
 msgstr "Variable anterior:"
 
-#: ../src/wxMaximaFrame.cpp:1387
+#: ../src/wxMaximaFrame.cpp:1386
 msgid "Omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1378
+#: ../src/wxMaximaFrame.cpp:1377
 msgid "Omicron"
 msgstr ""
 
@@ -3024,20 +3027,20 @@ msgid ""
 "stream for messages."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4763
+#: ../src/wxMaxima.cpp:4775
 msgid "One sample t-test"
 msgstr "Test t per a una mostra"
 
-#: ../src/wxMaximaFrame.cpp:971
+#: ../src/wxMaximaFrame.cpp:970
 msgid "Online tutorials"
 msgstr "Tutorials en línia"
 
 #: ../src/ConfigDialogue.cpp:656 ../src/main.cpp:347 ../src/ToolBar.cpp:119
-#: ../src/wxMaxima.cpp:2797
+#: ../src/wxMaxima.cpp:2805
 msgid "Open"
 msgstr "Obre"
 
-#: ../src/wxMaximaFrame.cpp:466
+#: ../src/wxMaximaFrame.cpp:465
 msgid "Open Recent"
 msgstr "Obre sessió &recent"
 
@@ -3045,11 +3048,11 @@ msgstr "Obre sessió &recent"
 msgid "Open a cell when Maxima expects input"
 msgstr "Obrir una cel·la quan Maxima espera una entrada"
 
-#: ../src/wxMaximaFrame.cpp:464
+#: ../src/wxMaximaFrame.cpp:463
 msgid "Open a document"
 msgstr "Obre un document"
 
-#: ../src/wxMaximaFrame.cpp:458 ../src/wxMaximaFrame.cpp:461
+#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
 msgid "Open a new window"
 msgstr "Obre nova finestra"
 
@@ -3057,11 +3060,11 @@ msgstr "Obre nova finestra"
 msgid "Open document"
 msgstr "Obre document"
 
-#: ../src/wxMaxima.cpp:4824
+#: ../src/wxMaxima.cpp:4836
 msgid "Open matrix"
 msgstr "Obre matriu"
 
-#: ../src/wxMaxima.cpp:1446 ../src/wxMaxima.cpp:1518
+#: ../src/wxMaxima.cpp:1451 ../src/wxMaxima.cpp:1523
 msgid "Opening file"
 msgstr "Obrint arxiu"
 
@@ -3085,11 +3088,11 @@ msgstr "Cel·les obsoletes"
 msgid "Output labels"
 msgstr "Etiquetes de sortida"
 
-#: ../src/wxMaximaFrame.cpp:796
+#: ../src/wxMaximaFrame.cpp:795
 msgid "P&ade Approximation..."
 msgstr "Aproximació de &Padé..."
 
-#: ../src/wxMaxima.cpp:3132 ../src/wxMaxima.cpp:5133
+#: ../src/wxMaxima.cpp:3141 ../src/wxMaxima.cpp:5145
 #, fuzzy
 msgid ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
@@ -3099,15 +3102,15 @@ msgstr ""
 "Imatge PNG (*.png)|*.png|Imatge JPEG (*.jpg)|*.jpg|bitmap Windows (*.bmp)|*."
 "mbp|pixmap X (*.xpm)|*.xpm"
 
-#: ../src/wxMaxima.cpp:4012
+#: ../src/wxMaxima.cpp:4024
 msgid "Pade approximation"
 msgstr "Aproximació de Padé"
 
-#: ../src/wxMaximaFrame.cpp:797
+#: ../src/wxMaximaFrame.cpp:796
 msgid "Pade approximation of a Taylor series"
 msgstr "Aproximació de Padé d'una sèrie de Taylor"
 
-#: ../src/wxMaximaFrame.cpp:1500
+#: ../src/wxMaximaFrame.cpp:1519
 msgid "Pagebreak"
 msgstr "﻿Salt de pàgina"
 
@@ -3119,19 +3122,19 @@ msgstr ""
 msgid "Parametric plot"
 msgstr "Gràfic paramètric"
 
-#: ../src/wxMaximaFrame.cpp:188
+#: ../src/wxMaximaFrame.cpp:187
 msgid "Parsing output"
 msgstr "Analitzant sortida"
 
-#: ../src/wxMaximaFrame.cpp:819
+#: ../src/wxMaximaFrame.cpp:818
 msgid "Partial &Fractions..."
 msgstr "Fraccion&s simples..."
 
-#: ../src/wxMaxima.cpp:4076
+#: ../src/wxMaxima.cpp:4088
 msgid "Partial fractions"
 msgstr "Fraccions simples"
 
-#: ../src/wxMaxima.cpp:1769
+#: ../src/wxMaxima.cpp:1774
 msgid "Parts of the document will not be loaded correctly!"
 msgstr "Parts del document no s'han carregat correctament!"
 
@@ -3142,11 +3145,11 @@ msgid ""
 "Found unknown XML Tag name "
 msgstr "Parts del document no s'han carregat correctament!"
 
-#: ../src/ToolBar.cpp:143 ../src/MathCtrl.cpp:1010 ../src/MathCtrl.cpp:1025
+#: ../src/MathCtrl.cpp:1052 ../src/MathCtrl.cpp:1067 ../src/ToolBar.cpp:143
 msgid "Paste"
 msgstr "Enganxa"
 
-#: ../src/wxMaximaFrame.cpp:518
+#: ../src/wxMaximaFrame.cpp:517
 msgid "Paste\tCtrl-V"
 msgstr "&Enganxa\tCtrl-V"
 
@@ -3154,7 +3157,7 @@ msgstr "&Enganxa\tCtrl-V"
 msgid "Paste from clipboard"
 msgstr "Enganxa des del porta-papers"
 
-#: ../src/wxMaximaFrame.cpp:519
+#: ../src/wxMaximaFrame.cpp:518
 msgid "Paste text from clipboard"
 msgstr "Aferra text des del porta-papers"
 
@@ -3162,19 +3165,19 @@ msgstr "Aferra text des del porta-papers"
 msgid "Perpendicular to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1384
+#: ../src/wxMaximaFrame.cpp:1383
 msgid "Phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1379
+#: ../src/wxMaximaFrame.cpp:1378
 msgid "Pi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1273
+#: ../src/wxMaximaFrame.cpp:1272
 msgid "Piechart..."
 msgstr "Diagrama de sectors..."
 
-#: ../src/wxMaxima.cpp:1952
+#: ../src/wxMaxima.cpp:1957
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr "Configuri wxMaxima amb 'Edita->Configura'."
 
@@ -3182,52 +3185,52 @@ msgstr "Configuri wxMaxima amb 'Edita->Configura'."
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr "Reiniciau wxMaxima per aplicar els canvis"
 
-#: ../src/wxMaximaFrame.cpp:923
+#: ../src/wxMaximaFrame.cpp:922
 msgid "Plot &2d..."
 msgstr "Gràfics &2D"
 
-#: ../src/wxMaximaFrame.cpp:925
+#: ../src/wxMaximaFrame.cpp:924
 msgid "Plot &3d..."
 msgstr "Gràfics &3D"
 
-#: ../src/wxMaximaFrame.cpp:927
+#: ../src/wxMaximaFrame.cpp:926
 msgid "Plot &Format..."
 msgstr "&Format de gràfics"
 
 #: ../src/Plot2dWiz.cpp:104 ../src/Plot2dWiz.cpp:450 ../src/Plot2dWiz.cpp:464
-#: ../src/wxMaxima.cpp:4283 ../src/wxMaxima.cpp:5102
+#: ../src/wxMaxima.cpp:4295 ../src/wxMaxima.cpp:5114
 msgid "Plot 2D"
 msgstr "Gràfics 2D"
 
-#: ../src/wxMaximaFrame.cpp:1227
+#: ../src/wxMaximaFrame.cpp:1226
 msgid "Plot 2D..."
 msgstr "Gràfics 2D..."
 
-#: ../src/MathCtrl.cpp:1003
+#: ../src/MathCtrl.cpp:1045
 msgid "Plot 2d..."
 msgstr "Gràfics 2D..."
 
-#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4269 ../src/wxMaxima.cpp:5115
+#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4281 ../src/wxMaxima.cpp:5127
 msgid "Plot 3D"
 msgstr "Gràfics 3D"
 
-#: ../src/wxMaximaFrame.cpp:1228
+#: ../src/wxMaximaFrame.cpp:1227
 msgid "Plot 3D..."
 msgstr "Gràfics 3D..."
 
-#: ../src/MathCtrl.cpp:1004
+#: ../src/MathCtrl.cpp:1046
 msgid "Plot 3d..."
 msgstr "Gràfics 3D...."
 
-#: ../src/wxMaxima.cpp:4296
+#: ../src/wxMaxima.cpp:4308
 msgid "Plot format"
 msgstr "Format dels gràfics"
 
-#: ../src/wxMaximaFrame.cpp:924
+#: ../src/wxMaximaFrame.cpp:923
 msgid "Plot in 2 dimensions"
 msgstr "Gràfic en 2 dimensions"
 
-#: ../src/wxMaximaFrame.cpp:926
+#: ../src/wxMaximaFrame.cpp:925
 msgid "Plot in 3 dimensions"
 msgstr "Gràfic en 3 dimensions"
 
@@ -3236,8 +3239,8 @@ msgid "Plot to file:"
 msgstr "Gràfic a l'arxiu:"
 
 #: ../src/BC2Wiz.cpp:30 ../src/BC2Wiz.cpp:36 ../src/LimitWiz.cpp:33
-#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
-#: ../src/wxMaxima.cpp:3648
+#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
+#: ../src/wxMaxima.cpp:3660
 msgid "Point:"
 msgstr "Punt:"
 
@@ -3245,11 +3248,11 @@ msgstr "Punt:"
 msgid "Polish"
 msgstr "Polonès"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 1:"
 msgstr "Polinomi 1:"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 2:"
 msgstr "Polinomi 2:"
 
@@ -3261,11 +3264,11 @@ msgstr "Portuguès (Brasil)"
 msgid "Postscript file (*.eps)|*.eps|All|*"
 msgstr "Arxiu postscript (*.eps)|*.eps|Tots|*"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Precision"
 msgstr "Precisió"
 
-#: ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:536
 msgid "Preferences...\tCtrl+,"
 msgstr "Preferències...\tCtrl+,"
 
@@ -3277,7 +3280,7 @@ msgid ""
 "packages and from functions that are defined in the current file."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:628
+#: ../src/wxMaximaFrame.cpp:627
 msgid "Previous Command\tAlt-Up"
 msgstr "Ordre anterior\tAlt-Up"
 
@@ -3285,11 +3288,11 @@ msgstr "Ordre anterior\tAlt-Up"
 msgid "Print"
 msgstr "Imprimir"
 
-#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:484
+#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:483
 msgid "Print document"
 msgstr "Imprimir document"
 
-#: ../src/wxMaxima.cpp:4242
+#: ../src/wxMaxima.cpp:4254
 msgid "Product"
 msgstr "Producte"
 
@@ -3298,35 +3301,35 @@ msgstr "Producte"
 msgid "Product sign"
 msgstr "Producte"
 
-#: ../src/wxMaximaFrame.cpp:1386
+#: ../src/wxMaximaFrame.cpp:1385
 msgid "Psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:331
+#: ../src/wxMaximaFrame.cpp:330
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:592
+#: ../src/wxMaximaFrame.cpp:591
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr "Avaluar les cel·les anteriors a la senyalada pel cursor"
 
-#: ../src/wxMaximaFrame.cpp:1278
+#: ../src/wxMaximaFrame.cpp:1277
 msgid "Read Matrix..."
 msgstr "Llegir matri"
 
-#: ../src/wxMaximaFrame.cpp:177
+#: ../src/wxMaximaFrame.cpp:176
 msgid "Reading Maxima output"
 msgstr "Llegint el resultat de Maxima"
 
-#: ../src/wxMaximaFrame.cpp:153
+#: ../src/wxMaximaFrame.cpp:152
 msgid "Ready for user input"
 msgstr "Preparat per a l'entrada de l'usuari"
 
-#: ../src/wxMaximaFrame.cpp:631
+#: ../src/wxMaximaFrame.cpp:630
 msgid "Recall next command from history"
 msgstr "Torna a executar la següent ordre del historial"
 
-#: ../src/wxMaximaFrame.cpp:629
+#: ../src/wxMaximaFrame.cpp:628
 msgid "Recall previous command from history"
 msgstr "Tornar executar l'ordre anterior  del historial"
 
@@ -3334,35 +3337,35 @@ msgstr "Tornar executar l'ordre anterior  del historial"
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1215
+#: ../src/wxMaximaFrame.cpp:1214
 msgid "Rectform"
 msgstr "Forma cartesiana"
 
-#: ../src/wxMaximaFrame.cpp:495
+#: ../src/wxMaximaFrame.cpp:494
 msgid "Redo\tCtrl-Y"
 msgstr "Desfer\tCtrl-Y"
 
-#: ../src/wxMaximaFrame.cpp:496
+#: ../src/wxMaximaFrame.cpp:495
 msgid "Redo last change"
 msgstr "Desfer el darrer canvi"
 
-#: ../src/wxMaximaFrame.cpp:1220
+#: ../src/wxMaximaFrame.cpp:1219
 msgid "Reduce (tr)"
 msgstr "Reduir (tr)"
 
-#: ../src/wxMaximaFrame.cpp:871
+#: ../src/wxMaximaFrame.cpp:870
 msgid "Reduce trigonometric expression"
 msgstr "Simplificar expressió trigonomètrica"
 
-#: ../src/wxMaxima.cpp:622 ../src/wxMaxima.cpp:5495
+#: ../src/wxMaxima.cpp:627 ../src/wxMaxima.cpp:5511
 msgid "Refusing to send cell to maxima: "
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:594
+#: ../src/wxMaximaFrame.cpp:593
 msgid "Remove All Output"
 msgstr "&Suprimeix tots els resultats"
 
-#: ../src/wxMaximaFrame.cpp:595
+#: ../src/wxMaximaFrame.cpp:594
 msgid "Remove output from input cells"
 msgstr "Suprimeix els resultats de les cel·les d'entrada"
 
@@ -3371,7 +3374,7 @@ msgstr "Suprimeix els resultats de les cel·les d'entrada"
 msgid "Replace All"
 msgstr "Selecciona tot"
 
-#: ../src/wxMaxima.cpp:3282
+#: ../src/wxMaxima.cpp:3294
 #, c-format
 msgid "Replaced %d occurrences."
 msgstr "﻿Reemplaçades %d coincidències."
@@ -3380,11 +3383,11 @@ msgstr "﻿Reemplaçades %d coincidències."
 msgid "Replacement:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:976
+#: ../src/wxMaximaFrame.cpp:975
 msgid "Report bug"
 msgstr "Informa de l'error"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "Restart Maxima"
 msgstr "Reinicia Maxima"
 
@@ -3392,7 +3395,7 @@ msgstr "Reinicia Maxima"
 msgid "Restart maxima"
 msgstr "Reinicia Maxima"
 
-#: ../src/MathCtrl.cpp:4442
+#: ../src/MathCtrl.cpp:4497
 msgid "Result"
 msgstr ""
 
@@ -3400,7 +3403,7 @@ msgstr ""
 msgid "Return to the cell that is currently being evaluated"
 msgstr "Retorna a la cel·la que s'està avaluant actualment."
 
-#: ../src/wxMaximaFrame.cpp:1380
+#: ../src/wxMaximaFrame.cpp:1379
 msgid "Rho"
 msgstr ""
 
@@ -3408,19 +3411,19 @@ msgstr ""
 msgid "Right arrow"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:779
+#: ../src/wxMaximaFrame.cpp:778
 msgid "Risch Integration..."
 msgstr "Integració &Risch"
 
-#: ../src/wxMaximaFrame.cpp:694
+#: ../src/wxMaximaFrame.cpp:693
 msgid "Roots of &Polynomial"
 msgstr "Arrels d'un &polinomi"
 
-#: ../src/wxMaximaFrame.cpp:697
+#: ../src/wxMaximaFrame.cpp:696
 msgid "Roots of Polynomial (bfloat)"
 msgstr "Arrels reals &grans d'un polinomi"
 
-#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Rows:"
 msgstr "Files:"
 
@@ -3428,56 +3431,56 @@ msgstr "Files:"
 msgid "Russian"
 msgstr "Russ"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 1:"
 msgstr "Exemple 1:"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 2:"
 msgstr "Exemple 2:"
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Sample:"
 msgstr "Mostra:"
 
 #: ../src/ConfigDialogue.cpp:781 ../src/ToolBar.cpp:122
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Save"
 msgstr "Desa"
 
-#: ../src/MathCtrl.cpp:921
+#: ../src/MathCtrl.cpp:963
 msgid "Save Animation..."
 msgstr "Desa animació"
 
-#: ../src/wxMaxima.cpp:2565
+#: ../src/wxMaxima.cpp:2572
 msgid "Save As"
 msgstr "Desa com"
 
-#: ../src/wxMaximaFrame.cpp:474
+#: ../src/wxMaximaFrame.cpp:473
 msgid "Save As...\tShift-Ctrl-S"
 msgstr "Desa &com\tShift-Ctrl-S"
 
-#: ../src/MathCtrl.cpp:919
+#: ../src/MathCtrl.cpp:961
 msgid "Save Image..."
 msgstr "Desa imatge..."
 
-#: ../src/wxMaxima.cpp:3130
+#: ../src/wxMaxima.cpp:3139
 msgid "Save Selection to Image"
 msgstr "Desa selecció a imatges"
 
-#: ../src/wxMaximaFrame.cpp:528
+#: ../src/wxMaximaFrame.cpp:527
 msgid "Save Selection to Image..."
 msgstr "&Desa selecció a imatges..."
 
-#: ../src/wxMaxima.cpp:5150
+#: ../src/wxMaxima.cpp:5162
 msgid "Save animation to file"
 msgstr "Desa animació en un arxiu"
 
-#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:473
+#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:472
 msgid "Save document"
 msgstr "Desa document"
 
-#: ../src/wxMaximaFrame.cpp:475
+#: ../src/wxMaximaFrame.cpp:474
 msgid "Save document as"
 msgstr "Desa document com"
 
@@ -3501,11 +3504,11 @@ msgstr "Desa la disposició de panells entre sessions."
 msgid "Save plot to file"
 msgstr "Desa gràfic en un arxiu"
 
-#: ../src/wxMaximaFrame.cpp:529
+#: ../src/wxMaximaFrame.cpp:528
 msgid "Save selection from document to an image file"
 msgstr "Copia la selecció del document a una imatge"
 
-#: ../src/wxMaxima.cpp:5131
+#: ../src/wxMaxima.cpp:5143
 msgid "Save selection to file"
 msgstr "Desa la selecció en un arxiu"
 
@@ -3521,27 +3524,27 @@ msgstr "Desa el mida/posició de la finestra de wxMaxima"
 msgid "Save wxMaxima window size/position between sessions."
 msgstr "Desa mida/posició de la finestra de wxMaxima entre sessions."
 
-#: ../src/wxMaximaFrame.cpp:246
+#: ../src/wxMaximaFrame.cpp:245
 msgid "Saving failed."
 msgstr "Error en desar."
 
-#: ../src/wxMaximaFrame.cpp:222
+#: ../src/wxMaximaFrame.cpp:221
 msgid "Saving successful."
 msgstr "Desat correctament."
 
-#: ../src/wxMaximaFrame.cpp:212
+#: ../src/wxMaximaFrame.cpp:211
 msgid "Saving..."
 msgstr "Desant..."
 
-#: ../src/wxMaxima.cpp:4699
+#: ../src/wxMaxima.cpp:4711
 msgid "Scatterplot"
 msgstr "Diagrama dispersió"
 
-#: ../src/wxMaximaFrame.cpp:1271
+#: ../src/wxMaximaFrame.cpp:1270
 msgid "Scatterplot..."
 msgstr "Diagrama dispersió..."
 
-#: ../src/wxMaximaFrame.cpp:1498
+#: ../src/wxMaximaFrame.cpp:1517
 msgid "Section"
 msgstr "Secció"
 
@@ -3549,26 +3552,26 @@ msgstr "Secció"
 msgid "Section cell"
 msgstr "Cel·la de secció"
 
-#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:292 ../src/TextCell.cpp:306
-#: ../src/TextCell.cpp:322 ../src/TextCell.cpp:334
+#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:290 ../src/TextCell.cpp:304
+#: ../src/TextCell.cpp:320 ../src/TextCell.cpp:332
 msgid ""
 "Seems like something is broken with a font. Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/TextCell.cpp:139
+#: ../src/TextCell.cpp:137
 msgid ""
 "Seems like something is broken with the maths font. Installing http://www."
 "math.union.edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use "
 "JSmath fonts\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1011 ../src/MathCtrl.cpp:1027
+#: ../src/MathCtrl.cpp:1053 ../src/MathCtrl.cpp:1069
 msgid "Select All"
 msgstr "Selecciona tot"
 
-#: ../src/wxMaximaFrame.cpp:525
+#: ../src/wxMaximaFrame.cpp:524
 msgid "Select All\tCtrl-A"
 msgstr "&Selecciona tot\tCtrl-A"
 
@@ -3576,7 +3579,7 @@ msgstr "&Selecciona tot\tCtrl-A"
 msgid "Select Maxima program"
 msgstr "Selecciona el programa Maxima"
 
-#: ../src/wxMaxima.cpp:4860
+#: ../src/wxMaxima.cpp:4872
 msgid "Select Subsample"
 msgstr "Selecciona sub-mostra"
 
@@ -3585,11 +3588,11 @@ msgstr "Selecciona sub-mostra"
 msgid "Select a constant"
 msgstr "Selecciona una constant"
 
-#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:526
+#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:525
 msgid "Select all"
 msgstr "Selecciona tot"
 
-#: ../src/wxMaxima.cpp:3319
+#: ../src/wxMaxima.cpp:3331
 msgid "Select math display algorithm"
 msgstr "Selecciona l'algoritme de sortida matemàtica"
 
@@ -3606,23 +3609,23 @@ msgstr ""
 msgid "Selection"
 msgstr "Selecció"
 
-#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4178
+#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4190
 msgid "Series"
 msgstr "Sèrie"
 
-#: ../src/wxMaximaFrame.cpp:1226
+#: ../src/wxMaximaFrame.cpp:1225
 msgid "Series..."
 msgstr "Sèrie..."
 
-#: ../src/wxMaxima.cpp:863
+#: ../src/wxMaxima.cpp:868
 msgid "Server started"
 msgstr "Servidor iniciat"
 
-#: ../src/wxMaximaFrame.cpp:575
+#: ../src/wxMaximaFrame.cpp:574
 msgid "Set Zoom"
 msgstr "Establir aug&ment"
 
-#: ../src/wxMaximaFrame.cpp:944
+#: ../src/wxMaximaFrame.cpp:943
 #, fuzzy
 msgid "Set bigfloat &Precision..."
 msgstr "Establir la precisió en coma flotant"
@@ -3631,63 +3634,63 @@ msgstr "Establir la precisió en coma flotant"
 msgid "Set fixed font in text controls."
 msgstr "Establir la font fitxa en els controls de text."
 
-#: ../src/wxMaximaFrame.cpp:928
+#: ../src/wxMaximaFrame.cpp:927
 msgid "Set plot format"
 msgstr "Establir el format dels gràfics"
 
-#: ../src/wxMaximaFrame.cpp:945
+#: ../src/wxMaximaFrame.cpp:944
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can "
 "be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:569
+#: ../src/wxMaximaFrame.cpp:568
 msgid "Set zoom to 100%"
 msgstr "Establir ampliació a 100%"
 
-#: ../src/wxMaximaFrame.cpp:570
+#: ../src/wxMaximaFrame.cpp:569
 msgid "Set zoom to 120%"
 msgstr "Establir ampliació a 120%"
 
-#: ../src/wxMaximaFrame.cpp:571
+#: ../src/wxMaximaFrame.cpp:570
 msgid "Set zoom to 150%"
 msgstr "Establir ampliació a 150%"
 
-#: ../src/wxMaximaFrame.cpp:572
+#: ../src/wxMaximaFrame.cpp:571
 msgid "Set zoom to 200%"
 msgstr "Establir ampliació a 200%"
 
-#: ../src/wxMaximaFrame.cpp:573
+#: ../src/wxMaximaFrame.cpp:572
 msgid "Set zoom to 300%"
 msgstr "Establir ampliació a 300%"
 
-#: ../src/wxMaximaFrame.cpp:568
+#: ../src/wxMaximaFrame.cpp:567
 msgid "Set zoom to 80%"
 msgstr "Establir reducció al 80%"
 
-#: ../src/wxMaximaFrame.cpp:732
+#: ../src/wxMaximaFrame.cpp:731
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
 "Establir les condicions inicials per a resoldre EDO mitjançant la "
 "transformada de Laplace"
 
-#: ../src/wxMaximaFrame.cpp:918
+#: ../src/wxMaximaFrame.cpp:917
 msgid "Setup modulus computation"
 msgstr "Configura el càlcul del mòdul"
 
-#: ../src/wxMaximaFrame.cpp:662
+#: ../src/wxMaximaFrame.cpp:661
 msgid "Show &Definition..."
 msgstr "Mostra &definició..."
 
-#: ../src/wxMaximaFrame.cpp:660
+#: ../src/wxMaximaFrame.cpp:659
 msgid "Show &Functions"
 msgstr "Mostra &funcions"
 
-#: ../src/wxMaximaFrame.cpp:967
+#: ../src/wxMaximaFrame.cpp:966
 msgid "Show &Tips..."
 msgstr "Mostra &suggiments..."
 
-#: ../src/wxMaximaFrame.cpp:665
+#: ../src/wxMaximaFrame.cpp:664
 msgid "Show &Variables"
 msgstr "Mostra &variables"
 
@@ -3695,43 +3698,43 @@ msgstr "Mostra &variables"
 msgid "Show Maxima help"
 msgstr "Mostra l'ajuda de Maxima"
 
-#: ../src/wxMaximaFrame.cpp:603
+#: ../src/wxMaximaFrame.cpp:602
 msgid "Show Template\tCtrl-Shift-K"
 msgstr "&Mostra plantilla\tCtrl-Shift-K"
 
-#: ../src/wxMaximaFrame.cpp:968
+#: ../src/wxMaximaFrame.cpp:967
 msgid "Show a tip"
 msgstr "Mostra un suggeriment"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Show all commands similar to:"
 msgstr "Mostra tots les ordres semblents a:"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Show an example for the command:"
 msgstr "Mostra un exemple per a l'ordre:"
 
-#: ../src/wxMaximaFrame.cpp:962
+#: ../src/wxMaximaFrame.cpp:961
 msgid "Show an example of usage"
 msgstr "Mostra un exemple d'ús"
 
-#: ../src/wxMaximaFrame.cpp:965
+#: ../src/wxMaximaFrame.cpp:964
 msgid "Show commands similar to"
 msgstr "Mostra ordres semblants a"
 
-#: ../src/wxMaximaFrame.cpp:661
+#: ../src/wxMaximaFrame.cpp:660
 msgid "Show defined functions"
 msgstr "Mostra les funcions definides"
 
-#: ../src/wxMaximaFrame.cpp:666
+#: ../src/wxMaximaFrame.cpp:665
 msgid "Show defined variables"
 msgstr "Mostra les variables definides"
 
-#: ../src/wxMaximaFrame.cpp:663
+#: ../src/wxMaximaFrame.cpp:662
 msgid "Show definition of a function"
 msgstr "Mostra la definició d'una funció"
 
-#: ../src/wxMaximaFrame.cpp:604
+#: ../src/wxMaximaFrame.cpp:603
 msgid "Show function template"
 msgstr "Mostra la plantilla de funció"
 
@@ -3744,7 +3747,7 @@ msgstr "Mostra expressions llargues en el document de wxMaxima."
 msgid "Show long expressions:"
 msgstr "Mostra expressions llargues"
 
-#: ../src/wxMaxima.cpp:3341
+#: ../src/wxMaxima.cpp:3353
 msgid "Show the definition of function:"
 msgstr "Mostra la definició de la funció:"
 
@@ -3753,43 +3756,43 @@ msgstr "Mostra la definició de la funció:"
 msgid "Show user-defined labels instead of (%oxx)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:953 ../src/wxMaximaFrame.cpp:956
+#: ../src/wxMaximaFrame.cpp:952 ../src/wxMaximaFrame.cpp:955
 msgid "Show wxMaxima help"
 msgstr "Mostra l'ajuda de Maxima"
 
-#: ../src/wxMaximaFrame.cpp:1381
+#: ../src/wxMaximaFrame.cpp:1380
 msgid "Sigma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1211
+#: ../src/wxMaximaFrame.cpp:1210
 msgid "Simplify"
 msgstr "Simplifica"
 
-#: ../src/wxMaximaFrame.cpp:831
+#: ../src/wxMaximaFrame.cpp:830
 msgid "Simplify &Radicals"
 msgstr "Simplifica &radicals"
 
-#: ../src/wxMaximaFrame.cpp:1212
+#: ../src/wxMaximaFrame.cpp:1211
 msgid "Simplify (r)"
 msgstr "Simplifica (r)"
 
-#: ../src/wxMaximaFrame.cpp:1218
+#: ../src/wxMaximaFrame.cpp:1217
 msgid "Simplify (tr)"
 msgstr "Simplifica (tr)"
 
-#: ../src/MathCtrl.cpp:995
+#: ../src/MathCtrl.cpp:1037
 msgid "Simplify Expression"
 msgstr "Simplifica expressió"
 
-#: ../src/wxMaximaFrame.cpp:857
+#: ../src/wxMaximaFrame.cpp:856
 msgid "Simplify an expression containing factorials"
 msgstr "Simplifica una expressió amb factorials"
 
-#: ../src/wxMaximaFrame.cpp:832
+#: ../src/wxMaximaFrame.cpp:831
 msgid "Simplify expression containing radicals"
 msgstr "Simplifica una expressió amb radicals"
 
-#: ../src/wxMaximaFrame.cpp:830
+#: ../src/wxMaximaFrame.cpp:829
 msgid "Simplify rational expression"
 msgstr "Simplifica expressió racional"
 
@@ -3797,7 +3800,7 @@ msgstr "Simplifica expressió racional"
 msgid "Simplify the sum"
 msgstr "Simplifica la suma"
 
-#: ../src/wxMaximaFrame.cpp:868
+#: ../src/wxMaximaFrame.cpp:867
 msgid "Simplify trigonometric expression"
 msgstr "Simplifica una expressió trigonomètrica"
 
@@ -3813,88 +3816,88 @@ msgstr ""
 "desar el document en format 'Document xml wxMaxima' si voleu que es desi la "
 "imatge amb la resta del document."
 
-#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
+#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
 msgid "Solution:"
 msgstr "Solució:"
 
-#: ../src/wxMaxima.cpp:3461 ../src/wxMaxima.cpp:3475 ../src/wxMaxima.cpp:5020
+#: ../src/wxMaxima.cpp:3473 ../src/wxMaxima.cpp:3487 ../src/wxMaxima.cpp:5032
 msgid "Solve"
 msgstr "Resoldre"
 
-#: ../src/wxMaximaFrame.cpp:706
+#: ../src/wxMaximaFrame.cpp:705
 msgid "Solve &Algebraic System..."
 msgstr "Reso&ldre sistema algebraic..."
 
-#: ../src/wxMaximaFrame.cpp:703
+#: ../src/wxMaximaFrame.cpp:702
 msgid "Solve &Linear System..."
 msgstr "Resoldre &sistema lineal..."
 
-#: ../src/wxMaximaFrame.cpp:714
+#: ../src/wxMaximaFrame.cpp:713
 msgid "Solve &ODE..."
 msgstr "Resoldre &EDO..."
 
-#: ../src/wxMaximaFrame.cpp:690
+#: ../src/wxMaximaFrame.cpp:689
 msgid "Solve (to_poly)..."
 msgstr "Res&oldre (to_poly)..."
 
-#: ../src/wxMaxima.cpp:3511 ../src/wxMaxima.cpp:3635
+#: ../src/wxMaxima.cpp:3523 ../src/wxMaxima.cpp:3647
 msgid "Solve ODE"
 msgstr "Resoldre EDO"
 
-#: ../src/wxMaximaFrame.cpp:728
+#: ../src/wxMaximaFrame.cpp:727
 msgid "Solve ODE with Lapla&ce..."
 msgstr "Resoldre E&DO amb Laplace..."
 
-#: ../src/wxMaximaFrame.cpp:1222
+#: ../src/wxMaximaFrame.cpp:1221
 msgid "Solve ODE..."
 msgstr "Resoldre EDO..."
 
-#: ../src/wxMaxima.cpp:3586 ../src/wxMaxima.cpp:3597
+#: ../src/wxMaxima.cpp:3598 ../src/wxMaxima.cpp:3609
 msgid "Solve algebraic system"
 msgstr "Resoldre sistema algebraic"
 
-#: ../src/wxMaximaFrame.cpp:707
+#: ../src/wxMaximaFrame.cpp:706
 msgid "Solve algebraic system of equations"
 msgstr "Resoldre sistema algebraic d'equacions"
 
-#: ../src/wxMaximaFrame.cpp:725
+#: ../src/wxMaximaFrame.cpp:724
 msgid "Solve boundary value problem for second degree ODE"
 msgstr "Resoldre problema de contorn per a una EDO de segon ordre"
 
-#: ../src/wxMaximaFrame.cpp:689
+#: ../src/wxMaximaFrame.cpp:688
 msgid "Solve equation(s)"
 msgstr "Resoldre equació(s)"
 
-#: ../src/wxMaximaFrame.cpp:691
+#: ../src/wxMaximaFrame.cpp:690
 msgid "Solve equation(s) with to_poly_solve"
 msgstr "Resoldre equació amb to_poly_solve"
 
-#: ../src/wxMaximaFrame.cpp:719
+#: ../src/wxMaximaFrame.cpp:718
 msgid "Solve initial value problem for first degree ODE"
 msgstr "Resoldre problema de valor inicial per a EDO de primer ordre"
 
-#: ../src/wxMaximaFrame.cpp:722
+#: ../src/wxMaximaFrame.cpp:721
 msgid "Solve initial value problem for second degree ODE"
 msgstr "Resoldre problema de valor inicial per a EDO de segon ordre"
 
-#: ../src/wxMaxima.cpp:3610 ../src/wxMaxima.cpp:3621
+#: ../src/wxMaxima.cpp:3622 ../src/wxMaxima.cpp:3633
 msgid "Solve linear system"
 msgstr "Resoldre sistema lineal"
 
-#: ../src/wxMaximaFrame.cpp:704
+#: ../src/wxMaximaFrame.cpp:703
 msgid "Solve linear system of equations"
 msgstr "Resoldre sistema d'equacions lineals"
 
-#: ../src/wxMaximaFrame.cpp:715
+#: ../src/wxMaximaFrame.cpp:714
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr "Resoldre equació diferencial ordinària d'ordre màxim 2"
 
-#: ../src/wxMaximaFrame.cpp:729
+#: ../src/wxMaximaFrame.cpp:728
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
 "Resoldre  equacions diferencials ordinàries amb la transformada de Laplace"
 
-#: ../src/wxMaximaFrame.cpp:1221 ../src/MathCtrl.cpp:992
+#: ../src/MathCtrl.cpp:1034 ../src/wxMaximaFrame.cpp:1220
 msgid "Solve..."
 msgstr "Resoldre"
 
@@ -3921,7 +3924,7 @@ msgstr "Especial"
 msgid "Special constants"
 msgstr "Constants especials"
 
-#: ../src/MathCtrl.cpp:922
+#: ../src/MathCtrl.cpp:964
 msgid "Start Animation"
 msgstr "Inicia animació"
 
@@ -3941,28 +3944,28 @@ msgstr ""
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:294
+#: ../src/wxMaxima.cpp:295
 msgid "Starting Maxima process failed"
 msgstr "Ha fallat l'engegada de Maxima"
 
-#: ../src/wxMaxima.cpp:928
+#: ../src/wxMaxima.cpp:933
 msgid "Starting Maxima..."
 msgstr "Engegant maxima..."
 
-#: ../src/wxMaxima.cpp:292 ../src/wxMaxima.cpp:860
+#: ../src/wxMaxima.cpp:293 ../src/wxMaxima.cpp:865
 msgid "Starting server failed"
 msgstr "L'engegada del servidor ha fallat"
 
-#: ../src/wxMaxima.cpp:841
+#: ../src/wxMaxima.cpp:846
 #, c-format
 msgid "Starting server on port %d"
 msgstr "Engegant el servidor en el port %d"
 
-#: ../src/wxMaximaFrame.cpp:342
+#: ../src/wxMaximaFrame.cpp:341
 msgid "Statistics"
 msgstr "Estadística"
 
-#: ../src/wxMaximaFrame.cpp:550
+#: ../src/wxMaximaFrame.cpp:549
 msgid "Statistics\tAlt-Shift-S"
 msgstr "&Estadística\tAlt-Shift-S"
 
@@ -3978,11 +3981,11 @@ msgstr "Estil"
 msgid "Styles"
 msgstr "Estils"
 
-#: ../src/wxMaximaFrame.cpp:1283
+#: ../src/wxMaximaFrame.cpp:1282
 msgid "Subsample..."
 msgstr "Sub-mostra"
 
-#: ../src/wxMaximaFrame.cpp:1496
+#: ../src/wxMaximaFrame.cpp:1515
 msgid "Subsection"
 msgstr "Sub-secció"
 
@@ -3990,20 +3993,20 @@ msgstr "Sub-secció"
 msgid "Subsection cell"
 msgstr "Cel·la de sub-secció"
 
-#: ../src/wxMaximaFrame.cpp:1216
+#: ../src/wxMaximaFrame.cpp:1215
 msgid "Subst..."
 msgstr "S&ubstitueix"
 
-#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3423
-#: ../src/wxMaxima.cpp:5089
+#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3435
+#: ../src/wxMaxima.cpp:5101
 msgid "Substitute"
 msgstr "Substitueix"
 
-#: ../src/wxMaximaFrame.cpp:906 ../src/MathCtrl.cpp:998
+#: ../src/MathCtrl.cpp:1040 ../src/wxMaximaFrame.cpp:905
 msgid "Substitute..."
 msgstr "Substitueix..."
 
-#: ../src/wxMaximaFrame.cpp:1497
+#: ../src/wxMaximaFrame.cpp:1516
 #, fuzzy
 msgid "Subsubsection"
 msgstr "Sub-secció"
@@ -4013,7 +4016,7 @@ msgstr "Sub-secció"
 msgid "Subsubsection cell"
 msgstr "Cel·la de sub-secció"
 
-#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4226
+#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4238
 msgid "Sum"
 msgstr "Suma"
 
@@ -4021,37 +4024,37 @@ msgstr "Suma"
 msgid "Sum sign"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:553
+#: ../src/wxMaximaFrame.cpp:552
 #, fuzzy
 msgid "Symbols\tAlt-Shift-Y"
 msgstr "&Estadística\tAlt-Shift-S"
 
-#: ../src/wxMaxima.cpp:4456
+#: ../src/wxMaxima.cpp:4468
 msgid "System info"
 msgstr "Informació del sistema"
 
-#: ../src/wxMaximaFrame.cpp:320
+#: ../src/wxMaximaFrame.cpp:319
 msgid "Table of Contents"
 msgstr "Taula de continguts"
 
-#: ../src/wxMaximaFrame.cpp:556
+#: ../src/wxMaximaFrame.cpp:555
 #, fuzzy
 msgid "Table of Contents\tAlt-Shift-T"
 msgstr "Taula de continguts\tAlt-Shift-I"
 
-#: ../src/wxMaximaFrame.cpp:1382
+#: ../src/wxMaximaFrame.cpp:1381
 msgid "Tau"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Taylor series:"
 msgstr "Sèrie de Taylor:"
 
-#: ../src/wxMaxima.cpp:3963
+#: ../src/wxMaxima.cpp:3975
 msgid "Tellrat"
 msgstr "Tellrat"
 
-#: ../src/wxMaximaFrame.cpp:1494
+#: ../src/wxMaximaFrame.cpp:1513
 msgid "Text"
 msgstr "Text"
 
@@ -4101,7 +4104,7 @@ msgstr ""
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr "Es farà servir l'ordre «documentclass» de LaTex en els seus documents."
 
-#: ../src/TextCell.cpp:136
+#: ../src/TextCell.cpp:134
 msgid ""
 "The letter \"X\" is of width zero. Installing http://www.math.union.edu/"
 "~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts\" in "
@@ -4118,7 +4121,7 @@ msgstr ""
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:959
+#: ../src/wxMaximaFrame.cpp:958
 msgid "The offline manual of maxima"
 msgstr "El manual oficial de Maxima"
 
@@ -4158,7 +4161,7 @@ msgstr ""
 "andrejv.github.com/wxmaxima/help.html per obtenir més informació i tutorials "
 "per fer servir wxMaxima i Maxima."
 
-#: ../src/SlideShowCell.cpp:332
+#: ../src/SlideShowCell.cpp:336
 msgid ""
 "There was an error during GIF export!\n"
 "\n"
@@ -4169,7 +4172,7 @@ msgstr ""
 "Assegurau-vos que el programa ImageMagick està instal·lat i què wxMaxima pot "
 "trobar el programa de conversió."
 
-#: ../src/wxMaxima.cpp:442
+#: ../src/wxMaxima.cpp:447
 msgid ""
 "There was an error in generated XML!\n"
 "\n"
@@ -4179,7 +4182,7 @@ msgstr ""
 "\n"
 "Si us plau, informeu de l'error."
 
-#: ../src/wxMaximaFrame.cpp:1371
+#: ../src/wxMaximaFrame.cpp:1370
 msgid "Theta"
 msgstr ""
 
@@ -4187,7 +4190,7 @@ msgstr ""
 msgid "Ticks:"
 msgstr "Graduacions:"
 
-#: ../src/wxMaxima.cpp:4153 ../src/wxMaxima.cpp:5065
+#: ../src/wxMaxima.cpp:4165 ../src/wxMaxima.cpp:5077
 msgid "Times:"
 msgstr "Repeticions:"
 
@@ -4195,7 +4198,7 @@ msgstr "Repeticions:"
 msgid "Tips not available, sorry!"
 msgstr "Perdoneu, el suggeriment no està disponible, "
 
-#: ../src/wxMaximaFrame.cpp:1495
+#: ../src/wxMaximaFrame.cpp:1514
 msgid "Title"
 msgstr "Títol"
 
@@ -4214,19 +4217,19 @@ msgstr ""
 "contigu a la cel·la. Si al mateix temps polsau 'Majúscules', tots els sub-"
 "nivells es plegaran/des-plegaran."
 
-#: ../src/wxMaximaFrame.cpp:938
+#: ../src/wxMaximaFrame.cpp:937
 msgid "To &Bigfloat"
 msgstr "A real gran (&bigfloat)"
 
-#: ../src/wxMaximaFrame.cpp:935
+#: ../src/wxMaximaFrame.cpp:934
 msgid "To &Float"
 msgstr "A &real"
 
-#: ../src/MathCtrl.cpp:990
+#: ../src/MathCtrl.cpp:1032
 msgid "To Float"
 msgstr "A real"
 
-#: ../src/wxMaximaFrame.cpp:941
+#: ../src/wxMaximaFrame.cpp:940
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr "A Numèri&c\tCtrl+Shift+N"
 
@@ -4268,51 +4271,51 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:41 ../src/Plot2dWiz.cpp:40 ../src/Plot2dWiz.cpp:50
 #: ../src/Plot2dWiz.cpp:539 ../src/Plot3dWiz.cpp:39 ../src/Plot3dWiz.cpp:48
-#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4241
+#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4253
 msgid "To:"
 msgstr "Fins a:"
 
-#: ../src/wxMaximaFrame.cpp:912
+#: ../src/wxMaximaFrame.cpp:911
 msgid "Toggle &Algebraic Flag"
 msgstr "Activa l'opció &algebraica"
 
-#: ../src/wxMaximaFrame.cpp:933
+#: ../src/wxMaximaFrame.cpp:932
 msgid "Toggle &Numeric Output"
 msgstr "Activa sortida &numèrica"
 
-#: ../src/wxMaximaFrame.cpp:673
+#: ../src/wxMaximaFrame.cpp:672
 msgid "Toggle &Time Display"
 msgstr "Activa la pantalla de &temps"
 
-#: ../src/wxMaximaFrame.cpp:913
+#: ../src/wxMaximaFrame.cpp:912
 msgid "Toggle algebraic flag"
 msgstr "Activa l'opció algebraica"
 
-#: ../src/wxMaximaFrame.cpp:577
+#: ../src/wxMaximaFrame.cpp:576
 msgid "Toggle full screen editing"
 msgstr "Activa l'edició de pantalla completa"
 
-#: ../src/wxMaximaFrame.cpp:934
+#: ../src/wxMaximaFrame.cpp:933
 msgid "Toggle numeric output"
 msgstr "Activa sortida numèrica"
 
-#: ../src/wxMaxima.cpp:4464
+#: ../src/wxMaxima.cpp:4476
 msgid "Toolbar icons"
 msgstr "Icones de la barra d'eines"
 
-#: ../src/wxMaxima.cpp:4465
+#: ../src/wxMaxima.cpp:4477
 msgid "Translated by"
 msgstr "Traduït per"
 
-#: ../src/wxMaximaFrame.cpp:763
+#: ../src/wxMaximaFrame.cpp:762
 msgid "Transpose a matrix"
 msgstr "Matriu transposta"
 
-#: ../src/MathCtrl.cpp:5834
+#: ../src/MathCtrl.cpp:5886
 msgid "Trying to undo an action without starting cell."
 msgstr "Intentant desfer una acció sense cel·la inicial."
 
-#: ../src/MathCtrl.cpp:5901
+#: ../src/MathCtrl.cpp:5953
 msgid "Trying to undo something but the undo action is empty."
 msgstr "Intentant desfer alguna acció sense que hi hagi accions per desfer."
 
@@ -4320,11 +4323,11 @@ msgstr "Intentant desfer alguna acció sense que hi hagi accions per desfer."
 msgid "Turkish"
 msgstr "Turc"
 
-#: ../src/wxMaximaFrame.cpp:970
+#: ../src/wxMaximaFrame.cpp:969
 msgid "Tutorials"
 msgstr "&Tutorials"
 
-#: ../src/wxMaxima.cpp:4778
+#: ../src/wxMaxima.cpp:4790
 msgid "Two sample t-test"
 msgstr "Test t amb dues mostres"
 
@@ -4336,16 +4339,16 @@ msgstr "Tipus:"
 msgid "Ukrainian"
 msgstr "Ucraïnés"
 
-#: ../src/wxMaxima.cpp:5356
+#: ../src/wxMaxima.cpp:5372
 msgid "Un-closed parenthesis"
 msgstr "Parèntesi sense tancar"
 
-#: ../src/wxMaxima.cpp:5323
+#: ../src/wxMaxima.cpp:5335
 #, fuzzy
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr "Parèntesi sense tancar"
 
-#: ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5889
 msgid ""
 "Unable to interpret the version info I got from http://andrejv.github.io//"
 "wxmaxima/version.txt: "
@@ -4359,11 +4362,11 @@ msgstr "Subrallat"
 msgid "Underscore converts to subscripts:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:492
+#: ../src/wxMaximaFrame.cpp:491
 msgid "Undo\tCtrl-Z"
 msgstr "D&esfer\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:493
+#: ../src/wxMaximaFrame.cpp:492
 msgid "Undo last change"
 msgstr "Desfer el darrer canvi"
 
@@ -4372,23 +4375,23 @@ msgstr "Desfer el darrer canvi"
 msgid "Undo limit (0 for none):"
 msgstr "Límit per desfer accions (0 per sense límit)"
 
-#: ../src/wxMaximaFrame.cpp:625
+#: ../src/wxMaximaFrame.cpp:624
 msgid "Unfold All\tCtrl-Alt-]"
 msgstr "Desplegar tot\tCtrl-Alt-]"
 
-#: ../src/wxMaximaFrame.cpp:626
+#: ../src/wxMaximaFrame.cpp:625
 msgid "Unfold all folded sections"
 msgstr "Desplegar totes les seccions plegades"
 
-#: ../src/wxMaxima.cpp:4458
+#: ../src/wxMaxima.cpp:4470
 msgid "Unicode Support"
 msgstr "Suport Unicode"
 
-#: ../src/wxMaxima.cpp:5335
+#: ../src/wxMaxima.cpp:5347
 msgid "Unterminated comment."
 msgstr "Comentari sense acabar."
 
-#: ../src/wxMaxima.cpp:5309
+#: ../src/wxMaxima.cpp:5321
 msgid "Unterminated string."
 msgstr "Cadena sense final."
 
@@ -4396,15 +4399,15 @@ msgstr "Cadena sense final."
 msgid "Up"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5859 ../src/wxMaxima.cpp:5866 ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5874 ../src/wxMaxima.cpp:5881 ../src/wxMaxima.cpp:5889
 msgid "Upgrade"
 msgstr "Actualitza"
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Upper bound:"
 msgstr "Cota superior:"
 
-#: ../src/wxMaximaFrame.cpp:1383
+#: ../src/wxMaximaFrame.cpp:1382
 #, fuzzy
 msgid "Upsilon"
 msgstr "Epsilon:"
@@ -4449,22 +4452,22 @@ msgstr ""
 msgid "User-defined labels"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3525
-#: ../src/wxMaxima.cpp:3541 ../src/wxMaxima.cpp:3649
+#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3537
+#: ../src/wxMaxima.cpp:3553 ../src/wxMaxima.cpp:3661
 msgid "Value:"
 msgstr "Valor:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:5019 ../src/wxMaxima.cpp:5064
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:5031 ../src/wxMaxima.cpp:5076
 msgid "Variable(s):"
 msgstr "Variable(s):"
 
 #: ../src/IntegrateWiz.cpp:33 ../src/LimitWiz.cpp:30 ../src/Plot2dWiz.cpp:34
 #: ../src/Plot2dWiz.cpp:44 ../src/Plot2dWiz.cpp:533 ../src/Plot3dWiz.cpp:33
 #: ../src/Plot3dWiz.cpp:42 ../src/SeriesWiz.cpp:36 ../src/SumWiz.cpp:30
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3749
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3761
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5045
 msgid "Variable:"
 msgstr "Variable:"
 
@@ -4472,25 +4475,25 @@ msgstr "Variable:"
 msgid "Variables"
 msgstr "Variables"
 
-#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3571 ../src/wxMaxima.cpp:4206
-#: ../src/wxMaxima.cpp:4807
+#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3583 ../src/wxMaxima.cpp:4218
+#: ../src/wxMaxima.cpp:4819
 msgid "Variables:"
 msgstr "Variables:"
 
-#: ../src/wxMaximaFrame.cpp:1257
+#: ../src/wxMaximaFrame.cpp:1256
 msgid "Variance..."
 msgstr "Variància..."
 
-#: ../src/wxMaximaFrame.cpp:580
+#: ../src/wxMaximaFrame.cpp:579
 msgid "View"
 msgstr ""
 
-#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1674 ../src/wxMaxima.cpp:1769
-#: ../src/wxMaxima.cpp:1950
+#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1679 ../src/wxMaxima.cpp:1774
+#: ../src/wxMaxima.cpp:1955
 msgid "Warning"
 msgstr "Avís"
 
-#: ../src/wxMaximaFrame.cpp:109 ../src/wxMaximaFrame.cpp:295
+#: ../src/wxMaximaFrame.cpp:108 ../src/wxMaximaFrame.cpp:294
 msgid "Welcome to wxMaxima"
 msgstr "Bienvingut a wxMaxima"
 
@@ -4518,7 +4521,7 @@ msgstr ""
 "dividiran si estan dividides en el full de càlcul. Si l'opció no està "
 "seleccionada, es podran introduir salts de línia afegint una línia buida."
 
-#: ../src/wxMaxima.cpp:2567
+#: ../src/wxMaxima.cpp:2574
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) "
 "(*.wxm)|*.wxm"
@@ -4534,7 +4537,7 @@ msgid ""
 "as equation markers"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6798
+#: ../src/MathCtrl.cpp:6856
 msgid "Wrapped search"
 msgstr ""
 
@@ -4542,16 +4545,16 @@ msgstr ""
 msgid "Write matching parenthesis in text controls."
 msgstr "Escriure parèntesi coincidents en els controls de text."
 
-#: ../src/wxMaxima.cpp:4461
+#: ../src/wxMaxima.cpp:4473
 msgid "Written by"
 msgstr "Escrit per"
 
-#: ../src/wxMaximaFrame.cpp:557
+#: ../src/wxMaximaFrame.cpp:556
 #, fuzzy
 msgid "XML Inspector"
 msgstr "Inspector"
 
-#: ../src/wxMaximaFrame.cpp:1377
+#: ../src/wxMaximaFrame.cpp:1376
 msgid "Xi"
 msgstr ""
 
@@ -4624,7 +4627,7 @@ msgstr ""
 "operar sobre la selecció. Això serà d'utilitat en haver de suprimir o "
 "avaluar vàries cel·les simultàniament."
 
-#: ../src/wxMaxima.cpp:5856
+#: ../src/wxMaxima.cpp:5871
 #, c-format
 msgid ""
 "You have version %s. Current version is %s.\n"
@@ -4635,41 +4638,41 @@ msgstr ""
 "\n"
 "Seleccionau d'Acord per visitar la web de wxMaxima."
 
-#: ../src/wxMaxima.cpp:5921
+#: ../src/wxMaxima.cpp:5936
 msgid "Your changes will be lost if you don't save them."
 msgstr "Els vostres canvis es perdran si no els desau."
 
-#: ../src/wxMaxima.cpp:5866
+#: ../src/wxMaxima.cpp:5881
 msgid "Your version of wxMaxima is up to date."
 msgstr "La vostra versió de wxMaxima està actualitzada."
 
-#: ../src/wxMaximaFrame.cpp:1369
+#: ../src/wxMaximaFrame.cpp:1368
 msgid "Zeta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:562
+#: ../src/wxMaximaFrame.cpp:561
 #, fuzzy
 msgid "Zoom &In\tCtrl-+"
 msgstr "Ampl&ia\tAlt-I"
 
-#: ../src/wxMaximaFrame.cpp:564
+#: ../src/wxMaximaFrame.cpp:563
 #, fuzzy
 msgid "Zoom Ou&t\tCtrl--"
 msgstr "&Redueix\tAlt-O"
 
-#: ../src/wxMaximaFrame.cpp:563
+#: ../src/wxMaximaFrame.cpp:562
 msgid "Zoom in 10%"
 msgstr "Redueix 10%"
 
-#: ../src/wxMaximaFrame.cpp:565
+#: ../src/wxMaximaFrame.cpp:564
 msgid "Zoom out 10%"
 msgstr "Amplia 10%"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaximaFrame.cpp:287
 msgid "[ unsaved ]"
 msgstr "[sense desar]"
 
-#: ../src/wxMaxima.cpp:5700
+#: ../src/wxMaxima.cpp:5715
 msgid "[ unsaved* ]"
 msgstr "[sense desar*]"
 
@@ -4678,17 +4681,17 @@ msgstr "[sense desar*]"
 msgid "[%i digits]"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4392
+#: ../src/MathCtrl.cpp:4447
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" style=\"max-width:90%%;\" >\n"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4517
+#: ../src/MathCtrl.cpp:4572
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" >"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1333
+#: ../src/wxMaximaFrame.cpp:1332
 msgid "alpha"
 msgstr ""
 
@@ -4701,7 +4704,7 @@ msgstr "tan"
 msgid "antisymmetric"
 msgstr "anti-simètrica"
 
-#: ../src/wxMaximaFrame.cpp:1334
+#: ../src/wxMaximaFrame.cpp:1333
 msgid "beta"
 msgstr ""
 
@@ -4745,7 +4748,7 @@ msgstr ""
 msgid "bug:Invalid sup tag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1354
+#: ../src/wxMaximaFrame.cpp:1353
 #, fuzzy
 msgid "chi"
 msgstr "orquídea"
@@ -4759,7 +4762,7 @@ msgstr ""
 msgid "default"
 msgstr "pre-determinat"
 
-#: ../src/wxMaximaFrame.cpp:1336
+#: ../src/wxMaximaFrame.cpp:1335
 msgid "delta"
 msgstr ""
 
@@ -4771,7 +4774,7 @@ msgstr "diagonal"
 msgid "empty"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1337
+#: ../src/wxMaximaFrame.cpp:1336
 #, fuzzy
 msgid "epsilon"
 msgstr "Epsilon:"
@@ -4780,7 +4783,7 @@ msgstr "Epsilon:"
 msgid "equivalent"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1339
+#: ../src/wxMaximaFrame.cpp:1338
 msgid "eta"
 msgstr ""
 
@@ -4796,7 +4799,7 @@ msgid ""
 "all=_ marks subscripts."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1335
+#: ../src/wxMaximaFrame.cpp:1334
 msgid "gamma"
 msgstr ""
 
@@ -4825,15 +4828,15 @@ msgstr "en línia"
 msgid "intersection"
 msgstr "Direcció:"
 
-#: ../src/wxMaximaFrame.cpp:1341
+#: ../src/wxMaximaFrame.cpp:1340
 msgid "iota"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1342
+#: ../src/wxMaximaFrame.cpp:1341
 msgid "kappa"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1343
+#: ../src/wxMaximaFrame.cpp:1342
 msgid "lambda"
 msgstr ""
 
@@ -4850,7 +4853,7 @@ msgstr "Cel·la de sub-secció"
 msgid "logscale"
 msgstr "escala logarítmica"
 
-#: ../src/wxMaxima.cpp:3783
+#: ../src/wxMaxima.cpp:3795
 msgid "matrix[i,j]:"
 msgstr "matriu[i,j]:"
 
@@ -4858,7 +4861,7 @@ msgstr "matriu[i,j]:"
 msgid "maxima's pwd is path to document"
 msgstr "El «pwd» de Maxima és la ruta al document"
 
-#: ../src/wxMaximaFrame.cpp:1344
+#: ../src/wxMaximaFrame.cpp:1343
 msgid "mu"
 msgstr ""
 
@@ -4875,7 +4878,7 @@ msgstr ""
 msgid "nand"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4524
+#: ../src/wxMaxima.cpp:4536
 msgid "no"
 msgstr "no"
 
@@ -4901,15 +4904,15 @@ msgstr ""
 msgid "not subset or equal"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1345
+#: ../src/wxMaximaFrame.cpp:1344
 msgid "nu"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1356
+#: ../src/wxMaximaFrame.cpp:1355
 msgid "omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1347
+#: ../src/wxMaximaFrame.cpp:1346
 msgid "omicron"
 msgstr ""
 
@@ -4922,11 +4925,11 @@ msgstr ""
 msgid "partial sign"
 msgstr "Fraccions simples"
 
-#: ../src/wxMaximaFrame.cpp:1353
+#: ../src/wxMaximaFrame.cpp:1352
 msgid "phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1348
+#: ../src/wxMaximaFrame.cpp:1347
 #, fuzzy
 msgid "pi"
 msgstr "rosa"
@@ -4939,11 +4942,11 @@ msgstr ""
 msgid "proportional to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1355
+#: ../src/wxMaximaFrame.cpp:1354
 msgid "psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1349
+#: ../src/wxMaximaFrame.cpp:1348
 msgid "rho"
 msgstr ""
 
@@ -4951,7 +4954,7 @@ msgstr ""
 msgid "right"
 msgstr "dreta"
 
-#: ../src/wxMaximaFrame.cpp:1350
+#: ../src/wxMaximaFrame.cpp:1349
 msgid "sigma"
 msgstr ""
 
@@ -4973,7 +4976,7 @@ msgstr "Cel·la de sub-secció"
 msgid "symmetric"
 msgstr "simètrica"
 
-#: ../src/wxMaximaFrame.cpp:1351
+#: ../src/wxMaximaFrame.cpp:1350
 msgid "tau"
 msgstr ""
 
@@ -4985,7 +4988,7 @@ msgstr ""
 msgid "there is no"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1340
+#: ../src/wxMaximaFrame.cpp:1339
 msgid "theta"
 msgstr ""
 
@@ -5001,12 +5004,12 @@ msgstr ""
 msgid "union"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5903
+#: ../src/wxMaxima.cpp:5918
 msgid "unsaved"
 msgstr "sense desar"
 
-#: ../src/wxMaximaFrame.cpp:290 ../src/wxMaxima.cpp:2559
-#: ../src/wxMaxima.cpp:2826
+#: ../src/wxMaxima.cpp:2566 ../src/wxMaxima.cpp:2834
+#: ../src/wxMaximaFrame.cpp:289
 msgid "untitled"
 msgstr "sense nom"
 
@@ -5015,26 +5018,26 @@ msgstr "sense nom"
 msgid "untitled %d"
 msgstr "sense nom %d"
 
-#: ../src/wxMaximaFrame.cpp:1352
+#: ../src/wxMaximaFrame.cpp:1351
 #, fuzzy
 msgid "upsilon"
 msgstr "Epsilon:"
 
-#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4538
+#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4550
 msgid "wxMaxima"
 msgstr "wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
-#: ../src/wxMaxima.cpp:5700 ../src/wxMaxima.cpp:5709 ../src/wxMaxima.cpp:5712
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaxima.cpp:5715 ../src/wxMaxima.cpp:5724
+#: ../src/wxMaxima.cpp:5727 ../src/wxMaximaFrame.cpp:287
 #, c-format
 msgid "wxMaxima %s "
 msgstr "wxMaxima %s "
 
-#: ../src/wxMaximaFrame.cpp:952
+#: ../src/wxMaximaFrame.cpp:951
 msgid "wxMaxima &Help\tCtrl+?"
 msgstr "A&juda de wxMaxima\tCtrl+?"
 
-#: ../src/wxMaximaFrame.cpp:955
+#: ../src/wxMaximaFrame.cpp:954
 msgid "wxMaxima &Help\tF1"
 msgstr "A&juda de wxMaxima\tF1"
 
@@ -5045,11 +5048,11 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1619
+#: ../src/wxMaxima.cpp:1624
 msgid "wxMaxima cannot open content.xml in the .wxmx zip archive "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1633
+#: ../src/wxMaxima.cpp:1638
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
@@ -5057,7 +5060,7 @@ msgstr ""
 msgid "wxMaxima configuration"
 msgstr "Configuració de wxMaxima"
 
-#: ../src/wxMaxima.cpp:1947
+#: ../src/wxMaxima.cpp:1952
 msgid ""
 "wxMaxima could not find Maxima!\n"
 "\n"
@@ -5069,7 +5072,7 @@ msgstr ""
 "Configureu wxMaxima amb 'Edita->Configura.\n"
 "A continuació engegueu Maxima amb 'Maxima->Re-engega maxima'."
 
-#: ../src/wxMaxima.cpp:2204
+#: ../src/wxMaxima.cpp:2209
 msgid ""
 "wxMaxima could not find help files.\n"
 "\n"
@@ -5078,7 +5081,7 @@ msgstr ""
 "wxMaxima no troba els arxius d'ajuda.\n"
 "Comproveu la instal·lació."
 
-#: ../src/wxMaxima.cpp:2032
+#: ../src/wxMaxima.cpp:2037
 msgid ""
 "wxMaxima could not find tip files.\n"
 "\n"
@@ -5088,7 +5091,7 @@ msgstr ""
 "\n"
 "Comproveu la instal·lació."
 
-#: ../src/wxMaxima.cpp:282
+#: ../src/wxMaxima.cpp:283
 msgid ""
 "wxMaxima could not start the server.\n"
 "\n"
@@ -5110,23 +5113,23 @@ msgstr ""
 "una de las quals és '%'. Si heu fet una selecció en el document, es farà "
 "servir enlloc de '%'."
 
-#: ../src/wxMaxima.cpp:2330
+#: ../src/wxMaxima.cpp:2336
 msgid "wxMaxima document"
 msgstr "Document wxMaxima"
 
-#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2799
+#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2807
 msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 msgstr "Document wxMaxima (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 
-#: ../src/wxMaxima.cpp:1455 ../src/wxMaxima.cpp:1469
+#: ../src/wxMaxima.cpp:1460 ../src/wxMaxima.cpp:1474
 msgid "wxMaxima encountered an error loading "
 msgstr "wxMaxima ha detectat un error en carregar "
 
-#: ../src/wxMaxima.cpp:4463
+#: ../src/wxMaxima.cpp:4475
 msgid "wxMaxima icon"
 msgstr "Icone de wxMaxima"
 
-#: ../src/wxMaxima.cpp:4455
+#: ../src/wxMaxima.cpp:4467
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "MAXIMA based on wxWidgets."
@@ -5134,7 +5137,7 @@ msgstr ""
 "wxMaxima es una interfície gràfica d'usuari per al Sistema d'Àlgebra "
 "Simbòlica (CAS) MAXIMA, basat en wxWidgets."
 
-#: ../src/wxMaxima.cpp:4516
+#: ../src/wxMaxima.cpp:4528
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "Maxima based on wxWidgets."
@@ -5154,12 +5157,12 @@ msgstr ""
 msgid "x"
 msgstr "x"
 
-#: ../src/wxMaximaFrame.cpp:1346
+#: ../src/wxMaximaFrame.cpp:1345
 #, fuzzy
 msgid "xi"
 msgstr "x"
 
-#: ../src/wxMaxima.cpp:1643
+#: ../src/wxMaxima.cpp:1648
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
@@ -5168,11 +5171,11 @@ msgstr ""
 msgid "xor"
 msgstr "&Exporta"
 
-#: ../src/wxMaxima.cpp:4522
+#: ../src/wxMaxima.cpp:4534
 msgid "yes"
 msgstr "sí"
 
-#: ../src/wxMaximaFrame.cpp:1338
+#: ../src/wxMaximaFrame.cpp:1337
 msgid "zeta"
 msgstr ""
 

--- a/locales/cs.po
+++ b/locales/cs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cs\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-07 21:42+0200\n"
+"POT-Creation-Date: 2016-10-16 17:47+0900\n"
 "PO-Revision-Date: 2010-03-10 14:21+0100\n"
 "Last-Translator: Robert Marik <maarik@mendelu.cz>\n"
 "Language-Team:  <cs@li.org>\n"
@@ -22,7 +22,7 @@ msgstr ""
 "X-Poedit-Country: CZECH REPUBLIC\n"
 "X-Generator: KBabel 1.11.4\n"
 
-#: ../src/wxMaxima.cpp:4519
+#: ../src/wxMaxima.cpp:4531
 #, c-format
 msgid ""
 "\n"
@@ -35,7 +35,7 @@ msgstr ""
 "wxWidgets: %d.%d.%d\n"
 "podpora Unicode: %s"
 
-#: ../src/wxMaxima.cpp:4532
+#: ../src/wxMaxima.cpp:4544
 msgid ""
 "\n"
 "Lisp: "
@@ -43,7 +43,7 @@ msgstr ""
 "\n"
 "Lisp: "
 
-#: ../src/wxMaxima.cpp:4528
+#: ../src/wxMaxima.cpp:4540
 msgid ""
 "\n"
 "Maxima version: "
@@ -51,7 +51,7 @@ msgstr ""
 "\n"
 "Verze programu Maxima: "
 
-#: ../src/wxMaxima.cpp:5381
+#: ../src/wxMaxima.cpp:5397
 msgid ""
 "\n"
 "Not connected to Maxima!\n"
@@ -59,7 +59,7 @@ msgstr ""
 "\n"
 "Není připojeno k programu Maxima!\n"
 
-#: ../src/wxMaxima.cpp:4530
+#: ../src/wxMaxima.cpp:4542
 msgid ""
 "\n"
 "Not connected."
@@ -79,7 +79,7 @@ msgstr ""
 msgid " (Graphics) "
 msgstr ""
 
-#: ../src/EditorCell.cpp:3045 ../src/EditorCell.cpp:3227
+#: ../src/EditorCell.cpp:3088 ../src/EditorCell.cpp:3270
 #, c-format
 msgid " ... + %i hidden lines"
 msgstr ""
@@ -88,7 +88,7 @@ msgstr ""
 msgid " << Expression longer than allowed by the configuration setting! >>"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1673
+#: ../src/wxMaxima.cpp:1678
 msgid ""
 " was saved using a newer version of wxMaxima so it may not load correctly. "
 "Please update your wxMaxima."
@@ -96,7 +96,7 @@ msgstr ""
 "bylo uloženo v novější verzi programu wxMaxima, takže nemůže být korektně "
 "načteno. Prosím proveďte update programu."
 
-#: ../src/wxMaxima.cpp:1665
+#: ../src/wxMaxima.cpp:1670
 msgid ""
 " was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr ""
@@ -111,64 +111,64 @@ msgstr ""
 msgid "\"implies\" symbol"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:101
+#: ../src/wxMaximaFrame.cpp:100
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:773
+#: ../src/wxMaximaFrame.cpp:772
 msgid "&Algebra"
 msgstr "&Algebra"
 
-#: ../src/wxMaximaFrame.cpp:767
+#: ../src/wxMaximaFrame.cpp:766
 msgid "&Apply to List..."
 msgstr "Přid&at do seznamu..."
 
-#: ../src/wxMaximaFrame.cpp:964
+#: ../src/wxMaximaFrame.cpp:963
 msgid "&Apropos..."
 msgstr "&Apropos..."
 
-#: ../src/wxMaximaFrame.cpp:478
+#: ../src/wxMaximaFrame.cpp:477
 msgid "&Batch File...\tCtrl-B"
 msgstr "Dávkový sou&bor...\tCtrl-B"
 
-#: ../src/wxMaximaFrame.cpp:724
+#: ../src/wxMaximaFrame.cpp:723
 msgid "&Boundary Value Problem..."
 msgstr "Okrajová &úloha..."
 
-#: ../src/wxMaximaFrame.cpp:975
+#: ../src/wxMaximaFrame.cpp:974
 msgid "&Bug Report"
 msgstr "Hlášení o chy&bě"
 
-#: ../src/wxMaximaFrame.cpp:825
+#: ../src/wxMaximaFrame.cpp:824
 msgid "&Calculus"
 msgstr "&Analýza"
 
-#: ../src/wxMaximaFrame.cpp:876
+#: ../src/wxMaximaFrame.cpp:875
 msgid "&Canonical Form"
 msgstr "&Kanonická forma"
 
-#: ../src/wxMaximaFrame.cpp:749
+#: ../src/wxMaximaFrame.cpp:748
 msgid "&Characteristic Polynomial..."
 msgstr "&Charakteristický polynom..."
 
-#: ../src/wxMaximaFrame.cpp:654
+#: ../src/wxMaximaFrame.cpp:653
 msgid "&Clear Memory"
 msgstr "&Vyčistit paměť"
 
-#: ../src/wxMaximaFrame.cpp:859
+#: ../src/wxMaximaFrame.cpp:858
 msgid "&Combine Factorials"
 msgstr "&Sloučit faktoriály"
 
-#: ../src/wxMaximaFrame.cpp:902
+#: ../src/wxMaximaFrame.cpp:901
 msgid "&Complex Simplification"
 msgstr "&Komplexní zjednodušení"
 
-#: ../src/wxMaximaFrame.cpp:822
+#: ../src/wxMaximaFrame.cpp:821
 msgid "&Continued Fraction"
 msgstr "&Celá část"
 
-#: ../src/wxMaximaFrame.cpp:502
+#: ../src/wxMaximaFrame.cpp:501
 msgid "&Copy\tCtrl-C"
 msgstr "&Kopírovat\tCtrl-C"
 
@@ -176,109 +176,109 @@ msgstr "&Kopírovat\tCtrl-C"
 msgid "&Definite integration"
 msgstr "&Určitý integrál"
 
-#: ../src/wxMaximaFrame.cpp:896
+#: ../src/wxMaximaFrame.cpp:895
 msgid "&Demoivre"
 msgstr "&Trigonometrický tvar"
 
-#: ../src/wxMaximaFrame.cpp:752
+#: ../src/wxMaximaFrame.cpp:751
 msgid "&Determinant"
 msgstr "&Determinant"
 
-#: ../src/wxMaximaFrame.cpp:785
+#: ../src/wxMaximaFrame.cpp:784
 msgid "&Differentiate..."
 msgstr "&Derivovat..."
 
-#: ../src/wxMaximaFrame.cpp:543
+#: ../src/wxMaximaFrame.cpp:542
 msgid "&Edit"
 msgstr "&Editovat"
 
-#: ../src/wxMaximaFrame.cpp:709
+#: ../src/wxMaximaFrame.cpp:708
 msgid "&Eliminate Variable..."
 msgstr "&Eliminovat proměnnou..."
 
-#: ../src/wxMaximaFrame.cpp:744
+#: ../src/wxMaximaFrame.cpp:743
 msgid "&Enter Matrix..."
 msgstr "Zadání matic&e..."
 
-#: ../src/wxMaximaFrame.cpp:961
+#: ../src/wxMaximaFrame.cpp:960
 msgid "&Example..."
 msgstr "&Příklad..."
 
-#: ../src/wxMaximaFrame.cpp:839
+#: ../src/wxMaximaFrame.cpp:838
 msgid "&Expand Expression"
 msgstr "&Rozložit výraz"
 
-#: ../src/wxMaximaFrame.cpp:873
+#: ../src/wxMaximaFrame.cpp:872
 msgid "&Expand Trigonometric"
 msgstr "Rozložit trigonom&etrický výraz"
 
-#: ../src/wxMaximaFrame.cpp:899
+#: ../src/wxMaximaFrame.cpp:898
 msgid "&Exponentialize"
 msgstr "Do &exponenciálního tvaru"
 
-#: ../src/wxMaximaFrame.cpp:480
+#: ../src/wxMaximaFrame.cpp:479
 msgid "&Export..."
 msgstr "&Export..."
 
-#: ../src/wxMaximaFrame.cpp:834
+#: ../src/wxMaximaFrame.cpp:833
 msgid "&Factor Expression"
 msgstr "Na součin"
 
-#: ../src/wxMaximaFrame.cpp:489
+#: ../src/wxMaximaFrame.cpp:488
 msgid "&File"
 msgstr "&Soubor"
 
-#: ../src/wxMaximaFrame.cpp:692
+#: ../src/wxMaximaFrame.cpp:691
 msgid "&Find Root..."
 msgstr "Najít &kořen..."
 
-#: ../src/wxMaximaFrame.cpp:738
+#: ../src/wxMaximaFrame.cpp:737
 msgid "&Generate Matrix..."
 msgstr "&Generovat matici..."
 
-#: ../src/wxMaximaFrame.cpp:809
+#: ../src/wxMaximaFrame.cpp:808
 msgid "&Greatest Common Divisor..."
 msgstr "&Největší společný dělitel..."
 
-#: ../src/wxMaximaFrame.cpp:994
+#: ../src/wxMaximaFrame.cpp:993
 msgid "&Help"
 msgstr "&Nápověda"
 
-#: ../src/wxMaximaFrame.cpp:777
+#: ../src/wxMaximaFrame.cpp:776
 msgid "&Integrate..."
 msgstr "&Integrovat..."
 
-#: ../src/wxMaximaFrame.cpp:645
+#: ../src/wxMaximaFrame.cpp:644
 msgid "&Interrupt\tCtrl-."
 msgstr "Přeruš&it\tCtrl-"
 
-#: ../src/wxMaximaFrame.cpp:649
+#: ../src/wxMaximaFrame.cpp:648
 msgid "&Interrupt\tCtrl-G"
 msgstr "Přeruš&it\tCtrl-G"
 
-#: ../src/wxMaximaFrame.cpp:746
+#: ../src/wxMaximaFrame.cpp:745
 msgid "&Invert Matrix"
 msgstr "&Inverzní matice"
 
-#: ../src/wxMaximaFrame.cpp:476
+#: ../src/wxMaximaFrame.cpp:475
 msgid "&Load Package...\tCtrl-L"
 msgstr "&Load Package\tCtrl-L"
 
-#: ../src/wxMaximaFrame.cpp:769
+#: ../src/wxMaximaFrame.cpp:768
 #, fuzzy
 msgid "&Map to List(s)..."
 msgstr "Použít funkci na prvky sezna&mu..."
 
-#: ../src/wxMaximaFrame.cpp:684
+#: ../src/wxMaximaFrame.cpp:683
 msgid "&Maxima"
 msgstr "&Maxima"
 
-#: ../src/wxMaximaFrame.cpp:958
+#: ../src/wxMaximaFrame.cpp:957
 #, fuzzy
 msgid "&Maxima help"
 msgstr "Zobrazit nápovědu programu Maxima"
 
-#: ../src/wxMaximaFrame.cpp:917
+#: ../src/wxMaximaFrame.cpp:916
 msgid "&Modulus Computation..."
 msgstr "Výpočet &modulo..."
 
@@ -286,7 +286,7 @@ msgstr "Výpočet &modulo..."
 msgid "&New\tCtrl-N"
 msgstr "&Nový\tCtrl-N"
 
-#: ../src/wxMaximaFrame.cpp:947
+#: ../src/wxMaximaFrame.cpp:946
 msgid "&Numeric"
 msgstr "N&umerické výpočty"
 
@@ -302,11 +302,11 @@ msgstr "&Numerické sčítání (nusum)"
 msgid "&Open\tCtrl-O"
 msgstr "&Otevřít\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:463
+#: ../src/wxMaximaFrame.cpp:462
 msgid "&Open...\tCtrl-O"
 msgstr "&Otevřít\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:929
+#: ../src/wxMaximaFrame.cpp:928
 msgid "&Plot"
 msgstr "&Grafy"
 
@@ -314,7 +314,7 @@ msgstr "&Grafy"
 msgid "&Power series"
 msgstr "&Mocninná řada"
 
-#: ../src/wxMaximaFrame.cpp:483
+#: ../src/wxMaximaFrame.cpp:482
 msgid "&Print...\tCtrl-P"
 msgstr "&Tisk...\tCtrl-P"
 
@@ -322,39 +322,39 @@ msgstr "&Tisk...\tCtrl-P"
 msgid "&Rational"
 msgstr "&Racionální výraz"
 
-#: ../src/wxMaximaFrame.cpp:870
+#: ../src/wxMaximaFrame.cpp:869
 msgid "&Reduce Trigonometric"
 msgstr "Zjednodušit t&rigonometrický výraz"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "&Restart Maxima"
 msgstr "&Restart programu Maxima"
 
-#: ../src/wxMaximaFrame.cpp:700
+#: ../src/wxMaximaFrame.cpp:699
 msgid "&Roots of Polynomial (Real)"
 msgstr "Kořeny polynomu (&reálné)"
 
-#: ../src/wxMaximaFrame.cpp:472
+#: ../src/wxMaximaFrame.cpp:471
 msgid "&Save\tCtrl-S"
 msgstr "&Uložit\tCtrl-S"
 
-#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:919
+#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:918
 msgid "&Simplify"
 msgstr "&Zjednodušit"
 
-#: ../src/wxMaximaFrame.cpp:829
+#: ../src/wxMaximaFrame.cpp:828
 msgid "&Simplify Expression"
 msgstr "Zjednodušit výraz"
 
-#: ../src/wxMaximaFrame.cpp:856
+#: ../src/wxMaximaFrame.cpp:855
 msgid "&Simplify Factorials"
 msgstr "Zjednodušit faktoriály"
 
-#: ../src/wxMaximaFrame.cpp:867
+#: ../src/wxMaximaFrame.cpp:866
 msgid "&Simplify Trigonometric"
 msgstr "Trigonometrické zjednodušení"
 
-#: ../src/wxMaximaFrame.cpp:688
+#: ../src/wxMaximaFrame.cpp:687
 msgid "&Solve..."
 msgstr "&Řešit..."
 
@@ -366,11 +366,11 @@ msgstr "&Special"
 msgid "&Taylor series"
 msgstr "&Taylorova řada"
 
-#: ../src/wxMaximaFrame.cpp:762
+#: ../src/wxMaximaFrame.cpp:761
 msgid "&Transpose Matrix"
 msgstr "&Transponovat matici"
 
-#: ../src/wxMaximaFrame.cpp:879
+#: ../src/wxMaximaFrame.cpp:878
 msgid "&Trigonometric Simplification"
 msgstr "&Trigonometrické zjednodušení"
 
@@ -388,7 +388,7 @@ msgstr "(Původní jazykové nastavení)"
 msgid "- Infinity"
 msgstr "- Nekonečno"
 
-#: ../src/wxMaxima.cpp:351
+#: ../src/wxMaxima.cpp:356
 msgid ""
 "... [suppressed additional lines since the output is longer than allowed in "
 "the configuration] "
@@ -398,19 +398,19 @@ msgstr ""
 msgid "1/2"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:103
+#: ../src/wxMaximaFrame.cpp:102
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4601
+#: ../src/wxMaxima.cpp:4613
 #, fuzzy
 msgid "<br>Lisp: "
 msgstr ""
 "\n"
 "Lisp: "
 
-#: ../src/wxMaxima.cpp:5487
+#: ../src/wxMaxima.cpp:5503
 msgid ""
 "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
@@ -442,11 +442,11 @@ msgid ""
 "\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1472
+#: ../src/wxMaximaFrame.cpp:1495
 msgid "A symbol from the configuration dialogue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:731
+#: ../src/wxMaximaFrame.cpp:730
 msgid "A&t Value..."
 msgstr "Hodno&ta v bodě..."
 
@@ -454,12 +454,12 @@ msgstr "Hodno&ta v bodě..."
 msgid "Abort evaluation on error"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaxima.cpp:4603
+#: ../src/wxMaxima.cpp:4615 ../src/wxMaximaFrame.cpp:985
 msgid "About"
 msgstr "O programu"
 
-#: ../src/wxMaximaFrame.cpp:987 ../src/wxMaximaFrame.cpp:990
-#: ../src/wxMaximaFrame.cpp:991
+#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaximaFrame.cpp:989
+#: ../src/wxMaximaFrame.cpp:990
 msgid "About wxMaxima"
 msgstr "O programu wxMaxima"
 
@@ -467,23 +467,23 @@ msgstr "O programu wxMaxima"
 msgid "Active cell bracket"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:760
+#: ../src/wxMaximaFrame.cpp:759
 msgid "Ad&joint Matrix"
 msgstr "Ad&jungovaná matice"
 
-#: ../src/wxMaximaFrame.cpp:914
+#: ../src/wxMaximaFrame.cpp:913
 msgid "Add Algebraic E&quality..."
 msgstr "Přidat alg&ebraickou rovnost..."
 
-#: ../src/wxMaximaFrame.cpp:657
+#: ../src/wxMaximaFrame.cpp:656
 msgid "Add a directory to search path"
 msgstr "Přidat adresář k prohledávaným (path)"
 
-#: ../src/wxMaxima.cpp:3353
+#: ../src/wxMaxima.cpp:3365
 msgid "Add dir to path:"
 msgstr "Přidat adresář do path:"
 
-#: ../src/wxMaximaFrame.cpp:915
+#: ../src/wxMaximaFrame.cpp:914
 msgid "Add equality to the rational simplifier"
 msgstr "Přidat rovnost k zjednodušovateli racionálních výrazů"
 
@@ -491,7 +491,7 @@ msgstr "Přidat rovnost k zjednodušovateli racionálních výrazů"
 msgid "Add the .wxmx file to the HTML export"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:656
+#: ../src/wxMaximaFrame.cpp:655
 msgid "Add to &Path..."
 msgstr "Přidat do &path..."
 
@@ -532,27 +532,27 @@ msgstr "Původní proměnná:"
 msgid "All|*"
 msgstr "Vše|* "
 
-#: ../src/wxMaximaFrame.cpp:1364
+#: ../src/wxMaximaFrame.cpp:1363
 msgid "Alpha"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3838
+#: ../src/wxMaxima.cpp:3850
 msgid "Apply"
 msgstr "Použít"
 
-#: ../src/wxMaximaFrame.cpp:768
+#: ../src/wxMaximaFrame.cpp:767
 msgid "Apply function to a list"
 msgstr "Přidat funkci do seznamu"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Apropos"
 msgstr "Hledání výskytů řetězce"
 
-#: ../src/wxMaxima.cpp:3764
+#: ../src/wxMaxima.cpp:3776
 msgid "Array:"
 msgstr "Pole:"
 
-#: ../src/wxMaxima.cpp:4462
+#: ../src/wxMaxima.cpp:4474
 msgid "Artwork by"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr ""
 msgid "Ask to save untitled documents"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3650
+#: ../src/wxMaxima.cpp:3662
 msgid "At value"
 msgstr "Hodnota v bodě"
 
@@ -581,11 +581,11 @@ msgstr ""
 msgid "Autosave interval (minutes, 0 means: off):"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3557
+#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3569
 msgid "BC2"
 msgstr "BC2"
 
-#: ../src/wxMaximaFrame.cpp:1272
+#: ../src/wxMaximaFrame.cpp:1271
 msgid "Barsplot..."
 msgstr ""
 
@@ -593,7 +593,7 @@ msgstr ""
 msgid "Bat files (*.bat)|*.bat|All|*"
 msgstr "Dávkové soubory (*.bat)|*.bat|Vše|*"
 
-#: ../src/wxMaxima.cpp:2943
+#: ../src/wxMaxima.cpp:2951
 msgid "Batch File"
 msgstr "Dávkový soubor"
 
@@ -606,7 +606,7 @@ msgid ""
 "cells."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1365
+#: ../src/wxMaximaFrame.cpp:1364
 msgid "Beta"
 msgstr ""
 
@@ -618,11 +618,11 @@ msgstr ""
 msgid "Bold"
 msgstr "Tučný"
 
-#: ../src/wxMaxima.cpp:2359
+#: ../src/wxMaxima.cpp:2366
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1274
+#: ../src/wxMaximaFrame.cpp:1273
 #, fuzzy
 msgid "Boxplot..."
 msgstr "Export"
@@ -635,15 +635,15 @@ msgstr "Prohlížení"
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2080
+#: ../src/MathCtrl.cpp:2127
 msgid "Bug: Cell left but not entered."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1178
+#: ../src/wxMaxima.cpp:1183
 msgid "Bug: Found a math end marker without any start marker."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1222
+#: ../src/wxMaxima.cpp:1227
 msgid "Bug: Found the end of autocompletion symbols but no beginning"
 msgstr ""
 
@@ -655,22 +655,22 @@ msgstr ""
 msgid "Bug: Fraction without enumerator"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2312
+#: ../src/MathCtrl.cpp:2359
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5839
+#: ../src/MathCtrl.cpp:5891
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of "
 "the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5913
+#: ../src/MathCtrl.cpp:5965
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5882
+#: ../src/MathCtrl.cpp:5934
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
@@ -680,49 +680,49 @@ msgstr ""
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
 msgstr ""
 
-#: ../src/GroupCell.cpp:780 ../src/GroupCell.cpp:951
+#: ../src/GroupCell.cpp:781 ../src/GroupCell.cpp:952
 msgid "Bug: No image counter to write to!"
 msgstr ""
 
-#: ../src/AbsCell.cpp:193
+#: ../src/AbsCell.cpp:199
 msgid "Bug: No last cell in an absCell!"
 msgstr ""
 
-#: ../src/ConjugateCell.cpp:185
+#: ../src/ConjugateCell.cpp:194
 msgid "Bug: No last cell in an conjugateCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:471
+#: ../src/FracCell.cpp:472
 msgid "Bug: No last cell in an denominator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:267
+#: ../src/ExptCell.cpp:270
 msgid "Bug: No last cell in an exponent of an exptCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:459
+#: ../src/FracCell.cpp:460
 msgid "Bug: No last cell in an numerator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:257
+#: ../src/ExptCell.cpp:260
 msgid "Bug: No last cell in the base of an exptCell!"
 msgstr ""
 
-#: ../src/ParenCell.cpp:534
+#: ../src/ParenCell.cpp:535
 msgid "Bug: No last cell inside a parenthesis!"
 msgstr ""
 
-#: ../src/SqrtCell.cpp:312
+#: ../src/SqrtCell.cpp:317
 msgid "Bug: No last cell inside a square root!"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2123
+#: ../src/MathCtrl.cpp:2170
 msgid ""
 "Bug: Start or end of merging of subsequent editing actions was requested two "
 "times in a row."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2090
+#: ../src/MathCtrl.cpp:2137
 msgid "Bug: Text changed, but no active cell."
 msgstr ""
 
@@ -730,39 +730,39 @@ msgstr ""
 msgid "Bug: Trying to append NULL to a group cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:555
+#: ../src/MathCtrl.cpp:600
 msgid "Bug: Trying to append maxima's output to a cell outside the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2014
+#: ../src/MathCtrl.cpp:2061
 msgid ""
 "Bug: Trying to merge individual cell adds to a region in the undo buffer but "
 "there are other cells between them."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6522
+#: ../src/MathCtrl.cpp:6577
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2092
+#: ../src/MathCtrl.cpp:2139
 msgid "Bug: Trying to record a cell contents change without a cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1495
+#: ../src/MathCtrl.cpp:1540
 msgid "Bug: Trying to select inside a cell without having a current cell"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5883
+#: ../src/MathCtrl.cpp:5935
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5844 ../src/MathCtrl.cpp:5918 ../src/MathCtrl.cpp:5952
+#: ../src/MathCtrl.cpp:5896 ../src/MathCtrl.cpp:5970 ../src/MathCtrl.cpp:6004
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:973
+#: ../src/wxMaximaFrame.cpp:972
 msgid "Build &Info"
 msgstr "Build &Info"
 
@@ -779,52 +779,52 @@ msgstr ""
 "možno změnit v Editovat -> Nastavení zaškrtnutím volby 'Enter vyhodnocuje "
 "výraz'. Toto nastavení prohodí výše uvedené příkazy."
 
-#: ../src/wxMaximaFrame.cpp:782
+#: ../src/wxMaximaFrame.cpp:781
 msgid "C&hange Variable..."
 msgstr "Změnit proměnnou..."
 
-#: ../src/wxMaximaFrame.cpp:540
+#: ../src/wxMaximaFrame.cpp:539
 msgid "C&onfigure"
 msgstr "Nastavení"
 
-#: ../src/wxMaximaFrame.cpp:801
+#: ../src/wxMaximaFrame.cpp:800
 msgid "Calculate &Product..."
 msgstr "Vý&počet součinu..."
 
-#: ../src/wxMaximaFrame.cpp:799
+#: ../src/wxMaximaFrame.cpp:798
 msgid "Calculate Su&m..."
 msgstr "Výpočet su&my..."
 
-#: ../src/wxMaximaFrame.cpp:939
+#: ../src/wxMaximaFrame.cpp:938
 msgid "Calculate bigfloat value of the last result"
 msgstr "Poslední výsledek s přesností bigfloat"
 
-#: ../src/wxMaximaFrame.cpp:936
+#: ../src/wxMaximaFrame.cpp:935
 msgid "Calculate float value of the last result"
 msgstr "Poslední výsledek s přesností float"
 
-#: ../src/wxMaxima.cpp:3971
+#: ../src/wxMaxima.cpp:3983
 msgid "Calculate modulus:"
 msgstr "Výpočet modulo:"
 
-#: ../src/wxMaximaFrame.cpp:942
+#: ../src/wxMaximaFrame.cpp:941
 #, fuzzy
 msgid "Calculate numeric value of the last result"
 msgstr "Poslední výsledek s přesností float"
 
-#: ../src/wxMaximaFrame.cpp:802
+#: ../src/wxMaximaFrame.cpp:801
 msgid "Calculate products"
 msgstr "Výpočet součinu"
 
-#: ../src/wxMaximaFrame.cpp:800
+#: ../src/wxMaximaFrame.cpp:799
 msgid "Calculate sums"
 msgstr "Výpočet sumy"
 
-#: ../src/wxMaxima.cpp:5830
+#: ../src/wxMaxima.cpp:5845
 msgid "Can not connect to the web server."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5881
+#: ../src/wxMaxima.cpp:5896
 msgid "Can not download version info."
 msgstr ""
 
@@ -840,15 +840,15 @@ msgstr ""
 #: ../src/PlotFormatWiz.cpp:48 ../src/SeriesWiz.cpp:49 ../src/SeriesWiz.cpp:51
 #: ../src/SubstituteWiz.cpp:41 ../src/SubstituteWiz.cpp:43 ../src/SumWiz.cpp:44
 #: ../src/SumWiz.cpp:46 ../src/SystemWiz.cpp:38 ../src/SystemWiz.cpp:40
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: ../src/wxMaximaFrame.cpp:126 ../src/wxMaxima.cpp:932
+#: ../src/wxMaxima.cpp:937 ../src/wxMaximaFrame.cpp:125
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1217
+#: ../src/wxMaximaFrame.cpp:1216
 #, fuzzy
 msgid "Canonical (tr)"
 msgstr "&Kanonická forma"
@@ -858,7 +858,7 @@ msgstr "&Kanonická forma"
 msgid "Catalan"
 msgstr "Italský"
 
-#: ../src/wxMaximaFrame.cpp:638
+#: ../src/wxMaximaFrame.cpp:637
 msgid "Ce&ll"
 msgstr ""
 
@@ -866,42 +866,42 @@ msgstr ""
 msgid "Cell bracket"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5261
+#: ../src/wxMaxima.cpp:5273
 msgid "Cell ends in a backslash"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:676
+#: ../src/wxMaximaFrame.cpp:675
 msgid "Change &2d Display"
 msgstr "Změnit &2D výstup"
 
-#: ../src/wxMaximaFrame.cpp:677
+#: ../src/wxMaximaFrame.cpp:676
 msgid "Change the 2d display algorithm used to display math output"
 msgstr "Změnit 2D výstup pro zobrazení výsledků výpočtů."
 
-#: ../src/wxMaxima.cpp:3995
+#: ../src/wxMaxima.cpp:4007
 msgid "Change variable"
 msgstr "Substituce"
 
-#: ../src/wxMaximaFrame.cpp:783
+#: ../src/wxMaximaFrame.cpp:782
 msgid "Change variable in integral or sum"
 msgstr "Substituce v integrálu nebo sumě"
 
-#: ../src/wxMaxima.cpp:3751
+#: ../src/wxMaxima.cpp:3763
 msgid "Char poly"
 msgstr "Charakteristický polynom Характеристический полином"
 
-#: ../src/wxMaximaFrame.cpp:978
+#: ../src/wxMaximaFrame.cpp:977
 msgid "Check for Updates"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:979
+#: ../src/wxMaximaFrame.cpp:978
 #, fuzzy
 msgid "Check if a newer version of wxMaxima/Maxima exist."
 msgstr ""
 "bylo uloženo v novější verzi programu wxMaxima. Prosím proveďte update "
 "programu."
 
-#: ../src/wxMaximaFrame.cpp:1385
+#: ../src/wxMaximaFrame.cpp:1384
 msgid "Chi"
 msgstr ""
 
@@ -923,16 +923,16 @@ msgstr "Výběr fontu"
 msgid "Choose new plot format:"
 msgstr "Zadejte nový formát grafů:"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710
 msgid "Classes:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:469
+#: ../src/wxMaximaFrame.cpp:468
 #, fuzzy
 msgid "Close\tCtrl-W"
 msgstr "&Kopírovat\tCtrl-C"
 
-#: ../src/wxMaximaFrame.cpp:470
+#: ../src/wxMaximaFrame.cpp:469
 msgid "Close window"
 msgstr ""
 
@@ -964,19 +964,19 @@ msgstr ""
 msgid "Code highlighting: Variables"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4806
+#: ../src/wxMaxima.cpp:4818
 msgid "Col. names:"
 msgstr "Jména sloupců:"
 
-#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Columns:"
 msgstr "Sloupce:"
 
-#: ../src/wxMaximaFrame.cpp:860
+#: ../src/wxMaximaFrame.cpp:859
 msgid "Combine factorials in an expression"
 msgstr "Sloučit faktoriály ve výrazu"
 
-#: ../src/wxMaxima.cpp:5293
+#: ../src/wxMaxima.cpp:5305
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
@@ -988,24 +988,24 @@ msgstr "Zadejte x-ové souřadnice oddělené čárkou"
 msgid "Comma separated y coordinates"
 msgstr "Zadejte y-ové souřadnice oddělené čárkou"
 
-#: ../src/MathCtrl.cpp:1030
+#: ../src/MathCtrl.cpp:1072
 msgid "Comment Selection"
 msgstr "Zakomentovat výběr"
 
-#: ../src/wxMaximaFrame.cpp:533
+#: ../src/wxMaximaFrame.cpp:532
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:532
+#: ../src/wxMaximaFrame.cpp:531
 #, fuzzy
 msgid "Comment selection\tCtrl-/"
 msgstr "Zakomentovat výběr"
 
-#: ../src/wxMaximaFrame.cpp:601
+#: ../src/wxMaximaFrame.cpp:600
 msgid "Complete Word\tCtrl-K"
 msgstr "Doplnit slovo\tCtrl-K"
 
-#: ../src/wxMaximaFrame.cpp:602
+#: ../src/wxMaximaFrame.cpp:601
 msgid "Complete word"
 msgstr "Doplnit slovo"
 
@@ -1013,35 +1013,35 @@ msgstr "Doplnit slovo"
 msgid "Completely stop maxima and restart it"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:823
+#: ../src/wxMaximaFrame.cpp:822
 msgid "Compute continued fraction of a value"
 msgstr "Výpočet celé části hodnoty"
 
-#: ../src/wxMaximaFrame.cpp:761
+#: ../src/wxMaximaFrame.cpp:760
 msgid "Compute the adjoint matrix"
 msgstr "Výpočet adjungované matice"
 
-#: ../src/wxMaximaFrame.cpp:750
+#: ../src/wxMaximaFrame.cpp:749
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr "Výpočet charakteristického polynomu matice"
 
-#: ../src/wxMaximaFrame.cpp:753
+#: ../src/wxMaximaFrame.cpp:752
 msgid "Compute the determinant of a matrix"
 msgstr "Výpočet determinantu matice"
 
-#: ../src/wxMaximaFrame.cpp:810
+#: ../src/wxMaximaFrame.cpp:809
 msgid "Compute the greatest common divisor"
 msgstr "Výpočet největšího společného dělitele"
 
-#: ../src/wxMaximaFrame.cpp:747
+#: ../src/wxMaximaFrame.cpp:746
 msgid "Compute the inverse of a matrix"
 msgstr "Výpočet inverzní matice"
 
-#: ../src/wxMaximaFrame.cpp:813
+#: ../src/wxMaximaFrame.cpp:812
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr "Výpočet nejmenšího společného násobku (před tím proveďte load(functs))"
 
-#: ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4868
 msgid "Condition:"
 msgstr "Podmínka:"
 
@@ -1053,8 +1053,8 @@ msgstr "Konfigurační soubor (*.ini)|*.ini"
 msgid "Configuration warning"
 msgstr "Nastavení varovných hlášení"
 
-#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:538
-#: ../src/wxMaximaFrame.cpp:541
+#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:540
 msgid "Configure wxMaxima"
 msgstr "Nastavení programu wxMaxima"
 
@@ -1063,133 +1063,135 @@ msgstr "Nastavení programu wxMaxima"
 msgid "Constant"
 msgstr "Konstanta"
 
-#: ../src/wxMaximaFrame.cpp:844
+#: ../src/wxMaximaFrame.cpp:843
 msgid "Contract Logarithms"
 msgstr "Sloučit logaritmy"
 
-#: ../src/wxMaximaFrame.cpp:851
+#: ../src/wxMaximaFrame.cpp:850
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr "Převod binomických koeficientů, beta a gama funkcí na faktoriály"
 
-#: ../src/wxMaximaFrame.cpp:854
+#: ../src/wxMaximaFrame.cpp:853
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr ""
 "Převod binomických koeficientů, faktoriálů a beta funkcí na gama funkce"
 
-#: ../src/wxMaximaFrame.cpp:888
+#: ../src/wxMaximaFrame.cpp:887
 msgid "Convert complex expression to polar form"
 msgstr "Převod komplexního výrazu na polární tvar"
 
-#: ../src/wxMaximaFrame.cpp:885
+#: ../src/wxMaximaFrame.cpp:884
 msgid "Convert complex expression to rect form"
 msgstr "Převod komplexního výrazu na standardní tvar"
 
-#: ../src/wxMaximaFrame.cpp:897
+#: ../src/wxMaximaFrame.cpp:896
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
 "Převod exponenciální funkce imaginárního argumentu na trigonometrický tvar"
 
-#: ../src/wxMaximaFrame.cpp:842
+#: ../src/wxMaximaFrame.cpp:841
 msgid "Convert logarithm of product to sum of logarithms"
 msgstr "Převod logaritmu součinu na součet logaritmů"
 
-#: ../src/wxMaximaFrame.cpp:845
+#: ../src/wxMaximaFrame.cpp:844
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "Převod součtu logaritmů na logaritmus součinu"
 
-#: ../src/wxMaximaFrame.cpp:850
+#: ../src/wxMaximaFrame.cpp:849
 msgid "Convert to &Factorials"
 msgstr "Konverze na faktoriály"
 
-#: ../src/wxMaximaFrame.cpp:853
+#: ../src/wxMaximaFrame.cpp:852
 msgid "Convert to &Gamma"
 msgstr "Konverze na &Gamma funkce"
 
-#: ../src/wxMaximaFrame.cpp:887
+#: ../src/wxMaximaFrame.cpp:886
 msgid "Convert to &Polarform"
 msgstr "Převod na &polární tvar"
 
-#: ../src/wxMaximaFrame.cpp:884
+#: ../src/wxMaximaFrame.cpp:883
 msgid "Convert to &Rectform"
 msgstr "Konverze na algeb&raický tvar"
 
-#: ../src/wxMaximaFrame.cpp:877
+#: ../src/wxMaximaFrame.cpp:876
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr "Převod trigonometrického výrazu na kanonický kvazilineární tvar"
 
-#: ../src/wxMaximaFrame.cpp:900
+#: ../src/wxMaximaFrame.cpp:899
 #, fuzzy
 msgid "Convert trigonometric functions to exponential form"
 msgstr "Převod trigonometrických funkcí do exponenciálního tvaru"
 
-#: ../src/ToolBar.cpp:140 ../src/MathCtrl.cpp:918 ../src/MathCtrl.cpp:931
-#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1024
+#: ../src/MathCtrl.cpp:960 ../src/MathCtrl.cpp:973 ../src/MathCtrl.cpp:1019
+#: ../src/MathCtrl.cpp:1066 ../src/ToolBar.cpp:140
 msgid "Copy"
 msgstr "Kopírovat"
 
-#: ../src/wxMaximaFrame.cpp:597
+#: ../src/wxMaximaFrame.cpp:596
 msgid "Copy Previous Input\tCtrl-I"
 msgstr "Kopírovat předchozí vstup\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:599
+#: ../src/wxMaximaFrame.cpp:598
 #, fuzzy
 msgid "Copy Previous Output\tCtrl-U"
 msgstr "Kopírovat předchozí vstup\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:514 ../src/MathCtrl.cpp:936 ../src/MathCtrl.cpp:982
+#: ../src/MathCtrl.cpp:978 ../src/MathCtrl.cpp:1024
+#: ../src/wxMaximaFrame.cpp:513
 msgid "Copy as Image"
 msgstr "Kopírovat jako obrázek"
 
-#: ../src/wxMaximaFrame.cpp:507 ../src/MathCtrl.cpp:932 ../src/MathCtrl.cpp:978
+#: ../src/MathCtrl.cpp:974 ../src/MathCtrl.cpp:1020
+#: ../src/wxMaximaFrame.cpp:506
 msgid "Copy as LaTeX"
 msgstr "Kopírovat jako LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:510
+#: ../src/wxMaximaFrame.cpp:509
 #, fuzzy
 msgid "Copy as MathML"
 msgstr "Kopírovat jako obrázek"
 
-#: ../src/MathCtrl.cpp:935 ../src/MathCtrl.cpp:980
+#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1022
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:504
+#: ../src/wxMaximaFrame.cpp:503
 msgid "Copy as Text\tCtrl-Shift-C"
 msgstr "Kopírovat jako text\tCtrl-Shift-C"
 
-#: ../src/MathCtrl.cpp:933 ../src/MathCtrl.cpp:979
+#: ../src/MathCtrl.cpp:975 ../src/MathCtrl.cpp:1021
 #, fuzzy
 msgid "Copy as plain text"
 msgstr "Kopírovat jako obrázek"
 
-#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:503
+#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:502
 msgid "Copy selection"
 msgstr "Kopírovat výběr"
 
-#: ../src/wxMaximaFrame.cpp:515
+#: ../src/wxMaximaFrame.cpp:514
 msgid "Copy selection from document as an image"
 msgstr "Kopírovat výběr z dokumentu jako obrázek"
 
-#: ../src/wxMaximaFrame.cpp:505
+#: ../src/wxMaximaFrame.cpp:504
 msgid "Copy selection from document as text"
 msgstr "Kopírovat výběr z dokumentu jako text"
 
-#: ../src/wxMaximaFrame.cpp:508
+#: ../src/wxMaximaFrame.cpp:507
 msgid "Copy selection from document in LaTeX format"
 msgstr "Kopírovat výběr z dokumentu jako kód LaTeXu"
 
-#: ../src/wxMaximaFrame.cpp:511
+#: ../src/wxMaximaFrame.cpp:510
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:598
+#: ../src/wxMaximaFrame.cpp:597
 msgid "Create a new cell with previous input"
 msgstr "Vytvořit vstupní pole s předchozím vstupem"
 
-#: ../src/wxMaximaFrame.cpp:600
+#: ../src/wxMaximaFrame.cpp:599
 #, fuzzy
 msgid "Create a new cell with previous output"
 msgstr "Vytvořit vstupní pole s předchozím vstupem"
@@ -1198,15 +1200,15 @@ msgstr "Vytvořit vstupní pole s předchozím vstupem"
 msgid "Cursor"
 msgstr "Kurzor"
 
-#: ../src/ToolBar.cpp:137 ../src/MathCtrl.cpp:1023
+#: ../src/MathCtrl.cpp:1065 ../src/ToolBar.cpp:137
 msgid "Cut"
 msgstr "Vyjmout"
 
-#: ../src/wxMaximaFrame.cpp:499
+#: ../src/wxMaximaFrame.cpp:498
 msgid "Cut\tCtrl-X"
 msgstr "Vyjmout\tCtrl-X"
 
-#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:500
+#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:499
 msgid "Cut selection"
 msgstr "Vystřihnout výběr"
 
@@ -1218,18 +1220,18 @@ msgstr "Česky"
 msgid "Danish"
 msgstr "Dánsky"
 
-#: ../src/wxMaxima.cpp:4799 ../src/wxMaxima.cpp:4806 ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4811 ../src/wxMaxima.cpp:4818 ../src/wxMaxima.cpp:4868
 msgid "Data Matrix:"
 msgstr "Matice dat:"
 
-#: ../src/wxMaxima.cpp:4826
+#: ../src/wxMaxima.cpp:4838
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr "Datový soubor (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698 ../src/wxMaxima.cpp:4712
-#: ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726 ../src/wxMaxima.cpp:4734
-#: ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748 ../src/wxMaxima.cpp:4755
-#: ../src/wxMaxima.cpp:4791
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710 ../src/wxMaxima.cpp:4724
+#: ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738 ../src/wxMaxima.cpp:4746
+#: ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760 ../src/wxMaxima.cpp:4767
+#: ../src/wxMaxima.cpp:4803
 msgid "Data:"
 msgstr "Data:"
 
@@ -1237,7 +1239,7 @@ msgstr "Data:"
 msgid "Debug: watch maxima's stdout stream"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:820
+#: ../src/wxMaximaFrame.cpp:819
 msgid "Decompose rational function to partial fractions"
 msgstr "Rozložit racionální funkci na parciální zlomky"
 
@@ -1268,47 +1270,47 @@ msgid ""
 "with."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3403 ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3415 ../src/wxMaxima.cpp:3424
 msgid "Delete"
 msgstr "Odstranit"
 
-#: ../src/wxMaximaFrame.cpp:667
+#: ../src/wxMaximaFrame.cpp:666
 msgid "Delete F&unction..."
 msgstr "Zrušit &funkci..."
 
-#: ../src/MathCtrl.cpp:939 ../src/MathCtrl.cpp:985
+#: ../src/MathCtrl.cpp:981 ../src/MathCtrl.cpp:1027
 msgid "Delete Selection"
 msgstr "Odstranit výběr"
 
-#: ../src/wxMaximaFrame.cpp:669
+#: ../src/wxMaximaFrame.cpp:668
 msgid "Delete V&ariable..."
 msgstr "Zrušit proměnnou..."
 
-#: ../src/wxMaximaFrame.cpp:668
+#: ../src/wxMaximaFrame.cpp:667
 msgid "Delete a function"
 msgstr "Zrušit funkci"
 
-#: ../src/wxMaximaFrame.cpp:670
+#: ../src/wxMaximaFrame.cpp:669
 msgid "Delete a variable"
 msgstr "Zrušit proměnnou"
 
-#: ../src/wxMaximaFrame.cpp:655
+#: ../src/wxMaximaFrame.cpp:654
 msgid "Delete all values from memory"
 msgstr "Zrušit všechny hodnoty z paměti"
 
-#: ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3424
 msgid "Delete function(s):"
 msgstr "Zrušit funkci (funkce)"
 
-#: ../src/wxMaxima.cpp:3403
+#: ../src/wxMaxima.cpp:3415
 msgid "Delete variable(s):"
 msgstr "Zrušit proměnnou (proměnné):"
 
-#: ../src/wxMaximaFrame.cpp:1367
+#: ../src/wxMaximaFrame.cpp:1366
 msgid "Delta"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4011
+#: ../src/wxMaxima.cpp:4023
 msgid "Denom. deg:"
 msgstr "Stupeň jmenovatele:"
 
@@ -1316,36 +1318,36 @@ msgstr "Stupeň jmenovatele:"
 msgid "Depth:"
 msgstr "Hloubka:"
 
-#: ../src/wxMaxima.cpp:3541
+#: ../src/wxMaxima.cpp:3553
 msgid "Derivative:"
 msgstr "Derivace:"
 
-#: ../src/wxMaximaFrame.cpp:1258
+#: ../src/wxMaximaFrame.cpp:1257
 #, fuzzy
 msgid "Deviation..."
 msgstr "Deviace"
 
-#: ../src/wxMaximaFrame.cpp:816
+#: ../src/wxMaximaFrame.cpp:815
 msgid "Di&vide Polynomials..."
 msgstr "Dělení polynomů..."
 
-#: ../src/wxMaximaFrame.cpp:1223
+#: ../src/wxMaximaFrame.cpp:1222
 msgid "Diff..."
 msgstr "Derivovat..."
 
-#: ../src/wxMaxima.cpp:4154 ../src/wxMaxima.cpp:5066
+#: ../src/wxMaxima.cpp:4166 ../src/wxMaxima.cpp:5078
 msgid "Differentiate"
 msgstr "Derivovat"
 
-#: ../src/wxMaximaFrame.cpp:786
+#: ../src/wxMaximaFrame.cpp:785
 msgid "Differentiate expression"
 msgstr "Derivovat výraz"
 
-#: ../src/MathCtrl.cpp:1001
+#: ../src/MathCtrl.cpp:1043
 msgid "Differentiate..."
 msgstr "Derivovat..."
 
-#: ../src/LimitWiz.cpp:37 ../src/FindReplacePane.cpp:76
+#: ../src/FindReplacePane.cpp:76 ../src/LimitWiz.cpp:37
 msgid "Direction:"
 msgstr "Směr:"
 
@@ -1353,48 +1355,49 @@ msgstr "Směr:"
 msgid "Discrete plot"
 msgstr "Diskrétní graf"
 
-#: ../src/wxMaximaFrame.cpp:679
+#: ../src/wxMaximaFrame.cpp:678
 msgid "Display Te&X Form"
 msgstr "Výstup ve formátu Te&X"
 
-#: ../src/wxMaxima.cpp:3320
+#: ../src/wxMaxima.cpp:3332
 msgid "Display algorithm"
 msgstr "Druh výstupu"
 
-#: ../src/wxMaximaFrame.cpp:680
+#: ../src/wxMaximaFrame.cpp:679
 msgid "Display last result in TeX form"
 msgstr "Poslední výsledek ve formátu TeX"
 
-#: ../src/wxMaximaFrame.cpp:674
+#: ../src/wxMaximaFrame.cpp:673
 msgid "Display time used for evaluation"
 msgstr "Zobrazit čas potřebný pro výpočet"
 
-#: ../src/wxMaxima.cpp:4061
+#: ../src/wxMaxima.cpp:4073
 msgid "Divide"
 msgstr "Dělit"
 
-#: ../src/MathCtrl.cpp:1032
+#: ../src/MathCtrl.cpp:1074
 msgid "Divide Cell"
 msgstr "Rozdělit pole"
 
-#: ../src/wxMaximaFrame.cpp:635
+#: ../src/wxMaximaFrame.cpp:634
 #, fuzzy
 msgid "Divide Cell\tCtrl-D"
 msgstr "Rozdělit pole"
 
-#: ../src/wxMaximaFrame.cpp:817
+#: ../src/wxMaximaFrame.cpp:816
 msgid "Divide numbers or polynomials"
 msgstr "Dělit čísla nebo polynomy"
 
-#: ../src/wxMaximaFrame.cpp:636
+#: ../src/wxMaximaFrame.cpp:635
 msgid "Divide this input cell into two cells"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5917
-msgid "Do you want to save the changes you made in the document \""
+#: ../src/wxMaxima.cpp:5932
+#, c-format
+msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1664 ../src/wxMaxima.cpp:1672
+#: ../src/wxMaxima.cpp:1669 ../src/wxMaxima.cpp:1677
 msgid "Document "
 msgstr "Dokument"
 
@@ -1413,7 +1416,7 @@ msgid ""
 "differences."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Don't save"
 msgstr ""
 
@@ -1421,27 +1424,27 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:734
+#: ../src/wxMaximaFrame.cpp:733
 msgid "E&quations"
 msgstr "&Rovnice"
 
-#: ../src/wxMaximaFrame.cpp:487
+#: ../src/wxMaximaFrame.cpp:486
 msgid "E&xit\tCtrl-Q"
 msgstr "Ukončit\tCtrl-Q"
 
-#: ../src/wxMaximaFrame.cpp:757
+#: ../src/wxMaximaFrame.cpp:756
 msgid "Eige&nvectors"
 msgstr "Vlastní &vektory"
 
-#: ../src/wxMaximaFrame.cpp:755
+#: ../src/wxMaximaFrame.cpp:754
 msgid "Eigen&values"
 msgstr "Vlastní &hodnoty"
 
-#: ../src/wxMaxima.cpp:3572
+#: ../src/wxMaxima.cpp:3584
 msgid "Eliminate"
 msgstr "Eliminovat"
 
-#: ../src/wxMaximaFrame.cpp:710
+#: ../src/wxMaximaFrame.cpp:709
 msgid "Eliminate a variable from a system of equations"
 msgstr "Eliminovat proměnnou ze soustavy rovnic"
 
@@ -1453,22 +1456,22 @@ msgstr ""
 msgid "English"
 msgstr "Anglický"
 
-#: ../src/wxMaxima.cpp:4712 ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726
-#: ../src/wxMaxima.cpp:4734 ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748
-#: ../src/wxMaxima.cpp:4755 ../src/wxMaxima.cpp:4791 ../src/wxMaxima.cpp:4799
+#: ../src/wxMaxima.cpp:4724 ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738
+#: ../src/wxMaxima.cpp:4746 ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760
+#: ../src/wxMaxima.cpp:4767 ../src/wxMaxima.cpp:4803 ../src/wxMaxima.cpp:4811
 #, fuzzy
 msgid "Enter Data"
 msgstr "Zadejte matici"
 
-#: ../src/wxMaximaFrame.cpp:1279
+#: ../src/wxMaximaFrame.cpp:1278
 msgid "Enter Matrix..."
 msgstr "Vložte matici..."
 
-#: ../src/wxMaximaFrame.cpp:745
+#: ../src/wxMaximaFrame.cpp:744
 msgid "Enter a matrix"
 msgstr "Zadání matice"
 
-#: ../src/wxMaxima.cpp:3962
+#: ../src/wxMaxima.cpp:3974
 msgid "Enter an equation for rational simplification:"
 msgstr "Zadejte rovnici pro racionální zjednodušení"
 
@@ -1480,11 +1483,11 @@ msgstr "Zadejte seznam proměnných oddělených čárkami."
 msgid "Enter evaluates cells"
 msgstr "Enter vyhodnocuje výraz"
 
-#: ../src/wxMaxima.cpp:3734
+#: ../src/wxMaxima.cpp:3746
 msgid "Enter matrix"
 msgstr "Zadejte matici"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 #, fuzzy
 msgid "Enter new precision for bigfloats:"
 msgstr "Zadejte novou přesnost:"
@@ -1493,12 +1496,12 @@ msgstr "Zadejte novou přesnost:"
 msgid "Enter the path to the Maxima executable."
 msgstr "Zadejte cestu ke spustitelnému souboru programu Maxima."
 
-#: ../src/wxMaximaFrame.cpp:1368
+#: ../src/wxMaximaFrame.cpp:1367
 #, fuzzy
 msgid "Epsilon"
 msgstr "Epsilon:"
 
-#: ../src/wxMaxima.cpp:4208
+#: ../src/wxMaxima.cpp:4220
 msgid "Epsilon:"
 msgstr "Epsilon:"
 
@@ -1507,13 +1510,13 @@ msgstr "Epsilon:"
 msgid "Equation %d:"
 msgstr "Rovnice %d:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:3633
-#: ../src/wxMaxima.cpp:5019
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:3645
+#: ../src/wxMaxima.cpp:5031
 msgid "Equation(s):"
 msgstr "Rovnice:"
 
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3993
-#: ../src/wxMaxima.cpp:4807 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:4005
+#: ../src/wxMaxima.cpp:4819 ../src/wxMaxima.cpp:5045
 msgid "Equation:"
 msgstr "Rovnice:"
 
@@ -1524,79 +1527,79 @@ msgid ""
 "be introduced one into another. Also they are always printed out as 2D maths."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3570
+#: ../src/wxMaxima.cpp:3582
 msgid "Equations:"
 msgstr "Rovnice:"
 
-#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1455
-#: ../src/wxMaxima.cpp:1469 ../src/wxMaxima.cpp:1620 ../src/wxMaxima.cpp:1633
-#: ../src/wxMaxima.cpp:1643 ../src/wxMaxima.cpp:1666 ../src/wxMaxima.cpp:2034
-#: ../src/wxMaxima.cpp:2206 ../src/wxMaxima.cpp:5381 ../src/wxMaxima.cpp:5830
-#: ../src/wxMaxima.cpp:5881
+#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1460
+#: ../src/wxMaxima.cpp:1474 ../src/wxMaxima.cpp:1625 ../src/wxMaxima.cpp:1638
+#: ../src/wxMaxima.cpp:1648 ../src/wxMaxima.cpp:1671 ../src/wxMaxima.cpp:2039
+#: ../src/wxMaxima.cpp:2211 ../src/wxMaxima.cpp:5397 ../src/wxMaxima.cpp:5845
+#: ../src/wxMaxima.cpp:5896
 msgid "Error"
 msgstr "Chyba"
 
-#: ../src/wxMaxima.cpp:2886 ../src/wxMaxima.cpp:2900 ../src/wxMaxima.cpp:2913
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617 ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:2894 ../src/wxMaxima.cpp:2908 ../src/wxMaxima.cpp:2921
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629 ../src/wxMaxima.cpp:3740
 msgid "Error!"
 msgstr "Chyba!"
 
-#: ../src/wxMaximaFrame.cpp:1370
+#: ../src/wxMaximaFrame.cpp:1369
 msgid "Eta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:909
+#: ../src/wxMaximaFrame.cpp:908
 msgid "Evaluate &Noun Forms"
 msgstr "Vyhodnotit nevyhodnocené funkce"
 
-#: ../src/wxMaximaFrame.cpp:589
+#: ../src/wxMaximaFrame.cpp:588
 #, fuzzy
 msgid "Evaluate All Cells\tCtrl-Shift-R"
 msgstr "Vyhodnotit všechna vstupní pole\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:587
+#: ../src/wxMaximaFrame.cpp:586
 #, fuzzy
 msgid "Evaluate All Visible Cells\tCtrl-R"
 msgstr "Vyhodnotit všechna vstupní pole\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:585 ../src/MathCtrl.cpp:942
+#: ../src/MathCtrl.cpp:984 ../src/wxMaximaFrame.cpp:584
 msgid "Evaluate Cell(s)"
 msgstr "Vyhodnotit vstupní pole"
 
-#: ../src/wxMaximaFrame.cpp:591
+#: ../src/wxMaximaFrame.cpp:590
 #, fuzzy
 msgid "Evaluate Cells Above\tCtrl-Shift-P"
 msgstr "Vyhodnotit všechna vstupní pole\tCtrl-R"
 
-#: ../src/MathCtrl.cpp:956 ../src/MathCtrl.cpp:1051
+#: ../src/MathCtrl.cpp:998 ../src/MathCtrl.cpp:1093
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:961 ../src/MathCtrl.cpp:1053
+#: ../src/MathCtrl.cpp:1003 ../src/MathCtrl.cpp:1095
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:971 ../src/MathCtrl.cpp:1057
+#: ../src/MathCtrl.cpp:1013 ../src/MathCtrl.cpp:1099
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:966 ../src/MathCtrl.cpp:1055
+#: ../src/MathCtrl.cpp:1008 ../src/MathCtrl.cpp:1097
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:586
+#: ../src/wxMaximaFrame.cpp:585
 msgid "Evaluate active or selected cell(s)"
 msgstr "Vyhodnotit aktivní nebo vybraná vstupní pole"
 
-#: ../src/wxMaximaFrame.cpp:590
+#: ../src/wxMaximaFrame.cpp:589
 msgid "Evaluate all cells in the document"
 msgstr "Vyhodnotit všechna vstupní pole v dokumentu"
 
-#: ../src/wxMaximaFrame.cpp:910
+#: ../src/wxMaximaFrame.cpp:909
 msgid "Evaluate all noun forms in expression"
 msgstr "Vyhodnotit všechny nevyhodnocené funkce ve výrazu"
 
-#: ../src/wxMaximaFrame.cpp:588
+#: ../src/wxMaximaFrame.cpp:587
 #, fuzzy
 msgid "Evaluate all visible cells in the document"
 msgstr "Vyhodnotit všechna vstupní pole v dokumentu"
@@ -1610,7 +1613,7 @@ msgstr ""
 msgid "Evaluate to point"
 msgstr "Vyhodnotit nevyhodnocené funkce"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Example"
 msgstr "Příklad"
 
@@ -1623,31 +1626,31 @@ msgstr "Text příkladu"
 msgid "Examples:"
 msgstr "Příklad"
 
-#: ../src/wxMaximaFrame.cpp:488
+#: ../src/wxMaximaFrame.cpp:487
 msgid "Exit wxMaxima"
 msgstr "Ukončení programu wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:1214
+#: ../src/wxMaximaFrame.cpp:1213
 msgid "Expand"
 msgstr "Rozložit"
 
-#: ../src/wxMaximaFrame.cpp:1219
+#: ../src/wxMaximaFrame.cpp:1218
 msgid "Expand (tr)"
 msgstr "Rozložit (trig.)"
 
-#: ../src/MathCtrl.cpp:997
+#: ../src/MathCtrl.cpp:1039
 msgid "Expand Expression"
 msgstr "Rozložit výraz"
 
-#: ../src/wxMaximaFrame.cpp:841
+#: ../src/wxMaximaFrame.cpp:840
 msgid "Expand Logarithms"
 msgstr "Rozvinout logaritmy"
 
-#: ../src/wxMaximaFrame.cpp:840
+#: ../src/wxMaximaFrame.cpp:839
 msgid "Expand an expression"
 msgstr "Rozložit výraz"
 
-#: ../src/wxMaximaFrame.cpp:874
+#: ../src/wxMaximaFrame.cpp:873
 msgid "Expand trigonometric expression"
 msgstr "Rozložit trigonometrický výraz"
 
@@ -1655,7 +1658,7 @@ msgstr "Rozložit trigonometrický výraz"
 msgid "Expected the icon files to be found at"
 msgstr ""
 
-#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2834
+#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2842
 msgid "Export"
 msgstr "Export"
 
@@ -1664,33 +1667,33 @@ msgid ""
 "Export animations to TeX (Images only move if the PDF viewer supports this)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:481
+#: ../src/wxMaximaFrame.cpp:480
 msgid "Export document to a HTML or pdfLaTeX file"
 msgstr "Export dokumentu do HTML nebo pdfLaTeXu"
 
-#: ../src/wxMaximaFrame.cpp:253
+#: ../src/wxMaximaFrame.cpp:252
 #, fuzzy
 msgid "Export failed."
 msgstr "Export do TeXu byl neúspěšný!"
 
-#: ../src/wxMaximaFrame.cpp:239
+#: ../src/wxMaximaFrame.cpp:238
 msgid "Export successful."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2913
+#: ../src/wxMaxima.cpp:2921
 msgid "Exporting to HTML failed!"
 msgstr "Export do HTML byl neúspěšný!"
 
-#: ../src/wxMaxima.cpp:2886
+#: ../src/wxMaxima.cpp:2894
 msgid "Exporting to TeX failed!"
 msgstr "Export do TeXu byl neúspěšný!"
 
-#: ../src/wxMaxima.cpp:2900
+#: ../src/wxMaxima.cpp:2908
 #, fuzzy
 msgid "Exporting to maxima batch file failed!"
 msgstr "Export do TeXu byl neúspěšný!"
 
-#: ../src/wxMaximaFrame.cpp:229
+#: ../src/wxMaximaFrame.cpp:228
 #, fuzzy
 msgid "Exporting..."
 msgstr "&Export..."
@@ -1704,42 +1707,42 @@ msgid "Expression(s):"
 msgstr "Výraz(y):"
 
 #: ../src/IntegrateWiz.cpp:30 ../src/LimitWiz.cpp:27 ../src/SeriesWiz.cpp:33
-#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3648
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:4205 ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5064
+#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3660
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:4217 ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5076
 msgid "Expression:"
 msgstr "Výraz:"
 
-#: ../src/wxMaximaFrame.cpp:1213
+#: ../src/wxMaximaFrame.cpp:1212
 msgid "Factor"
 msgstr "Na součin"
 
-#: ../src/wxMaximaFrame.cpp:836
+#: ../src/wxMaximaFrame.cpp:835
 msgid "Factor Complex"
 msgstr "Faktorizovat komplexní výraz"
 
-#: ../src/MathCtrl.cpp:996
+#: ../src/MathCtrl.cpp:1038
 msgid "Factor Expression"
 msgstr "Faktorizovat výraz"
 
-#: ../src/wxMaximaFrame.cpp:835
+#: ../src/wxMaximaFrame.cpp:834
 msgid "Factor an expression"
 msgstr "Faktorizovat výraz"
 
-#: ../src/wxMaximaFrame.cpp:837
+#: ../src/wxMaximaFrame.cpp:836
 msgid "Factor an expression in Gaussian numbers"
 msgstr "Faktorizovat výraz v Gaussových číslech"
 
-#: ../src/wxMaximaFrame.cpp:862
+#: ../src/wxMaximaFrame.cpp:861
 msgid "Factorials and &Gamma"
 msgstr "Faktoriály a &gamma funkce"
 
-#: ../src/wxMaxima.cpp:285
+#: ../src/wxMaxima.cpp:286
 msgid "Fatal error"
 msgstr "Závažná chyba"
 
-#: ../src/GroupCell.cpp:1571
+#: ../src/GroupCell.cpp:1572
 #, fuzzy, c-format
 msgid "Figure %d:"
 msgstr "Obrázek"
@@ -1748,22 +1751,22 @@ msgstr "Obrázek"
 msgid "File"
 msgstr "Soubor"
 
-#: ../src/wxMaxima.cpp:1457 ../src/wxMaxima.cpp:1623 ../src/wxMaxima.cpp:1636
-#: ../src/wxMaxima.cpp:1646 ../src/wxMaxima.cpp:1668
+#: ../src/wxMaxima.cpp:1462 ../src/wxMaxima.cpp:1628 ../src/wxMaxima.cpp:1641
+#: ../src/wxMaxima.cpp:1651 ../src/wxMaxima.cpp:1673
 #, fuzzy
 msgid "File could not be opened"
 msgstr "Soubor nenalezen"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File not found"
 msgstr "Soubor nenalezen"
 
-#: ../src/wxMaxima.cpp:1511 ../src/wxMaxima.cpp:1729
+#: ../src/wxMaxima.cpp:1516 ../src/wxMaxima.cpp:1734
 #, fuzzy
 msgid "File opened"
 msgstr "Soubor nenalezen"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File you tried to open does not exist."
 msgstr "Soubor, který se pokoušíte otevřít, neexistuje."
 
@@ -1775,67 +1778,67 @@ msgstr "Soubor:"
 msgid "Find"
 msgstr "Najdi"
 
-#: ../src/wxMaximaFrame.cpp:523
+#: ../src/wxMaximaFrame.cpp:522
 msgid "Find\tCtrl-F"
 msgstr "Najdi\tCtrl-F"
 
-#: ../src/wxMaximaFrame.cpp:787
+#: ../src/wxMaximaFrame.cpp:786
 msgid "Find &Limit..."
 msgstr "Najít &limitu..."
 
-#: ../src/wxMaximaFrame.cpp:790
+#: ../src/wxMaximaFrame.cpp:789
 msgid "Find Minimum..."
 msgstr "Najít minimum..."
 
-#: ../src/MathCtrl.cpp:993
+#: ../src/MathCtrl.cpp:1035
 msgid "Find Root..."
 msgstr "Najít kořen..."
 
-#: ../src/wxMaximaFrame.cpp:791
+#: ../src/wxMaximaFrame.cpp:790
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr "Najít minimum výrazu"
 
-#: ../src/wxMaximaFrame.cpp:788
+#: ../src/wxMaximaFrame.cpp:787
 msgid "Find a limit of an expression"
 msgstr "Najít limitu výrazu"
 
-#: ../src/wxMaximaFrame.cpp:693
+#: ../src/wxMaximaFrame.cpp:692
 msgid "Find a root of an equation on an interval"
 msgstr "Najít kořen rovnice z intervalu"
 
-#: ../src/wxMaximaFrame.cpp:695
+#: ../src/wxMaximaFrame.cpp:694
 msgid "Find all roots of a polynomial"
 msgstr "Najít všechny kořeny polynomu"
 
-#: ../src/wxMaximaFrame.cpp:698
+#: ../src/wxMaximaFrame.cpp:697
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr "Najít všechny kořeny polynomu (bfloat)"
 
-#: ../src/wxMaxima.cpp:3220
+#: ../src/wxMaxima.cpp:3215
 msgid "Find and Replace"
 msgstr "Najdi a nahraď"
 
-#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:523
+#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:522
 msgid "Find and replace"
 msgstr "Najdi a nahraď"
 
-#: ../src/wxMaximaFrame.cpp:756
+#: ../src/wxMaximaFrame.cpp:755
 msgid "Find eigenvalues of a matrix"
 msgstr "Nаjít vlastní hodnoty matice"
 
-#: ../src/wxMaximaFrame.cpp:758
+#: ../src/wxMaximaFrame.cpp:757
 msgid "Find eigenvectors of a matrix"
 msgstr "Nаjít vlastní vektory matice"
 
-#: ../src/wxMaxima.cpp:4210
+#: ../src/wxMaxima.cpp:4222
 msgid "Find minimum"
 msgstr "Najít minimum"
 
-#: ../src/wxMaximaFrame.cpp:701
+#: ../src/wxMaximaFrame.cpp:700
 msgid "Find real roots of a polynomial"
 msgstr "Nаjít reálné kořeny polynomu"
 
-#: ../src/wxMaxima.cpp:3493 ../src/wxMaxima.cpp:5036
+#: ../src/wxMaxima.cpp:3505 ../src/wxMaxima.cpp:5048
 msgid "Find root"
 msgstr "Najdi kořen"
 
@@ -1858,12 +1861,12 @@ msgstr ""
 msgid "Fixed font in text controls"
 msgstr "Fixní font v textových vstupech"
 
-#: ../src/wxMaximaFrame.cpp:623
+#: ../src/wxMaximaFrame.cpp:622
 #, fuzzy
 msgid "Fold All\tCtrl-Alt-["
 msgstr "Vybrat vše\tCtrl-A"
 
-#: ../src/wxMaximaFrame.cpp:624
+#: ../src/wxMaximaFrame.cpp:623
 msgid "Fold all sections"
 msgstr ""
 
@@ -1871,25 +1874,25 @@ msgstr ""
 msgid "Follow"
 msgstr ""
 
-#: ../src/ParenCell.cpp:319
+#: ../src/ParenCell.cpp:320
 msgid "Font issue: The Parenthesis sign is too small!"
 msgstr ""
 
-#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:381
+#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:382
 msgid ""
 "Font issue: The char height is too small! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:199
+#: ../src/SqrtCell.cpp:202
 msgid ""
 "Font issue: The sqrt() sign has the size 0! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:198
+#: ../src/SqrtCell.cpp:201
 msgid "Font issue? The contents of a sqrt() has the size 0."
 msgstr ""
 
@@ -1920,15 +1923,15 @@ msgstr "Francouzský"
 
 #: ../src/IntegrateWiz.cpp:37 ../src/Plot2dWiz.cpp:37 ../src/Plot2dWiz.cpp:47
 #: ../src/Plot2dWiz.cpp:536 ../src/Plot3dWiz.cpp:36 ../src/Plot3dWiz.cpp:45
-#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4240
+#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4252
 msgid "From:"
 msgstr "Od:"
 
-#: ../src/wxMaximaFrame.cpp:576
+#: ../src/wxMaximaFrame.cpp:575
 msgid "Full Screen\tAlt-Enter"
 msgstr "Celá obrazovka\tAlt-Enter"
 
-#: ../src/wxMaxima.cpp:3342
+#: ../src/wxMaxima.cpp:3354
 msgid "Function"
 msgstr "Funkce"
 
@@ -1936,32 +1939,32 @@ msgstr "Funkce"
 msgid "Function names"
 msgstr "Názvy funkcí"
 
-#: ../src/wxMaxima.cpp:3633
+#: ../src/wxMaxima.cpp:3645
 msgid "Function(s):"
 msgstr "Funkce:"
 
-#: ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3803
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3815
+#: ../src/wxMaxima.cpp:3848
 msgid "Function:"
 msgstr "Funkce:"
 
-#: ../src/wxMaximaFrame.cpp:904
+#: ../src/wxMaximaFrame.cpp:903
 msgid "Functions for complex simplification"
 msgstr "Funkce pro zjednodušení komplexních čísel"
 
-#: ../src/wxMaximaFrame.cpp:864
+#: ../src/wxMaximaFrame.cpp:863
 msgid "Functions for simplifying factorials and gamma function"
 msgstr "Funkce pro zjednodušení faktoriálů a gamma funkcí"
 
-#: ../src/wxMaximaFrame.cpp:881
+#: ../src/wxMaximaFrame.cpp:880
 msgid "Functions for simplifying trigonometric expressions"
 msgstr "Funkce pro zjednodušení trigonometických výrazů"
 
-#: ../src/wxMaxima.cpp:4046
+#: ../src/wxMaxima.cpp:4058
 msgid "GCD"
 msgstr "Největší společný dělitel"
 
-#: ../src/wxMaxima.cpp:5152
+#: ../src/wxMaxima.cpp:5164
 msgid "GIF image (*.gif)|*.gif"
 msgstr "GIF image (*.gif)|*.gif"
 
@@ -1969,31 +1972,31 @@ msgstr "GIF image (*.gif)|*.gif"
 msgid "Galician"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1366
+#: ../src/wxMaximaFrame.cpp:1365
 msgid "Gamma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:391
+#: ../src/wxMaximaFrame.cpp:390
 msgid "General Math"
 msgstr "Matematické operace"
 
-#: ../src/wxMaximaFrame.cpp:549
+#: ../src/wxMaximaFrame.cpp:548
 msgid "General Math\tAlt-Shift-M"
 msgstr "Matematické operace\tAlt-Shift-M"
 
-#: ../src/wxMaxima.cpp:3766 ../src/wxMaxima.cpp:3785
+#: ../src/wxMaxima.cpp:3778 ../src/wxMaxima.cpp:3797
 msgid "Generate Matrix"
 msgstr "Vytvořit matici"
 
-#: ../src/wxMaximaFrame.cpp:741
+#: ../src/wxMaximaFrame.cpp:740
 msgid "Generate Matrix from Expression..."
 msgstr "Generovat matici z výrazu..."
 
-#: ../src/wxMaximaFrame.cpp:739
+#: ../src/wxMaximaFrame.cpp:738
 msgid "Generate a matrix from a 2-dimensional array"
 msgstr "Vytvořit matici z 2D pole"
 
-#: ../src/wxMaximaFrame.cpp:742
+#: ../src/wxMaximaFrame.cpp:741
 msgid "Generate a matrix from a lambda expression"
 msgstr "Vytvořit matici z lambda výrazu"
 
@@ -2001,39 +2004,39 @@ msgstr "Vytvořit matici z lambda výrazu"
 msgid "German"
 msgstr "Německý"
 
-#: ../src/wxMaximaFrame.cpp:893
+#: ../src/wxMaximaFrame.cpp:892
 msgid "Get &Imaginary Part"
 msgstr "Imaginární část"
 
-#: ../src/wxMaximaFrame.cpp:793
+#: ../src/wxMaximaFrame.cpp:792
 msgid "Get &Series..."
 msgstr "Rozložit v řadu..."
 
-#: ../src/wxMaximaFrame.cpp:804
+#: ../src/wxMaximaFrame.cpp:803
 msgid "Get Laplace transformation of an expression"
 msgstr "Použít Laplaceovu transformaci"
 
-#: ../src/wxMaximaFrame.cpp:890
+#: ../src/wxMaximaFrame.cpp:889
 msgid "Get Real P&art"
 msgstr "Reálná část"
 
-#: ../src/wxMaximaFrame.cpp:807
+#: ../src/wxMaximaFrame.cpp:806
 msgid "Get inverse Laplace transformation of an expression"
 msgstr "Použít inverzní Laplaceovu transformaci"
 
-#: ../src/wxMaximaFrame.cpp:794
+#: ../src/wxMaximaFrame.cpp:793
 msgid "Get the Taylor or power series of expression"
 msgstr "Rozložit výraz v mocninnou Taylorovu řadu"
 
-#: ../src/wxMaximaFrame.cpp:894
+#: ../src/wxMaximaFrame.cpp:893
 msgid "Get the imaginary part of complex expression"
 msgstr "Určit imaginární část komplexního výrazu"
 
-#: ../src/wxMaximaFrame.cpp:891
+#: ../src/wxMaximaFrame.cpp:890
 msgid "Get the real part of complex expression"
 msgstr "Určit reálnou část komplexního výrazu"
 
-#: ../src/MathCtrl.cpp:5932
+#: ../src/MathCtrl.cpp:5984
 msgid ""
 "Got a request to undo an action that involves an delete which isn't possible "
 "at this moment."
@@ -2043,12 +2046,12 @@ msgstr ""
 msgid "Greek"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:356
+#: ../src/wxMaximaFrame.cpp:355
 #, fuzzy
 msgid "Greek Letters"
 msgstr "Konstanty označené řeckými písmeny"
 
-#: ../src/wxMaximaFrame.cpp:552
+#: ../src/wxMaximaFrame.cpp:551
 #, fuzzy
 msgid "Greek Letters\tAlt-Shift-G"
 msgstr "Matematické operace\tAlt-Shift-M"
@@ -2061,7 +2064,7 @@ msgstr "Konstanty označené řeckými písmeny"
 msgid "Grid:"
 msgstr "Mřížka:"
 
-#: ../src/wxMaxima.cpp:2836
+#: ../src/wxMaxima.cpp:2844
 #, fuzzy
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|pdfLaTeX file (*."
@@ -2076,12 +2079,12 @@ msgstr ""
 msgid "Help"
 msgstr "Nápověda"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 #, fuzzy
 msgid "Hide All Toolbars\tAlt-Shift--"
 msgstr "Skrýt vše\tAlt-Shift--"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide all panes"
 msgstr "Skrýt panely nástrojů"
 
@@ -2089,19 +2092,19 @@ msgstr "Skrýt panely nástrojů"
 msgid "Highlight (dpart)"
 msgstr "Zvýraznění (dpart)"
 
-#: ../src/wxMaxima.cpp:4685
+#: ../src/wxMaxima.cpp:4697
 msgid "Histogram"
 msgstr "Histogram"
 
-#: ../src/wxMaximaFrame.cpp:1270
+#: ../src/wxMaximaFrame.cpp:1269
 msgid "Histogram..."
 msgstr "Histogram..."
 
-#: ../src/wxMaximaFrame.cpp:309
+#: ../src/wxMaximaFrame.cpp:308
 msgid "History"
 msgstr "History"
 
-#: ../src/wxMaximaFrame.cpp:555
+#: ../src/wxMaximaFrame.cpp:554
 #, fuzzy
 msgid "History\tAlt-Shift-I"
 msgstr "History\tAlt-Shift-H"
@@ -2122,11 +2125,11 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Maďarský"
 
-#: ../src/wxMaxima.cpp:3527
+#: ../src/wxMaxima.cpp:3539
 msgid "IC1"
 msgstr "IC1"
 
-#: ../src/wxMaxima.cpp:3543
+#: ../src/wxMaxima.cpp:3555
 msgid "IC2"
 msgstr "IC2"
 
@@ -2142,7 +2145,7 @@ msgid ""
 "same output cell."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:683
+#: ../src/wxMaximaFrame.cpp:682
 msgid ""
 "If maxima ever finishes evaluating without wxMaxima realizing this this menu "
 "item can force wxMaxima to try to send commands to maxima again."
@@ -2204,11 +2207,11 @@ msgstr ""
 "Jestliže výpočet trvá příliš dlouho, můžete zkusit volby 'Maxima->Interrupt' "
 "nebo 'Maxima->Restart Maxima'."
 
-#: ../src/wxMaximaFrame.cpp:1499
+#: ../src/wxMaximaFrame.cpp:1518
 msgid "Image"
 msgstr "Obraz"
 
-#: ../src/wxMaxima.cpp:5644
+#: ../src/wxMaxima.cpp:5659
 msgid "Image files (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 msgstr "Soubory s obrázky (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 
@@ -2235,7 +2238,7 @@ msgid ""
 "above it. Might increase readability for some fonts and short subscripts."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Include columns:"
 msgstr ""
 
@@ -2254,19 +2257,19 @@ msgstr ""
 msgid "Infinity"
 msgstr "Nekonečno"
 
-#: ../src/wxMaximaFrame.cpp:974
+#: ../src/wxMaximaFrame.cpp:973
 msgid "Info about Maxima build"
 msgstr "Informace o programu Maxima"
 
-#: ../src/wxMaxima.cpp:4207
+#: ../src/wxMaxima.cpp:4219
 msgid "Initial Estimates:"
 msgstr "Počáteční odhady:"
 
-#: ../src/wxMaximaFrame.cpp:718
+#: ../src/wxMaximaFrame.cpp:717
 msgid "Initial Value Problem (&1)..."
 msgstr "Počáteční podmínka (&1) ..."
 
-#: ../src/wxMaximaFrame.cpp:721
+#: ../src/wxMaximaFrame.cpp:720
 msgid "Initial Value Problem (&2)..."
 msgstr "Počáteční podmínka (&2) ..."
 
@@ -2274,7 +2277,7 @@ msgstr "Počáteční podmínka (&2) ..."
 msgid "Input labels"
 msgstr "Značka pro vstup"
 
-#: ../src/wxMaximaFrame.cpp:403
+#: ../src/wxMaximaFrame.cpp:402
 msgid "Insert"
 msgstr "Vložit"
 
@@ -2282,108 +2285,108 @@ msgstr "Vložit"
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:612
+#: ../src/wxMaximaFrame.cpp:611
 #, fuzzy
 msgid "Insert &Section Cell\tCtrl-3"
 msgstr "Vložit pole s kapitolou\tF8"
 
-#: ../src/wxMaximaFrame.cpp:608
+#: ../src/wxMaximaFrame.cpp:607
 #, fuzzy
 msgid "Insert &Text Cell\tCtrl-1"
 msgstr "Vložit textové pole\tF6"
 
-#: ../src/wxMaximaFrame.cpp:558
+#: ../src/wxMaximaFrame.cpp:557
 msgid "Insert Cell\tAlt-Shift-C"
 msgstr "Vložit pole\tAlt-Shift-C"
 
-#: ../src/wxMaxima.cpp:5642
+#: ../src/wxMaxima.cpp:5657
 msgid "Insert Image"
 msgstr "Vložit obrázek"
 
-#: ../src/wxMaximaFrame.cpp:620
+#: ../src/wxMaximaFrame.cpp:619
 msgid "Insert Image..."
 msgstr "Vložit obrázek..."
 
-#: ../src/wxMaximaFrame.cpp:606
+#: ../src/wxMaximaFrame.cpp:605
 #, fuzzy
 msgid "Insert Input &Cell"
 msgstr "Vložit vstupní pole\tF5"
 
-#: ../src/wxMaximaFrame.cpp:618
+#: ../src/wxMaximaFrame.cpp:617
 #, fuzzy
 msgid "Insert Page Break"
 msgstr "Vložit zlom stránky\tF10"
 
-#: ../src/wxMaximaFrame.cpp:614
+#: ../src/wxMaximaFrame.cpp:613
 #, fuzzy
 msgid "Insert S&ubsection Cell\tCtrl-4"
 msgstr "Vložit pole s podkapitolou\tF8"
 
-#: ../src/wxMaximaFrame.cpp:616
+#: ../src/wxMaximaFrame.cpp:615
 #, fuzzy
 msgid "Insert S&ubsubsection Cell\tCtrl-5"
 msgstr "Vložit pole s podkapitolou\tF8"
 
-#: ../src/MathCtrl.cpp:1015
+#: ../src/MathCtrl.cpp:1057
 #, fuzzy
 msgid "Insert Section Cell"
 msgstr "Vložit pole s kapitolou\tF8"
 
-#: ../src/MathCtrl.cpp:1016
+#: ../src/MathCtrl.cpp:1058
 #, fuzzy
 msgid "Insert Subsection Cell"
 msgstr "Vložit pole s podkapitolou\tF8"
 
-#: ../src/MathCtrl.cpp:1017
+#: ../src/MathCtrl.cpp:1059
 #, fuzzy
 msgid "Insert Subsubsection Cell"
 msgstr "Vložit pole s podkapitolou\tF8"
 
-#: ../src/wxMaximaFrame.cpp:610
+#: ../src/wxMaximaFrame.cpp:609
 #, fuzzy
 msgid "Insert T&itle Cell\tCtrl-2"
 msgstr "Vložit pole s nadpisem\tF9"
 
-#: ../src/MathCtrl.cpp:1013
+#: ../src/MathCtrl.cpp:1055
 #, fuzzy
 msgid "Insert Text Cell"
 msgstr "Vložit textové pole\tF6"
 
-#: ../src/MathCtrl.cpp:1014
+#: ../src/MathCtrl.cpp:1056
 #, fuzzy
 msgid "Insert Title Cell"
 msgstr "Vložit pole s nadpisem\tF9"
 
-#: ../src/wxMaximaFrame.cpp:607
+#: ../src/wxMaximaFrame.cpp:606
 msgid "Insert a new input cell"
 msgstr "Vložit nové vstupní pole"
 
-#: ../src/wxMaximaFrame.cpp:613
+#: ../src/wxMaximaFrame.cpp:612
 msgid "Insert a new section cell"
 msgstr "Vložit pole s novou kapitolou"
 
-#: ../src/wxMaximaFrame.cpp:615
+#: ../src/wxMaximaFrame.cpp:614
 msgid "Insert a new subsection cell"
 msgstr "Vložit pole s novou podkapitolou"
 
-#: ../src/wxMaximaFrame.cpp:617
+#: ../src/wxMaximaFrame.cpp:616
 #, fuzzy
 msgid "Insert a new subsubsection cell"
 msgstr "Vložit pole s novou podkapitolou"
 
-#: ../src/wxMaximaFrame.cpp:609
+#: ../src/wxMaximaFrame.cpp:608
 msgid "Insert a new text cell"
 msgstr "Vložit nové textové pole"
 
-#: ../src/wxMaximaFrame.cpp:611
+#: ../src/wxMaximaFrame.cpp:610
 msgid "Insert a new title cell"
 msgstr "Vložit pole s novým nadpisem"
 
-#: ../src/wxMaximaFrame.cpp:619
+#: ../src/wxMaximaFrame.cpp:618
 msgid "Insert a page break"
 msgstr "Vložit zlom stránky"
 
-#: ../src/wxMaximaFrame.cpp:621
+#: ../src/wxMaximaFrame.cpp:620
 msgid "Insert image"
 msgstr "Vložit obrázek"
 
@@ -2396,27 +2399,27 @@ msgstr ""
 msgid "Integral sign"
 msgstr "Integrovat výraz"
 
-#: ../src/wxMaxima.cpp:3992
+#: ../src/wxMaxima.cpp:4004
 msgid "Integral/Sum:"
 msgstr "Integrál/suma:"
 
-#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4105 ../src/wxMaxima.cpp:5051
+#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4117 ../src/wxMaxima.cpp:5063
 msgid "Integrate"
 msgstr "Integrovat"
 
-#: ../src/wxMaxima.cpp:4091
+#: ../src/wxMaxima.cpp:4103
 msgid "Integrate (risch)"
 msgstr "Integrovat (Rischův algoritmus)"
 
-#: ../src/wxMaximaFrame.cpp:778
+#: ../src/wxMaximaFrame.cpp:777
 msgid "Integrate expression"
 msgstr "Integrovat výraz"
 
-#: ../src/wxMaximaFrame.cpp:780
+#: ../src/wxMaximaFrame.cpp:779
 msgid "Integrate expression with Risch algorithm"
 msgstr "Integrovat výraz pomocí Rischova algoritmu"
 
-#: ../src/wxMaximaFrame.cpp:1224 ../src/MathCtrl.cpp:1000
+#: ../src/MathCtrl.cpp:1042 ../src/wxMaximaFrame.cpp:1223
 msgid "Integrate..."
 msgstr "Integrovat..."
 
@@ -2424,7 +2427,7 @@ msgstr "Integrovat..."
 msgid "Interrupt"
 msgstr "Přerušit"
 
-#: ../src/wxMaximaFrame.cpp:646 ../src/wxMaximaFrame.cpp:650
+#: ../src/wxMaximaFrame.cpp:645 ../src/wxMaximaFrame.cpp:649
 msgid "Interrupt current computation"
 msgstr "Přerušit probíhající výpočet"
 
@@ -2444,15 +2447,15 @@ msgstr ""
 "\n"
 "Zadejte prosím znovu cestu k programu Maxima."
 
-#: ../src/wxMaxima.cpp:4137
+#: ../src/wxMaxima.cpp:4149
 msgid "Inverse Laplace"
 msgstr "Inverzní Laplaceova transformace"
 
-#: ../src/wxMaximaFrame.cpp:806
+#: ../src/wxMaximaFrame.cpp:805
 msgid "Inverse Laplace T&ransform..."
 msgstr "Inverzní Laplaceova transformace..."
 
-#: ../src/wxMaximaFrame.cpp:1372
+#: ../src/wxMaximaFrame.cpp:1371
 msgid "Iota"
 msgstr ""
 
@@ -2487,7 +2490,7 @@ msgstr "Panely nástrojů"
 msgid "Kabyle"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1373
+#: ../src/wxMaximaFrame.cpp:1372
 msgid "Kappa"
 msgstr ""
 
@@ -2496,7 +2499,7 @@ msgstr ""
 msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4031
+#: ../src/wxMaxima.cpp:4043
 msgid "LCM"
 msgstr "Nejmenší společný násobek"
 
@@ -2512,7 +2515,7 @@ msgstr ""
 msgid "Label width:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1374
+#: ../src/wxMaximaFrame.cpp:1373
 msgid "Lambda"
 msgstr ""
 
@@ -2524,11 +2527,11 @@ msgstr "Jazyk používaný GUI programu wxMaxima."
 msgid "Language:"
 msgstr "Jazyk:"
 
-#: ../src/wxMaxima.cpp:4120
+#: ../src/wxMaxima.cpp:4132
 msgid "Laplace"
 msgstr "Laplaceova transformace"
 
-#: ../src/wxMaximaFrame.cpp:803
+#: ../src/wxMaximaFrame.cpp:802
 msgid "Laplace &Transform..."
 msgstr "Laplaceova transformace..."
 
@@ -2536,15 +2539,15 @@ msgstr "Laplaceova transformace..."
 msgid "Leads to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:812
+#: ../src/wxMaximaFrame.cpp:811
 msgid "Least Common Multiple..."
 msgstr "Nejmenší společný násobek..."
 
-#: ../src/wxMaxima.cpp:4809
+#: ../src/wxMaxima.cpp:4821
 msgid "Least Squares Fit"
 msgstr "Metoda nejmenších čtverců"
 
-#: ../src/wxMaximaFrame.cpp:1266
+#: ../src/wxMaximaFrame.cpp:1265
 msgid "Least Squares Fit..."
 msgstr "Metoda nejmenších čtverců..."
 
@@ -2555,25 +2558,25 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4192
+#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4204
 msgid "Limit"
 msgstr "Limita"
 
-#: ../src/wxMaximaFrame.cpp:1225
+#: ../src/wxMaximaFrame.cpp:1224
 msgid "Limit..."
 msgstr "Limita..."
 
-#: ../src/wxMaximaFrame.cpp:1265
+#: ../src/wxMaximaFrame.cpp:1264
 #, fuzzy
 msgid "Linear Regression..."
 msgstr "LIneární regrese"
 
-#: ../src/wxMaxima.cpp:3803
+#: ../src/wxMaxima.cpp:3815
 #, fuzzy
 msgid "List(s):"
 msgstr "Seznam:"
 
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3848
 msgid "List:"
 msgstr "Seznam:"
 
@@ -2581,15 +2584,15 @@ msgstr "Seznam:"
 msgid "Load"
 msgstr "Načíst"
 
-#: ../src/wxMaxima.cpp:2932
+#: ../src/wxMaxima.cpp:2940
 msgid "Load Package"
 msgstr "Načíst balíček\tCtrl-L"
 
-#: ../src/wxMaximaFrame.cpp:479
+#: ../src/wxMaximaFrame.cpp:478
 msgid "Load a Maxima file using the batch command"
 msgstr "Načíst soubor programu Maxima s použitím dávkového příkazu"
 
-#: ../src/wxMaximaFrame.cpp:477
+#: ../src/wxMaximaFrame.cpp:476
 msgid "Load a Maxima package file"
 msgstr "Načíst Maxima balíček"
 
@@ -2601,49 +2604,49 @@ msgstr "Načíst styl ze souboru"
 msgid "Long Right arrow"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Lower bound:"
 msgstr "Dolní mez:"
 
-#: ../src/wxMaximaFrame.cpp:771
+#: ../src/wxMaximaFrame.cpp:770
 msgid "Ma&p to Matrix..."
 msgstr "&Použít na matici..."
 
-#: ../src/wxMaximaFrame.cpp:547
+#: ../src/wxMaximaFrame.cpp:546
 #, fuzzy
 msgid "Main Toolbar\tAlt-Shift-B"
 msgstr "Panel nástrojů\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:765
+#: ../src/wxMaximaFrame.cpp:764
 msgid "Make &List..."
 msgstr "Vytvořit seznam..."
 
-#: ../src/wxMaxima.cpp:3821
+#: ../src/wxMaxima.cpp:3833
 msgid "Make list"
 msgstr "Vytvořit seznam"
 
-#: ../src/wxMaximaFrame.cpp:766
+#: ../src/wxMaximaFrame.cpp:765
 msgid "Make list from expression"
 msgstr "Vytvořit seznam z výrazů"
 
-#: ../src/wxMaximaFrame.cpp:907
+#: ../src/wxMaximaFrame.cpp:906
 msgid "Make substitution in expression"
 msgstr "Zavést substituci ve výrazu"
 
-#: ../src/wxMaximaFrame.cpp:682
+#: ../src/wxMaximaFrame.cpp:681
 #, fuzzy
 msgid "Manually Trigger Evaluation"
 msgstr "Zobrazit čas potřebný pro výpočet"
 
-#: ../src/wxMaxima.cpp:3805
+#: ../src/wxMaxima.cpp:3817
 msgid "Map"
 msgstr "Použít na prvky"
 
-#: ../src/wxMaximaFrame.cpp:770
+#: ../src/wxMaximaFrame.cpp:769
 msgid "Map function to a list"
 msgstr "Použít funkci na prvky seznamu"
 
-#: ../src/wxMaximaFrame.cpp:772
+#: ../src/wxMaximaFrame.cpp:771
 msgid "Map function to a matrix"
 msgstr "Použít funkci na prvky matice"
 
@@ -2660,23 +2663,23 @@ msgstr "Kontrola závorek v textovém vstupu"
 msgid "Math font:"
 msgstr "Matematický font:"
 
-#: ../src/wxMaximaFrame.cpp:374
+#: ../src/wxMaximaFrame.cpp:373
 msgid "Mathematical Symbols"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3716
+#: ../src/wxMaxima.cpp:3728
 msgid "Matrix"
 msgstr "Matice"
 
-#: ../src/wxMaxima.cpp:3702
+#: ../src/wxMaxima.cpp:3714
 msgid "Matrix map"
 msgstr "Použít na matici"
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Matrix name:"
 msgstr "Název matice:"
 
-#: ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3749
+#: ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3761
 msgid "Matrix:"
 msgstr "Matice:"
 
@@ -2685,7 +2688,7 @@ msgstr "Matice:"
 msgid "Maxima"
 msgstr "&Maxima"
 
-#: ../src/wxMaximaFrame.cpp:137
+#: ../src/wxMaximaFrame.cpp:136
 #, fuzzy
 msgid "Maxima has a question"
 msgstr "Otázka programu Maxima"
@@ -2694,24 +2697,24 @@ msgstr "Otázka programu Maxima"
 msgid "Maxima input"
 msgstr "Vstup programu Maxima"
 
-#: ../src/wxMaximaFrame.cpp:166
+#: ../src/wxMaximaFrame.cpp:165
 msgid "Maxima is calculating"
 msgstr "Maxima počítá"
 
-#: ../src/wxMaximaFrame.cpp:111
+#: ../src/wxMaximaFrame.cpp:110
 #, fuzzy
 msgid "Maxima is ready for input."
 msgstr "Vstup programu Maxima"
 
-#: ../src/wxMaxima.cpp:2945
+#: ../src/wxMaxima.cpp:2953
 msgid "Maxima package (*.mac)|*.mac"
 msgstr "Maxima balíček (*.mac)|*.mac"
 
-#: ../src/wxMaxima.cpp:2934
+#: ../src/wxMaxima.cpp:2942
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr "Maxima balíček (*.mac)|*.mac|Lisp balíček (*.lisp)|*.lisp|Vše|*"
 
-#: ../src/wxMaxima.cpp:1014
+#: ../src/wxMaxima.cpp:1019
 msgid "Maxima process terminated."
 msgstr "Proces Maxima ukončen."
 
@@ -2723,7 +2726,7 @@ msgstr "Program Maxima:"
 msgid "Maxima questions"
 msgstr "Otázka programu Maxima"
 
-#: ../src/wxMaxima.cpp:942
+#: ../src/wxMaxima.cpp:947
 msgid "Maxima started. Waiting for connection..."
 msgstr "Maxima je spuštěna. Čekání na připojení..."
 
@@ -2747,7 +2750,7 @@ msgstr ""
 "Maxima používá ':' pro přiřazení hodnot ('a : 3;') a ':=' pro definici "
 "funkcí ('f(x) := x^2;')."
 
-#: ../src/wxMaxima.cpp:4597
+#: ../src/wxMaxima.cpp:4609
 #, fuzzy
 msgid "Maxima version: "
 msgstr ""
@@ -2787,44 +2790,44 @@ msgstr ""
 msgid "Maximum displayed number of digits:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1263
+#: ../src/wxMaximaFrame.cpp:1262
 #, fuzzy
 msgid "Mean Difference Test..."
 msgstr "Derivovat..."
 
-#: ../src/wxMaximaFrame.cpp:1262
+#: ../src/wxMaximaFrame.cpp:1261
 #, fuzzy
 msgid "Mean Test..."
 msgstr "Vytvořit seznam..."
 
-#: ../src/wxMaximaFrame.cpp:1255
+#: ../src/wxMaximaFrame.cpp:1254
 #, fuzzy
 msgid "Mean..."
 msgstr "Vytvořit seznam..."
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Mean:"
 msgstr "Průměr:"
 
-#: ../src/wxMaximaFrame.cpp:1256
+#: ../src/wxMaximaFrame.cpp:1255
 #, fuzzy
 msgid "Median..."
 msgstr "Medián"
 
-#: ../src/MathCtrl.cpp:945
+#: ../src/MathCtrl.cpp:987
 msgid "Merge Cells"
 msgstr "Spojit pole"
 
-#: ../src/wxMaximaFrame.cpp:633
+#: ../src/wxMaximaFrame.cpp:632
 #, fuzzy
 msgid "Merge Cells\tCtrl-M"
 msgstr "Spojit pole"
 
-#: ../src/wxMaximaFrame.cpp:634
+#: ../src/wxMaximaFrame.cpp:633
 msgid "Merge the text from two input cells into one"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2668
+#: ../src/wxMaxima.cpp:2676
 msgid "Message from the stdout of Maxima: "
 msgstr ""
 
@@ -2832,20 +2835,20 @@ msgstr ""
 msgid "Method:"
 msgstr "Metoda:"
 
-#: ../src/wxMaxima.cpp:5289
+#: ../src/wxMaxima.cpp:5301
 #, fuzzy
 msgid "Mismatched parenthesis"
 msgstr "Kontrola závorek v textovém vstupu"
 
-#: ../src/wxMaxima.cpp:3972
+#: ../src/wxMaxima.cpp:3984
 msgid "Modulus"
 msgstr "Modul"
 
-#: ../src/wxMaximaFrame.cpp:1375
+#: ../src/wxMaximaFrame.cpp:1374
 msgid "Mu"
 msgstr ""
 
-#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Name:"
 msgstr "Jméno:"
 
@@ -2853,7 +2856,7 @@ msgstr "Jméno:"
 msgid "New"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
+#: ../src/wxMaximaFrame.cpp:456 ../src/wxMaximaFrame.cpp:459
 #, fuzzy
 msgid "New\tCtrl-N"
 msgstr "&Nový\tCtrl-N"
@@ -2871,11 +2874,11 @@ msgstr ""
 msgid "New value:"
 msgstr "Nová hodnota:"
 
-#: ../src/wxMaxima.cpp:3993 ../src/wxMaxima.cpp:4119 ../src/wxMaxima.cpp:4136
+#: ../src/wxMaxima.cpp:4005 ../src/wxMaxima.cpp:4131 ../src/wxMaxima.cpp:4148
 msgid "New variable:"
 msgstr "Nová proměnná:"
 
-#: ../src/wxMaximaFrame.cpp:630
+#: ../src/wxMaximaFrame.cpp:629
 msgid "Next Command\tAlt-Down"
 msgstr ""
 
@@ -2883,15 +2886,15 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5362
+#: ../src/wxMaxima.cpp:5378
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3249 ../src/wxMaxima.cpp:3271
+#: ../src/wxMaxima.cpp:3260 ../src/wxMaxima.cpp:3283
 msgid "No matches found!"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1264
+#: ../src/wxMaximaFrame.cpp:1263
 #, fuzzy
 msgid "Normality Test..."
 msgstr "Test normality"
@@ -2915,37 +2918,37 @@ msgstr ""
 msgid "Norwegian"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:3740
 msgid "Not a valid matrix dimension!"
 msgstr "Nesprávná hodnota řádu matice!"
 
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629
 msgid "Not a valid number of equations!"
 msgstr "Nesprávný počet rovnic!"
 
-#: ../src/wxMaximaFrame.cpp:197
+#: ../src/wxMaximaFrame.cpp:196
 #, fuzzy
 msgid "Not connected to maxima"
 msgstr ""
 "\n"
 "Není připojeno k programu Maxima!\n"
 
-#: ../src/wxMaxima.cpp:4599
+#: ../src/wxMaxima.cpp:4611
 #, fuzzy
 msgid "Not connected."
 msgstr ""
 "\n"
 "Není připojeno."
 
-#: ../src/wxMaximaFrame.cpp:1376
+#: ../src/wxMaximaFrame.cpp:1375
 msgid "Nu"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Num. deg:"
 msgstr "Stupeň polynomu v čitateli:"
 
-#: ../src/wxMaxima.cpp:3585 ../src/wxMaxima.cpp:3609
+#: ../src/wxMaxima.cpp:3597 ../src/wxMaxima.cpp:3621
 msgid "Number of equations:"
 msgstr "Počet rovnic:"
 
@@ -2972,15 +2975,15 @@ msgstr "OK"
 msgid "Old value:"
 msgstr "Původní hodnota:"
 
-#: ../src/wxMaxima.cpp:3992 ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135
+#: ../src/wxMaxima.cpp:4004 ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147
 msgid "Old variable:"
 msgstr "Původní proměnná:"
 
-#: ../src/wxMaximaFrame.cpp:1387
+#: ../src/wxMaximaFrame.cpp:1386
 msgid "Omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1378
+#: ../src/wxMaximaFrame.cpp:1377
 msgid "Omicron"
 msgstr ""
 
@@ -2994,21 +2997,21 @@ msgid ""
 "stream for messages."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4763
+#: ../src/wxMaxima.cpp:4775
 #, fuzzy
 msgid "One sample t-test"
 msgstr "Text příkladu"
 
-#: ../src/wxMaximaFrame.cpp:971
+#: ../src/wxMaximaFrame.cpp:970
 msgid "Online tutorials"
 msgstr "Online tutoriály"
 
 #: ../src/ConfigDialogue.cpp:656 ../src/main.cpp:347 ../src/ToolBar.cpp:119
-#: ../src/wxMaxima.cpp:2797
+#: ../src/wxMaxima.cpp:2805
 msgid "Open"
 msgstr "Otevřít"
 
-#: ../src/wxMaximaFrame.cpp:466
+#: ../src/wxMaximaFrame.cpp:465
 msgid "Open Recent"
 msgstr "Otevřít naposledy použité"
 
@@ -3016,11 +3019,11 @@ msgstr "Otevřít naposledy použité"
 msgid "Open a cell when Maxima expects input"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:464
+#: ../src/wxMaximaFrame.cpp:463
 msgid "Open a document"
 msgstr "Otevřít dokument"
 
-#: ../src/wxMaximaFrame.cpp:458 ../src/wxMaximaFrame.cpp:461
+#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
 msgid "Open a new window"
 msgstr "Otevřít nové okno"
 
@@ -3028,12 +3031,12 @@ msgstr "Otevřít nové okno"
 msgid "Open document"
 msgstr "Otevřít dokument"
 
-#: ../src/wxMaxima.cpp:4824
+#: ../src/wxMaxima.cpp:4836
 #, fuzzy
 msgid "Open matrix"
 msgstr "Otevřít matici"
 
-#: ../src/wxMaxima.cpp:1446 ../src/wxMaxima.cpp:1518
+#: ../src/wxMaxima.cpp:1451 ../src/wxMaxima.cpp:1523
 msgid "Opening file"
 msgstr "Chyba při otevírání souboru"
 
@@ -3057,11 +3060,11 @@ msgstr ""
 msgid "Output labels"
 msgstr "Značky výstupů"
 
-#: ../src/wxMaximaFrame.cpp:796
+#: ../src/wxMaximaFrame.cpp:795
 msgid "P&ade Approximation..."
 msgstr "P&adého aproximace..."
 
-#: ../src/wxMaxima.cpp:3132 ../src/wxMaxima.cpp:5133
+#: ../src/wxMaxima.cpp:3141 ../src/wxMaxima.cpp:5145
 #, fuzzy
 msgid ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
@@ -3071,15 +3074,15 @@ msgstr ""
 "Obrázek PNG (*.png)|*.png|obrázek JPEG (*.jpg)|*.jpg|Windows bitmapa (*.bmp)|"
 "*.bmp|X pixmapa (*.xpm)|*.xpm"
 
-#: ../src/wxMaxima.cpp:4012
+#: ../src/wxMaxima.cpp:4024
 msgid "Pade approximation"
 msgstr "Padého aproximace"
 
-#: ../src/wxMaximaFrame.cpp:797
+#: ../src/wxMaximaFrame.cpp:796
 msgid "Pade approximation of a Taylor series"
 msgstr "Padého aproximace Taylorovy řady"
 
-#: ../src/wxMaximaFrame.cpp:1500
+#: ../src/wxMaximaFrame.cpp:1519
 msgid "Pagebreak"
 msgstr "Zlom stránky"
 
@@ -3091,19 +3094,19 @@ msgstr ""
 msgid "Parametric plot"
 msgstr "Graf zadaný parametricky"
 
-#: ../src/wxMaximaFrame.cpp:188
+#: ../src/wxMaximaFrame.cpp:187
 msgid "Parsing output"
 msgstr "Analýza výstupu"
 
-#: ../src/wxMaximaFrame.cpp:819
+#: ../src/wxMaximaFrame.cpp:818
 msgid "Partial &Fractions..."
 msgstr "Parciální zlomky..."
 
-#: ../src/wxMaxima.cpp:4076
+#: ../src/wxMaxima.cpp:4088
 msgid "Partial fractions"
 msgstr "Parciální zlomky"
 
-#: ../src/wxMaxima.cpp:1769
+#: ../src/wxMaxima.cpp:1774
 msgid "Parts of the document will not be loaded correctly!"
 msgstr "Část dokumentu nebude otevřena korektně!"
 
@@ -3114,11 +3117,11 @@ msgid ""
 "Found unknown XML Tag name "
 msgstr "Část dokumentu nebude otevřena korektně!"
 
-#: ../src/ToolBar.cpp:143 ../src/MathCtrl.cpp:1010 ../src/MathCtrl.cpp:1025
+#: ../src/MathCtrl.cpp:1052 ../src/MathCtrl.cpp:1067 ../src/ToolBar.cpp:143
 msgid "Paste"
 msgstr "Vložit"
 
-#: ../src/wxMaximaFrame.cpp:518
+#: ../src/wxMaximaFrame.cpp:517
 msgid "Paste\tCtrl-V"
 msgstr "Vložit\tCtrl-V"
 
@@ -3126,7 +3129,7 @@ msgstr "Vložit\tCtrl-V"
 msgid "Paste from clipboard"
 msgstr "Vložit ze schránky"
 
-#: ../src/wxMaximaFrame.cpp:519
+#: ../src/wxMaximaFrame.cpp:518
 msgid "Paste text from clipboard"
 msgstr "Vložit text z clipboardu"
 
@@ -3134,20 +3137,20 @@ msgstr "Vložit text z clipboardu"
 msgid "Perpendicular to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1384
+#: ../src/wxMaximaFrame.cpp:1383
 msgid "Phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1379
+#: ../src/wxMaximaFrame.cpp:1378
 msgid "Pi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1273
+#: ../src/wxMaximaFrame.cpp:1272
 #, fuzzy
 msgid "Piechart..."
 msgstr "Koláčový graf"
 
-#: ../src/wxMaxima.cpp:1952
+#: ../src/wxMaxima.cpp:1957
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr "Konfigurujte program wxMaxima pomocí 'Edit->Configure'."
 
@@ -3155,52 +3158,52 @@ msgstr "Konfigurujte program wxMaxima pomocí 'Edit->Configure'."
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr "Aby změny byly provedeny, je nutné program wxMaxima restartovat!"
 
-#: ../src/wxMaximaFrame.cpp:923
+#: ../src/wxMaximaFrame.cpp:922
 msgid "Plot &2d..."
 msgstr "&2D graf..."
 
-#: ../src/wxMaximaFrame.cpp:925
+#: ../src/wxMaximaFrame.cpp:924
 msgid "Plot &3d..."
 msgstr "&3D graf..."
 
-#: ../src/wxMaximaFrame.cpp:927
+#: ../src/wxMaximaFrame.cpp:926
 msgid "Plot &Format..."
 msgstr "&Formát grafu..."
 
 #: ../src/Plot2dWiz.cpp:104 ../src/Plot2dWiz.cpp:450 ../src/Plot2dWiz.cpp:464
-#: ../src/wxMaxima.cpp:4283 ../src/wxMaxima.cpp:5102
+#: ../src/wxMaxima.cpp:4295 ../src/wxMaxima.cpp:5114
 msgid "Plot 2D"
 msgstr "2D graf"
 
-#: ../src/wxMaximaFrame.cpp:1227
+#: ../src/wxMaximaFrame.cpp:1226
 msgid "Plot 2D..."
 msgstr "2D graf..."
 
-#: ../src/MathCtrl.cpp:1003
+#: ../src/MathCtrl.cpp:1045
 msgid "Plot 2d..."
 msgstr "2D graf..."
 
-#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4269 ../src/wxMaxima.cpp:5115
+#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4281 ../src/wxMaxima.cpp:5127
 msgid "Plot 3D"
 msgstr "3D graf"
 
-#: ../src/wxMaximaFrame.cpp:1228
+#: ../src/wxMaximaFrame.cpp:1227
 msgid "Plot 3D..."
 msgstr "3D graf..."
 
-#: ../src/MathCtrl.cpp:1004
+#: ../src/MathCtrl.cpp:1046
 msgid "Plot 3d..."
 msgstr "3D graf..."
 
-#: ../src/wxMaxima.cpp:4296
+#: ../src/wxMaxima.cpp:4308
 msgid "Plot format"
 msgstr "Formát grafu"
 
-#: ../src/wxMaximaFrame.cpp:924
+#: ../src/wxMaximaFrame.cpp:923
 msgid "Plot in 2 dimensions"
 msgstr "2D graf"
 
-#: ../src/wxMaximaFrame.cpp:926
+#: ../src/wxMaximaFrame.cpp:925
 msgid "Plot in 3 dimensions"
 msgstr "3D graf"
 
@@ -3209,8 +3212,8 @@ msgid "Plot to file:"
 msgstr "Graf do souboru:"
 
 #: ../src/BC2Wiz.cpp:30 ../src/BC2Wiz.cpp:36 ../src/LimitWiz.cpp:33
-#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
-#: ../src/wxMaxima.cpp:3648
+#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
+#: ../src/wxMaxima.cpp:3660
 msgid "Point:"
 msgstr "Bod:"
 
@@ -3218,11 +3221,11 @@ msgstr "Bod:"
 msgid "Polish"
 msgstr "Polský"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 1:"
 msgstr "Polynom 1:"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 2:"
 msgstr "Polynom 2:"
 
@@ -3234,11 +3237,11 @@ msgstr "Portugalský (Brazilský)"
 msgid "Postscript file (*.eps)|*.eps|All|*"
 msgstr "Postscriptový soubor (*.eps)|*.eps|Vše|*"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Precision"
 msgstr "Přesnost"
 
-#: ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:536
 msgid "Preferences...\tCtrl+,"
 msgstr ""
 
@@ -3250,7 +3253,7 @@ msgid ""
 "packages and from functions that are defined in the current file."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:628
+#: ../src/wxMaximaFrame.cpp:627
 msgid "Previous Command\tAlt-Up"
 msgstr ""
 
@@ -3258,11 +3261,11 @@ msgstr ""
 msgid "Print"
 msgstr "Tisk"
 
-#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:484
+#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:483
 msgid "Print document"
 msgstr "Tisk dokumentu"
 
-#: ../src/wxMaxima.cpp:4242
+#: ../src/wxMaxima.cpp:4254
 msgid "Product"
 msgstr "Součin"
 
@@ -3271,37 +3274,37 @@ msgstr "Součin"
 msgid "Product sign"
 msgstr "Součin"
 
-#: ../src/wxMaximaFrame.cpp:1386
+#: ../src/wxMaximaFrame.cpp:1385
 msgid "Psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:331
+#: ../src/wxMaximaFrame.cpp:330
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:592
+#: ../src/wxMaximaFrame.cpp:591
 #, fuzzy
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr "Vyhodnotit všechna vstupní pole v dokumentu"
 
-#: ../src/wxMaximaFrame.cpp:1278
+#: ../src/wxMaximaFrame.cpp:1277
 #, fuzzy
 msgid "Read Matrix..."
 msgstr "Zadání matic&e..."
 
-#: ../src/wxMaximaFrame.cpp:177
+#: ../src/wxMaximaFrame.cpp:176
 msgid "Reading Maxima output"
 msgstr "Čtení výstupu programu Maxima"
 
-#: ../src/wxMaximaFrame.cpp:153
+#: ../src/wxMaximaFrame.cpp:152
 msgid "Ready for user input"
 msgstr "Připraven na vstup"
 
-#: ../src/wxMaximaFrame.cpp:631
+#: ../src/wxMaximaFrame.cpp:630
 msgid "Recall next command from history"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:629
+#: ../src/wxMaximaFrame.cpp:628
 msgid "Recall previous command from history"
 msgstr ""
 
@@ -3309,37 +3312,37 @@ msgstr ""
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1215
+#: ../src/wxMaximaFrame.cpp:1214
 msgid "Rectform"
 msgstr "Algebraický tvar"
 
-#: ../src/wxMaximaFrame.cpp:495
+#: ../src/wxMaximaFrame.cpp:494
 #, fuzzy
 msgid "Redo\tCtrl-Y"
 msgstr "Zpět\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:496
+#: ../src/wxMaximaFrame.cpp:495
 #, fuzzy
 msgid "Redo last change"
 msgstr "Zpět poslední změnu"
 
-#: ../src/wxMaximaFrame.cpp:1220
+#: ../src/wxMaximaFrame.cpp:1219
 msgid "Reduce (tr)"
 msgstr "Zjednodušit (trig.)"
 
-#: ../src/wxMaximaFrame.cpp:871
+#: ../src/wxMaximaFrame.cpp:870
 msgid "Reduce trigonometric expression"
 msgstr "Zjednodušení trigonometrických výrazů"
 
-#: ../src/wxMaxima.cpp:622 ../src/wxMaxima.cpp:5495
+#: ../src/wxMaxima.cpp:627 ../src/wxMaxima.cpp:5511
 msgid "Refusing to send cell to maxima: "
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:594
+#: ../src/wxMaximaFrame.cpp:593
 msgid "Remove All Output"
 msgstr "Vymazat všechny výsledky výpočtů"
 
-#: ../src/wxMaximaFrame.cpp:595
+#: ../src/wxMaximaFrame.cpp:594
 msgid "Remove output from input cells"
 msgstr "Odstranit výsledky ze vstupních polí"
 
@@ -3348,7 +3351,7 @@ msgstr "Odstranit výsledky ze vstupních polí"
 msgid "Replace All"
 msgstr "Vybrat vše"
 
-#: ../src/wxMaxima.cpp:3282
+#: ../src/wxMaxima.cpp:3294
 #, c-format
 msgid "Replaced %d occurrences."
 msgstr "Nahrazeno %d výskytů"
@@ -3357,11 +3360,11 @@ msgstr "Nahrazeno %d výskytů"
 msgid "Replacement:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:976
+#: ../src/wxMaximaFrame.cpp:975
 msgid "Report bug"
 msgstr "Nahlásit chybu"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "Restart Maxima"
 msgstr "Restart programu Maxima"
 
@@ -3370,7 +3373,7 @@ msgstr "Restart programu Maxima"
 msgid "Restart maxima"
 msgstr "Restart programu Maxima"
 
-#: ../src/MathCtrl.cpp:4442
+#: ../src/MathCtrl.cpp:4497
 msgid "Result"
 msgstr ""
 
@@ -3378,7 +3381,7 @@ msgstr ""
 msgid "Return to the cell that is currently being evaluated"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1380
+#: ../src/wxMaximaFrame.cpp:1379
 msgid "Rho"
 msgstr ""
 
@@ -3386,19 +3389,19 @@ msgstr ""
 msgid "Right arrow"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:779
+#: ../src/wxMaximaFrame.cpp:778
 msgid "Risch Integration..."
 msgstr "Integrovat (Rischův algoritmus)..."
 
-#: ../src/wxMaximaFrame.cpp:694
+#: ../src/wxMaximaFrame.cpp:693
 msgid "Roots of &Polynomial"
 msgstr "Kořeny &polynomu"
 
-#: ../src/wxMaximaFrame.cpp:697
+#: ../src/wxMaximaFrame.cpp:696
 msgid "Roots of Polynomial (bfloat)"
 msgstr "Kořeny polynomu (bfloat)"
 
-#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Rows:"
 msgstr "Řádky:"
 
@@ -3406,56 +3409,56 @@ msgstr "Řádky:"
 msgid "Russian"
 msgstr "Ruský"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 1:"
 msgstr "Příklad 1:"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 2:"
 msgstr "Příklad 2:"
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Sample:"
 msgstr "Příklad:"
 
 #: ../src/ConfigDialogue.cpp:781 ../src/ToolBar.cpp:122
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Save"
 msgstr "Uložit"
 
-#: ../src/MathCtrl.cpp:921
+#: ../src/MathCtrl.cpp:963
 msgid "Save Animation..."
 msgstr "Uložit animaci..."
 
-#: ../src/wxMaxima.cpp:2565
+#: ../src/wxMaxima.cpp:2572
 msgid "Save As"
 msgstr "Uložit jako"
 
-#: ../src/wxMaximaFrame.cpp:474
+#: ../src/wxMaximaFrame.cpp:473
 msgid "Save As...\tShift-Ctrl-S"
 msgstr "Uložit jako...\tShift-Ctrl-S"
 
-#: ../src/MathCtrl.cpp:919
+#: ../src/MathCtrl.cpp:961
 msgid "Save Image..."
 msgstr "Uložit obrázek..."
 
-#: ../src/wxMaxima.cpp:3130
+#: ../src/wxMaxima.cpp:3139
 msgid "Save Selection to Image"
 msgstr "Uložit výběr jako obrázek"
 
-#: ../src/wxMaximaFrame.cpp:528
+#: ../src/wxMaximaFrame.cpp:527
 msgid "Save Selection to Image..."
 msgstr "Uložit výběr jako obrázek..."
 
-#: ../src/wxMaxima.cpp:5150
+#: ../src/wxMaxima.cpp:5162
 msgid "Save animation to file"
 msgstr "Uložit animaci do souboru"
 
-#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:473
+#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:472
 msgid "Save document"
 msgstr "Uložit dokument"
 
-#: ../src/wxMaximaFrame.cpp:475
+#: ../src/wxMaximaFrame.cpp:474
 msgid "Save document as"
 msgstr "Uložit dokument jako"
 
@@ -3477,11 +3480,11 @@ msgstr "Uložit velikost/pozici oken mezi sezeními"
 msgid "Save plot to file"
 msgstr "Uložit graf do souboru"
 
-#: ../src/wxMaximaFrame.cpp:529
+#: ../src/wxMaximaFrame.cpp:528
 msgid "Save selection from document to an image file"
 msgstr "Uložit výběr z dokumentu jako obrázkový soubor"
 
-#: ../src/wxMaxima.cpp:5131
+#: ../src/wxMaxima.cpp:5143
 msgid "Save selection to file"
 msgstr "Uložit označené do souboru"
 
@@ -3497,28 +3500,28 @@ msgstr "Uložit velikost/pozici okna wxMaxima"
 msgid "Save wxMaxima window size/position between sessions."
 msgstr "Uložit velikost/pozici okna wxMaxima mezi sessions."
 
-#: ../src/wxMaximaFrame.cpp:246
+#: ../src/wxMaximaFrame.cpp:245
 #, fuzzy
 msgid "Saving failed."
 msgstr "Start serveru selhal"
 
-#: ../src/wxMaximaFrame.cpp:222
+#: ../src/wxMaximaFrame.cpp:221
 msgid "Saving successful."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:212
+#: ../src/wxMaximaFrame.cpp:211
 msgid "Saving..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4699
+#: ../src/wxMaxima.cpp:4711
 msgid "Scatterplot"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1271
+#: ../src/wxMaximaFrame.cpp:1270
 msgid "Scatterplot..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1498
+#: ../src/wxMaximaFrame.cpp:1517
 msgid "Section"
 msgstr "Sekce"
 
@@ -3526,26 +3529,26 @@ msgstr "Sekce"
 msgid "Section cell"
 msgstr "Pole kapitoly"
 
-#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:292 ../src/TextCell.cpp:306
-#: ../src/TextCell.cpp:322 ../src/TextCell.cpp:334
+#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:290 ../src/TextCell.cpp:304
+#: ../src/TextCell.cpp:320 ../src/TextCell.cpp:332
 msgid ""
 "Seems like something is broken with a font. Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/TextCell.cpp:139
+#: ../src/TextCell.cpp:137
 msgid ""
 "Seems like something is broken with the maths font. Installing http://www."
 "math.union.edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use "
 "JSmath fonts\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1011 ../src/MathCtrl.cpp:1027
+#: ../src/MathCtrl.cpp:1053 ../src/MathCtrl.cpp:1069
 msgid "Select All"
 msgstr "Vybrat vše"
 
-#: ../src/wxMaximaFrame.cpp:525
+#: ../src/wxMaximaFrame.cpp:524
 msgid "Select All\tCtrl-A"
 msgstr "Vybrat vše\tCtrl-A"
 
@@ -3553,7 +3556,7 @@ msgstr "Vybrat vše\tCtrl-A"
 msgid "Select Maxima program"
 msgstr "Výběr programu Maxima"
 
-#: ../src/wxMaxima.cpp:4860
+#: ../src/wxMaxima.cpp:4872
 #, fuzzy
 msgid "Select Subsample"
 msgstr "Vybrat vše"
@@ -3563,11 +3566,11 @@ msgstr "Vybrat vše"
 msgid "Select a constant"
 msgstr "Vybrat konstantu"
 
-#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:526
+#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:525
 msgid "Select all"
 msgstr "Vybrat vše"
 
-#: ../src/wxMaxima.cpp:3319
+#: ../src/wxMaxima.cpp:3331
 msgid "Select math display algorithm"
 msgstr "Vybrat způsob zobrazení"
 
@@ -3584,23 +3587,23 @@ msgstr ""
 msgid "Selection"
 msgstr "Výběr"
 
-#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4178
+#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4190
 msgid "Series"
 msgstr "Řady"
 
-#: ../src/wxMaximaFrame.cpp:1226
+#: ../src/wxMaximaFrame.cpp:1225
 msgid "Series..."
 msgstr "Řady..."
 
-#: ../src/wxMaxima.cpp:863
+#: ../src/wxMaxima.cpp:868
 msgid "Server started"
 msgstr "Spouštění serveru"
 
-#: ../src/wxMaximaFrame.cpp:575
+#: ../src/wxMaximaFrame.cpp:574
 msgid "Set Zoom"
 msgstr "Nastavit zvětšení"
 
-#: ../src/wxMaximaFrame.cpp:944
+#: ../src/wxMaximaFrame.cpp:943
 #, fuzzy
 msgid "Set bigfloat &Precision..."
 msgstr "Nastavit přesnost bigfloat"
@@ -3609,61 +3612,61 @@ msgstr "Nastavit přesnost bigfloat"
 msgid "Set fixed font in text controls."
 msgstr "Nastavit fixní font pro textové příkazy."
 
-#: ../src/wxMaximaFrame.cpp:928
+#: ../src/wxMaximaFrame.cpp:927
 msgid "Set plot format"
 msgstr "Nastavit formát grafu"
 
-#: ../src/wxMaximaFrame.cpp:945
+#: ../src/wxMaximaFrame.cpp:944
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can "
 "be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:569
+#: ../src/wxMaximaFrame.cpp:568
 msgid "Set zoom to 100%"
 msgstr "Nastavit zvětšení na 100%"
 
-#: ../src/wxMaximaFrame.cpp:570
+#: ../src/wxMaximaFrame.cpp:569
 msgid "Set zoom to 120%"
 msgstr "Nastavit zvětšení na 120%"
 
-#: ../src/wxMaximaFrame.cpp:571
+#: ../src/wxMaximaFrame.cpp:570
 msgid "Set zoom to 150%"
 msgstr "Nastavit zvětšení na 150%"
 
-#: ../src/wxMaximaFrame.cpp:572
+#: ../src/wxMaximaFrame.cpp:571
 msgid "Set zoom to 200%"
 msgstr "Nastavit zvětšení na 200%"
 
-#: ../src/wxMaximaFrame.cpp:573
+#: ../src/wxMaximaFrame.cpp:572
 msgid "Set zoom to 300%"
 msgstr "Nastavit zvětšení na 300%"
 
-#: ../src/wxMaximaFrame.cpp:568
+#: ../src/wxMaximaFrame.cpp:567
 msgid "Set zoom to 80%"
 msgstr "Nastavit zvětšení na 80%"
 
-#: ../src/wxMaximaFrame.cpp:732
+#: ../src/wxMaximaFrame.cpp:731
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr "Nastavit hodnoty pro řešení ODR pomocí Laplaceovy transformace"
 
-#: ../src/wxMaximaFrame.cpp:918
+#: ../src/wxMaximaFrame.cpp:917
 msgid "Setup modulus computation"
 msgstr "Nastavit výpočet modulo"
 
-#: ../src/wxMaximaFrame.cpp:662
+#: ../src/wxMaximaFrame.cpp:661
 msgid "Show &Definition..."
 msgstr "Zobrazit &definici..."
 
-#: ../src/wxMaximaFrame.cpp:660
+#: ../src/wxMaximaFrame.cpp:659
 msgid "Show &Functions"
 msgstr "Zobrazit &funkce"
 
-#: ../src/wxMaximaFrame.cpp:967
+#: ../src/wxMaximaFrame.cpp:966
 msgid "Show &Tips..."
 msgstr "Ukázat &tipy"
 
-#: ../src/wxMaximaFrame.cpp:665
+#: ../src/wxMaximaFrame.cpp:664
 msgid "Show &Variables"
 msgstr "Zobrazit &proměnné"
 
@@ -3671,43 +3674,43 @@ msgstr "Zobrazit &proměnné"
 msgid "Show Maxima help"
 msgstr "Zobrazit nápovědu programu Maxima"
 
-#: ../src/wxMaximaFrame.cpp:603
+#: ../src/wxMaximaFrame.cpp:602
 msgid "Show Template\tCtrl-Shift-K"
 msgstr "Ukázat vzor\tCtrl-Shift-K"
 
-#: ../src/wxMaximaFrame.cpp:968
+#: ../src/wxMaximaFrame.cpp:967
 msgid "Show a tip"
 msgstr "Zobrazit tip"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Show all commands similar to:"
 msgstr "Zobrazit všechny příkazy podobné na:"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Show an example for the command:"
 msgstr "Zobrazit příklad k příkazu:"
 
-#: ../src/wxMaximaFrame.cpp:962
+#: ../src/wxMaximaFrame.cpp:961
 msgid "Show an example of usage"
 msgstr "Ukázat příklad použití"
 
-#: ../src/wxMaximaFrame.cpp:965
+#: ../src/wxMaximaFrame.cpp:964
 msgid "Show commands similar to"
 msgstr "Zobrazit podobné příkazy"
 
-#: ../src/wxMaximaFrame.cpp:661
+#: ../src/wxMaximaFrame.cpp:660
 msgid "Show defined functions"
 msgstr "Zobrazit definované funkce"
 
-#: ../src/wxMaximaFrame.cpp:666
+#: ../src/wxMaximaFrame.cpp:665
 msgid "Show defined variables"
 msgstr "Zobrazit definované proměnné"
 
-#: ../src/wxMaximaFrame.cpp:663
+#: ../src/wxMaximaFrame.cpp:662
 msgid "Show definition of a function"
 msgstr "Zobrazit definici funkcí"
 
-#: ../src/wxMaximaFrame.cpp:604
+#: ../src/wxMaximaFrame.cpp:603
 msgid "Show function template"
 msgstr ""
 
@@ -3720,7 +3723,7 @@ msgstr "Zobrazovat dlouhé výrazy v dokumentu wxMaxima."
 msgid "Show long expressions:"
 msgstr "Zobrazit dlouhé výrazy"
 
-#: ../src/wxMaxima.cpp:3341
+#: ../src/wxMaxima.cpp:3353
 msgid "Show the definition of function:"
 msgstr "Zobrazit definici funkce:"
 
@@ -3729,44 +3732,44 @@ msgstr "Zobrazit definici funkce:"
 msgid "Show user-defined labels instead of (%oxx)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:953 ../src/wxMaximaFrame.cpp:956
+#: ../src/wxMaximaFrame.cpp:952 ../src/wxMaximaFrame.cpp:955
 #, fuzzy
 msgid "Show wxMaxima help"
 msgstr "Zobrazit nápovědu programu Maxima"
 
-#: ../src/wxMaximaFrame.cpp:1381
+#: ../src/wxMaximaFrame.cpp:1380
 msgid "Sigma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1211
+#: ../src/wxMaximaFrame.cpp:1210
 msgid "Simplify"
 msgstr "Zjednodušit"
 
-#: ../src/wxMaximaFrame.cpp:831
+#: ../src/wxMaximaFrame.cpp:830
 msgid "Simplify &Radicals"
 msgstr "Zjednodušit vý&raz s odmocninami"
 
-#: ../src/wxMaximaFrame.cpp:1212
+#: ../src/wxMaximaFrame.cpp:1211
 msgid "Simplify (r)"
 msgstr "Zjednodušit (rac.)"
 
-#: ../src/wxMaximaFrame.cpp:1218
+#: ../src/wxMaximaFrame.cpp:1217
 msgid "Simplify (tr)"
 msgstr "Zjednodušit (trig.)"
 
-#: ../src/MathCtrl.cpp:995
+#: ../src/MathCtrl.cpp:1037
 msgid "Simplify Expression"
 msgstr "Zjednodušit výraz"
 
-#: ../src/wxMaximaFrame.cpp:857
+#: ../src/wxMaximaFrame.cpp:856
 msgid "Simplify an expression containing factorials"
 msgstr "Zjednodušit výraz obsahující faktoriály"
 
-#: ../src/wxMaximaFrame.cpp:832
+#: ../src/wxMaximaFrame.cpp:831
 msgid "Simplify expression containing radicals"
 msgstr "Zjednodušit výraz s odmocninami"
 
-#: ../src/wxMaximaFrame.cpp:830
+#: ../src/wxMaximaFrame.cpp:829
 msgid "Simplify rational expression"
 msgstr "Zjednodušit racionální výraz"
 
@@ -3774,7 +3777,7 @@ msgstr "Zjednodušit racionální výraz"
 msgid "Simplify the sum"
 msgstr "Zjednodušit sumu"
 
-#: ../src/wxMaximaFrame.cpp:868
+#: ../src/wxMaximaFrame.cpp:867
 msgid "Simplify trigonometric expression"
 msgstr "Zjednodušit trigonometrický výraz"
 
@@ -3790,87 +3793,87 @@ msgstr ""
 "Zvolte nabídku 'Edit->Insert Image...' . Nezapomeňte, že v takovém případě "
 "musíte dokument uložit ve formátu 'wxMaxima XML document'."
 
-#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
+#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
 msgid "Solution:"
 msgstr "Řešení:"
 
-#: ../src/wxMaxima.cpp:3461 ../src/wxMaxima.cpp:3475 ../src/wxMaxima.cpp:5020
+#: ../src/wxMaxima.cpp:3473 ../src/wxMaxima.cpp:3487 ../src/wxMaxima.cpp:5032
 msgid "Solve"
 msgstr "Řešit"
 
-#: ../src/wxMaximaFrame.cpp:706
+#: ../src/wxMaximaFrame.cpp:705
 msgid "Solve &Algebraic System..."
 msgstr "Řešit &algebraický systém..."
 
-#: ../src/wxMaximaFrame.cpp:703
+#: ../src/wxMaximaFrame.cpp:702
 msgid "Solve &Linear System..."
 msgstr "Řešit &lineární systém..."
 
-#: ../src/wxMaximaFrame.cpp:714
+#: ../src/wxMaximaFrame.cpp:713
 msgid "Solve &ODE..."
 msgstr "Řešit &ODR..."
 
-#: ../src/wxMaximaFrame.cpp:690
+#: ../src/wxMaximaFrame.cpp:689
 msgid "Solve (to_poly)..."
 msgstr "Řešit (to_poly)..."
 
-#: ../src/wxMaxima.cpp:3511 ../src/wxMaxima.cpp:3635
+#: ../src/wxMaxima.cpp:3523 ../src/wxMaxima.cpp:3647
 msgid "Solve ODE"
 msgstr "Řešit ODR"
 
-#: ../src/wxMaximaFrame.cpp:728
+#: ../src/wxMaximaFrame.cpp:727
 msgid "Solve ODE with Lapla&ce..."
 msgstr "Řešit ODR pomocí LTR..."
 
-#: ../src/wxMaximaFrame.cpp:1222
+#: ../src/wxMaximaFrame.cpp:1221
 msgid "Solve ODE..."
 msgstr "Řešit ODR..."
 
-#: ../src/wxMaxima.cpp:3586 ../src/wxMaxima.cpp:3597
+#: ../src/wxMaxima.cpp:3598 ../src/wxMaxima.cpp:3609
 msgid "Solve algebraic system"
 msgstr "Řesit algebraický systém"
 
-#: ../src/wxMaximaFrame.cpp:707
+#: ../src/wxMaximaFrame.cpp:706
 msgid "Solve algebraic system of equations"
 msgstr "Řesit systém algebraických rovnic"
 
-#: ../src/wxMaximaFrame.cpp:725
+#: ../src/wxMaximaFrame.cpp:724
 msgid "Solve boundary value problem for second degree ODE"
 msgstr "Řešit okrajovou úlohu pro ODR druhého řádu"
 
-#: ../src/wxMaximaFrame.cpp:689
+#: ../src/wxMaximaFrame.cpp:688
 msgid "Solve equation(s)"
 msgstr "Řešit rovnici/rovnice"
 
-#: ../src/wxMaximaFrame.cpp:691
+#: ../src/wxMaximaFrame.cpp:690
 msgid "Solve equation(s) with to_poly_solve"
 msgstr "Řešit rovnici/rovnice pomocí to_poly_solve"
 
-#: ../src/wxMaximaFrame.cpp:719
+#: ../src/wxMaximaFrame.cpp:718
 msgid "Solve initial value problem for first degree ODE"
 msgstr "Řešit ODR 1. řádu s počáteční podmínkou"
 
-#: ../src/wxMaximaFrame.cpp:722
+#: ../src/wxMaximaFrame.cpp:721
 msgid "Solve initial value problem for second degree ODE"
 msgstr "Řešit ODR 2. řádu s počáteční podmínkou"
 
-#: ../src/wxMaxima.cpp:3610 ../src/wxMaxima.cpp:3621
+#: ../src/wxMaxima.cpp:3622 ../src/wxMaxima.cpp:3633
 msgid "Solve linear system"
 msgstr "Řešit lineární systém"
 
-#: ../src/wxMaximaFrame.cpp:704
+#: ../src/wxMaximaFrame.cpp:703
 msgid "Solve linear system of equations"
 msgstr "Řešit systém lineárních rovnic"
 
-#: ../src/wxMaximaFrame.cpp:715
+#: ../src/wxMaximaFrame.cpp:714
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr "Řešit ODR nejvýše 2. řádu"
 
-#: ../src/wxMaximaFrame.cpp:729
+#: ../src/wxMaximaFrame.cpp:728
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr "Řešit ODR pomocí Laplaceovy transfromace"
 
-#: ../src/wxMaximaFrame.cpp:1221 ../src/MathCtrl.cpp:992
+#: ../src/MathCtrl.cpp:1034 ../src/wxMaximaFrame.cpp:1220
 msgid "Solve..."
 msgstr "Řešit..."
 
@@ -3894,7 +3897,7 @@ msgstr "Speciální"
 msgid "Special constants"
 msgstr "Speciální konstanty"
 
-#: ../src/MathCtrl.cpp:922
+#: ../src/MathCtrl.cpp:964
 #, fuzzy
 msgid "Start Animation"
 msgstr "Spustit animaci"
@@ -3914,28 +3917,28 @@ msgstr ""
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:294
+#: ../src/wxMaxima.cpp:295
 msgid "Starting Maxima process failed"
 msgstr "Start programu Maxima selhal"
 
-#: ../src/wxMaxima.cpp:928
+#: ../src/wxMaxima.cpp:933
 msgid "Starting Maxima..."
 msgstr "Spouštím program Maxima..."
 
-#: ../src/wxMaxima.cpp:292 ../src/wxMaxima.cpp:860
+#: ../src/wxMaxima.cpp:293 ../src/wxMaxima.cpp:865
 msgid "Starting server failed"
 msgstr "Start serveru selhal"
 
-#: ../src/wxMaxima.cpp:841
+#: ../src/wxMaxima.cpp:846
 #, c-format
 msgid "Starting server on port %d"
 msgstr "Spouštím server na portu %d"
 
-#: ../src/wxMaximaFrame.cpp:342
+#: ../src/wxMaximaFrame.cpp:341
 msgid "Statistics"
 msgstr "Statistika"
 
-#: ../src/wxMaximaFrame.cpp:550
+#: ../src/wxMaximaFrame.cpp:549
 msgid "Statistics\tAlt-Shift-S"
 msgstr "Statistika\tAlt-Shift-S"
 
@@ -3951,12 +3954,12 @@ msgstr "Styl"
 msgid "Styles"
 msgstr "Styly"
 
-#: ../src/wxMaximaFrame.cpp:1283
+#: ../src/wxMaximaFrame.cpp:1282
 #, fuzzy
 msgid "Subsample..."
 msgstr "Subst..."
 
-#: ../src/wxMaximaFrame.cpp:1496
+#: ../src/wxMaximaFrame.cpp:1515
 msgid "Subsection"
 msgstr "Podkapitola"
 
@@ -3964,20 +3967,20 @@ msgstr "Podkapitola"
 msgid "Subsection cell"
 msgstr "Pole podkapitoly"
 
-#: ../src/wxMaximaFrame.cpp:1216
+#: ../src/wxMaximaFrame.cpp:1215
 msgid "Subst..."
 msgstr "Subst..."
 
-#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3423
-#: ../src/wxMaxima.cpp:5089
+#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3435
+#: ../src/wxMaxima.cpp:5101
 msgid "Substitute"
 msgstr "Provést substituci"
 
-#: ../src/wxMaximaFrame.cpp:906 ../src/MathCtrl.cpp:998
+#: ../src/MathCtrl.cpp:1040 ../src/wxMaximaFrame.cpp:905
 msgid "Substitute..."
 msgstr "Substituce..."
 
-#: ../src/wxMaximaFrame.cpp:1497
+#: ../src/wxMaximaFrame.cpp:1516
 #, fuzzy
 msgid "Subsubsection"
 msgstr "Podkapitola"
@@ -3987,7 +3990,7 @@ msgstr "Podkapitola"
 msgid "Subsubsection cell"
 msgstr "Pole podkapitoly"
 
-#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4226
+#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4238
 msgid "Sum"
 msgstr "Suma"
 
@@ -3995,37 +3998,37 @@ msgstr "Suma"
 msgid "Sum sign"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:553
+#: ../src/wxMaximaFrame.cpp:552
 #, fuzzy
 msgid "Symbols\tAlt-Shift-Y"
 msgstr "Statistika\tAlt-Shift-S"
 
-#: ../src/wxMaxima.cpp:4456
+#: ../src/wxMaxima.cpp:4468
 msgid "System info"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:320
+#: ../src/wxMaximaFrame.cpp:319
 msgid "Table of Contents"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:556
+#: ../src/wxMaximaFrame.cpp:555
 #, fuzzy
 msgid "Table of Contents\tAlt-Shift-T"
 msgstr "Panel nástrojů\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:1382
+#: ../src/wxMaximaFrame.cpp:1381
 msgid "Tau"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Taylor series:"
 msgstr "Taylorova řada:"
 
-#: ../src/wxMaxima.cpp:3963
+#: ../src/wxMaxima.cpp:3975
 msgid "Tellrat"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1494
+#: ../src/wxMaximaFrame.cpp:1513
 msgid "Text"
 msgstr "Text"
 
@@ -4071,7 +4074,7 @@ msgstr ""
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr ""
 
-#: ../src/TextCell.cpp:136
+#: ../src/TextCell.cpp:134
 msgid ""
 "The letter \"X\" is of width zero. Installing http://www.math.union.edu/"
 "~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts\" in "
@@ -4088,7 +4091,7 @@ msgstr ""
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:959
+#: ../src/wxMaximaFrame.cpp:958
 msgid "The offline manual of maxima"
 msgstr ""
 
@@ -4126,7 +4129,7 @@ msgstr ""
 "Navštivte http://wxmaxima.sourceforge.net/wiki/index.php/Tutorials pro "
 "získání více informací o používání obou programů."
 
-#: ../src/SlideShowCell.cpp:332
+#: ../src/SlideShowCell.cpp:336
 msgid ""
 "There was an error during GIF export!\n"
 "\n"
@@ -4137,7 +4140,7 @@ msgstr ""
 "Ujistěte se, že máte nainstalovaný program ImageMagick a wxMaxima je schopna "
 "najít program convert."
 
-#: ../src/wxMaxima.cpp:442
+#: ../src/wxMaxima.cpp:447
 msgid ""
 "There was an error in generated XML!\n"
 "\n"
@@ -4147,7 +4150,7 @@ msgstr ""
 "\n"
 "Nahlaste prosím tuto chybu."
 
-#: ../src/wxMaximaFrame.cpp:1371
+#: ../src/wxMaximaFrame.cpp:1370
 msgid "Theta"
 msgstr ""
 
@@ -4155,7 +4158,7 @@ msgstr ""
 msgid "Ticks:"
 msgstr "Počet dělicích bodů:"
 
-#: ../src/wxMaxima.cpp:4153 ../src/wxMaxima.cpp:5065
+#: ../src/wxMaxima.cpp:4165 ../src/wxMaxima.cpp:5077
 msgid "Times:"
 msgstr "Násobit:"
 
@@ -4163,7 +4166,7 @@ msgstr "Násobit:"
 msgid "Tips not available, sorry!"
 msgstr "Tipy nejsou bohužel k dispozici!"
 
-#: ../src/wxMaximaFrame.cpp:1495
+#: ../src/wxMaximaFrame.cpp:1514
 msgid "Title"
 msgstr "Název"
 
@@ -4181,19 +4184,19 @@ msgstr ""
 "sbalení nebo rozbalení klikněte na čtvereček vedle pole. Kliknutí s "
 "tlačítkem Shift sbalí/rozbalí také všechny podčásti."
 
-#: ../src/wxMaximaFrame.cpp:938
+#: ../src/wxMaximaFrame.cpp:937
 msgid "To &Bigfloat"
 msgstr "Přesnost &bigfloat"
 
-#: ../src/wxMaximaFrame.cpp:935
+#: ../src/wxMaximaFrame.cpp:934
 msgid "To &Float"
 msgstr "převést na &Float (plovoucí řádová čárka)"
 
-#: ../src/MathCtrl.cpp:990
+#: ../src/MathCtrl.cpp:1032
 msgid "To Float"
 msgstr "Float (plovoucí řádová čárka)"
 
-#: ../src/wxMaximaFrame.cpp:941
+#: ../src/wxMaximaFrame.cpp:940
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr ""
 
@@ -4233,51 +4236,51 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:41 ../src/Plot2dWiz.cpp:40 ../src/Plot2dWiz.cpp:50
 #: ../src/Plot2dWiz.cpp:539 ../src/Plot3dWiz.cpp:39 ../src/Plot3dWiz.cpp:48
-#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4241
+#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4253
 msgid "To:"
 msgstr "Do:"
 
-#: ../src/wxMaximaFrame.cpp:912
+#: ../src/wxMaximaFrame.cpp:911
 msgid "Toggle &Algebraic Flag"
 msgstr "Přepnout příznak &algebraic"
 
-#: ../src/wxMaximaFrame.cpp:933
+#: ../src/wxMaximaFrame.cpp:932
 msgid "Toggle &Numeric Output"
 msgstr "Přepnout &numerický výstup"
 
-#: ../src/wxMaximaFrame.cpp:673
+#: ../src/wxMaximaFrame.cpp:672
 msgid "Toggle &Time Display"
 msgstr "Přepnou&t zobrazení času"
 
-#: ../src/wxMaximaFrame.cpp:913
+#: ../src/wxMaximaFrame.cpp:912
 msgid "Toggle algebraic flag"
 msgstr "Přepnout příznak algebraic"
 
-#: ../src/wxMaximaFrame.cpp:577
+#: ../src/wxMaximaFrame.cpp:576
 msgid "Toggle full screen editing"
 msgstr "Zapnutí celoobrazovkového editačního režimu"
 
-#: ../src/wxMaximaFrame.cpp:934
+#: ../src/wxMaximaFrame.cpp:933
 msgid "Toggle numeric output"
 msgstr "Přepnout numerický výstup"
 
-#: ../src/wxMaxima.cpp:4464
+#: ../src/wxMaxima.cpp:4476
 msgid "Toolbar icons"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4465
+#: ../src/wxMaxima.cpp:4477
 msgid "Translated by"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:763
+#: ../src/wxMaximaFrame.cpp:762
 msgid "Transpose a matrix"
 msgstr "Transponovat matici"
 
-#: ../src/MathCtrl.cpp:5834
+#: ../src/MathCtrl.cpp:5886
 msgid "Trying to undo an action without starting cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5901
+#: ../src/MathCtrl.cpp:5953
 msgid "Trying to undo something but the undo action is empty."
 msgstr ""
 
@@ -4285,11 +4288,11 @@ msgstr ""
 msgid "Turkish"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:970
+#: ../src/wxMaximaFrame.cpp:969
 msgid "Tutorials"
 msgstr "Tutoriál"
 
-#: ../src/wxMaxima.cpp:4778
+#: ../src/wxMaxima.cpp:4790
 #, fuzzy
 msgid "Two sample t-test"
 msgstr "Text příkladu"
@@ -4302,15 +4305,15 @@ msgstr "Typ:"
 msgid "Ukrainian"
 msgstr "Ukrajinský"
 
-#: ../src/wxMaxima.cpp:5356
+#: ../src/wxMaxima.cpp:5372
 msgid "Un-closed parenthesis"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5323
+#: ../src/wxMaxima.cpp:5335
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5889
 msgid ""
 "Unable to interpret the version info I got from http://andrejv.github.io//"
 "wxmaxima/version.txt: "
@@ -4324,11 +4327,11 @@ msgstr "Podtržení"
 msgid "Underscore converts to subscripts:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:492
+#: ../src/wxMaximaFrame.cpp:491
 msgid "Undo\tCtrl-Z"
 msgstr "Zpět\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:493
+#: ../src/wxMaximaFrame.cpp:492
 msgid "Undo last change"
 msgstr "Zpět poslední změnu"
 
@@ -4336,24 +4339,24 @@ msgstr "Zpět poslední změnu"
 msgid "Undo limit (0 for none):"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:625
+#: ../src/wxMaximaFrame.cpp:624
 #, fuzzy
 msgid "Unfold All\tCtrl-Alt-]"
 msgstr "Vybrat vše\tCtrl-A"
 
-#: ../src/wxMaximaFrame.cpp:626
+#: ../src/wxMaximaFrame.cpp:625
 msgid "Unfold all folded sections"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4458
+#: ../src/wxMaxima.cpp:4470
 msgid "Unicode Support"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5335
+#: ../src/wxMaxima.cpp:5347
 msgid "Unterminated comment."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5309
+#: ../src/wxMaxima.cpp:5321
 msgid "Unterminated string."
 msgstr ""
 
@@ -4361,15 +4364,15 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5859 ../src/wxMaxima.cpp:5866 ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5874 ../src/wxMaxima.cpp:5881 ../src/wxMaxima.cpp:5889
 msgid "Upgrade"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Upper bound:"
 msgstr "Horní mez:"
 
-#: ../src/wxMaximaFrame.cpp:1383
+#: ../src/wxMaximaFrame.cpp:1382
 #, fuzzy
 msgid "Upsilon"
 msgstr "Epsilon:"
@@ -4414,22 +4417,22 @@ msgstr ""
 msgid "User-defined labels"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3525
-#: ../src/wxMaxima.cpp:3541 ../src/wxMaxima.cpp:3649
+#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3537
+#: ../src/wxMaxima.cpp:3553 ../src/wxMaxima.cpp:3661
 msgid "Value:"
 msgstr "Hodnota:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:5019 ../src/wxMaxima.cpp:5064
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:5031 ../src/wxMaxima.cpp:5076
 msgid "Variable(s):"
 msgstr "Proměnné:"
 
 #: ../src/IntegrateWiz.cpp:33 ../src/LimitWiz.cpp:30 ../src/Plot2dWiz.cpp:34
 #: ../src/Plot2dWiz.cpp:44 ../src/Plot2dWiz.cpp:533 ../src/Plot3dWiz.cpp:33
 #: ../src/Plot3dWiz.cpp:42 ../src/SeriesWiz.cpp:36 ../src/SumWiz.cpp:30
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3749
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3761
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5045
 msgid "Variable:"
 msgstr "Proměnná:"
 
@@ -4437,26 +4440,26 @@ msgstr "Proměnná:"
 msgid "Variables"
 msgstr "Proměnné"
 
-#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3571 ../src/wxMaxima.cpp:4206
-#: ../src/wxMaxima.cpp:4807
+#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3583 ../src/wxMaxima.cpp:4218
+#: ../src/wxMaxima.cpp:4819
 msgid "Variables:"
 msgstr "Proměnné:"
 
-#: ../src/wxMaximaFrame.cpp:1257
+#: ../src/wxMaximaFrame.cpp:1256
 #, fuzzy
 msgid "Variance..."
 msgstr "Rozptyl"
 
-#: ../src/wxMaximaFrame.cpp:580
+#: ../src/wxMaximaFrame.cpp:579
 msgid "View"
 msgstr ""
 
-#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1674 ../src/wxMaxima.cpp:1769
-#: ../src/wxMaxima.cpp:1950
+#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1679 ../src/wxMaxima.cpp:1774
+#: ../src/wxMaxima.cpp:1955
 msgid "Warning"
 msgstr "Varování"
 
-#: ../src/wxMaximaFrame.cpp:109 ../src/wxMaximaFrame.cpp:295
+#: ../src/wxMaximaFrame.cpp:108 ../src/wxMaximaFrame.cpp:294
 msgid "Welcome to wxMaxima"
 msgstr "Vítejte v programu wxMaxima"
 
@@ -4479,7 +4482,7 @@ msgid ""
 "introducing an empty line."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2567
+#: ../src/wxMaxima.cpp:2574
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) "
 "(*.wxm)|*.wxm"
@@ -4495,7 +4498,7 @@ msgid ""
 "as equation markers"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6798
+#: ../src/MathCtrl.cpp:6856
 msgid "Wrapped search"
 msgstr ""
 
@@ -4503,15 +4506,15 @@ msgstr ""
 msgid "Write matching parenthesis in text controls."
 msgstr "Psát párové závorky v textových vstupech."
 
-#: ../src/wxMaxima.cpp:4461
+#: ../src/wxMaxima.cpp:4473
 msgid "Written by"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:557
+#: ../src/wxMaximaFrame.cpp:556
 msgid "XML Inspector"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1377
+#: ../src/wxMaximaFrame.cpp:1376
 msgid "Xi"
 msgstr ""
 
@@ -4581,7 +4584,7 @@ msgstr ""
 "Shift) můžete vybratvíce polí a pracovat s nimi. Toto je vhodné, pokud "
 "chcete vymazat nebo vyhodnotit více polí."
 
-#: ../src/wxMaxima.cpp:5856
+#: ../src/wxMaxima.cpp:5871
 #, c-format
 msgid ""
 "You have version %s. Current version is %s.\n"
@@ -4589,41 +4592,41 @@ msgid ""
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5921
+#: ../src/wxMaxima.cpp:5936
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5866
+#: ../src/wxMaxima.cpp:5881
 msgid "Your version of wxMaxima is up to date."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1369
+#: ../src/wxMaximaFrame.cpp:1368
 msgid "Zeta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:562
+#: ../src/wxMaximaFrame.cpp:561
 #, fuzzy
 msgid "Zoom &In\tCtrl-+"
 msgstr "Zvětš&it\tAlt-I"
 
-#: ../src/wxMaximaFrame.cpp:564
+#: ../src/wxMaximaFrame.cpp:563
 #, fuzzy
 msgid "Zoom Ou&t\tCtrl--"
 msgstr "Zmenšit\tAlt-O"
 
-#: ../src/wxMaximaFrame.cpp:563
+#: ../src/wxMaximaFrame.cpp:562
 msgid "Zoom in 10%"
 msgstr "Zvětšit o 10%"
 
-#: ../src/wxMaximaFrame.cpp:565
+#: ../src/wxMaximaFrame.cpp:564
 msgid "Zoom out 10%"
 msgstr "Zmenšit o 10%"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaximaFrame.cpp:287
 msgid "[ unsaved ]"
 msgstr "[ neuloženo ]"
 
-#: ../src/wxMaxima.cpp:5700
+#: ../src/wxMaxima.cpp:5715
 msgid "[ unsaved* ]"
 msgstr "[ neuloženo* ]"
 
@@ -4632,17 +4635,17 @@ msgstr "[ neuloženo* ]"
 msgid "[%i digits]"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4392
+#: ../src/MathCtrl.cpp:4447
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" style=\"max-width:90%%;\" >\n"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4517
+#: ../src/MathCtrl.cpp:4572
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" >"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1333
+#: ../src/wxMaximaFrame.cpp:1332
 msgid "alpha"
 msgstr ""
 
@@ -4655,7 +4658,7 @@ msgstr "Rozložit"
 msgid "antisymmetric"
 msgstr "antisymetrická"
 
-#: ../src/wxMaximaFrame.cpp:1334
+#: ../src/wxMaximaFrame.cpp:1333
 msgid "beta"
 msgstr ""
 
@@ -4699,7 +4702,7 @@ msgstr ""
 msgid "bug:Invalid sup tag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1354
+#: ../src/wxMaximaFrame.cpp:1353
 msgid "chi"
 msgstr ""
 
@@ -4712,7 +4715,7 @@ msgstr ""
 msgid "default"
 msgstr "standardní nastavení"
 
-#: ../src/wxMaximaFrame.cpp:1336
+#: ../src/wxMaximaFrame.cpp:1335
 msgid "delta"
 msgstr ""
 
@@ -4724,7 +4727,7 @@ msgstr "diagonální"
 msgid "empty"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1337
+#: ../src/wxMaximaFrame.cpp:1336
 #, fuzzy
 msgid "epsilon"
 msgstr "Epsilon:"
@@ -4733,7 +4736,7 @@ msgstr "Epsilon:"
 msgid "equivalent"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1339
+#: ../src/wxMaximaFrame.cpp:1338
 msgid "eta"
 msgstr ""
 
@@ -4749,7 +4752,7 @@ msgid ""
 "all=_ marks subscripts."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1335
+#: ../src/wxMaximaFrame.cpp:1334
 msgid "gamma"
 msgstr ""
 
@@ -4778,15 +4781,15 @@ msgstr "vestavěný"
 msgid "intersection"
 msgstr "Směr:"
 
-#: ../src/wxMaximaFrame.cpp:1341
+#: ../src/wxMaximaFrame.cpp:1340
 msgid "iota"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1342
+#: ../src/wxMaximaFrame.cpp:1341
 msgid "kappa"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1343
+#: ../src/wxMaximaFrame.cpp:1342
 msgid "lambda"
 msgstr ""
 
@@ -4803,7 +4806,7 @@ msgstr "Pole podkapitoly"
 msgid "logscale"
 msgstr "logaritmické měřítko"
 
-#: ../src/wxMaxima.cpp:3783
+#: ../src/wxMaxima.cpp:3795
 msgid "matrix[i,j]:"
 msgstr "matice[i,j]:"
 
@@ -4811,7 +4814,7 @@ msgstr "matice[i,j]:"
 msgid "maxima's pwd is path to document"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1344
+#: ../src/wxMaximaFrame.cpp:1343
 msgid "mu"
 msgstr ""
 
@@ -4828,7 +4831,7 @@ msgstr ""
 msgid "nand"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4524
+#: ../src/wxMaxima.cpp:4536
 msgid "no"
 msgstr "ne"
 
@@ -4854,15 +4857,15 @@ msgstr ""
 msgid "not subset or equal"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1345
+#: ../src/wxMaximaFrame.cpp:1344
 msgid "nu"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1356
+#: ../src/wxMaximaFrame.cpp:1355
 msgid "omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1347
+#: ../src/wxMaximaFrame.cpp:1346
 msgid "omicron"
 msgstr ""
 
@@ -4875,11 +4878,11 @@ msgstr ""
 msgid "partial sign"
 msgstr "Parciální zlomky"
 
-#: ../src/wxMaximaFrame.cpp:1353
+#: ../src/wxMaximaFrame.cpp:1352
 msgid "phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1348
+#: ../src/wxMaximaFrame.cpp:1347
 msgid "pi"
 msgstr ""
 
@@ -4891,11 +4894,11 @@ msgstr ""
 msgid "proportional to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1355
+#: ../src/wxMaximaFrame.cpp:1354
 msgid "psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1349
+#: ../src/wxMaximaFrame.cpp:1348
 msgid "rho"
 msgstr ""
 
@@ -4903,7 +4906,7 @@ msgstr ""
 msgid "right"
 msgstr "zprava"
 
-#: ../src/wxMaximaFrame.cpp:1350
+#: ../src/wxMaximaFrame.cpp:1349
 msgid "sigma"
 msgstr ""
 
@@ -4925,7 +4928,7 @@ msgstr "Pole podkapitoly"
 msgid "symmetric"
 msgstr "symetrická"
 
-#: ../src/wxMaximaFrame.cpp:1351
+#: ../src/wxMaximaFrame.cpp:1350
 msgid "tau"
 msgstr ""
 
@@ -4937,7 +4940,7 @@ msgstr ""
 msgid "there is no"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1340
+#: ../src/wxMaximaFrame.cpp:1339
 msgid "theta"
 msgstr ""
 
@@ -4953,13 +4956,13 @@ msgstr ""
 msgid "union"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5903
+#: ../src/wxMaxima.cpp:5918
 #, fuzzy
 msgid "unsaved"
 msgstr "[ neuloženo ]"
 
-#: ../src/wxMaximaFrame.cpp:290 ../src/wxMaxima.cpp:2559
-#: ../src/wxMaxima.cpp:2826
+#: ../src/wxMaxima.cpp:2566 ../src/wxMaxima.cpp:2834
+#: ../src/wxMaximaFrame.cpp:289
 msgid "untitled"
 msgstr "untitled"
 
@@ -4968,27 +4971,27 @@ msgstr "untitled"
 msgid "untitled %d"
 msgstr "untitled"
 
-#: ../src/wxMaximaFrame.cpp:1352
+#: ../src/wxMaximaFrame.cpp:1351
 #, fuzzy
 msgid "upsilon"
 msgstr "Epsilon:"
 
-#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4538
+#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4550
 msgid "wxMaxima"
 msgstr "wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
-#: ../src/wxMaxima.cpp:5700 ../src/wxMaxima.cpp:5709 ../src/wxMaxima.cpp:5712
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaxima.cpp:5715 ../src/wxMaxima.cpp:5724
+#: ../src/wxMaxima.cpp:5727 ../src/wxMaximaFrame.cpp:287
 #, c-format
 msgid "wxMaxima %s "
 msgstr "wxMaxima %s"
 
-#: ../src/wxMaximaFrame.cpp:952
+#: ../src/wxMaximaFrame.cpp:951
 #, fuzzy
 msgid "wxMaxima &Help\tCtrl+?"
 msgstr "Nápověda programu Maxima\tF1"
 
-#: ../src/wxMaximaFrame.cpp:955
+#: ../src/wxMaximaFrame.cpp:954
 #, fuzzy
 msgid "wxMaxima &Help\tF1"
 msgstr "Nápověda programu Maxima\tF1"
@@ -5000,11 +5003,11 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1619
+#: ../src/wxMaxima.cpp:1624
 msgid "wxMaxima cannot open content.xml in the .wxmx zip archive "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1633
+#: ../src/wxMaxima.cpp:1638
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
@@ -5012,7 +5015,7 @@ msgstr ""
 msgid "wxMaxima configuration"
 msgstr "Konfigurace programu wxMaxima"
 
-#: ../src/wxMaxima.cpp:1947
+#: ../src/wxMaxima.cpp:1952
 msgid ""
 "wxMaxima could not find Maxima!\n"
 "\n"
@@ -5024,7 +5027,7 @@ msgstr ""
 "Prosím nakonfigurujte program wxMaxima pomocí 'Edit->Configure'.\n"
 "Poté proveďte restart pomocí 'Maxima->Restart Maxima'."
 
-#: ../src/wxMaxima.cpp:2204
+#: ../src/wxMaxima.cpp:2209
 msgid ""
 "wxMaxima could not find help files.\n"
 "\n"
@@ -5034,7 +5037,7 @@ msgstr ""
 "\n"
 "Zkontrolujte si instalaci programu."
 
-#: ../src/wxMaxima.cpp:2032
+#: ../src/wxMaxima.cpp:2037
 msgid ""
 "wxMaxima could not find tip files.\n"
 "\n"
@@ -5044,7 +5047,7 @@ msgstr ""
 "\n"
 "Zkontrolujte si instalaci programu."
 
-#: ../src/wxMaxima.cpp:282
+#: ../src/wxMaxima.cpp:283
 msgid ""
 "wxMaxima could not start the server.\n"
 "\n"
@@ -5065,31 +5068,31 @@ msgstr ""
 "Dialog programu wxMaxima nastaví vstupní hodnoty, z nichž jedna je '%'. "
 "Pokud v dokumentu vyberete část textu, je místo toho použit tento výběr."
 
-#: ../src/wxMaxima.cpp:2330
+#: ../src/wxMaxima.cpp:2336
 msgid "wxMaxima document"
 msgstr "wxMaxima dokument"
 
-#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2799
+#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2807
 msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 msgstr "wxMaxima dokument (*.wxm)|*.wxm"
 
-#: ../src/wxMaxima.cpp:1455 ../src/wxMaxima.cpp:1469
+#: ../src/wxMaxima.cpp:1460 ../src/wxMaxima.cpp:1474
 msgid "wxMaxima encountered an error loading "
 msgstr "Chyba při načítání programu wxMaxima"
 
-#: ../src/wxMaxima.cpp:4463
+#: ../src/wxMaxima.cpp:4475
 #, fuzzy
 msgid "wxMaxima icon"
 msgstr "Nastavení programu wxMaxima"
 
-#: ../src/wxMaxima.cpp:4455
+#: ../src/wxMaxima.cpp:4467
 #, fuzzy
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "MAXIMA based on wxWidgets."
 msgstr "wxMaxima je GUI algebraického systému Maxima, založený na wxWidgets."
 
-#: ../src/wxMaxima.cpp:4516
+#: ../src/wxMaxima.cpp:4528
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "Maxima based on wxWidgets."
@@ -5107,11 +5110,11 @@ msgstr ""
 msgid "x"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1346
+#: ../src/wxMaximaFrame.cpp:1345
 msgid "xi"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1643
+#: ../src/wxMaxima.cpp:1648
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
@@ -5120,11 +5123,11 @@ msgstr ""
 msgid "xor"
 msgstr "Export"
 
-#: ../src/wxMaxima.cpp:4522
+#: ../src/wxMaxima.cpp:4534
 msgid "yes"
 msgstr "ano"
 
-#: ../src/wxMaximaFrame.cpp:1338
+#: ../src/wxMaximaFrame.cpp:1337
 msgid "zeta"
 msgstr ""
 

--- a/locales/da.po
+++ b/locales/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: da\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-07 21:42+0200\n"
+"POT-Creation-Date: 2016-10-16 17:47+0900\n"
 "PO-Revision-Date: 2009-06-08 20:39-0300\n"
 "Last-Translator: Jens Thostrup <jt@gu-nuuk.gl>\n"
 "Language-Team: danish <matematik@gu_nuuk.gl>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "X-Poedit-Language: Danish\n"
 "X-Poedit-Country: DENMARK\n"
 
-#: ../src/wxMaxima.cpp:4519
+#: ../src/wxMaxima.cpp:4531
 #, c-format
 msgid ""
 "\n"
@@ -27,27 +27,27 @@ msgid ""
 "Unicode support: %s"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4532
+#: ../src/wxMaxima.cpp:4544
 #, fuzzy
 msgid ""
 "\n"
 "Lisp: "
 msgstr "Liste:"
 
-#: ../src/wxMaxima.cpp:4528
+#: ../src/wxMaxima.cpp:4540
 #, fuzzy
 msgid ""
 "\n"
 "Maxima version: "
 msgstr "Maxima-spørgsmål"
 
-#: ../src/wxMaxima.cpp:5381
+#: ../src/wxMaxima.cpp:5397
 msgid ""
 "\n"
 "Not connected to Maxima!\n"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4530
+#: ../src/wxMaxima.cpp:4542
 msgid ""
 "\n"
 "Not connected."
@@ -65,7 +65,7 @@ msgstr ""
 msgid " (Graphics) "
 msgstr ""
 
-#: ../src/EditorCell.cpp:3045 ../src/EditorCell.cpp:3227
+#: ../src/EditorCell.cpp:3088 ../src/EditorCell.cpp:3270
 #, c-format
 msgid " ... + %i hidden lines"
 msgstr ""
@@ -74,7 +74,7 @@ msgstr ""
 msgid " << Expression longer than allowed by the configuration setting! >>"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1673
+#: ../src/wxMaxima.cpp:1678
 msgid ""
 " was saved using a newer version of wxMaxima so it may not load correctly. "
 "Please update your wxMaxima."
@@ -82,7 +82,7 @@ msgstr ""
 " er gemt fra en nyere version af wxMaxima, så den indlæses måske ikke "
 "korrekt. Opdater venligst din wxMaxima."
 
-#: ../src/wxMaxima.cpp:1665
+#: ../src/wxMaxima.cpp:1670
 msgid ""
 " was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr ""
@@ -96,64 +96,64 @@ msgstr ""
 msgid "\"implies\" symbol"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:101
+#: ../src/wxMaximaFrame.cpp:100
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:773
+#: ../src/wxMaximaFrame.cpp:772
 msgid "&Algebra"
 msgstr "&Algebra"
 
-#: ../src/wxMaximaFrame.cpp:767
+#: ../src/wxMaximaFrame.cpp:766
 msgid "&Apply to List..."
 msgstr "&Anvend på liste..."
 
-#: ../src/wxMaximaFrame.cpp:964
+#: ../src/wxMaximaFrame.cpp:963
 msgid "&Apropos..."
 msgstr "&Apropros..."
 
-#: ../src/wxMaximaFrame.cpp:478
+#: ../src/wxMaximaFrame.cpp:477
 msgid "&Batch File...\tCtrl-B"
 msgstr "&Batchfil...\tCtrl-B"
 
-#: ../src/wxMaximaFrame.cpp:724
+#: ../src/wxMaximaFrame.cpp:723
 msgid "&Boundary Value Problem..."
 msgstr "Rand&værdiproblem..."
 
-#: ../src/wxMaximaFrame.cpp:975
+#: ../src/wxMaximaFrame.cpp:974
 msgid "&Bug Report"
 msgstr "&Fejlrapportering"
 
-#: ../src/wxMaximaFrame.cpp:825
+#: ../src/wxMaximaFrame.cpp:824
 msgid "&Calculus"
 msgstr "&Infinitesimalregning"
 
-#: ../src/wxMaximaFrame.cpp:876
+#: ../src/wxMaximaFrame.cpp:875
 msgid "&Canonical Form"
 msgstr "&Kanonisk form"
 
-#: ../src/wxMaximaFrame.cpp:749
+#: ../src/wxMaximaFrame.cpp:748
 msgid "&Characteristic Polynomial..."
 msgstr "&Karakteristisk polynomium..."
 
-#: ../src/wxMaximaFrame.cpp:654
+#: ../src/wxMaximaFrame.cpp:653
 msgid "&Clear Memory"
 msgstr "&Ryd hukommelse"
 
-#: ../src/wxMaximaFrame.cpp:859
+#: ../src/wxMaximaFrame.cpp:858
 msgid "&Combine Factorials"
 msgstr "&Kombiner fakulteter"
 
-#: ../src/wxMaximaFrame.cpp:902
+#: ../src/wxMaximaFrame.cpp:901
 msgid "&Complex Simplification"
 msgstr "&Kompleks omskrivning"
 
-#: ../src/wxMaximaFrame.cpp:822
+#: ../src/wxMaximaFrame.cpp:821
 msgid "&Continued Fraction"
 msgstr "&Kædebrøk"
 
-#: ../src/wxMaximaFrame.cpp:502
+#: ../src/wxMaximaFrame.cpp:501
 msgid "&Copy\tCtrl-C"
 msgstr "K&opier\tCtrl-C"
 
@@ -162,111 +162,111 @@ msgid "&Definite integration"
 msgstr "&Bestemt integration"
 
 # de Moivres formel !!!
-#: ../src/wxMaximaFrame.cpp:896
+#: ../src/wxMaximaFrame.cpp:895
 msgid "&Demoivre"
 msgstr "&Demoivre"
 
-#: ../src/wxMaximaFrame.cpp:752
+#: ../src/wxMaximaFrame.cpp:751
 msgid "&Determinant"
 msgstr "&Determinant"
 
-#: ../src/wxMaximaFrame.cpp:785
+#: ../src/wxMaximaFrame.cpp:784
 msgid "&Differentiate..."
 msgstr "&Differentier..."
 
-#: ../src/wxMaximaFrame.cpp:543
+#: ../src/wxMaximaFrame.cpp:542
 msgid "&Edit"
 msgstr "&Rediger"
 
-#: ../src/wxMaximaFrame.cpp:709
+#: ../src/wxMaximaFrame.cpp:708
 msgid "&Eliminate Variable..."
 msgstr "&Eliminer variabel..."
 
-#: ../src/wxMaximaFrame.cpp:744
+#: ../src/wxMaximaFrame.cpp:743
 msgid "&Enter Matrix..."
 msgstr "I&ndtast matrix..."
 
-#: ../src/wxMaximaFrame.cpp:961
+#: ../src/wxMaximaFrame.cpp:960
 msgid "&Example..."
 msgstr "&Eksempel..."
 
 # Ledfom?
-#: ../src/wxMaximaFrame.cpp:839
+#: ../src/wxMaximaFrame.cpp:838
 msgid "&Expand Expression"
 msgstr "&Udvid udtryk"
 
 # Ledfom? - for langt?
-#: ../src/wxMaximaFrame.cpp:873
+#: ../src/wxMaximaFrame.cpp:872
 msgid "&Expand Trigonometric"
 msgstr "&Udvid trigonometrisk udtryk"
 
-#: ../src/wxMaximaFrame.cpp:899
+#: ../src/wxMaximaFrame.cpp:898
 msgid "&Exponentialize"
 msgstr "&Eksponentiel form"
 
-#: ../src/wxMaximaFrame.cpp:480
+#: ../src/wxMaximaFrame.cpp:479
 msgid "&Export..."
 msgstr "&Eksporter..."
 
-#: ../src/wxMaximaFrame.cpp:834
+#: ../src/wxMaximaFrame.cpp:833
 msgid "&Factor Expression"
 msgstr "&Faktoriser udtryk"
 
-#: ../src/wxMaximaFrame.cpp:489
+#: ../src/wxMaximaFrame.cpp:488
 msgid "&File"
 msgstr "&Filer"
 
-#: ../src/wxMaximaFrame.cpp:692
+#: ../src/wxMaximaFrame.cpp:691
 msgid "&Find Root..."
 msgstr "&Bestem nulpunkt..."
 
-#: ../src/wxMaximaFrame.cpp:738
+#: ../src/wxMaximaFrame.cpp:737
 msgid "&Generate Matrix..."
 msgstr "&Opret matrix..."
 
-#: ../src/wxMaximaFrame.cpp:809
+#: ../src/wxMaximaFrame.cpp:808
 msgid "&Greatest Common Divisor..."
 msgstr "Største &fælles divisor..."
 
-#: ../src/wxMaximaFrame.cpp:994
+#: ../src/wxMaximaFrame.cpp:993
 msgid "&Help"
 msgstr "&Hjælp"
 
-#: ../src/wxMaximaFrame.cpp:777
+#: ../src/wxMaximaFrame.cpp:776
 msgid "&Integrate..."
 msgstr "&Integrer..."
 
-#: ../src/wxMaximaFrame.cpp:645
+#: ../src/wxMaximaFrame.cpp:644
 msgid "&Interrupt\tCtrl-."
 msgstr "&Afbryd\tCtrl-."
 
-#: ../src/wxMaximaFrame.cpp:649
+#: ../src/wxMaximaFrame.cpp:648
 msgid "&Interrupt\tCtrl-G"
 msgstr "&Afbryd\tCtrl-."
 
-#: ../src/wxMaximaFrame.cpp:746
+#: ../src/wxMaximaFrame.cpp:745
 msgid "&Invert Matrix"
 msgstr "&Inverter matrix"
 
-#: ../src/wxMaximaFrame.cpp:476
+#: ../src/wxMaximaFrame.cpp:475
 msgid "&Load Package...\tCtrl-L"
 msgstr "Ind&læs pakke...\tCtrl-L"
 
-#: ../src/wxMaximaFrame.cpp:769
+#: ../src/wxMaximaFrame.cpp:768
 #, fuzzy
 msgid "&Map to List(s)..."
 msgstr "A&fbild liste"
 
-#: ../src/wxMaximaFrame.cpp:684
+#: ../src/wxMaximaFrame.cpp:683
 msgid "&Maxima"
 msgstr "&Maxima"
 
-#: ../src/wxMaximaFrame.cpp:958
+#: ../src/wxMaximaFrame.cpp:957
 #, fuzzy
 msgid "&Maxima help"
 msgstr "Vis Maxima Hjælp"
 
-#: ../src/wxMaximaFrame.cpp:917
+#: ../src/wxMaximaFrame.cpp:916
 msgid "&Modulus Computation..."
 msgstr "&Modulus-beregning..."
 
@@ -274,7 +274,7 @@ msgstr "&Modulus-beregning..."
 msgid "&New\tCtrl-N"
 msgstr "&Ny\tCtrl-N"
 
-#: ../src/wxMaximaFrame.cpp:947
+#: ../src/wxMaximaFrame.cpp:946
 msgid "&Numeric"
 msgstr "&Talformat"
 
@@ -292,11 +292,11 @@ msgstr "Anvend &nusum"
 msgid "&Open\tCtrl-O"
 msgstr "&Åbn\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:463
+#: ../src/wxMaximaFrame.cpp:462
 msgid "&Open...\tCtrl-O"
 msgstr "Å&bn...\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:929
+#: ../src/wxMaximaFrame.cpp:928
 msgid "&Plot"
 msgstr "&Plot"
 
@@ -304,7 +304,7 @@ msgstr "&Plot"
 msgid "&Power series"
 msgstr "&Potensrækker"
 
-#: ../src/wxMaximaFrame.cpp:483
+#: ../src/wxMaximaFrame.cpp:482
 msgid "&Print...\tCtrl-P"
 msgstr "&Udskriv...\tCtrl-P"
 
@@ -312,39 +312,39 @@ msgstr "&Udskriv...\tCtrl-P"
 msgid "&Rational"
 msgstr "Anvend &ratsubst"
 
-#: ../src/wxMaximaFrame.cpp:870
+#: ../src/wxMaximaFrame.cpp:869
 msgid "&Reduce Trigonometric"
 msgstr "&Sammentræk trigonometrisk udtryk"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "&Restart Maxima"
 msgstr "&Genstart Maxima"
 
-#: ../src/wxMaximaFrame.cpp:700
+#: ../src/wxMaximaFrame.cpp:699
 msgid "&Roots of Polynomial (Real)"
 msgstr "&Reelle rødder i polynomium"
 
-#: ../src/wxMaximaFrame.cpp:472
+#: ../src/wxMaximaFrame.cpp:471
 msgid "&Save\tCtrl-S"
 msgstr "&Gem\tCtrl-S"
 
-#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:919
+#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:918
 msgid "&Simplify"
 msgstr "&Omskriv"
 
-#: ../src/wxMaximaFrame.cpp:829
+#: ../src/wxMaximaFrame.cpp:828
 msgid "&Simplify Expression"
 msgstr "Re&ducer udtryk"
 
-#: ../src/wxMaximaFrame.cpp:856
+#: ../src/wxMaximaFrame.cpp:855
 msgid "&Simplify Factorials"
 msgstr "&Reducer fakulteter"
 
-#: ../src/wxMaximaFrame.cpp:867
+#: ../src/wxMaximaFrame.cpp:866
 msgid "&Simplify Trigonometric"
 msgstr "&Reducer trigonometrisk udtryk"
 
-#: ../src/wxMaximaFrame.cpp:688
+#: ../src/wxMaximaFrame.cpp:687
 msgid "&Solve..."
 msgstr "&Løs..."
 
@@ -356,11 +356,11 @@ msgstr "&Plottype"
 msgid "&Taylor series"
 msgstr "&Taylorrækker"
 
-#: ../src/wxMaximaFrame.cpp:762
+#: ../src/wxMaximaFrame.cpp:761
 msgid "&Transpose Matrix"
 msgstr "&Transponer matrix"
 
-#: ../src/wxMaximaFrame.cpp:879
+#: ../src/wxMaximaFrame.cpp:878
 msgid "&Trigonometric Simplification"
 msgstr "&Trigonometrisk omskrivning"
 
@@ -380,7 +380,7 @@ msgstr "(Anvend standard sprog)"
 msgid "- Infinity"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:351
+#: ../src/wxMaxima.cpp:356
 msgid ""
 "... [suppressed additional lines since the output is longer than allowed in "
 "the configuration] "
@@ -390,17 +390,17 @@ msgstr ""
 msgid "1/2"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:103
+#: ../src/wxMaximaFrame.cpp:102
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4601
+#: ../src/wxMaxima.cpp:4613
 #, fuzzy
 msgid "<br>Lisp: "
 msgstr "Liste:"
 
-#: ../src/wxMaxima.cpp:5487
+#: ../src/wxMaxima.cpp:5503
 msgid ""
 "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
@@ -434,11 +434,11 @@ msgid ""
 "\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1472
+#: ../src/wxMaximaFrame.cpp:1495
 msgid "A symbol from the configuration dialogue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:731
+#: ../src/wxMaximaFrame.cpp:730
 msgid "A&t Value..."
 msgstr "Ra&ndbetingelser..."
 
@@ -446,12 +446,12 @@ msgstr "Ra&ndbetingelser..."
 msgid "Abort evaluation on error"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaxima.cpp:4603
+#: ../src/wxMaxima.cpp:4615 ../src/wxMaximaFrame.cpp:985
 msgid "About"
 msgstr "&Om"
 
-#: ../src/wxMaximaFrame.cpp:987 ../src/wxMaximaFrame.cpp:990
-#: ../src/wxMaximaFrame.cpp:991
+#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaximaFrame.cpp:989
+#: ../src/wxMaximaFrame.cpp:990
 msgid "About wxMaxima"
 msgstr "Om wxMaxima"
 
@@ -459,23 +459,23 @@ msgstr "Om wxMaxima"
 msgid "Active cell bracket"
 msgstr "Parentes for aktiv celle"
 
-#: ../src/wxMaximaFrame.cpp:760
+#: ../src/wxMaximaFrame.cpp:759
 msgid "Ad&joint Matrix"
 msgstr "Ad&jungeret matrix"
 
-#: ../src/wxMaximaFrame.cpp:914
+#: ../src/wxMaximaFrame.cpp:913
 msgid "Add Algebraic E&quality..."
 msgstr "Tilføj alge&braisk udtryk (tellrat)..."
 
-#: ../src/wxMaximaFrame.cpp:657
+#: ../src/wxMaximaFrame.cpp:656
 msgid "Add a directory to search path"
 msgstr "Føj en mappe til søgestien"
 
-#: ../src/wxMaxima.cpp:3353
+#: ../src/wxMaxima.cpp:3365
 msgid "Add dir to path:"
 msgstr "Føj mappe til sti:"
 
-#: ../src/wxMaximaFrame.cpp:915
+#: ../src/wxMaximaFrame.cpp:914
 msgid "Add equality to the rational simplifier"
 msgstr "Tilføj algebraisk udtryk med Maxima-kommandoen tellrat"
 
@@ -483,7 +483,7 @@ msgstr "Tilføj algebraisk udtryk med Maxima-kommandoen tellrat"
 msgid "Add the .wxmx file to the HTML export"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:656
+#: ../src/wxMaximaFrame.cpp:655
 msgid "Add to &Path..."
 msgstr "Føj &til sti"
 
@@ -524,27 +524,27 @@ msgstr "Tidligere variabel:"
 msgid "All|*"
 msgstr "Alle|*"
 
-#: ../src/wxMaximaFrame.cpp:1364
+#: ../src/wxMaximaFrame.cpp:1363
 msgid "Alpha"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3838
+#: ../src/wxMaxima.cpp:3850
 msgid "Apply"
 msgstr "Anvend"
 
-#: ../src/wxMaximaFrame.cpp:768
+#: ../src/wxMaximaFrame.cpp:767
 msgid "Apply function to a list"
 msgstr "Anvend funktion på liste"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Apropos"
 msgstr "Apropros"
 
-#: ../src/wxMaxima.cpp:3764
+#: ../src/wxMaxima.cpp:3776
 msgid "Array:"
 msgstr "2D-array:"
 
-#: ../src/wxMaxima.cpp:4462
+#: ../src/wxMaxima.cpp:4474
 msgid "Artwork by"
 msgstr ""
 
@@ -552,7 +552,7 @@ msgstr ""
 msgid "Ask to save untitled documents"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3650
+#: ../src/wxMaxima.cpp:3662
 msgid "At value"
 msgstr "Randbetingelser"
 
@@ -574,11 +574,11 @@ msgid "Autosave interval (minutes, 0 means: off):"
 msgstr ""
 
 # Randværdi - Maxima
-#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3557
+#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3569
 msgid "BC2"
 msgstr "BC2"
 
-#: ../src/wxMaximaFrame.cpp:1272
+#: ../src/wxMaximaFrame.cpp:1271
 msgid "Barsplot..."
 msgstr ""
 
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Bat files (*.bat)|*.bat|All|*"
 msgstr "Batchfiler (*.bat)|*.bat|Alle|*"
 
-#: ../src/wxMaxima.cpp:2943
+#: ../src/wxMaxima.cpp:2951
 msgid "Batch File"
 msgstr "Batchfil"
 
@@ -599,7 +599,7 @@ msgid ""
 "cells."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1365
+#: ../src/wxMaximaFrame.cpp:1364
 msgid "Beta"
 msgstr ""
 
@@ -611,11 +611,11 @@ msgstr ""
 msgid "Bold"
 msgstr "Fed"
 
-#: ../src/wxMaxima.cpp:2359
+#: ../src/wxMaxima.cpp:2366
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1274
+#: ../src/wxMaximaFrame.cpp:1273
 #, fuzzy
 msgid "Boxplot..."
 msgstr "Eksporter"
@@ -628,15 +628,15 @@ msgstr "Gennemse"
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2080
+#: ../src/MathCtrl.cpp:2127
 msgid "Bug: Cell left but not entered."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1178
+#: ../src/wxMaxima.cpp:1183
 msgid "Bug: Found a math end marker without any start marker."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1222
+#: ../src/wxMaxima.cpp:1227
 msgid "Bug: Found the end of autocompletion symbols but no beginning"
 msgstr ""
 
@@ -648,22 +648,22 @@ msgstr ""
 msgid "Bug: Fraction without enumerator"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2312
+#: ../src/MathCtrl.cpp:2359
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5839
+#: ../src/MathCtrl.cpp:5891
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of "
 "the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5913
+#: ../src/MathCtrl.cpp:5965
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5882
+#: ../src/MathCtrl.cpp:5934
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
@@ -673,49 +673,49 @@ msgstr ""
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
 msgstr ""
 
-#: ../src/GroupCell.cpp:780 ../src/GroupCell.cpp:951
+#: ../src/GroupCell.cpp:781 ../src/GroupCell.cpp:952
 msgid "Bug: No image counter to write to!"
 msgstr ""
 
-#: ../src/AbsCell.cpp:193
+#: ../src/AbsCell.cpp:199
 msgid "Bug: No last cell in an absCell!"
 msgstr ""
 
-#: ../src/ConjugateCell.cpp:185
+#: ../src/ConjugateCell.cpp:194
 msgid "Bug: No last cell in an conjugateCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:471
+#: ../src/FracCell.cpp:472
 msgid "Bug: No last cell in an denominator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:267
+#: ../src/ExptCell.cpp:270
 msgid "Bug: No last cell in an exponent of an exptCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:459
+#: ../src/FracCell.cpp:460
 msgid "Bug: No last cell in an numerator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:257
+#: ../src/ExptCell.cpp:260
 msgid "Bug: No last cell in the base of an exptCell!"
 msgstr ""
 
-#: ../src/ParenCell.cpp:534
+#: ../src/ParenCell.cpp:535
 msgid "Bug: No last cell inside a parenthesis!"
 msgstr ""
 
-#: ../src/SqrtCell.cpp:312
+#: ../src/SqrtCell.cpp:317
 msgid "Bug: No last cell inside a square root!"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2123
+#: ../src/MathCtrl.cpp:2170
 msgid ""
 "Bug: Start or end of merging of subsequent editing actions was requested two "
 "times in a row."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2090
+#: ../src/MathCtrl.cpp:2137
 msgid "Bug: Text changed, but no active cell."
 msgstr ""
 
@@ -723,39 +723,39 @@ msgstr ""
 msgid "Bug: Trying to append NULL to a group cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:555
+#: ../src/MathCtrl.cpp:600
 msgid "Bug: Trying to append maxima's output to a cell outside the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2014
+#: ../src/MathCtrl.cpp:2061
 msgid ""
 "Bug: Trying to merge individual cell adds to a region in the undo buffer but "
 "there are other cells between them."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6522
+#: ../src/MathCtrl.cpp:6577
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2092
+#: ../src/MathCtrl.cpp:2139
 msgid "Bug: Trying to record a cell contents change without a cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1495
+#: ../src/MathCtrl.cpp:1540
 msgid "Bug: Trying to select inside a cell without having a current cell"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5883
+#: ../src/MathCtrl.cpp:5935
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5844 ../src/MathCtrl.cpp:5918 ../src/MathCtrl.cpp:5952
+#: ../src/MathCtrl.cpp:5896 ../src/MathCtrl.cpp:5970 ../src/MathCtrl.cpp:6004
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:973
+#: ../src/wxMaximaFrame.cpp:972
 msgid "Build &Info"
 msgstr "&Version"
 
@@ -772,53 +772,53 @@ msgstr ""
 ">Indstillinger' og afkrydsning af boksen 'Enter til beregning' kan denne "
 "mulighed vælges."
 
-#: ../src/wxMaximaFrame.cpp:782
+#: ../src/wxMaximaFrame.cpp:781
 msgid "C&hange Variable..."
 msgstr "&Udskift variabel..."
 
-#: ../src/wxMaximaFrame.cpp:540
+#: ../src/wxMaximaFrame.cpp:539
 msgid "C&onfigure"
 msgstr "&Indstillinger..."
 
-#: ../src/wxMaximaFrame.cpp:801
+#: ../src/wxMaximaFrame.cpp:800
 msgid "Calculate &Product..."
 msgstr "Beregn &produkt"
 
-#: ../src/wxMaximaFrame.cpp:799
+#: ../src/wxMaximaFrame.cpp:798
 msgid "Calculate Su&m..."
 msgstr "Beregn &sum"
 
 # Det er lidt tungt med decimaltal 1 og 2
-#: ../src/wxMaximaFrame.cpp:939
+#: ../src/wxMaximaFrame.cpp:938
 msgid "Calculate bigfloat value of the last result"
 msgstr "Beregn seneste værdi som decimaltal 2"
 
-#: ../src/wxMaximaFrame.cpp:936
+#: ../src/wxMaximaFrame.cpp:935
 msgid "Calculate float value of the last result"
 msgstr "Beregn seneste værdi som decimaltal 1"
 
-#: ../src/wxMaxima.cpp:3971
+#: ../src/wxMaxima.cpp:3983
 msgid "Calculate modulus:"
 msgstr "Beregn modulo:"
 
-#: ../src/wxMaximaFrame.cpp:942
+#: ../src/wxMaximaFrame.cpp:941
 #, fuzzy
 msgid "Calculate numeric value of the last result"
 msgstr "Beregn seneste værdi som decimaltal 1"
 
-#: ../src/wxMaximaFrame.cpp:802
+#: ../src/wxMaximaFrame.cpp:801
 msgid "Calculate products"
 msgstr "Beregn produkter"
 
-#: ../src/wxMaximaFrame.cpp:800
+#: ../src/wxMaximaFrame.cpp:799
 msgid "Calculate sums"
 msgstr "Beregn summer"
 
-#: ../src/wxMaxima.cpp:5830
+#: ../src/wxMaxima.cpp:5845
 msgid "Can not connect to the web server."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5881
+#: ../src/wxMaxima.cpp:5896
 msgid "Can not download version info."
 msgstr ""
 
@@ -834,15 +834,15 @@ msgstr ""
 #: ../src/PlotFormatWiz.cpp:48 ../src/SeriesWiz.cpp:49 ../src/SeriesWiz.cpp:51
 #: ../src/SubstituteWiz.cpp:41 ../src/SubstituteWiz.cpp:43 ../src/SumWiz.cpp:44
 #: ../src/SumWiz.cpp:46 ../src/SystemWiz.cpp:38 ../src/SystemWiz.cpp:40
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Cancel"
 msgstr "Annuller"
 
-#: ../src/wxMaximaFrame.cpp:126 ../src/wxMaxima.cpp:932
+#: ../src/wxMaxima.cpp:937 ../src/wxMaximaFrame.cpp:125
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1217
+#: ../src/wxMaximaFrame.cpp:1216
 #, fuzzy
 msgid "Canonical (tr)"
 msgstr "&Kanonisk form"
@@ -852,7 +852,7 @@ msgstr "&Kanonisk form"
 msgid "Catalan"
 msgstr "Italiensk"
 
-#: ../src/wxMaximaFrame.cpp:638
+#: ../src/wxMaximaFrame.cpp:637
 msgid "Ce&ll"
 msgstr ""
 
@@ -860,41 +860,41 @@ msgstr ""
 msgid "Cell bracket"
 msgstr "Celleparentes"
 
-#: ../src/wxMaxima.cpp:5261
+#: ../src/wxMaxima.cpp:5273
 msgid "Cell ends in a backslash"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:676
+#: ../src/wxMaximaFrame.cpp:675
 msgid "Change &2d Display"
 msgstr "2D-visning"
 
-#: ../src/wxMaximaFrame.cpp:677
+#: ../src/wxMaximaFrame.cpp:676
 msgid "Change the 2d display algorithm used to display math output"
 msgstr "Vælg algoritme til 2D-visning af matematisk output"
 
-#: ../src/wxMaxima.cpp:3995
+#: ../src/wxMaxima.cpp:4007
 msgid "Change variable"
 msgstr "Udskift variabel"
 
-#: ../src/wxMaximaFrame.cpp:783
+#: ../src/wxMaximaFrame.cpp:782
 msgid "Change variable in integral or sum"
 msgstr "Udskift variabel i integral eller sum"
 
-#: ../src/wxMaxima.cpp:3751
+#: ../src/wxMaxima.cpp:3763
 msgid "Char poly"
 msgstr "Karakteristisk polynomium"
 
-#: ../src/wxMaximaFrame.cpp:978
+#: ../src/wxMaximaFrame.cpp:977
 msgid "Check for Updates"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:979
+#: ../src/wxMaximaFrame.cpp:978
 #, fuzzy
 msgid "Check if a newer version of wxMaxima/Maxima exist."
 msgstr ""
 " er gemt fra en nyere version af wxMaxima. Opdater venligst din wxMaxima."
 
-#: ../src/wxMaximaFrame.cpp:1385
+#: ../src/wxMaximaFrame.cpp:1384
 msgid "Chi"
 msgstr ""
 
@@ -916,16 +916,16 @@ msgstr "Vælg skrifttype"
 msgid "Choose new plot format:"
 msgstr "Vælg nyt plot format"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710
 msgid "Classes:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:469
+#: ../src/wxMaximaFrame.cpp:468
 #, fuzzy
 msgid "Close\tCtrl-W"
 msgstr "K&opier\tCtrl-C"
 
-#: ../src/wxMaximaFrame.cpp:470
+#: ../src/wxMaximaFrame.cpp:469
 msgid "Close window"
 msgstr ""
 
@@ -957,20 +957,20 @@ msgstr ""
 msgid "Code highlighting: Variables"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4806
+#: ../src/wxMaxima.cpp:4818
 #, fuzzy
 msgid "Col. names:"
 msgstr "Søjler:"
 
-#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Columns:"
 msgstr "Søjler:"
 
-#: ../src/wxMaximaFrame.cpp:860
+#: ../src/wxMaximaFrame.cpp:859
 msgid "Combine factorials in an expression"
 msgstr "Kombiner fakulteter i et udtryk"
 
-#: ../src/wxMaxima.cpp:5293
+#: ../src/wxMaxima.cpp:5305
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
@@ -982,25 +982,25 @@ msgstr "Kommaseparerede y-koordinater"
 msgid "Comma separated y coordinates"
 msgstr "Kommaseparerede x-koordinater"
 
-#: ../src/MathCtrl.cpp:1030
+#: ../src/MathCtrl.cpp:1072
 #, fuzzy
 msgid "Comment Selection"
 msgstr "Klip markering"
 
-#: ../src/wxMaximaFrame.cpp:533
+#: ../src/wxMaximaFrame.cpp:532
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:532
+#: ../src/wxMaximaFrame.cpp:531
 #, fuzzy
 msgid "Comment selection\tCtrl-/"
 msgstr "Klip markering"
 
-#: ../src/wxMaximaFrame.cpp:601
+#: ../src/wxMaximaFrame.cpp:600
 msgid "Complete Word\tCtrl-K"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:602
+#: ../src/wxMaximaFrame.cpp:601
 msgid "Complete word"
 msgstr ""
 
@@ -1008,37 +1008,37 @@ msgstr ""
 msgid "Completely stop maxima and restart it"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:823
+#: ../src/wxMaximaFrame.cpp:822
 msgid "Compute continued fraction of a value"
 msgstr "Beregn en størrelses kædebrøk"
 
-#: ../src/wxMaximaFrame.cpp:761
+#: ../src/wxMaximaFrame.cpp:760
 #, fuzzy
 msgid "Compute the adjoint matrix"
 msgstr "Beregn den adjungerede matrix"
 
-#: ../src/wxMaximaFrame.cpp:750
+#: ../src/wxMaximaFrame.cpp:749
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr "Beregn en matrixs karakteristiske polynomium"
 
-#: ../src/wxMaximaFrame.cpp:753
+#: ../src/wxMaximaFrame.cpp:752
 msgid "Compute the determinant of a matrix"
 msgstr "Beregn en matrixs determinant"
 
-#: ../src/wxMaximaFrame.cpp:810
+#: ../src/wxMaximaFrame.cpp:809
 msgid "Compute the greatest common divisor"
 msgstr "Beregn største fælles divisor"
 
-#: ../src/wxMaximaFrame.cpp:747
+#: ../src/wxMaximaFrame.cpp:746
 msgid "Compute the inverse of a matrix"
 msgstr "Beregn en matrixs inverse"
 
-#: ../src/wxMaximaFrame.cpp:813
+#: ../src/wxMaximaFrame.cpp:812
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
 "Beregn mindste fælles multiplum (anvend kommandoen load(functs) før brug)"
 
-#: ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4868
 #, fuzzy
 msgid "Condition:"
 msgstr "Animation"
@@ -1051,8 +1051,8 @@ msgstr "Konfigurationsfil (*.ini)|*.ini"
 msgid "Configuration warning"
 msgstr "Konfigurationsadvarsel"
 
-#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:538
-#: ../src/wxMaximaFrame.cpp:541
+#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:540
 msgid "Configure wxMaxima"
 msgstr "wxMaxima indstillinger"
 
@@ -1061,136 +1061,138 @@ msgstr "wxMaxima indstillinger"
 msgid "Constant"
 msgstr "Konstant"
 
-#: ../src/wxMaximaFrame.cpp:844
+#: ../src/wxMaximaFrame.cpp:843
 msgid "Contract Logarithms"
 msgstr "Sammentræk logaritmer"
 
-#: ../src/wxMaximaFrame.cpp:851
+#: ../src/wxMaximaFrame.cpp:850
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr "Omregn binomialkoefficienter, Beta- og Gamma-funktioner til fakulteter"
 
-#: ../src/wxMaximaFrame.cpp:854
+#: ../src/wxMaximaFrame.cpp:853
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr ""
 "Omregn binomialkoefficienter, fakulteter og Beta-funktioner til Gamma-"
 "funktion"
 
-#: ../src/wxMaximaFrame.cpp:888
+#: ../src/wxMaximaFrame.cpp:887
 msgid "Convert complex expression to polar form"
 msgstr "Omregn komplekst udtryk til polær form"
 
-#: ../src/wxMaximaFrame.cpp:885
+#: ../src/wxMaximaFrame.cpp:884
 msgid "Convert complex expression to rect form"
 msgstr "Omregn komplekst udtryk til rektangulær form"
 
-#: ../src/wxMaximaFrame.cpp:897
+#: ../src/wxMaximaFrame.cpp:896
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
 "Omregn eksponentiel funktion med imaginært argument til trigonometrisk form"
 
-#: ../src/wxMaximaFrame.cpp:842
+#: ../src/wxMaximaFrame.cpp:841
 msgid "Convert logarithm of product to sum of logarithms"
 msgstr "Omregn logaritme af produkt til sum af logaritmer"
 
-#: ../src/wxMaximaFrame.cpp:845
+#: ../src/wxMaximaFrame.cpp:844
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "Omregn sum af logaritmer til logaritme af produkt"
 
-#: ../src/wxMaximaFrame.cpp:850
+#: ../src/wxMaximaFrame.cpp:849
 msgid "Convert to &Factorials"
 msgstr "Omregn til &fakultet"
 
-#: ../src/wxMaximaFrame.cpp:853
+#: ../src/wxMaximaFrame.cpp:852
 msgid "Convert to &Gamma"
 msgstr "Omregn til &Gamma-funktion"
 
-#: ../src/wxMaximaFrame.cpp:887
+#: ../src/wxMaximaFrame.cpp:886
 msgid "Convert to &Polarform"
 msgstr "Omregn til &polær form"
 
-#: ../src/wxMaximaFrame.cpp:884
+#: ../src/wxMaximaFrame.cpp:883
 msgid "Convert to &Rectform"
 msgstr "&Omregn til rektangulær form"
 
-#: ../src/wxMaximaFrame.cpp:877
+#: ../src/wxMaximaFrame.cpp:876
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr "Omregn trigonometrisk udtryk til kanonisk kvasilineær form"
 
-#: ../src/wxMaximaFrame.cpp:900
+#: ../src/wxMaximaFrame.cpp:899
 #, fuzzy
 msgid "Convert trigonometric functions to exponential form"
 msgstr "Omregn trigonometrisk funktion til eksponentiel form"
 
-#: ../src/ToolBar.cpp:140 ../src/MathCtrl.cpp:918 ../src/MathCtrl.cpp:931
-#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1024
+#: ../src/MathCtrl.cpp:960 ../src/MathCtrl.cpp:973 ../src/MathCtrl.cpp:1019
+#: ../src/MathCtrl.cpp:1066 ../src/ToolBar.cpp:140
 msgid "Copy"
 msgstr "Kopier"
 
-#: ../src/wxMaximaFrame.cpp:597
+#: ../src/wxMaximaFrame.cpp:596
 msgid "Copy Previous Input\tCtrl-I"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:599
+#: ../src/wxMaximaFrame.cpp:598
 msgid "Copy Previous Output\tCtrl-U"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:514 ../src/MathCtrl.cpp:936 ../src/MathCtrl.cpp:982
+#: ../src/MathCtrl.cpp:978 ../src/MathCtrl.cpp:1024
+#: ../src/wxMaximaFrame.cpp:513
 msgid "Copy as Image"
 msgstr "Kopier som billede"
 
-#: ../src/wxMaximaFrame.cpp:507 ../src/MathCtrl.cpp:932 ../src/MathCtrl.cpp:978
+#: ../src/MathCtrl.cpp:974 ../src/MathCtrl.cpp:1020
+#: ../src/wxMaximaFrame.cpp:506
 #, fuzzy
 msgid "Copy as LaTeX"
 msgstr "Kopier som LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:510
+#: ../src/wxMaximaFrame.cpp:509
 #, fuzzy
 msgid "Copy as MathML"
 msgstr "Kopier som billede"
 
-#: ../src/MathCtrl.cpp:935 ../src/MathCtrl.cpp:980
+#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1022
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:504
+#: ../src/wxMaximaFrame.cpp:503
 #, fuzzy
 msgid "Copy as Text\tCtrl-Shift-C"
 msgstr "Kopier celle(r)\tCtrl-Shift-C"
 
-#: ../src/MathCtrl.cpp:933 ../src/MathCtrl.cpp:979
+#: ../src/MathCtrl.cpp:975 ../src/MathCtrl.cpp:1021
 #, fuzzy
 msgid "Copy as plain text"
 msgstr "Kopier som billede"
 
-#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:503
+#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:502
 msgid "Copy selection"
 msgstr "Kopier markering"
 
-#: ../src/wxMaximaFrame.cpp:515
+#: ../src/wxMaximaFrame.cpp:514
 msgid "Copy selection from document as an image"
 msgstr "Kopier markering fra dokument som billede"
 
-#: ../src/wxMaximaFrame.cpp:505
+#: ../src/wxMaximaFrame.cpp:504
 #, fuzzy
 msgid "Copy selection from document as text"
 msgstr "Kopier markering fra dokument som billede"
 
-#: ../src/wxMaximaFrame.cpp:508
+#: ../src/wxMaximaFrame.cpp:507
 msgid "Copy selection from document in LaTeX format"
 msgstr "Kopier markering fra dokument som LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:511
+#: ../src/wxMaximaFrame.cpp:510
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:598
+#: ../src/wxMaximaFrame.cpp:597
 msgid "Create a new cell with previous input"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:600
+#: ../src/wxMaximaFrame.cpp:599
 msgid "Create a new cell with previous output"
 msgstr ""
 
@@ -1198,15 +1200,15 @@ msgstr ""
 msgid "Cursor"
 msgstr "Markør"
 
-#: ../src/ToolBar.cpp:137 ../src/MathCtrl.cpp:1023
+#: ../src/MathCtrl.cpp:1065 ../src/ToolBar.cpp:137
 msgid "Cut"
 msgstr "Klip"
 
-#: ../src/wxMaximaFrame.cpp:499
+#: ../src/wxMaximaFrame.cpp:498
 msgid "Cut\tCtrl-X"
 msgstr "&Klip\tCtrl-X"
 
-#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:500
+#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:499
 msgid "Cut selection"
 msgstr "Klip markering"
 
@@ -1219,19 +1221,19 @@ msgstr ""
 msgid "Danish"
 msgstr "Spansk"
 
-#: ../src/wxMaxima.cpp:4799 ../src/wxMaxima.cpp:4806 ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4811 ../src/wxMaxima.cpp:4818 ../src/wxMaxima.cpp:4868
 #, fuzzy
 msgid "Data Matrix:"
 msgstr "Matrix:"
 
-#: ../src/wxMaxima.cpp:4826
+#: ../src/wxMaxima.cpp:4838
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698 ../src/wxMaxima.cpp:4712
-#: ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726 ../src/wxMaxima.cpp:4734
-#: ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748 ../src/wxMaxima.cpp:4755
-#: ../src/wxMaxima.cpp:4791
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710 ../src/wxMaxima.cpp:4724
+#: ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738 ../src/wxMaxima.cpp:4746
+#: ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760 ../src/wxMaxima.cpp:4767
+#: ../src/wxMaxima.cpp:4803
 msgid "Data:"
 msgstr ""
 
@@ -1239,7 +1241,7 @@ msgstr ""
 msgid "Debug: watch maxima's stdout stream"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:820
+#: ../src/wxMaximaFrame.cpp:819
 msgid "Decompose rational function to partial fractions"
 msgstr "Opløs rational funktion i partialbrøker"
 
@@ -1270,47 +1272,47 @@ msgid ""
 "with."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3403 ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3415 ../src/wxMaxima.cpp:3424
 msgid "Delete"
 msgstr "Slet"
 
-#: ../src/wxMaximaFrame.cpp:667
+#: ../src/wxMaximaFrame.cpp:666
 msgid "Delete F&unction..."
 msgstr "Slet f&unktion"
 
-#: ../src/MathCtrl.cpp:939 ../src/MathCtrl.cpp:985
+#: ../src/MathCtrl.cpp:981 ../src/MathCtrl.cpp:1027
 msgid "Delete Selection"
 msgstr "Slet markering"
 
-#: ../src/wxMaximaFrame.cpp:669
+#: ../src/wxMaximaFrame.cpp:668
 msgid "Delete V&ariable..."
 msgstr "&Slet variabel"
 
-#: ../src/wxMaximaFrame.cpp:668
+#: ../src/wxMaximaFrame.cpp:667
 msgid "Delete a function"
 msgstr "Slet en funktion"
 
-#: ../src/wxMaximaFrame.cpp:670
+#: ../src/wxMaximaFrame.cpp:669
 msgid "Delete a variable"
 msgstr "Slet en variabel"
 
-#: ../src/wxMaximaFrame.cpp:655
+#: ../src/wxMaximaFrame.cpp:654
 msgid "Delete all values from memory"
 msgstr "Slet alle værdier fra hukommelsen"
 
-#: ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3424
 msgid "Delete function(s):"
 msgstr "Slet funktion(er):"
 
-#: ../src/wxMaxima.cpp:3403
+#: ../src/wxMaxima.cpp:3415
 msgid "Delete variable(s):"
 msgstr "Slet variable:"
 
-#: ../src/wxMaximaFrame.cpp:1367
+#: ../src/wxMaximaFrame.cpp:1366
 msgid "Delta"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4011
+#: ../src/wxMaxima.cpp:4023
 msgid "Denom. deg:"
 msgstr "Nævners grad:"
 
@@ -1319,36 +1321,36 @@ msgid "Depth:"
 msgstr "Orden:"
 
 # kontekst?
-#: ../src/wxMaxima.cpp:3541
+#: ../src/wxMaxima.cpp:3553
 msgid "Derivative:"
 msgstr "Afledet:"
 
-#: ../src/wxMaximaFrame.cpp:1258
+#: ../src/wxMaximaFrame.cpp:1257
 #, fuzzy
 msgid "Deviation..."
 msgstr "Animation"
 
-#: ../src/wxMaximaFrame.cpp:816
+#: ../src/wxMaximaFrame.cpp:815
 msgid "Di&vide Polynomials..."
 msgstr "P&olynomiers division..."
 
-#: ../src/wxMaximaFrame.cpp:1223
+#: ../src/wxMaximaFrame.cpp:1222
 msgid "Diff..."
 msgstr "Differentier..."
 
-#: ../src/wxMaxima.cpp:4154 ../src/wxMaxima.cpp:5066
+#: ../src/wxMaxima.cpp:4166 ../src/wxMaxima.cpp:5078
 msgid "Differentiate"
 msgstr "Differentier"
 
-#: ../src/wxMaximaFrame.cpp:786
+#: ../src/wxMaximaFrame.cpp:785
 msgid "Differentiate expression"
 msgstr "Differentier udtryk"
 
-#: ../src/MathCtrl.cpp:1001
+#: ../src/MathCtrl.cpp:1043
 msgid "Differentiate..."
 msgstr "Differentier..."
 
-#: ../src/LimitWiz.cpp:37 ../src/FindReplacePane.cpp:76
+#: ../src/FindReplacePane.cpp:76 ../src/LimitWiz.cpp:37
 msgid "Direction:"
 msgstr "Fra:"
 
@@ -1356,49 +1358,50 @@ msgstr "Fra:"
 msgid "Discrete plot"
 msgstr "Diskret plot"
 
-#: ../src/wxMaximaFrame.cpp:679
+#: ../src/wxMaximaFrame.cpp:678
 msgid "Display Te&X Form"
 msgstr "Vis som Te&X"
 
-#: ../src/wxMaxima.cpp:3320
+#: ../src/wxMaxima.cpp:3332
 msgid "Display algorithm"
 msgstr "2D-visning"
 
-#: ../src/wxMaximaFrame.cpp:680
+#: ../src/wxMaximaFrame.cpp:679
 msgid "Display last result in TeX form"
 msgstr "Vis seneste resultat som TeX"
 
-#: ../src/wxMaximaFrame.cpp:674
+#: ../src/wxMaximaFrame.cpp:673
 msgid "Display time used for evaluation"
 msgstr "Vis beregningstid"
 
-#: ../src/wxMaxima.cpp:4061
+#: ../src/wxMaxima.cpp:4073
 msgid "Divide"
 msgstr "Division"
 
-#: ../src/MathCtrl.cpp:1032
+#: ../src/MathCtrl.cpp:1074
 #, fuzzy
 msgid "Divide Cell"
 msgstr "Division"
 
-#: ../src/wxMaximaFrame.cpp:635
+#: ../src/wxMaximaFrame.cpp:634
 #, fuzzy
 msgid "Divide Cell\tCtrl-D"
 msgstr "Division"
 
-#: ../src/wxMaximaFrame.cpp:817
+#: ../src/wxMaximaFrame.cpp:816
 msgid "Divide numbers or polynomials"
 msgstr "Division med tal eller polynomier"
 
-#: ../src/wxMaximaFrame.cpp:636
+#: ../src/wxMaximaFrame.cpp:635
 msgid "Divide this input cell into two cells"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5917
-msgid "Do you want to save the changes you made in the document \""
+#: ../src/wxMaxima.cpp:5932
+#, c-format
+msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1664 ../src/wxMaxima.cpp:1672
+#: ../src/wxMaxima.cpp:1669 ../src/wxMaxima.cpp:1677
 msgid "Document "
 msgstr "Dokument "
 
@@ -1417,7 +1420,7 @@ msgid ""
 "differences."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Don't save"
 msgstr ""
 
@@ -1425,27 +1428,27 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:734
+#: ../src/wxMaximaFrame.cpp:733
 msgid "E&quations"
 msgstr "&Ligninger"
 
-#: ../src/wxMaximaFrame.cpp:487
+#: ../src/wxMaximaFrame.cpp:486
 msgid "E&xit\tCtrl-Q"
 msgstr "&Afslut\tCtrl-Q"
 
-#: ../src/wxMaximaFrame.cpp:757
+#: ../src/wxMaximaFrame.cpp:756
 msgid "Eige&nvectors"
 msgstr "Egenv&ektorer"
 
-#: ../src/wxMaximaFrame.cpp:755
+#: ../src/wxMaximaFrame.cpp:754
 msgid "Eigen&values"
 msgstr "Egen&værdier"
 
-#: ../src/wxMaxima.cpp:3572
+#: ../src/wxMaxima.cpp:3584
 msgid "Eliminate"
 msgstr "Eliminer"
 
-#: ../src/wxMaximaFrame.cpp:710
+#: ../src/wxMaximaFrame.cpp:709
 msgid "Eliminate a variable from a system of equations"
 msgstr "Eliminer en variabel i et ligningssystem"
 
@@ -1457,23 +1460,23 @@ msgstr ""
 msgid "English"
 msgstr "Engelsk"
 
-#: ../src/wxMaxima.cpp:4712 ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726
-#: ../src/wxMaxima.cpp:4734 ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748
-#: ../src/wxMaxima.cpp:4755 ../src/wxMaxima.cpp:4791 ../src/wxMaxima.cpp:4799
+#: ../src/wxMaxima.cpp:4724 ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738
+#: ../src/wxMaxima.cpp:4746 ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760
+#: ../src/wxMaxima.cpp:4767 ../src/wxMaxima.cpp:4803 ../src/wxMaxima.cpp:4811
 #, fuzzy
 msgid "Enter Data"
 msgstr "Indtast matrixelementer"
 
-#: ../src/wxMaximaFrame.cpp:1279
+#: ../src/wxMaximaFrame.cpp:1278
 #, fuzzy
 msgid "Enter Matrix..."
 msgstr "I&ndtast matrix..."
 
-#: ../src/wxMaximaFrame.cpp:745
+#: ../src/wxMaximaFrame.cpp:744
 msgid "Enter a matrix"
 msgstr "Opret matrix og indtast elementer"
 
-#: ../src/wxMaxima.cpp:3962
+#: ../src/wxMaxima.cpp:3974
 msgid "Enter an equation for rational simplification:"
 msgstr "Indtast udtryk:"
 
@@ -1486,11 +1489,11 @@ msgstr "Indtast kommasepareret liste med variable."
 msgid "Enter evaluates cells"
 msgstr "Anvend Enter til beregning"
 
-#: ../src/wxMaxima.cpp:3734
+#: ../src/wxMaxima.cpp:3746
 msgid "Enter matrix"
 msgstr "Indtast matrixelementer"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 #, fuzzy
 msgid "Enter new precision for bigfloats:"
 msgstr "Angiv ny nøjagtighed:"
@@ -1499,12 +1502,12 @@ msgstr "Angiv ny nøjagtighed:"
 msgid "Enter the path to the Maxima executable."
 msgstr "Indtast stien til Maxima-programmet."
 
-#: ../src/wxMaximaFrame.cpp:1368
+#: ../src/wxMaximaFrame.cpp:1367
 #, fuzzy
 msgid "Epsilon"
 msgstr "Udtryk:"
 
-#: ../src/wxMaxima.cpp:4208
+#: ../src/wxMaxima.cpp:4220
 #, fuzzy
 msgid "Epsilon:"
 msgstr "Udtryk:"
@@ -1514,13 +1517,13 @@ msgstr "Udtryk:"
 msgid "Equation %d:"
 msgstr "Ligning %d:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:3633
-#: ../src/wxMaxima.cpp:5019
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:3645
+#: ../src/wxMaxima.cpp:5031
 msgid "Equation(s):"
 msgstr "Ligning(er):"
 
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3993
-#: ../src/wxMaxima.cpp:4807 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:4005
+#: ../src/wxMaxima.cpp:4819 ../src/wxMaxima.cpp:5045
 msgid "Equation:"
 msgstr "Ligning:"
 
@@ -1531,82 +1534,82 @@ msgid ""
 "be introduced one into another. Also they are always printed out as 2D maths."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3570
+#: ../src/wxMaxima.cpp:3582
 msgid "Equations:"
 msgstr "Ligninger:"
 
-#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1455
-#: ../src/wxMaxima.cpp:1469 ../src/wxMaxima.cpp:1620 ../src/wxMaxima.cpp:1633
-#: ../src/wxMaxima.cpp:1643 ../src/wxMaxima.cpp:1666 ../src/wxMaxima.cpp:2034
-#: ../src/wxMaxima.cpp:2206 ../src/wxMaxima.cpp:5381 ../src/wxMaxima.cpp:5830
-#: ../src/wxMaxima.cpp:5881
+#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1460
+#: ../src/wxMaxima.cpp:1474 ../src/wxMaxima.cpp:1625 ../src/wxMaxima.cpp:1638
+#: ../src/wxMaxima.cpp:1648 ../src/wxMaxima.cpp:1671 ../src/wxMaxima.cpp:2039
+#: ../src/wxMaxima.cpp:2211 ../src/wxMaxima.cpp:5397 ../src/wxMaxima.cpp:5845
+#: ../src/wxMaxima.cpp:5896
 msgid "Error"
 msgstr "Fejl"
 
-#: ../src/wxMaxima.cpp:2886 ../src/wxMaxima.cpp:2900 ../src/wxMaxima.cpp:2913
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617 ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:2894 ../src/wxMaxima.cpp:2908 ../src/wxMaxima.cpp:2921
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629 ../src/wxMaxima.cpp:3740
 msgid "Error!"
 msgstr "Fejl!"
 
-#: ../src/wxMaximaFrame.cpp:1370
+#: ../src/wxMaximaFrame.cpp:1369
 msgid "Eta"
 msgstr ""
 
 # Jeg ved ikke hvad man skal oversætte noun til?
 # JT: Navn(eord) - det vil u.a.o. kun være for "kendere"?
-#: ../src/wxMaximaFrame.cpp:909
+#: ../src/wxMaximaFrame.cpp:908
 msgid "Evaluate &Noun Forms"
 msgstr "Evaluer &navneformer"
 
-#: ../src/wxMaximaFrame.cpp:589
+#: ../src/wxMaximaFrame.cpp:588
 #, fuzzy
 msgid "Evaluate All Cells\tCtrl-Shift-R"
 msgstr "Beregn alle celler\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:587
+#: ../src/wxMaximaFrame.cpp:586
 #, fuzzy
 msgid "Evaluate All Visible Cells\tCtrl-R"
 msgstr "Beregn alle celler\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:585 ../src/MathCtrl.cpp:942
+#: ../src/MathCtrl.cpp:984 ../src/wxMaximaFrame.cpp:584
 msgid "Evaluate Cell(s)"
 msgstr "Beregn celle(r)"
 
-#: ../src/wxMaximaFrame.cpp:591
+#: ../src/wxMaximaFrame.cpp:590
 #, fuzzy
 msgid "Evaluate Cells Above\tCtrl-Shift-P"
 msgstr "Beregn alle celler\tCtrl-R"
 
-#: ../src/MathCtrl.cpp:956 ../src/MathCtrl.cpp:1051
+#: ../src/MathCtrl.cpp:998 ../src/MathCtrl.cpp:1093
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:961 ../src/MathCtrl.cpp:1053
+#: ../src/MathCtrl.cpp:1003 ../src/MathCtrl.cpp:1095
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:971 ../src/MathCtrl.cpp:1057
+#: ../src/MathCtrl.cpp:1013 ../src/MathCtrl.cpp:1099
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:966 ../src/MathCtrl.cpp:1055
+#: ../src/MathCtrl.cpp:1008 ../src/MathCtrl.cpp:1097
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:586
+#: ../src/wxMaximaFrame.cpp:585
 msgid "Evaluate active or selected cell(s)"
 msgstr "Beregn aktiv(e) eller valgt(e) celle(r)"
 
-#: ../src/wxMaximaFrame.cpp:590
+#: ../src/wxMaximaFrame.cpp:589
 msgid "Evaluate all cells in the document"
 msgstr "Beregn alle celler i dokumentet"
 
 # Nouns in Verbs umwandeln und auswerten
-#: ../src/wxMaximaFrame.cpp:910
+#: ../src/wxMaximaFrame.cpp:909
 msgid "Evaluate all noun forms in expression"
 msgstr "Evaluer alle navneformer i udtryk"
 
-#: ../src/wxMaximaFrame.cpp:588
+#: ../src/wxMaximaFrame.cpp:587
 #, fuzzy
 msgid "Evaluate all visible cells in the document"
 msgstr "Beregn alle celler i dokumentet"
@@ -1622,7 +1625,7 @@ msgstr ""
 msgid "Evaluate to point"
 msgstr "Evaluer &navneformer"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Example"
 msgstr "Eksempel"
 
@@ -1635,32 +1638,32 @@ msgstr "Teksteksempel"
 msgid "Examples:"
 msgstr "Eksempel"
 
-#: ../src/wxMaximaFrame.cpp:488
+#: ../src/wxMaximaFrame.cpp:487
 msgid "Exit wxMaxima"
 msgstr "Afslut wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:1214
+#: ../src/wxMaximaFrame.cpp:1213
 msgid "Expand"
 msgstr "Udvid til ledform"
 
-#: ../src/wxMaximaFrame.cpp:1219
+#: ../src/wxMaximaFrame.cpp:1218
 msgid "Expand (tr)"
 msgstr "Udvid trig."
 
-#: ../src/MathCtrl.cpp:997
+#: ../src/MathCtrl.cpp:1039
 msgid "Expand Expression"
 msgstr "Udvid udtryk til ledform"
 
-#: ../src/wxMaximaFrame.cpp:841
+#: ../src/wxMaximaFrame.cpp:840
 msgid "Expand Logarithms"
 msgstr "Udvid logaritmer"
 
-#: ../src/wxMaximaFrame.cpp:840
+#: ../src/wxMaximaFrame.cpp:839
 msgid "Expand an expression"
 msgstr "Udvid et udtryk til ledform"
 
 # brug af addtitionsformler?
-#: ../src/wxMaximaFrame.cpp:874
+#: ../src/wxMaximaFrame.cpp:873
 msgid "Expand trigonometric expression"
 msgstr "Udvid trigonometrisk udtryk til ledform"
 
@@ -1668,7 +1671,7 @@ msgstr "Udvid trigonometrisk udtryk til ledform"
 msgid "Expected the icon files to be found at"
 msgstr ""
 
-#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2834
+#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2842
 msgid "Export"
 msgstr "Eksporter"
 
@@ -1677,34 +1680,34 @@ msgid ""
 "Export animations to TeX (Images only move if the PDF viewer supports this)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:481
+#: ../src/wxMaximaFrame.cpp:480
 #, fuzzy
 msgid "Export document to a HTML or pdfLaTeX file"
 msgstr "Eksporter dokument til HTML eller LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:253
+#: ../src/wxMaximaFrame.cpp:252
 #, fuzzy
 msgid "Export failed."
 msgstr "TeX-eksport mislykkedes!"
 
-#: ../src/wxMaximaFrame.cpp:239
+#: ../src/wxMaximaFrame.cpp:238
 msgid "Export successful."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2913
+#: ../src/wxMaxima.cpp:2921
 msgid "Exporting to HTML failed!"
 msgstr "HTML-eksport mislykkedes!"
 
-#: ../src/wxMaxima.cpp:2886
+#: ../src/wxMaxima.cpp:2894
 msgid "Exporting to TeX failed!"
 msgstr "TeX-eksport mislykkedes!"
 
-#: ../src/wxMaxima.cpp:2900
+#: ../src/wxMaxima.cpp:2908
 #, fuzzy
 msgid "Exporting to maxima batch file failed!"
 msgstr "TeX-eksport mislykkedes!"
 
-#: ../src/wxMaximaFrame.cpp:229
+#: ../src/wxMaximaFrame.cpp:228
 #, fuzzy
 msgid "Exporting..."
 msgstr "&Eksporter..."
@@ -1718,42 +1721,42 @@ msgid "Expression(s):"
 msgstr "Udtryk:"
 
 #: ../src/IntegrateWiz.cpp:30 ../src/LimitWiz.cpp:27 ../src/SeriesWiz.cpp:33
-#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3648
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:4205 ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5064
+#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3660
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:4217 ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5076
 msgid "Expression:"
 msgstr "Udtryk:"
 
-#: ../src/wxMaximaFrame.cpp:1213
+#: ../src/wxMaximaFrame.cpp:1212
 msgid "Factor"
 msgstr "Faktoriser"
 
-#: ../src/wxMaximaFrame.cpp:836
+#: ../src/wxMaximaFrame.cpp:835
 msgid "Factor Complex"
 msgstr "Faktoriser komplekst udtryk"
 
-#: ../src/MathCtrl.cpp:996
+#: ../src/MathCtrl.cpp:1038
 msgid "Factor Expression"
 msgstr "Faktoriser udtryk"
 
-#: ../src/wxMaximaFrame.cpp:835
+#: ../src/wxMaximaFrame.cpp:834
 msgid "Factor an expression"
 msgstr "Faktoriser et udtryk"
 
-#: ../src/wxMaximaFrame.cpp:837
+#: ../src/wxMaximaFrame.cpp:836
 msgid "Factor an expression in Gaussian numbers"
 msgstr "Faktoriser et udtryk i Gaussiske heltal"
 
-#: ../src/wxMaximaFrame.cpp:862
+#: ../src/wxMaximaFrame.cpp:861
 msgid "Factorials and &Gamma"
 msgstr "Fakultet og &Gamma-funktion"
 
-#: ../src/wxMaxima.cpp:285
+#: ../src/wxMaxima.cpp:286
 msgid "Fatal error"
 msgstr "Alvorlig fejl"
 
-#: ../src/GroupCell.cpp:1571
+#: ../src/GroupCell.cpp:1572
 #, fuzzy, c-format
 msgid "Figure %d:"
 msgstr "&Indstillinger..."
@@ -1762,22 +1765,22 @@ msgstr "&Indstillinger..."
 msgid "File"
 msgstr "Fil"
 
-#: ../src/wxMaxima.cpp:1457 ../src/wxMaxima.cpp:1623 ../src/wxMaxima.cpp:1636
-#: ../src/wxMaxima.cpp:1646 ../src/wxMaxima.cpp:1668
+#: ../src/wxMaxima.cpp:1462 ../src/wxMaxima.cpp:1628 ../src/wxMaxima.cpp:1641
+#: ../src/wxMaxima.cpp:1651 ../src/wxMaxima.cpp:1673
 #, fuzzy
 msgid "File could not be opened"
 msgstr "Filen blev ikke fundet"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File not found"
 msgstr "Filen blev ikke fundet"
 
-#: ../src/wxMaxima.cpp:1511 ../src/wxMaxima.cpp:1729
+#: ../src/wxMaxima.cpp:1516 ../src/wxMaxima.cpp:1734
 #, fuzzy
 msgid "File opened"
 msgstr "Filen blev ikke fundet"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File you tried to open does not exist."
 msgstr "Filen findes ikke."
 
@@ -1790,71 +1793,71 @@ msgstr "Fil:"
 msgid "Find"
 msgstr "Bestem nulpunkt"
 
-#: ../src/wxMaximaFrame.cpp:523
+#: ../src/wxMaximaFrame.cpp:522
 #, fuzzy
 msgid "Find\tCtrl-F"
 msgstr "Fortryd\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:787
+#: ../src/wxMaximaFrame.cpp:786
 msgid "Find &Limit..."
 msgstr "Bestem &grænseværdi..."
 
-#: ../src/wxMaximaFrame.cpp:790
+#: ../src/wxMaximaFrame.cpp:789
 #, fuzzy
 msgid "Find Minimum..."
 msgstr "Bestem &grænseværdi..."
 
-#: ../src/MathCtrl.cpp:993
+#: ../src/MathCtrl.cpp:1035
 msgid "Find Root..."
 msgstr "Bestem nulpunkt..."
 
-#: ../src/wxMaximaFrame.cpp:791
+#: ../src/wxMaximaFrame.cpp:790
 #, fuzzy
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr "Bestem grænseværdi for et udtryk"
 
-#: ../src/wxMaximaFrame.cpp:788
+#: ../src/wxMaximaFrame.cpp:787
 msgid "Find a limit of an expression"
 msgstr "Bestem grænseværdi for et udtryk"
 
-#: ../src/wxMaximaFrame.cpp:693
+#: ../src/wxMaximaFrame.cpp:692
 msgid "Find a root of an equation on an interval"
 msgstr "Bestem et nulpunkt for et udtryk indenfor et interval"
 
-#: ../src/wxMaximaFrame.cpp:695
+#: ../src/wxMaximaFrame.cpp:694
 msgid "Find all roots of a polynomial"
 msgstr "Bestem alle rødder i et polynomium"
 
-#: ../src/wxMaximaFrame.cpp:698
+#: ../src/wxMaximaFrame.cpp:697
 #, fuzzy
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr "Bestem alle rødder i et polynomium"
 
-#: ../src/wxMaxima.cpp:3220
+#: ../src/wxMaxima.cpp:3215
 msgid "Find and Replace"
 msgstr ""
 
-#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:523
+#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:522
 msgid "Find and replace"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:756
+#: ../src/wxMaximaFrame.cpp:755
 msgid "Find eigenvalues of a matrix"
 msgstr "Bestem en matrixs egenværdier"
 
-#: ../src/wxMaximaFrame.cpp:758
+#: ../src/wxMaximaFrame.cpp:757
 msgid "Find eigenvectors of a matrix"
 msgstr "Bestem en matrixs egenvektorer"
 
-#: ../src/wxMaxima.cpp:4210
+#: ../src/wxMaxima.cpp:4222
 msgid "Find minimum"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:701
+#: ../src/wxMaximaFrame.cpp:700
 msgid "Find real roots of a polynomial"
 msgstr "Bestem et polynomiums reelle rødder"
 
-#: ../src/wxMaxima.cpp:3493 ../src/wxMaxima.cpp:5036
+#: ../src/wxMaxima.cpp:3505 ../src/wxMaxima.cpp:5048
 msgid "Find root"
 msgstr "Bestem nulpunkt"
 
@@ -1877,12 +1880,12 @@ msgstr ""
 msgid "Fixed font in text controls"
 msgstr "Fast tegnbredde i indtastningsfelter"
 
-#: ../src/wxMaximaFrame.cpp:623
+#: ../src/wxMaximaFrame.cpp:622
 #, fuzzy
 msgid "Fold All\tCtrl-Alt-["
 msgstr "&Marker alt\tCtrl-A"
 
-#: ../src/wxMaximaFrame.cpp:624
+#: ../src/wxMaximaFrame.cpp:623
 msgid "Fold all sections"
 msgstr ""
 
@@ -1890,25 +1893,25 @@ msgstr ""
 msgid "Follow"
 msgstr ""
 
-#: ../src/ParenCell.cpp:319
+#: ../src/ParenCell.cpp:320
 msgid "Font issue: The Parenthesis sign is too small!"
 msgstr ""
 
-#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:381
+#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:382
 msgid ""
 "Font issue: The char height is too small! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:199
+#: ../src/SqrtCell.cpp:202
 msgid ""
 "Font issue: The sqrt() sign has the size 0! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:198
+#: ../src/SqrtCell.cpp:201
 msgid "Font issue? The contents of a sqrt() has the size 0."
 msgstr ""
 
@@ -1940,15 +1943,15 @@ msgstr "Fransk"
 
 #: ../src/IntegrateWiz.cpp:37 ../src/Plot2dWiz.cpp:37 ../src/Plot2dWiz.cpp:47
 #: ../src/Plot2dWiz.cpp:536 ../src/Plot3dWiz.cpp:36 ../src/Plot3dWiz.cpp:45
-#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4240
+#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4252
 msgid "From:"
 msgstr "Fra:"
 
-#: ../src/wxMaximaFrame.cpp:576
+#: ../src/wxMaximaFrame.cpp:575
 msgid "Full Screen\tAlt-Enter"
 msgstr "Fuld skærm\tAlt-Enter"
 
-#: ../src/wxMaxima.cpp:3342
+#: ../src/wxMaxima.cpp:3354
 msgid "Function"
 msgstr "Funktion"
 
@@ -1956,32 +1959,32 @@ msgstr "Funktion"
 msgid "Function names"
 msgstr "Navne på funktioner"
 
-#: ../src/wxMaxima.cpp:3633
+#: ../src/wxMaxima.cpp:3645
 msgid "Function(s):"
 msgstr "Funktion(er):"
 
-#: ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3803
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3815
+#: ../src/wxMaxima.cpp:3848
 msgid "Function:"
 msgstr "Funktion:"
 
-#: ../src/wxMaximaFrame.cpp:904
+#: ../src/wxMaximaFrame.cpp:903
 msgid "Functions for complex simplification"
 msgstr "Faciliteter til reduktion af komplekse udtryk"
 
-#: ../src/wxMaximaFrame.cpp:864
+#: ../src/wxMaximaFrame.cpp:863
 msgid "Functions for simplifying factorials and gamma function"
 msgstr "Faciliteter til reduktion af fakulteter og Gamma-funktion"
 
-#: ../src/wxMaximaFrame.cpp:881
+#: ../src/wxMaximaFrame.cpp:880
 msgid "Functions for simplifying trigonometric expressions"
 msgstr "Faciliteter til reduktion af trigonometriske funktioner"
 
-#: ../src/wxMaxima.cpp:4046
+#: ../src/wxMaxima.cpp:4058
 msgid "GCD"
 msgstr "SFD"
 
-#: ../src/wxMaxima.cpp:5152
+#: ../src/wxMaxima.cpp:5164
 msgid "GIF image (*.gif)|*.gif"
 msgstr ""
 
@@ -1989,33 +1992,33 @@ msgstr ""
 msgid "Galician"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1366
+#: ../src/wxMaximaFrame.cpp:1365
 msgid "Gamma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:391
+#: ../src/wxMaximaFrame.cpp:390
 #, fuzzy
 msgid "General Math"
 msgstr "Opret matrix"
 
-#: ../src/wxMaximaFrame.cpp:549
+#: ../src/wxMaximaFrame.cpp:548
 msgid "General Math\tAlt-Shift-M"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3766 ../src/wxMaxima.cpp:3785
+#: ../src/wxMaxima.cpp:3778 ../src/wxMaxima.cpp:3797
 msgid "Generate Matrix"
 msgstr "Opret matrix"
 
-#: ../src/wxMaximaFrame.cpp:741
+#: ../src/wxMaximaFrame.cpp:740
 #, fuzzy
 msgid "Generate Matrix from Expression..."
 msgstr "&Opret matrix..."
 
-#: ../src/wxMaximaFrame.cpp:739
+#: ../src/wxMaximaFrame.cpp:738
 msgid "Generate a matrix from a 2-dimensional array"
 msgstr "Opret matrix ud fra et 2-dimensionalt array"
 
-#: ../src/wxMaximaFrame.cpp:742
+#: ../src/wxMaximaFrame.cpp:741
 #, fuzzy
 msgid "Generate a matrix from a lambda expression"
 msgstr "Opret matrix ud fra et 2-dimensionalt array"
@@ -2024,39 +2027,39 @@ msgstr "Opret matrix ud fra et 2-dimensionalt array"
 msgid "German"
 msgstr "Tysk"
 
-#: ../src/wxMaximaFrame.cpp:893
+#: ../src/wxMaximaFrame.cpp:892
 msgid "Get &Imaginary Part"
 msgstr "&Imaginærdel"
 
-#: ../src/wxMaximaFrame.cpp:793
+#: ../src/wxMaximaFrame.cpp:792
 msgid "Get &Series..."
 msgstr "&Rækkeudvikling..."
 
-#: ../src/wxMaximaFrame.cpp:804
+#: ../src/wxMaximaFrame.cpp:803
 msgid "Get Laplace transformation of an expression"
 msgstr "Bestem Laplace-transformation for et udtryk"
 
-#: ../src/wxMaximaFrame.cpp:890
+#: ../src/wxMaximaFrame.cpp:889
 msgid "Get Real P&art"
 msgstr "&Realdel"
 
-#: ../src/wxMaximaFrame.cpp:807
+#: ../src/wxMaximaFrame.cpp:806
 msgid "Get inverse Laplace transformation of an expression"
 msgstr "Bestem invers Laplace-transformation for et udtryk"
 
-#: ../src/wxMaximaFrame.cpp:794
+#: ../src/wxMaximaFrame.cpp:793
 msgid "Get the Taylor or power series of expression"
 msgstr "Bestem Taylor- eller potensrække for et udtryk"
 
-#: ../src/wxMaximaFrame.cpp:894
+#: ../src/wxMaximaFrame.cpp:893
 msgid "Get the imaginary part of complex expression"
 msgstr "Bestem imaginærdelen af komplekst udtryk"
 
-#: ../src/wxMaximaFrame.cpp:891
+#: ../src/wxMaximaFrame.cpp:890
 msgid "Get the real part of complex expression"
 msgstr "Bestem realdelen af komplekst udtryk"
 
-#: ../src/MathCtrl.cpp:5932
+#: ../src/MathCtrl.cpp:5984
 msgid ""
 "Got a request to undo an action that involves an delete which isn't possible "
 "at this moment."
@@ -2066,12 +2069,12 @@ msgstr ""
 msgid "Greek"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:356
+#: ../src/wxMaximaFrame.cpp:355
 #, fuzzy
 msgid "Greek Letters"
 msgstr "Græske konstanter"
 
-#: ../src/wxMaximaFrame.cpp:552
+#: ../src/wxMaximaFrame.cpp:551
 #, fuzzy
 msgid "Greek Letters\tAlt-Shift-G"
 msgstr "Græske konstanter"
@@ -2084,7 +2087,7 @@ msgstr "Græske konstanter"
 msgid "Grid:"
 msgstr "Gitter:"
 
-#: ../src/wxMaxima.cpp:2836
+#: ../src/wxMaxima.cpp:2844
 #, fuzzy
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|pdfLaTeX file (*."
@@ -2099,12 +2102,12 @@ msgstr ""
 msgid "Help"
 msgstr "Hjælp"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 #, fuzzy
 msgid "Hide All Toolbars\tAlt-Shift--"
 msgstr "Indsæt celle(r)\tCtrl-Shift-V"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide all panes"
 msgstr ""
 
@@ -2112,19 +2115,19 @@ msgstr ""
 msgid "Highlight (dpart)"
 msgstr "Fremhævning (dpart)"
 
-#: ../src/wxMaxima.cpp:4685
+#: ../src/wxMaxima.cpp:4697
 msgid "Histogram"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1270
+#: ../src/wxMaximaFrame.cpp:1269
 msgid "Histogram..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:309
+#: ../src/wxMaximaFrame.cpp:308
 msgid "History"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:555
+#: ../src/wxMaximaFrame.cpp:554
 #, fuzzy
 msgid "History\tAlt-Shift-I"
 msgstr "Indsæt celle(r)\tCtrl-Shift-V"
@@ -2146,12 +2149,12 @@ msgid "Hungarian"
 msgstr "Ungarsk"
 
 # Begyndelsesværdi - Maxima
-#: ../src/wxMaxima.cpp:3527
+#: ../src/wxMaxima.cpp:3539
 msgid "IC1"
 msgstr "IC1"
 
 # Begyndelsesværdi - Maxima
-#: ../src/wxMaxima.cpp:3543
+#: ../src/wxMaxima.cpp:3555
 msgid "IC2"
 msgstr "IC2"
 
@@ -2167,7 +2170,7 @@ msgid ""
 "same output cell."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:683
+#: ../src/wxMaximaFrame.cpp:682
 msgid ""
 "If maxima ever finishes evaluating without wxMaxima realizing this this menu "
 "item can force wxMaxima to try to send commands to maxima again."
@@ -2229,11 +2232,11 @@ msgstr ""
 "Hvis din beregning tager for lang tid, kan du benytte 'Maxima->Afbryd' eller "
 "'Maxima->Genstart Maxima'"
 
-#: ../src/wxMaximaFrame.cpp:1499
+#: ../src/wxMaximaFrame.cpp:1518
 msgid "Image"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5644
+#: ../src/wxMaxima.cpp:5659
 msgid "Image files (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 msgstr "Billedfiler  (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 
@@ -2260,7 +2263,7 @@ msgid ""
 "above it. Might increase readability for some fonts and short subscripts."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Include columns:"
 msgstr ""
 
@@ -2279,19 +2282,19 @@ msgstr ""
 msgid "Infinity"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:974
+#: ../src/wxMaximaFrame.cpp:973
 msgid "Info about Maxima build"
 msgstr "Information om Maxima-version"
 
-#: ../src/wxMaxima.cpp:4207
+#: ../src/wxMaxima.cpp:4219
 msgid "Initial Estimates:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:718
+#: ../src/wxMaximaFrame.cpp:717
 msgid "Initial Value Problem (&1)..."
 msgstr "Begyndelsesværdiproblem (&1)..."
 
-#: ../src/wxMaximaFrame.cpp:721
+#: ../src/wxMaximaFrame.cpp:720
 msgid "Initial Value Problem (&2)..."
 msgstr "Begyndelsesværdiproblem (&2)..."
 
@@ -2299,7 +2302,7 @@ msgstr "Begyndelsesværdiproblem (&2)..."
 msgid "Input labels"
 msgstr "Input-etiketter"
 
-#: ../src/wxMaximaFrame.cpp:403
+#: ../src/wxMaximaFrame.cpp:402
 #, fuzzy
 msgid "Insert"
 msgstr "Indsæt tekstcelle"
@@ -2308,111 +2311,111 @@ msgstr "Indsæt tekstcelle"
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:612
+#: ../src/wxMaximaFrame.cpp:611
 #, fuzzy
 msgid "Insert &Section Cell\tCtrl-3"
 msgstr "Indsæt &afsnitscelle\tCtrl-F6 "
 
-#: ../src/wxMaximaFrame.cpp:608
+#: ../src/wxMaximaFrame.cpp:607
 #, fuzzy
 msgid "Insert &Text Cell\tCtrl-1"
 msgstr "Indsæt &tekstcelle\tF6"
 
-#: ../src/wxMaximaFrame.cpp:558
+#: ../src/wxMaximaFrame.cpp:557
 #, fuzzy
 msgid "Insert Cell\tAlt-Shift-C"
 msgstr "Indsæt celle(r)\tCtrl-Shift-V"
 
-#: ../src/wxMaxima.cpp:5642
+#: ../src/wxMaxima.cpp:5657
 msgid "Insert Image"
 msgstr "Indsæt billede"
 
-#: ../src/wxMaximaFrame.cpp:620
+#: ../src/wxMaximaFrame.cpp:619
 msgid "Insert Image..."
 msgstr "Indsæt billede..."
 
-#: ../src/wxMaximaFrame.cpp:606
+#: ../src/wxMaximaFrame.cpp:605
 #, fuzzy
 msgid "Insert Input &Cell"
 msgstr "Indsæt &input\tF7"
 
-#: ../src/wxMaximaFrame.cpp:618
+#: ../src/wxMaximaFrame.cpp:617
 #, fuzzy
 msgid "Insert Page Break"
 msgstr "Indsæt billede"
 
-#: ../src/wxMaximaFrame.cpp:614
+#: ../src/wxMaximaFrame.cpp:613
 #, fuzzy
 msgid "Insert S&ubsection Cell\tCtrl-4"
 msgstr "Indsæt &afsnitscelle\tCtrl-F6 "
 
-#: ../src/wxMaximaFrame.cpp:616
+#: ../src/wxMaximaFrame.cpp:615
 #, fuzzy
 msgid "Insert S&ubsubsection Cell\tCtrl-5"
 msgstr "Indsæt &afsnitscelle\tCtrl-F6 "
 
-#: ../src/MathCtrl.cpp:1015
+#: ../src/MathCtrl.cpp:1057
 #, fuzzy
 msgid "Insert Section Cell"
 msgstr "Indsæt &afsnitscelle\tCtrl-F6 "
 
-#: ../src/MathCtrl.cpp:1016
+#: ../src/MathCtrl.cpp:1058
 #, fuzzy
 msgid "Insert Subsection Cell"
 msgstr "Indsæt &afsnitscelle\tCtrl-F6 "
 
-#: ../src/MathCtrl.cpp:1017
+#: ../src/MathCtrl.cpp:1059
 #, fuzzy
 msgid "Insert Subsubsection Cell"
 msgstr "Indsæt &afsnitscelle\tCtrl-F6 "
 
-#: ../src/wxMaximaFrame.cpp:610
+#: ../src/wxMaximaFrame.cpp:609
 #, fuzzy
 msgid "Insert T&itle Cell\tCtrl-2"
 msgstr "Indsæt &tekstcelle\tF6"
 
-#: ../src/MathCtrl.cpp:1013
+#: ../src/MathCtrl.cpp:1055
 #, fuzzy
 msgid "Insert Text Cell"
 msgstr "Indsæt &tekstcelle\tF6"
 
-#: ../src/MathCtrl.cpp:1014
+#: ../src/MathCtrl.cpp:1056
 #, fuzzy
 msgid "Insert Title Cell"
 msgstr "Indsæt &tekstcelle\tF6"
 
-#: ../src/wxMaximaFrame.cpp:607
+#: ../src/wxMaximaFrame.cpp:606
 msgid "Insert a new input cell"
 msgstr "Indsæt en ny celle"
 
-#: ../src/wxMaximaFrame.cpp:613
+#: ../src/wxMaximaFrame.cpp:612
 msgid "Insert a new section cell"
 msgstr "Indsæt en ny afsnitscelle"
 
-#: ../src/wxMaximaFrame.cpp:615
+#: ../src/wxMaximaFrame.cpp:614
 #, fuzzy
 msgid "Insert a new subsection cell"
 msgstr "Indsæt en ny afsnitscelle"
 
-#: ../src/wxMaximaFrame.cpp:617
+#: ../src/wxMaximaFrame.cpp:616
 #, fuzzy
 msgid "Insert a new subsubsection cell"
 msgstr "Indsæt en ny afsnitscelle"
 
-#: ../src/wxMaximaFrame.cpp:609
+#: ../src/wxMaximaFrame.cpp:608
 msgid "Insert a new text cell"
 msgstr "Indsæt ny tekstcelle"
 
-#: ../src/wxMaximaFrame.cpp:611
+#: ../src/wxMaximaFrame.cpp:610
 msgid "Insert a new title cell"
 msgstr "Indsæt en ny celle til overskrift"
 
-#: ../src/wxMaximaFrame.cpp:619
+#: ../src/wxMaximaFrame.cpp:618
 #, fuzzy
 msgid "Insert a page break"
 msgstr "Indsæt billede"
 
-#: ../src/wxMaximaFrame.cpp:621
+#: ../src/wxMaximaFrame.cpp:620
 msgid "Insert image"
 msgstr "Indsæt billede"
 
@@ -2425,27 +2428,27 @@ msgstr ""
 msgid "Integral sign"
 msgstr "Integrer udtryk"
 
-#: ../src/wxMaxima.cpp:3992
+#: ../src/wxMaxima.cpp:4004
 msgid "Integral/Sum:"
 msgstr "Integral/Sum:"
 
-#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4105 ../src/wxMaxima.cpp:5051
+#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4117 ../src/wxMaxima.cpp:5063
 msgid "Integrate"
 msgstr "Integrer"
 
-#: ../src/wxMaxima.cpp:4091
+#: ../src/wxMaxima.cpp:4103
 msgid "Integrate (risch)"
 msgstr "Integrer (Risch)"
 
-#: ../src/wxMaximaFrame.cpp:778
+#: ../src/wxMaximaFrame.cpp:777
 msgid "Integrate expression"
 msgstr "Integrer udtryk"
 
-#: ../src/wxMaximaFrame.cpp:780
+#: ../src/wxMaximaFrame.cpp:779
 msgid "Integrate expression with Risch algorithm"
 msgstr "Integrer udtryk ved hjælp af Risch-algoritme"
 
-#: ../src/wxMaximaFrame.cpp:1224 ../src/MathCtrl.cpp:1000
+#: ../src/MathCtrl.cpp:1042 ../src/wxMaximaFrame.cpp:1223
 msgid "Integrate..."
 msgstr "Integrer..."
 
@@ -2453,7 +2456,7 @@ msgstr "Integrer..."
 msgid "Interrupt"
 msgstr "Afbryd"
 
-#: ../src/wxMaximaFrame.cpp:646 ../src/wxMaximaFrame.cpp:650
+#: ../src/wxMaximaFrame.cpp:645 ../src/wxMaximaFrame.cpp:649
 msgid "Interrupt current computation"
 msgstr "Afbryd igangværende beregning"
 
@@ -2473,15 +2476,15 @@ msgstr ""
 "\n"
 "Indtast venligst stien til Maxima-programmet igen."
 
-#: ../src/wxMaxima.cpp:4137
+#: ../src/wxMaxima.cpp:4149
 msgid "Inverse Laplace"
 msgstr "Invers Laplace"
 
-#: ../src/wxMaximaFrame.cpp:806
+#: ../src/wxMaximaFrame.cpp:805
 msgid "Inverse Laplace T&ransform..."
 msgstr "In&vers Laplace Transformation..."
 
-#: ../src/wxMaximaFrame.cpp:1372
+#: ../src/wxMaximaFrame.cpp:1371
 msgid "Iota"
 msgstr ""
 
@@ -2515,7 +2518,7 @@ msgstr ""
 msgid "Kabyle"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1373
+#: ../src/wxMaximaFrame.cpp:1372
 msgid "Kappa"
 msgstr ""
 
@@ -2524,7 +2527,7 @@ msgstr ""
 msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4031
+#: ../src/wxMaxima.cpp:4043
 msgid "LCM"
 msgstr "MFM"
 
@@ -2540,7 +2543,7 @@ msgstr ""
 msgid "Label width:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1374
+#: ../src/wxMaximaFrame.cpp:1373
 msgid "Lambda"
 msgstr ""
 
@@ -2552,11 +2555,11 @@ msgstr "Sprog for wxMaxima-brugerfladen."
 msgid "Language:"
 msgstr "Sprog:"
 
-#: ../src/wxMaxima.cpp:4120
+#: ../src/wxMaxima.cpp:4132
 msgid "Laplace"
 msgstr "Laplace"
 
-#: ../src/wxMaximaFrame.cpp:803
+#: ../src/wxMaximaFrame.cpp:802
 msgid "Laplace &Transform..."
 msgstr "Laplace &transformation..."
 
@@ -2564,15 +2567,15 @@ msgstr "Laplace &transformation..."
 msgid "Leads to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:812
+#: ../src/wxMaximaFrame.cpp:811
 msgid "Least Common Multiple..."
 msgstr "Mindste fælles multiplum..."
 
-#: ../src/wxMaxima.cpp:4809
+#: ../src/wxMaxima.cpp:4821
 msgid "Least Squares Fit"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1266
+#: ../src/wxMaximaFrame.cpp:1265
 msgid "Least Squares Fit..."
 msgstr ""
 
@@ -2583,25 +2586,25 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4192
+#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4204
 msgid "Limit"
 msgstr "Grænseværdi"
 
-#: ../src/wxMaximaFrame.cpp:1225
+#: ../src/wxMaximaFrame.cpp:1224
 msgid "Limit..."
 msgstr "Grænseværdi..."
 
-#: ../src/wxMaximaFrame.cpp:1265
+#: ../src/wxMaximaFrame.cpp:1264
 #, fuzzy
 msgid "Linear Regression..."
 msgstr "Integrer udtryk"
 
-#: ../src/wxMaxima.cpp:3803
+#: ../src/wxMaxima.cpp:3815
 #, fuzzy
 msgid "List(s):"
 msgstr "Liste:"
 
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3848
 msgid "List:"
 msgstr "Liste:"
 
@@ -2609,15 +2612,15 @@ msgstr "Liste:"
 msgid "Load"
 msgstr "Indlæs"
 
-#: ../src/wxMaxima.cpp:2932
+#: ../src/wxMaxima.cpp:2940
 msgid "Load Package"
 msgstr "Indlæs pakke"
 
-#: ../src/wxMaximaFrame.cpp:479
+#: ../src/wxMaximaFrame.cpp:478
 msgid "Load a Maxima file using the batch command"
 msgstr "Indlæs en Maxima-fil ved hjælp af batch-kommando"
 
-#: ../src/wxMaximaFrame.cpp:477
+#: ../src/wxMaximaFrame.cpp:476
 msgid "Load a Maxima package file"
 msgstr "Indlæs fil med Maxima-pakke"
 
@@ -2629,49 +2632,49 @@ msgstr "Indlæs typografi fra fil"
 msgid "Long Right arrow"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Lower bound:"
 msgstr "Nedre grænse:"
 
-#: ../src/wxMaximaFrame.cpp:771
+#: ../src/wxMaximaFrame.cpp:770
 msgid "Ma&p to Matrix..."
 msgstr "Afbild &matrix"
 
-#: ../src/wxMaximaFrame.cpp:547
+#: ../src/wxMaximaFrame.cpp:546
 #, fuzzy
 msgid "Main Toolbar\tAlt-Shift-B"
 msgstr "Indsæt celle(r)\tCtrl-Shift-V"
 
-#: ../src/wxMaximaFrame.cpp:765
+#: ../src/wxMaximaFrame.cpp:764
 msgid "Make &List..."
 msgstr "O&pret liste..."
 
-#: ../src/wxMaxima.cpp:3821
+#: ../src/wxMaxima.cpp:3833
 msgid "Make list"
 msgstr "Opret liste"
 
-#: ../src/wxMaximaFrame.cpp:766
+#: ../src/wxMaximaFrame.cpp:765
 msgid "Make list from expression"
 msgstr "Opret liste ud fra udtryk"
 
-#: ../src/wxMaximaFrame.cpp:907
+#: ../src/wxMaximaFrame.cpp:906
 msgid "Make substitution in expression"
 msgstr "Udfør substitution i udtryk"
 
-#: ../src/wxMaximaFrame.cpp:682
+#: ../src/wxMaximaFrame.cpp:681
 #, fuzzy
 msgid "Manually Trigger Evaluation"
 msgstr "Vis beregningstid"
 
-#: ../src/wxMaxima.cpp:3805
+#: ../src/wxMaxima.cpp:3817
 msgid "Map"
 msgstr "Afbildning af liste"
 
-#: ../src/wxMaximaFrame.cpp:770
+#: ../src/wxMaximaFrame.cpp:769
 msgid "Map function to a list"
 msgstr "Anvend funktion på listeelementer"
 
-#: ../src/wxMaximaFrame.cpp:772
+#: ../src/wxMaximaFrame.cpp:771
 msgid "Map function to a matrix"
 msgstr "Anvend funktion på matrixelementer"
 
@@ -2689,24 +2692,24 @@ msgstr "Automatisk parring af parenteser"
 msgid "Math font:"
 msgstr "Standardskrifttype:"
 
-#: ../src/wxMaximaFrame.cpp:374
+#: ../src/wxMaximaFrame.cpp:373
 msgid "Mathematical Symbols"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3716
+#: ../src/wxMaxima.cpp:3728
 msgid "Matrix"
 msgstr "Matrix"
 
-#: ../src/wxMaxima.cpp:3702
+#: ../src/wxMaxima.cpp:3714
 msgid "Matrix map"
 msgstr "Afbildning af matrix"
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 #, fuzzy
 msgid "Matrix name:"
 msgstr "Matrix:"
 
-#: ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3749
+#: ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3761
 msgid "Matrix:"
 msgstr "Matrix:"
 
@@ -2715,7 +2718,7 @@ msgstr "Matrix:"
 msgid "Maxima"
 msgstr "&Maxima"
 
-#: ../src/wxMaximaFrame.cpp:137
+#: ../src/wxMaximaFrame.cpp:136
 #, fuzzy
 msgid "Maxima has a question"
 msgstr "Maxima-spørgsmål"
@@ -2724,24 +2727,24 @@ msgstr "Maxima-spørgsmål"
 msgid "Maxima input"
 msgstr "Maxima-input"
 
-#: ../src/wxMaximaFrame.cpp:166
+#: ../src/wxMaximaFrame.cpp:165
 msgid "Maxima is calculating"
 msgstr "Maxima beregner"
 
-#: ../src/wxMaximaFrame.cpp:111
+#: ../src/wxMaximaFrame.cpp:110
 #, fuzzy
 msgid "Maxima is ready for input."
 msgstr "Maxima-input"
 
-#: ../src/wxMaxima.cpp:2945
+#: ../src/wxMaxima.cpp:2953
 msgid "Maxima package (*.mac)|*.mac"
 msgstr "Maxima-pakke (*.mac)|*.mac"
 
-#: ../src/wxMaxima.cpp:2934
+#: ../src/wxMaxima.cpp:2942
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr "Maxima-pakke (*.mac)|*.mac|Lisp-pakke (*.lisp)|*.lisp|Alle|*"
 
-#: ../src/wxMaxima.cpp:1014
+#: ../src/wxMaxima.cpp:1019
 msgid "Maxima process terminated."
 msgstr "Maxima-proces er afsluttet."
 
@@ -2753,7 +2756,7 @@ msgstr "Sti til Maxima-program:"
 msgid "Maxima questions"
 msgstr "Maxima-spørgsmål"
 
-#: ../src/wxMaxima.cpp:942
+#: ../src/wxMaxima.cpp:947
 msgid "Maxima started. Waiting for connection..."
 msgstr "Maxima er i gang. Vent på forbindelse..."
 
@@ -2777,7 +2780,7 @@ msgstr ""
 "Maxima anvender ':' for at tildele værdier (f.eks. 'a : 3;') og ':=' for at "
 "definere funktioner (f.eks. 'f(x) := x^2;')."
 
-#: ../src/wxMaxima.cpp:4597
+#: ../src/wxMaxima.cpp:4609
 #, fuzzy
 msgid "Maxima version: "
 msgstr "Maxima-spørgsmål"
@@ -2815,45 +2818,45 @@ msgstr ""
 msgid "Maximum displayed number of digits:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1263
+#: ../src/wxMaximaFrame.cpp:1262
 #, fuzzy
 msgid "Mean Difference Test..."
 msgstr "Differentier..."
 
-#: ../src/wxMaximaFrame.cpp:1262
+#: ../src/wxMaximaFrame.cpp:1261
 #, fuzzy
 msgid "Mean Test..."
 msgstr "O&pret liste..."
 
-#: ../src/wxMaximaFrame.cpp:1255
+#: ../src/wxMaximaFrame.cpp:1254
 #, fuzzy
 msgid "Mean..."
 msgstr "Afbild liste..."
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Mean:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1256
+#: ../src/wxMaximaFrame.cpp:1255
 #, fuzzy
 msgid "Median..."
 msgstr "O&pret liste..."
 
-#: ../src/MathCtrl.cpp:945
+#: ../src/MathCtrl.cpp:987
 #, fuzzy
 msgid "Merge Cells"
 msgstr "&Slet celle(r)"
 
-#: ../src/wxMaximaFrame.cpp:633
+#: ../src/wxMaximaFrame.cpp:632
 #, fuzzy
 msgid "Merge Cells\tCtrl-M"
 msgstr "&Slet celle(r)"
 
-#: ../src/wxMaximaFrame.cpp:634
+#: ../src/wxMaximaFrame.cpp:633
 msgid "Merge the text from two input cells into one"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2668
+#: ../src/wxMaxima.cpp:2676
 msgid "Message from the stdout of Maxima: "
 msgstr ""
 
@@ -2861,20 +2864,20 @@ msgstr ""
 msgid "Method:"
 msgstr "Metode:"
 
-#: ../src/wxMaxima.cpp:5289
+#: ../src/wxMaxima.cpp:5301
 #, fuzzy
 msgid "Mismatched parenthesis"
 msgstr "Automatisk parring af parenteser"
 
-#: ../src/wxMaxima.cpp:3972
+#: ../src/wxMaxima.cpp:3984
 msgid "Modulus"
 msgstr "Modulus"
 
-#: ../src/wxMaximaFrame.cpp:1375
+#: ../src/wxMaximaFrame.cpp:1374
 msgid "Mu"
 msgstr ""
 
-#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Name:"
 msgstr "Navn:"
 
@@ -2882,7 +2885,7 @@ msgstr "Navn:"
 msgid "New"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
+#: ../src/wxMaximaFrame.cpp:456 ../src/wxMaximaFrame.cpp:459
 #, fuzzy
 msgid "New\tCtrl-N"
 msgstr "&Ny\tCtrl-N"
@@ -2900,11 +2903,11 @@ msgstr ""
 msgid "New value:"
 msgstr "Ny værdi:"
 
-#: ../src/wxMaxima.cpp:3993 ../src/wxMaxima.cpp:4119 ../src/wxMaxima.cpp:4136
+#: ../src/wxMaxima.cpp:4005 ../src/wxMaxima.cpp:4131 ../src/wxMaxima.cpp:4148
 msgid "New variable:"
 msgstr "Ny variabel:"
 
-#: ../src/wxMaximaFrame.cpp:630
+#: ../src/wxMaximaFrame.cpp:629
 msgid "Next Command\tAlt-Down"
 msgstr ""
 
@@ -2912,15 +2915,15 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5362
+#: ../src/wxMaxima.cpp:5378
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3249 ../src/wxMaxima.cpp:3271
+#: ../src/wxMaxima.cpp:3260 ../src/wxMaxima.cpp:3283
 msgid "No matches found!"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1264
+#: ../src/wxMaximaFrame.cpp:1263
 #, fuzzy
 msgid "Normality Test..."
 msgstr "O&pret liste..."
@@ -2944,31 +2947,31 @@ msgstr ""
 msgid "Norwegian"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:3740
 msgid "Not a valid matrix dimension!"
 msgstr "Ugyldig dimension for matrix!"
 
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629
 msgid "Not a valid number of equations!"
 msgstr "Ugyldigt antal ligninger!"
 
-#: ../src/wxMaximaFrame.cpp:197
+#: ../src/wxMaximaFrame.cpp:196
 msgid "Not connected to maxima"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4599
+#: ../src/wxMaxima.cpp:4611
 msgid "Not connected."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1376
+#: ../src/wxMaximaFrame.cpp:1375
 msgid "Nu"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Num. deg:"
 msgstr "Tællers grad:"
 
-#: ../src/wxMaxima.cpp:3585 ../src/wxMaxima.cpp:3609
+#: ../src/wxMaxima.cpp:3597 ../src/wxMaxima.cpp:3621
 msgid "Number of equations:"
 msgstr "Antal ligninger:"
 
@@ -2995,15 +2998,15 @@ msgstr "OK"
 msgid "Old value:"
 msgstr "Tidligere værdi:"
 
-#: ../src/wxMaxima.cpp:3992 ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135
+#: ../src/wxMaxima.cpp:4004 ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147
 msgid "Old variable:"
 msgstr "Tidligere variabel:"
 
-#: ../src/wxMaximaFrame.cpp:1387
+#: ../src/wxMaximaFrame.cpp:1386
 msgid "Omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1378
+#: ../src/wxMaximaFrame.cpp:1377
 msgid "Omicron"
 msgstr ""
 
@@ -3017,22 +3020,22 @@ msgid ""
 "stream for messages."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4763
+#: ../src/wxMaxima.cpp:4775
 #, fuzzy
 msgid "One sample t-test"
 msgstr "Teksteksempel"
 
-#: ../src/wxMaximaFrame.cpp:971
+#: ../src/wxMaximaFrame.cpp:970
 #, fuzzy
 msgid "Online tutorials"
 msgstr "&Kombiner fakulteter"
 
 #: ../src/ConfigDialogue.cpp:656 ../src/main.cpp:347 ../src/ToolBar.cpp:119
-#: ../src/wxMaxima.cpp:2797
+#: ../src/wxMaxima.cpp:2805
 msgid "Open"
 msgstr "Åbn"
 
-#: ../src/wxMaximaFrame.cpp:466
+#: ../src/wxMaximaFrame.cpp:465
 msgid "Open Recent"
 msgstr "Åbn seneste"
 
@@ -3040,11 +3043,11 @@ msgstr "Åbn seneste"
 msgid "Open a cell when Maxima expects input"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:464
+#: ../src/wxMaximaFrame.cpp:463
 msgid "Open a document"
 msgstr "Åbn dokument"
 
-#: ../src/wxMaximaFrame.cpp:458 ../src/wxMaximaFrame.cpp:461
+#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
 msgid "Open a new window"
 msgstr "Åbn nyt vindue"
 
@@ -3052,12 +3055,12 @@ msgstr "Åbn nyt vindue"
 msgid "Open document"
 msgstr "Åbn dokument"
 
-#: ../src/wxMaxima.cpp:4824
+#: ../src/wxMaxima.cpp:4836
 #, fuzzy
 msgid "Open matrix"
 msgstr "Indtast matrixelementer"
 
-#: ../src/wxMaxima.cpp:1446 ../src/wxMaxima.cpp:1518
+#: ../src/wxMaxima.cpp:1451 ../src/wxMaxima.cpp:1523
 msgid "Opening file"
 msgstr "Åbner fil"
 
@@ -3082,11 +3085,11 @@ msgid "Output labels"
 msgstr "Output-etiketter"
 
 # Skulle vi have ´ eller ej?
-#: ../src/wxMaximaFrame.cpp:796
+#: ../src/wxMaximaFrame.cpp:795
 msgid "P&ade Approximation..."
 msgstr "Padé-&approksimation"
 
-#: ../src/wxMaxima.cpp:3132 ../src/wxMaxima.cpp:5133
+#: ../src/wxMaxima.cpp:3141 ../src/wxMaxima.cpp:5145
 #, fuzzy
 msgid ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
@@ -3096,15 +3099,15 @@ msgstr ""
 "PNG-billede (*.png)|*.png|JPEG-billede (*.jpg)|*.jpg|Windows-bitmap (*.bmp)|"
 "*.bmp|X pixmap (*.xpm)|*.xpm"
 
-#: ../src/wxMaxima.cpp:4012
+#: ../src/wxMaxima.cpp:4024
 msgid "Pade approximation"
 msgstr "Padé-approksimation"
 
-#: ../src/wxMaximaFrame.cpp:797
+#: ../src/wxMaximaFrame.cpp:796
 msgid "Pade approximation of a Taylor series"
 msgstr "Padé-approksimation for Taylorrække"
 
-#: ../src/wxMaximaFrame.cpp:1500
+#: ../src/wxMaximaFrame.cpp:1519
 msgid "Pagebreak"
 msgstr ""
 
@@ -3117,19 +3120,19 @@ msgstr ""
 msgid "Parametric plot"
 msgstr "Parameterplot"
 
-#: ../src/wxMaximaFrame.cpp:188
+#: ../src/wxMaximaFrame.cpp:187
 msgid "Parsing output"
 msgstr "Output fortolkes"
 
-#: ../src/wxMaximaFrame.cpp:819
+#: ../src/wxMaximaFrame.cpp:818
 msgid "Partial &Fractions..."
 msgstr "Partial&brøker..."
 
-#: ../src/wxMaxima.cpp:4076
+#: ../src/wxMaxima.cpp:4088
 msgid "Partial fractions"
 msgstr "Partialbrøker"
 
-#: ../src/wxMaxima.cpp:1769
+#: ../src/wxMaxima.cpp:1774
 msgid "Parts of the document will not be loaded correctly!"
 msgstr ""
 
@@ -3139,11 +3142,11 @@ msgid ""
 "Found unknown XML Tag name "
 msgstr ""
 
-#: ../src/ToolBar.cpp:143 ../src/MathCtrl.cpp:1010 ../src/MathCtrl.cpp:1025
+#: ../src/MathCtrl.cpp:1052 ../src/MathCtrl.cpp:1067 ../src/ToolBar.cpp:143
 msgid "Paste"
 msgstr "Sæt ind"
 
-#: ../src/wxMaximaFrame.cpp:518
+#: ../src/wxMaximaFrame.cpp:517
 msgid "Paste\tCtrl-V"
 msgstr "&Sæt ind\tCtrl-V"
 
@@ -3152,7 +3155,7 @@ msgstr "&Sæt ind\tCtrl-V"
 msgid "Paste from clipboard"
 msgstr "Indsæt tekst fra Udklipsholder"
 
-#: ../src/wxMaximaFrame.cpp:519
+#: ../src/wxMaximaFrame.cpp:518
 msgid "Paste text from clipboard"
 msgstr "Indsæt tekst fra Udklipsholder"
 
@@ -3160,19 +3163,19 @@ msgstr "Indsæt tekst fra Udklipsholder"
 msgid "Perpendicular to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1384
+#: ../src/wxMaximaFrame.cpp:1383
 msgid "Phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1379
+#: ../src/wxMaximaFrame.cpp:1378
 msgid "Pi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1273
+#: ../src/wxMaximaFrame.cpp:1272
 msgid "Piechart..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1952
+#: ../src/wxMaxima.cpp:1957
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr "Ændrer indstillinger for wxMaxima i 'Rediger->Indstillinger'"
 
@@ -3180,52 +3183,52 @@ msgstr "Ændrer indstillinger for wxMaxima i 'Rediger->Indstillinger'"
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr "Genstart wxMaxima for at ændringer træder i kraft!"
 
-#: ../src/wxMaximaFrame.cpp:923
+#: ../src/wxMaximaFrame.cpp:922
 msgid "Plot &2d..."
 msgstr "&2D-plot..."
 
-#: ../src/wxMaximaFrame.cpp:925
+#: ../src/wxMaximaFrame.cpp:924
 msgid "Plot &3d..."
 msgstr "&3D-plot..."
 
-#: ../src/wxMaximaFrame.cpp:927
+#: ../src/wxMaximaFrame.cpp:926
 msgid "Plot &Format..."
 msgstr "Plot&format..."
 
 #: ../src/Plot2dWiz.cpp:104 ../src/Plot2dWiz.cpp:450 ../src/Plot2dWiz.cpp:464
-#: ../src/wxMaxima.cpp:4283 ../src/wxMaxima.cpp:5102
+#: ../src/wxMaxima.cpp:4295 ../src/wxMaxima.cpp:5114
 msgid "Plot 2D"
 msgstr "2D-plot"
 
-#: ../src/wxMaximaFrame.cpp:1227
+#: ../src/wxMaximaFrame.cpp:1226
 msgid "Plot 2D..."
 msgstr "2D-plot..."
 
-#: ../src/MathCtrl.cpp:1003
+#: ../src/MathCtrl.cpp:1045
 msgid "Plot 2d..."
 msgstr "2D-plot..."
 
-#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4269 ../src/wxMaxima.cpp:5115
+#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4281 ../src/wxMaxima.cpp:5127
 msgid "Plot 3D"
 msgstr "3D-plot"
 
-#: ../src/wxMaximaFrame.cpp:1228
+#: ../src/wxMaximaFrame.cpp:1227
 msgid "Plot 3D..."
 msgstr "3D-plot..."
 
-#: ../src/MathCtrl.cpp:1004
+#: ../src/MathCtrl.cpp:1046
 msgid "Plot 3d..."
 msgstr "3D-plot..."
 
-#: ../src/wxMaxima.cpp:4296
+#: ../src/wxMaxima.cpp:4308
 msgid "Plot format"
 msgstr "Plotformat"
 
-#: ../src/wxMaximaFrame.cpp:924
+#: ../src/wxMaximaFrame.cpp:923
 msgid "Plot in 2 dimensions"
 msgstr "Plot i 2 dimensioner"
 
-#: ../src/wxMaximaFrame.cpp:926
+#: ../src/wxMaximaFrame.cpp:925
 msgid "Plot in 3 dimensions"
 msgstr "Plot i 3 dimensioner"
 
@@ -3234,8 +3237,8 @@ msgid "Plot to file:"
 msgstr "Plot til fil:"
 
 #: ../src/BC2Wiz.cpp:30 ../src/BC2Wiz.cpp:36 ../src/LimitWiz.cpp:33
-#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
-#: ../src/wxMaxima.cpp:3648
+#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
+#: ../src/wxMaxima.cpp:3660
 msgid "Point:"
 msgstr "Punkt:"
 
@@ -3243,11 +3246,11 @@ msgstr "Punkt:"
 msgid "Polish"
 msgstr "Polsk"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 1:"
 msgstr "Polynomium 1:"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 2:"
 msgstr "Polynomium 2:"
 
@@ -3259,11 +3262,11 @@ msgstr "Portugisisk (brasiliansk)"
 msgid "Postscript file (*.eps)|*.eps|All|*"
 msgstr "Postscript-fil (*.eps)|*.eps|Alle|*"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Precision"
 msgstr "Nøjagtighed"
 
-#: ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:536
 msgid "Preferences...\tCtrl+,"
 msgstr ""
 
@@ -3275,7 +3278,7 @@ msgid ""
 "packages and from functions that are defined in the current file."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:628
+#: ../src/wxMaximaFrame.cpp:627
 msgid "Previous Command\tAlt-Up"
 msgstr ""
 
@@ -3283,11 +3286,11 @@ msgstr ""
 msgid "Print"
 msgstr "Udskriv"
 
-#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:484
+#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:483
 msgid "Print document"
 msgstr "Udskriv dokument"
 
-#: ../src/wxMaxima.cpp:4242
+#: ../src/wxMaxima.cpp:4254
 msgid "Product"
 msgstr "Produkt"
 
@@ -3296,37 +3299,37 @@ msgstr "Produkt"
 msgid "Product sign"
 msgstr "Produkt"
 
-#: ../src/wxMaximaFrame.cpp:1386
+#: ../src/wxMaximaFrame.cpp:1385
 msgid "Psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:331
+#: ../src/wxMaximaFrame.cpp:330
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:592
+#: ../src/wxMaximaFrame.cpp:591
 #, fuzzy
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr "Beregn alle celler i dokumentet"
 
-#: ../src/wxMaximaFrame.cpp:1278
+#: ../src/wxMaximaFrame.cpp:1277
 #, fuzzy
 msgid "Read Matrix..."
 msgstr "I&ndtast matrix..."
 
-#: ../src/wxMaximaFrame.cpp:177
+#: ../src/wxMaximaFrame.cpp:176
 msgid "Reading Maxima output"
 msgstr "Maxima-output behandles"
 
-#: ../src/wxMaximaFrame.cpp:153
+#: ../src/wxMaximaFrame.cpp:152
 msgid "Ready for user input"
 msgstr "Klar til input fra bruger"
 
-#: ../src/wxMaximaFrame.cpp:631
+#: ../src/wxMaximaFrame.cpp:630
 msgid "Recall next command from history"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:629
+#: ../src/wxMaximaFrame.cpp:628
 msgid "Recall previous command from history"
 msgstr ""
 
@@ -3334,40 +3337,40 @@ msgstr ""
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1215
+#: ../src/wxMaximaFrame.cpp:1214
 msgid "Rectform"
 msgstr "Rektangulær form"
 
-#: ../src/wxMaximaFrame.cpp:495
+#: ../src/wxMaximaFrame.cpp:494
 #, fuzzy
 msgid "Redo\tCtrl-Y"
 msgstr "Fortryd\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:496
+#: ../src/wxMaximaFrame.cpp:495
 #, fuzzy
 msgid "Redo last change"
 msgstr "Fortryd seneste ændring"
 
-#: ../src/wxMaximaFrame.cpp:1220
+#: ../src/wxMaximaFrame.cpp:1219
 msgid "Reduce (tr)"
 msgstr "Sammentræk trig."
 
-#: ../src/wxMaximaFrame.cpp:871
+#: ../src/wxMaximaFrame.cpp:870
 msgid "Reduce trigonometric expression"
 msgstr "Sammentræk trigonometrisk udtryk"
 
-#: ../src/wxMaxima.cpp:622 ../src/wxMaxima.cpp:5495
+#: ../src/wxMaxima.cpp:627 ../src/wxMaxima.cpp:5511
 msgid "Refusing to send cell to maxima: "
 msgstr ""
 
 # Jeg mener kun den skjuler, for jeg kan bede om det i en senere input selvom jeg ikke kan se outputtet længere
 # JT: men hvordan kalder man dem mon frem igen?
-#: ../src/wxMaximaFrame.cpp:594
+#: ../src/wxMaximaFrame.cpp:593
 #, fuzzy
 msgid "Remove All Output"
 msgstr "Fjern alle output"
 
-#: ../src/wxMaximaFrame.cpp:595
+#: ../src/wxMaximaFrame.cpp:594
 msgid "Remove output from input cells"
 msgstr "Fjern visning af hidtidige output"
 
@@ -3376,7 +3379,7 @@ msgstr "Fjern visning af hidtidige output"
 msgid "Replace All"
 msgstr "Marker alt"
 
-#: ../src/wxMaxima.cpp:3282
+#: ../src/wxMaxima.cpp:3294
 #, c-format
 msgid "Replaced %d occurrences."
 msgstr ""
@@ -3385,11 +3388,11 @@ msgstr ""
 msgid "Replacement:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:976
+#: ../src/wxMaximaFrame.cpp:975
 msgid "Report bug"
 msgstr "Information om fejlrapportering"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "Restart Maxima"
 msgstr "Genstart Maxima"
 
@@ -3398,7 +3401,7 @@ msgstr "Genstart Maxima"
 msgid "Restart maxima"
 msgstr "Genstart Maxima"
 
-#: ../src/MathCtrl.cpp:4442
+#: ../src/MathCtrl.cpp:4497
 msgid "Result"
 msgstr ""
 
@@ -3406,7 +3409,7 @@ msgstr ""
 msgid "Return to the cell that is currently being evaluated"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1380
+#: ../src/wxMaximaFrame.cpp:1379
 msgid "Rho"
 msgstr ""
 
@@ -3414,20 +3417,20 @@ msgstr ""
 msgid "Right arrow"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:779
+#: ../src/wxMaximaFrame.cpp:778
 msgid "Risch Integration..."
 msgstr "Risch-integration..."
 
-#: ../src/wxMaximaFrame.cpp:694
+#: ../src/wxMaximaFrame.cpp:693
 msgid "Roots of &Polynomial"
 msgstr "&Polynomiumsrødder"
 
-#: ../src/wxMaximaFrame.cpp:697
+#: ../src/wxMaximaFrame.cpp:696
 #, fuzzy
 msgid "Roots of Polynomial (bfloat)"
 msgstr "&Reelle rødder i polynomium"
 
-#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Rows:"
 msgstr "Rækker:"
 
@@ -3435,63 +3438,63 @@ msgstr "Rækker:"
 msgid "Russian"
 msgstr "Russisk"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 #, fuzzy
 msgid "Sample 1:"
 msgstr "Eksempel"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 #, fuzzy
 msgid "Sample 2:"
 msgstr "Eksempel"
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 #, fuzzy
 msgid "Sample:"
 msgstr "Eksempel"
 
 #: ../src/ConfigDialogue.cpp:781 ../src/ToolBar.cpp:122
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Save"
 msgstr "Gem"
 
 # Skulle vi have ´ eller ej?
-#: ../src/MathCtrl.cpp:921
+#: ../src/MathCtrl.cpp:963
 #, fuzzy
 msgid "Save Animation..."
 msgstr "Padé-&approksimation"
 
-#: ../src/wxMaxima.cpp:2565
+#: ../src/wxMaxima.cpp:2572
 msgid "Save As"
 msgstr "Gem som"
 
-#: ../src/wxMaximaFrame.cpp:474
+#: ../src/wxMaximaFrame.cpp:473
 msgid "Save As...\tShift-Ctrl-S"
 msgstr "Ge&m som...\tShift-Ctrl-S"
 
-#: ../src/MathCtrl.cpp:919
+#: ../src/MathCtrl.cpp:961
 msgid "Save Image..."
 msgstr "Gem billede..."
 
-#: ../src/wxMaxima.cpp:3130
+#: ../src/wxMaxima.cpp:3139
 msgid "Save Selection to Image"
 msgstr "Gem markering som billede"
 
-#: ../src/wxMaximaFrame.cpp:528
+#: ../src/wxMaximaFrame.cpp:527
 msgid "Save Selection to Image..."
 msgstr "Gem markering som billede..."
 
 # Gem billedet i filen
-#: ../src/wxMaxima.cpp:5150
+#: ../src/wxMaxima.cpp:5162
 #, fuzzy
 msgid "Save animation to file"
 msgstr "Gem markering i fil"
 
-#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:473
+#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:472
 msgid "Save document"
 msgstr "Gem dokument"
 
-#: ../src/wxMaximaFrame.cpp:475
+#: ../src/wxMaximaFrame.cpp:474
 #, fuzzy
 msgid "Save document as"
 msgstr "Gem dokument"
@@ -3515,12 +3518,12 @@ msgstr "Gem størrelse og position for wxMaxima-vindue mellem sessioner."
 msgid "Save plot to file"
 msgstr "Gem plot som fil"
 
-#: ../src/wxMaximaFrame.cpp:529
+#: ../src/wxMaximaFrame.cpp:528
 msgid "Save selection from document to an image file"
 msgstr "Gem det markerede område i dokumentet i en billedfil"
 
 # Gem billedet i filen
-#: ../src/wxMaxima.cpp:5131
+#: ../src/wxMaxima.cpp:5143
 msgid "Save selection to file"
 msgstr "Gem markering i fil"
 
@@ -3536,28 +3539,28 @@ msgstr "Gem størrelse og position for wxMaxima-vindue"
 msgid "Save wxMaxima window size/position between sessions."
 msgstr "Gem størrelse og position for wxMaxima-vindue mellem sessioner."
 
-#: ../src/wxMaximaFrame.cpp:246
+#: ../src/wxMaximaFrame.cpp:245
 #, fuzzy
 msgid "Saving failed."
 msgstr "Server-opstart slog fejl"
 
-#: ../src/wxMaximaFrame.cpp:222
+#: ../src/wxMaximaFrame.cpp:221
 msgid "Saving successful."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:212
+#: ../src/wxMaximaFrame.cpp:211
 msgid "Saving..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4699
+#: ../src/wxMaxima.cpp:4711
 msgid "Scatterplot"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1271
+#: ../src/wxMaximaFrame.cpp:1270
 msgid "Scatterplot..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1498
+#: ../src/wxMaximaFrame.cpp:1517
 #, fuzzy
 msgid "Section"
 msgstr "Markering"
@@ -3566,27 +3569,27 @@ msgstr "Markering"
 msgid "Section cell"
 msgstr "Afsnitscelle"
 
-#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:292 ../src/TextCell.cpp:306
-#: ../src/TextCell.cpp:322 ../src/TextCell.cpp:334
+#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:290 ../src/TextCell.cpp:304
+#: ../src/TextCell.cpp:320 ../src/TextCell.cpp:332
 msgid ""
 "Seems like something is broken with a font. Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/TextCell.cpp:139
+#: ../src/TextCell.cpp:137
 msgid ""
 "Seems like something is broken with the maths font. Installing http://www."
 "math.union.edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use "
 "JSmath fonts\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1011 ../src/MathCtrl.cpp:1027
+#: ../src/MathCtrl.cpp:1053 ../src/MathCtrl.cpp:1069
 #, fuzzy
 msgid "Select All"
 msgstr "Marker alt"
 
-#: ../src/wxMaximaFrame.cpp:525
+#: ../src/wxMaximaFrame.cpp:524
 msgid "Select All\tCtrl-A"
 msgstr "&Marker alt\tCtrl-A"
 
@@ -3594,7 +3597,7 @@ msgstr "&Marker alt\tCtrl-A"
 msgid "Select Maxima program"
 msgstr "Vælg sti for Maxima-program"
 
-#: ../src/wxMaxima.cpp:4860
+#: ../src/wxMaxima.cpp:4872
 #, fuzzy
 msgid "Select Subsample"
 msgstr "Marker alt"
@@ -3604,11 +3607,11 @@ msgstr "Marker alt"
 msgid "Select a constant"
 msgstr "Vælg en konstant"
 
-#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:526
+#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:525
 msgid "Select all"
 msgstr "Marker alt"
 
-#: ../src/wxMaxima.cpp:3319
+#: ../src/wxMaxima.cpp:3331
 msgid "Select math display algorithm"
 msgstr "Vælg algoritme"
 
@@ -3625,24 +3628,24 @@ msgstr ""
 msgid "Selection"
 msgstr "Markering"
 
-#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4178
+#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4190
 msgid "Series"
 msgstr "Rækker"
 
-#: ../src/wxMaximaFrame.cpp:1226
+#: ../src/wxMaximaFrame.cpp:1225
 msgid "Series..."
 msgstr "Rækker..."
 
-#: ../src/wxMaxima.cpp:863
+#: ../src/wxMaxima.cpp:868
 msgid "Server started"
 msgstr "Server er startet"
 
-#: ../src/wxMaximaFrame.cpp:575
+#: ../src/wxMaximaFrame.cpp:574
 #, fuzzy
 msgid "Set Zoom"
 msgstr "Vælg plot format"
 
-#: ../src/wxMaximaFrame.cpp:944
+#: ../src/wxMaximaFrame.cpp:943
 #, fuzzy
 msgid "Set bigfloat &Precision..."
 msgstr "Vælg nøjagtighed decimaltal 2"
@@ -3651,61 +3654,61 @@ msgstr "Vælg nøjagtighed decimaltal 2"
 msgid "Set fixed font in text controls."
 msgstr "Brug fast tegnbredde i indtastningsfelter"
 
-#: ../src/wxMaximaFrame.cpp:928
+#: ../src/wxMaximaFrame.cpp:927
 msgid "Set plot format"
 msgstr "Vælg plot format"
 
-#: ../src/wxMaximaFrame.cpp:945
+#: ../src/wxMaximaFrame.cpp:944
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can "
 "be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:569
+#: ../src/wxMaximaFrame.cpp:568
 msgid "Set zoom to 100%"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:570
+#: ../src/wxMaximaFrame.cpp:569
 msgid "Set zoom to 120%"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:571
+#: ../src/wxMaximaFrame.cpp:570
 msgid "Set zoom to 150%"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:572
+#: ../src/wxMaximaFrame.cpp:571
 msgid "Set zoom to 200%"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:573
+#: ../src/wxMaximaFrame.cpp:572
 msgid "Set zoom to 300%"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:568
+#: ../src/wxMaximaFrame.cpp:567
 msgid "Set zoom to 80%"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:732
+#: ../src/wxMaximaFrame.cpp:731
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr "Opstil randbetingelser til løsning af ODL med Laplace-transformation"
 
-#: ../src/wxMaximaFrame.cpp:918
+#: ../src/wxMaximaFrame.cpp:917
 msgid "Setup modulus computation"
 msgstr "Opsætning af modulus-beregning"
 
-#: ../src/wxMaximaFrame.cpp:662
+#: ../src/wxMaximaFrame.cpp:661
 msgid "Show &Definition..."
 msgstr "Vis &definitioner..."
 
-#: ../src/wxMaximaFrame.cpp:660
+#: ../src/wxMaximaFrame.cpp:659
 msgid "Show &Functions"
 msgstr "Vis &funktioner"
 
-#: ../src/wxMaximaFrame.cpp:967
+#: ../src/wxMaximaFrame.cpp:966
 msgid "Show &Tips..."
 msgstr "Vis &tips..."
 
-#: ../src/wxMaximaFrame.cpp:665
+#: ../src/wxMaximaFrame.cpp:664
 msgid "Show &Variables"
 msgstr "&Vis variable"
 
@@ -3713,44 +3716,44 @@ msgstr "&Vis variable"
 msgid "Show Maxima help"
 msgstr "Vis Maxima Hjælp"
 
-#: ../src/wxMaximaFrame.cpp:603
+#: ../src/wxMaximaFrame.cpp:602
 #, fuzzy
 msgid "Show Template\tCtrl-Shift-K"
 msgstr "Kopier celle(r)\tCtrl-Shift-C"
 
-#: ../src/wxMaximaFrame.cpp:968
+#: ../src/wxMaximaFrame.cpp:967
 msgid "Show a tip"
 msgstr "Vis et tip"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Show all commands similar to:"
 msgstr "Vis alle kommandoer i stil med:"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Show an example for the command:"
 msgstr "Vis eksempel med kommandoen:"
 
-#: ../src/wxMaximaFrame.cpp:962
+#: ../src/wxMaximaFrame.cpp:961
 msgid "Show an example of usage"
 msgstr "Vis et eksempel med anvendelse"
 
-#: ../src/wxMaximaFrame.cpp:965
+#: ../src/wxMaximaFrame.cpp:964
 msgid "Show commands similar to"
 msgstr "Vis alle kommandoer i stil med"
 
-#: ../src/wxMaximaFrame.cpp:661
+#: ../src/wxMaximaFrame.cpp:660
 msgid "Show defined functions"
 msgstr "Vis erklærede funktioner"
 
-#: ../src/wxMaximaFrame.cpp:666
+#: ../src/wxMaximaFrame.cpp:665
 msgid "Show defined variables"
 msgstr "Vis erklærede variable"
 
-#: ../src/wxMaximaFrame.cpp:663
+#: ../src/wxMaximaFrame.cpp:662
 msgid "Show definition of a function"
 msgstr "Vis definition for en funktion"
 
-#: ../src/wxMaximaFrame.cpp:604
+#: ../src/wxMaximaFrame.cpp:603
 #, fuzzy
 msgid "Show function template"
 msgstr "Vis &funktioner"
@@ -3764,7 +3767,7 @@ msgstr "Vis lange udtryk i wxMaxima-dokument."
 msgid "Show long expressions:"
 msgstr "Vis lange udtryk"
 
-#: ../src/wxMaxima.cpp:3341
+#: ../src/wxMaxima.cpp:3353
 msgid "Show the definition of function:"
 msgstr "Vis definition for funktionen:"
 
@@ -3773,44 +3776,44 @@ msgstr "Vis definition for funktionen:"
 msgid "Show user-defined labels instead of (%oxx)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:953 ../src/wxMaximaFrame.cpp:956
+#: ../src/wxMaximaFrame.cpp:952 ../src/wxMaximaFrame.cpp:955
 #, fuzzy
 msgid "Show wxMaxima help"
 msgstr "Vis Maxima Hjælp"
 
-#: ../src/wxMaximaFrame.cpp:1381
+#: ../src/wxMaximaFrame.cpp:1380
 msgid "Sigma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1211
+#: ../src/wxMaximaFrame.cpp:1210
 msgid "Simplify"
 msgstr "Reducer (ratsimp)"
 
-#: ../src/wxMaximaFrame.cpp:831
+#: ../src/wxMaximaFrame.cpp:830
 msgid "Simplify &Radicals"
 msgstr "Reducer (&radcan)"
 
-#: ../src/wxMaximaFrame.cpp:1212
+#: ../src/wxMaximaFrame.cpp:1211
 msgid "Simplify (r)"
 msgstr "Reducer (radcan)"
 
-#: ../src/wxMaximaFrame.cpp:1218
+#: ../src/wxMaximaFrame.cpp:1217
 msgid "Simplify (tr)"
 msgstr "Reducer trig."
 
-#: ../src/MathCtrl.cpp:995
+#: ../src/MathCtrl.cpp:1037
 msgid "Simplify Expression"
 msgstr "Reducer udtryk (ratsimp)"
 
-#: ../src/wxMaximaFrame.cpp:857
+#: ../src/wxMaximaFrame.cpp:856
 msgid "Simplify an expression containing factorials"
 msgstr "Reducer et udtryk indeholdende fakulteter"
 
-#: ../src/wxMaximaFrame.cpp:832
+#: ../src/wxMaximaFrame.cpp:831
 msgid "Simplify expression containing radicals"
 msgstr "Reducer udtryk indeholdende radikaler/rødder"
 
-#: ../src/wxMaximaFrame.cpp:830
+#: ../src/wxMaximaFrame.cpp:829
 msgid "Simplify rational expression"
 msgstr "Reducer rationalt udtryk"
 
@@ -3818,7 +3821,7 @@ msgstr "Reducer rationalt udtryk"
 msgid "Simplify the sum"
 msgstr "Reducer sum"
 
-#: ../src/wxMaximaFrame.cpp:868
+#: ../src/wxMaximaFrame.cpp:867
 msgid "Simplify trigonometric expression"
 msgstr "Reducer trigonometrisk udtryk"
 
@@ -3835,89 +3838,89 @@ msgstr ""
 "'wxMaxima XML dokument' hvis du vil have dit billede gemt sammen med dit "
 "dokument."
 
-#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
+#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
 msgid "Solution:"
 msgstr "Løsning:"
 
-#: ../src/wxMaxima.cpp:3461 ../src/wxMaxima.cpp:3475 ../src/wxMaxima.cpp:5020
+#: ../src/wxMaxima.cpp:3473 ../src/wxMaxima.cpp:3487 ../src/wxMaxima.cpp:5032
 msgid "Solve"
 msgstr "Løs"
 
-#: ../src/wxMaximaFrame.cpp:706
+#: ../src/wxMaximaFrame.cpp:705
 msgid "Solve &Algebraic System..."
 msgstr "Løs &algebraisk ligningssystem..."
 
-#: ../src/wxMaximaFrame.cpp:703
+#: ../src/wxMaximaFrame.cpp:702
 msgid "Solve &Linear System..."
 msgstr "Løs l&ineært ligningssystem"
 
-#: ../src/wxMaximaFrame.cpp:714
+#: ../src/wxMaximaFrame.cpp:713
 msgid "Solve &ODE..."
 msgstr "Løs &ODL..."
 
-#: ../src/wxMaximaFrame.cpp:690
+#: ../src/wxMaximaFrame.cpp:689
 #, fuzzy
 msgid "Solve (to_poly)..."
 msgstr "Løs..."
 
-#: ../src/wxMaxima.cpp:3511 ../src/wxMaxima.cpp:3635
+#: ../src/wxMaxima.cpp:3523 ../src/wxMaxima.cpp:3647
 msgid "Solve ODE"
 msgstr "Løs ODL"
 
-#: ../src/wxMaximaFrame.cpp:728
+#: ../src/wxMaximaFrame.cpp:727
 msgid "Solve ODE with Lapla&ce..."
 msgstr "Løs O&DL med Laplace..."
 
-#: ../src/wxMaximaFrame.cpp:1222
+#: ../src/wxMaximaFrame.cpp:1221
 msgid "Solve ODE..."
 msgstr "Løs ODL..."
 
-#: ../src/wxMaxima.cpp:3586 ../src/wxMaxima.cpp:3597
+#: ../src/wxMaxima.cpp:3598 ../src/wxMaxima.cpp:3609
 msgid "Solve algebraic system"
 msgstr "Løs algebraisk ligningssystem"
 
-#: ../src/wxMaximaFrame.cpp:707
+#: ../src/wxMaximaFrame.cpp:706
 msgid "Solve algebraic system of equations"
 msgstr "Løs algebraisk ligningssystem"
 
-#: ../src/wxMaximaFrame.cpp:725
+#: ../src/wxMaximaFrame.cpp:724
 msgid "Solve boundary value problem for second degree ODE"
 msgstr "Løs randværdiproblem for 2. ordens ODL"
 
-#: ../src/wxMaximaFrame.cpp:689
+#: ../src/wxMaximaFrame.cpp:688
 msgid "Solve equation(s)"
 msgstr "Løs ligning(er)"
 
-#: ../src/wxMaximaFrame.cpp:691
+#: ../src/wxMaximaFrame.cpp:690
 #, fuzzy
 msgid "Solve equation(s) with to_poly_solve"
 msgstr "Løs ligning(er)"
 
-#: ../src/wxMaximaFrame.cpp:719
+#: ../src/wxMaximaFrame.cpp:718
 msgid "Solve initial value problem for first degree ODE"
 msgstr "Løs begyndelsesværdiproblem for 1. ordens ODL"
 
-#: ../src/wxMaximaFrame.cpp:722
+#: ../src/wxMaximaFrame.cpp:721
 msgid "Solve initial value problem for second degree ODE"
 msgstr "Løs begyndelsesværdiproblem for 2. ordens ODL"
 
-#: ../src/wxMaxima.cpp:3610 ../src/wxMaxima.cpp:3621
+#: ../src/wxMaxima.cpp:3622 ../src/wxMaxima.cpp:3633
 msgid "Solve linear system"
 msgstr "Løs lineært ligningssystem..."
 
-#: ../src/wxMaximaFrame.cpp:704
+#: ../src/wxMaximaFrame.cpp:703
 msgid "Solve linear system of equations"
 msgstr "Løs lineært ligningssystem"
 
-#: ../src/wxMaximaFrame.cpp:715
+#: ../src/wxMaximaFrame.cpp:714
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr "Løs ordinær differentialligning af orden højst 2"
 
-#: ../src/wxMaximaFrame.cpp:729
+#: ../src/wxMaximaFrame.cpp:728
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr "Løs ordinære differentialligninger ved hjælp af Laplace-transformation"
 
-#: ../src/wxMaximaFrame.cpp:1221 ../src/MathCtrl.cpp:992
+#: ../src/MathCtrl.cpp:1034 ../src/wxMaximaFrame.cpp:1220
 msgid "Solve..."
 msgstr "Løs..."
 
@@ -3942,7 +3945,7 @@ msgstr "Specialtegn"
 msgid "Special constants"
 msgstr "Særlige konstanter"
 
-#: ../src/MathCtrl.cpp:922
+#: ../src/MathCtrl.cpp:964
 #, fuzzy
 msgid "Start Animation"
 msgstr "Afspil animation"
@@ -3962,29 +3965,29 @@ msgstr ""
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:294
+#: ../src/wxMaxima.cpp:295
 msgid "Starting Maxima process failed"
 msgstr "Maxima-opstart slog fejl"
 
-#: ../src/wxMaxima.cpp:928
+#: ../src/wxMaxima.cpp:933
 msgid "Starting Maxima..."
 msgstr "Maxima startes..."
 
-#: ../src/wxMaxima.cpp:292 ../src/wxMaxima.cpp:860
+#: ../src/wxMaxima.cpp:293 ../src/wxMaxima.cpp:865
 msgid "Starting server failed"
 msgstr "Server-opstart slog fejl"
 
-#: ../src/wxMaxima.cpp:841
+#: ../src/wxMaxima.cpp:846
 #, c-format
 msgid "Starting server on port %d"
 msgstr "Server startes via port %d"
 
-#: ../src/wxMaximaFrame.cpp:342
+#: ../src/wxMaximaFrame.cpp:341
 #, fuzzy
 msgid "Statistics"
 msgstr "antisymmetrisk"
 
-#: ../src/wxMaximaFrame.cpp:550
+#: ../src/wxMaximaFrame.cpp:549
 msgid "Statistics\tAlt-Shift-S"
 msgstr ""
 
@@ -4000,12 +4003,12 @@ msgstr "Typografi"
 msgid "Styles"
 msgstr "Typografier"
 
-#: ../src/wxMaximaFrame.cpp:1283
+#: ../src/wxMaximaFrame.cpp:1282
 #, fuzzy
 msgid "Subsample..."
 msgstr "Substituer..."
 
-#: ../src/wxMaximaFrame.cpp:1496
+#: ../src/wxMaximaFrame.cpp:1515
 #, fuzzy
 msgid "Subsection"
 msgstr "Markering"
@@ -4015,20 +4018,20 @@ msgstr "Markering"
 msgid "Subsection cell"
 msgstr "Afsnitscelle"
 
-#: ../src/wxMaximaFrame.cpp:1216
+#: ../src/wxMaximaFrame.cpp:1215
 msgid "Subst..."
 msgstr "Substituer..."
 
-#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3423
-#: ../src/wxMaxima.cpp:5089
+#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3435
+#: ../src/wxMaxima.cpp:5101
 msgid "Substitute"
 msgstr "Substituer"
 
-#: ../src/wxMaximaFrame.cpp:906 ../src/MathCtrl.cpp:998
+#: ../src/MathCtrl.cpp:1040 ../src/wxMaximaFrame.cpp:905
 msgid "Substitute..."
 msgstr "Substituer..."
 
-#: ../src/wxMaximaFrame.cpp:1497
+#: ../src/wxMaximaFrame.cpp:1516
 #, fuzzy
 msgid "Subsubsection"
 msgstr "Markering"
@@ -4038,7 +4041,7 @@ msgstr "Markering"
 msgid "Subsubsection cell"
 msgstr "Afsnitscelle"
 
-#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4226
+#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4238
 msgid "Sum"
 msgstr "Sum"
 
@@ -4046,37 +4049,37 @@ msgstr "Sum"
 msgid "Sum sign"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:553
+#: ../src/wxMaximaFrame.cpp:552
 #, fuzzy
 msgid "Symbols\tAlt-Shift-Y"
 msgstr "Indsæt celle(r)\tCtrl-Shift-V"
 
-#: ../src/wxMaxima.cpp:4456
+#: ../src/wxMaxima.cpp:4468
 msgid "System info"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:320
+#: ../src/wxMaximaFrame.cpp:319
 msgid "Table of Contents"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:556
+#: ../src/wxMaximaFrame.cpp:555
 #, fuzzy
 msgid "Table of Contents\tAlt-Shift-T"
 msgstr "Indsæt celle(r)\tCtrl-Shift-V"
 
-#: ../src/wxMaximaFrame.cpp:1382
+#: ../src/wxMaximaFrame.cpp:1381
 msgid "Tau"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Taylor series:"
 msgstr "Taylorrækker:"
 
-#: ../src/wxMaxima.cpp:3963
+#: ../src/wxMaxima.cpp:3975
 msgid "Tellrat"
 msgstr "Tellrat"
 
-#: ../src/wxMaximaFrame.cpp:1494
+#: ../src/wxMaximaFrame.cpp:1513
 #, fuzzy
 msgid "Text"
 msgstr "Tekstcelle"
@@ -4123,7 +4126,7 @@ msgstr ""
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr ""
 
-#: ../src/TextCell.cpp:136
+#: ../src/TextCell.cpp:134
 msgid ""
 "The letter \"X\" is of width zero. Installing http://www.math.union.edu/"
 "~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts\" in "
@@ -4140,7 +4143,7 @@ msgstr ""
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:959
+#: ../src/wxMaximaFrame.cpp:958
 msgid "The offline manual of maxima"
 msgstr ""
 
@@ -4178,14 +4181,14 @@ msgstr ""
 "wxmaxima.sourceforge.net/wiki/index.php/Tutorials for mere information om "
 "brug af wxMaxima og Maxima."
 
-#: ../src/SlideShowCell.cpp:332
+#: ../src/SlideShowCell.cpp:336
 msgid ""
 "There was an error during GIF export!\n"
 "\n"
 "Make sure ImageMagick is installed and wxMaxima can find the convert program."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:442
+#: ../src/wxMaxima.cpp:447
 msgid ""
 "There was an error in generated XML!\n"
 "\n"
@@ -4195,7 +4198,7 @@ msgstr ""
 "\n"
 "Rapporter venligdt dette som en programfejl."
 
-#: ../src/wxMaximaFrame.cpp:1371
+#: ../src/wxMaximaFrame.cpp:1370
 msgid "Theta"
 msgstr ""
 
@@ -4205,7 +4208,7 @@ msgid "Ticks:"
 msgstr "Inddeling:"
 
 # Hvilken kontekst?
-#: ../src/wxMaxima.cpp:4153 ../src/wxMaxima.cpp:5065
+#: ../src/wxMaxima.cpp:4165 ../src/wxMaxima.cpp:5077
 msgid "Times:"
 msgstr "Gange:"
 
@@ -4213,7 +4216,7 @@ msgstr "Gange:"
 msgid "Tips not available, sorry!"
 msgstr "Ingen tips er tilgængelige, beklager!"
 
-#: ../src/wxMaximaFrame.cpp:1495
+#: ../src/wxMaximaFrame.cpp:1514
 #, fuzzy
 msgid "Title"
 msgstr "Fil"
@@ -4229,20 +4232,20 @@ msgid ""
 "all sublevels of that cell will also fold/unfold."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:938
+#: ../src/wxMaximaFrame.cpp:937
 msgid "To &Bigfloat"
 msgstr "Angiv som decimaltal &2\tCtrl-2"
 
-#: ../src/wxMaximaFrame.cpp:935
+#: ../src/wxMaximaFrame.cpp:934
 #, fuzzy
 msgid "To &Float"
 msgstr "Angiv som decimaltal 1"
 
-#: ../src/MathCtrl.cpp:990
+#: ../src/MathCtrl.cpp:1032
 msgid "To Float"
 msgstr "Angiv som decimaltal 1"
 
-#: ../src/wxMaximaFrame.cpp:941
+#: ../src/wxMaximaFrame.cpp:940
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr ""
 
@@ -4283,51 +4286,51 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:41 ../src/Plot2dWiz.cpp:40 ../src/Plot2dWiz.cpp:50
 #: ../src/Plot2dWiz.cpp:539 ../src/Plot3dWiz.cpp:39 ../src/Plot3dWiz.cpp:48
-#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4241
+#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4253
 msgid "To:"
 msgstr "Til:"
 
-#: ../src/wxMaximaFrame.cpp:912
+#: ../src/wxMaximaFrame.cpp:911
 msgid "Toggle &Algebraic Flag"
 msgstr "Slå &algebraic-indikator til/fra"
 
-#: ../src/wxMaximaFrame.cpp:933
+#: ../src/wxMaximaFrame.cpp:932
 msgid "Toggle &Numeric Output"
 msgstr "&Vis eksakt/decimaltal "
 
-#: ../src/wxMaximaFrame.cpp:673
+#: ../src/wxMaximaFrame.cpp:672
 msgid "Toggle &Time Display"
 msgstr "Skjul/vis beregningstid "
 
-#: ../src/wxMaximaFrame.cpp:913
+#: ../src/wxMaximaFrame.cpp:912
 msgid "Toggle algebraic flag"
 msgstr "Slå Maxima-indikatoren algebraic til eller fra"
 
-#: ../src/wxMaximaFrame.cpp:577
+#: ../src/wxMaximaFrame.cpp:576
 msgid "Toggle full screen editing"
 msgstr "Skift til fuldskærmsvisning"
 
-#: ../src/wxMaximaFrame.cpp:934
+#: ../src/wxMaximaFrame.cpp:933
 msgid "Toggle numeric output"
 msgstr "Slå numerisk beregning til eller fra"
 
-#: ../src/wxMaxima.cpp:4464
+#: ../src/wxMaxima.cpp:4476
 msgid "Toolbar icons"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4465
+#: ../src/wxMaxima.cpp:4477
 msgid "Translated by"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:763
+#: ../src/wxMaximaFrame.cpp:762
 msgid "Transpose a matrix"
 msgstr "Transponer en matrix"
 
-#: ../src/MathCtrl.cpp:5834
+#: ../src/MathCtrl.cpp:5886
 msgid "Trying to undo an action without starting cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5901
+#: ../src/MathCtrl.cpp:5953
 msgid "Trying to undo something but the undo action is empty."
 msgstr ""
 
@@ -4335,11 +4338,11 @@ msgstr ""
 msgid "Turkish"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:970
+#: ../src/wxMaximaFrame.cpp:969
 msgid "Tutorials"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4778
+#: ../src/wxMaxima.cpp:4790
 #, fuzzy
 msgid "Two sample t-test"
 msgstr "Teksteksempel"
@@ -4352,15 +4355,15 @@ msgstr "Type:"
 msgid "Ukrainian"
 msgstr "Ukrainsk"
 
-#: ../src/wxMaxima.cpp:5356
+#: ../src/wxMaxima.cpp:5372
 msgid "Un-closed parenthesis"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5323
+#: ../src/wxMaxima.cpp:5335
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5889
 msgid ""
 "Unable to interpret the version info I got from http://andrejv.github.io//"
 "wxmaxima/version.txt: "
@@ -4374,11 +4377,11 @@ msgstr "Understreget"
 msgid "Underscore converts to subscripts:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:492
+#: ../src/wxMaximaFrame.cpp:491
 msgid "Undo\tCtrl-Z"
 msgstr "Fortryd\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:493
+#: ../src/wxMaximaFrame.cpp:492
 msgid "Undo last change"
 msgstr "Fortryd seneste ændring"
 
@@ -4386,24 +4389,24 @@ msgstr "Fortryd seneste ændring"
 msgid "Undo limit (0 for none):"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:625
+#: ../src/wxMaximaFrame.cpp:624
 #, fuzzy
 msgid "Unfold All\tCtrl-Alt-]"
 msgstr "&Marker alt\tCtrl-A"
 
-#: ../src/wxMaximaFrame.cpp:626
+#: ../src/wxMaximaFrame.cpp:625
 msgid "Unfold all folded sections"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4458
+#: ../src/wxMaxima.cpp:4470
 msgid "Unicode Support"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5335
+#: ../src/wxMaxima.cpp:5347
 msgid "Unterminated comment."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5309
+#: ../src/wxMaxima.cpp:5321
 msgid "Unterminated string."
 msgstr ""
 
@@ -4411,15 +4414,15 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5859 ../src/wxMaxima.cpp:5866 ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5874 ../src/wxMaxima.cpp:5881 ../src/wxMaxima.cpp:5889
 msgid "Upgrade"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Upper bound:"
 msgstr "Øvre grænse:"
 
-#: ../src/wxMaximaFrame.cpp:1383
+#: ../src/wxMaximaFrame.cpp:1382
 #, fuzzy
 msgid "Upsilon"
 msgstr "Udtryk:"
@@ -4464,22 +4467,22 @@ msgstr ""
 msgid "User-defined labels"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3525
-#: ../src/wxMaxima.cpp:3541 ../src/wxMaxima.cpp:3649
+#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3537
+#: ../src/wxMaxima.cpp:3553 ../src/wxMaxima.cpp:3661
 msgid "Value:"
 msgstr "Værdi:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:5019 ../src/wxMaxima.cpp:5064
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:5031 ../src/wxMaxima.cpp:5076
 msgid "Variable(s):"
 msgstr "Variable:"
 
 #: ../src/IntegrateWiz.cpp:33 ../src/LimitWiz.cpp:30 ../src/Plot2dWiz.cpp:34
 #: ../src/Plot2dWiz.cpp:44 ../src/Plot2dWiz.cpp:533 ../src/Plot3dWiz.cpp:33
 #: ../src/Plot3dWiz.cpp:42 ../src/SeriesWiz.cpp:36 ../src/SumWiz.cpp:30
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3749
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3761
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5045
 msgid "Variable:"
 msgstr "Variabel:"
 
@@ -4487,26 +4490,26 @@ msgstr "Variabel:"
 msgid "Variables"
 msgstr "Variable"
 
-#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3571 ../src/wxMaxima.cpp:4206
-#: ../src/wxMaxima.cpp:4807
+#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3583 ../src/wxMaxima.cpp:4218
+#: ../src/wxMaxima.cpp:4819
 msgid "Variables:"
 msgstr "Variable:"
 
-#: ../src/wxMaximaFrame.cpp:1257
+#: ../src/wxMaximaFrame.cpp:1256
 #, fuzzy
 msgid "Variance..."
 msgstr "Variabel:"
 
-#: ../src/wxMaximaFrame.cpp:580
+#: ../src/wxMaximaFrame.cpp:579
 msgid "View"
 msgstr ""
 
-#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1674 ../src/wxMaxima.cpp:1769
-#: ../src/wxMaxima.cpp:1950
+#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1679 ../src/wxMaxima.cpp:1774
+#: ../src/wxMaxima.cpp:1955
 msgid "Warning"
 msgstr "Advarsel"
 
-#: ../src/wxMaximaFrame.cpp:109 ../src/wxMaximaFrame.cpp:295
+#: ../src/wxMaximaFrame.cpp:108 ../src/wxMaximaFrame.cpp:294
 msgid "Welcome to wxMaxima"
 msgstr "Velkommen til wxMaxima"
 
@@ -4530,7 +4533,7 @@ msgid ""
 "introducing an empty line."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2567
+#: ../src/wxMaxima.cpp:2574
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) "
 "(*.wxm)|*.wxm"
@@ -4546,7 +4549,7 @@ msgid ""
 "as equation markers"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6798
+#: ../src/MathCtrl.cpp:6856
 msgid "Wrapped search"
 msgstr ""
 
@@ -4554,15 +4557,15 @@ msgstr ""
 msgid "Write matching parenthesis in text controls."
 msgstr "Anvend automatisk parring af parenteser i indtastningsfelter."
 
-#: ../src/wxMaxima.cpp:4461
+#: ../src/wxMaxima.cpp:4473
 msgid "Written by"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:557
+#: ../src/wxMaximaFrame.cpp:556
 msgid "XML Inspector"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1377
+#: ../src/wxMaximaFrame.cpp:1376
 msgid "Xi"
 msgstr ""
 
@@ -4635,7 +4638,7 @@ msgstr ""
 "piletastern og den horisontale markør. Herefter kan du udføre beregning på "
 "de markerede celler på én gang."
 
-#: ../src/wxMaxima.cpp:5856
+#: ../src/wxMaxima.cpp:5871
 #, c-format
 msgid ""
 "You have version %s. Current version is %s.\n"
@@ -4643,41 +4646,41 @@ msgid ""
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5921
+#: ../src/wxMaxima.cpp:5936
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5866
+#: ../src/wxMaxima.cpp:5881
 msgid "Your version of wxMaxima is up to date."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1369
+#: ../src/wxMaximaFrame.cpp:1368
 msgid "Zeta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:562
+#: ../src/wxMaximaFrame.cpp:561
 #, fuzzy
 msgid "Zoom &In\tCtrl-+"
 msgstr "Zoom i&nd\tAlt-I"
 
-#: ../src/wxMaximaFrame.cpp:564
+#: ../src/wxMaximaFrame.cpp:563
 #, fuzzy
 msgid "Zoom Ou&t\tCtrl--"
 msgstr "Zoom &ud\tAlt-O"
 
-#: ../src/wxMaximaFrame.cpp:563
+#: ../src/wxMaximaFrame.cpp:562
 msgid "Zoom in 10%"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:565
+#: ../src/wxMaximaFrame.cpp:564
 msgid "Zoom out 10%"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaximaFrame.cpp:287
 msgid "[ unsaved ]"
 msgstr "[ ikke gemt ]"
 
-#: ../src/wxMaxima.cpp:5700
+#: ../src/wxMaxima.cpp:5715
 msgid "[ unsaved* ]"
 msgstr "[ ikke gemt* ]"
 
@@ -4686,17 +4689,17 @@ msgstr "[ ikke gemt* ]"
 msgid "[%i digits]"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4392
+#: ../src/MathCtrl.cpp:4447
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" style=\"max-width:90%%;\" >\n"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4517
+#: ../src/MathCtrl.cpp:4572
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" >"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1333
+#: ../src/wxMaximaFrame.cpp:1332
 msgid "alpha"
 msgstr ""
 
@@ -4709,7 +4712,7 @@ msgstr "Udvid til ledform"
 msgid "antisymmetric"
 msgstr "antisymmetrisk"
 
-#: ../src/wxMaximaFrame.cpp:1334
+#: ../src/wxMaximaFrame.cpp:1333
 msgid "beta"
 msgstr ""
 
@@ -4753,7 +4756,7 @@ msgstr ""
 msgid "bug:Invalid sup tag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1354
+#: ../src/wxMaximaFrame.cpp:1353
 msgid "chi"
 msgstr ""
 
@@ -4766,7 +4769,7 @@ msgstr ""
 msgid "default"
 msgstr "standard"
 
-#: ../src/wxMaximaFrame.cpp:1336
+#: ../src/wxMaximaFrame.cpp:1335
 msgid "delta"
 msgstr ""
 
@@ -4778,7 +4781,7 @@ msgstr "diagonal"
 msgid "empty"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1337
+#: ../src/wxMaximaFrame.cpp:1336
 #, fuzzy
 msgid "epsilon"
 msgstr "Udtryk:"
@@ -4787,7 +4790,7 @@ msgstr "Udtryk:"
 msgid "equivalent"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1339
+#: ../src/wxMaximaFrame.cpp:1338
 msgid "eta"
 msgstr ""
 
@@ -4803,7 +4806,7 @@ msgid ""
 "all=_ marks subscripts."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1335
+#: ../src/wxMaximaFrame.cpp:1334
 msgid "gamma"
 msgstr ""
 
@@ -4832,15 +4835,15 @@ msgstr "på linje med tekst"
 msgid "intersection"
 msgstr "Fra:"
 
-#: ../src/wxMaximaFrame.cpp:1341
+#: ../src/wxMaximaFrame.cpp:1340
 msgid "iota"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1342
+#: ../src/wxMaximaFrame.cpp:1341
 msgid "kappa"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1343
+#: ../src/wxMaximaFrame.cpp:1342
 msgid "lambda"
 msgstr ""
 
@@ -4857,7 +4860,7 @@ msgstr "Afsnitscelle"
 msgid "logscale"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3783
+#: ../src/wxMaxima.cpp:3795
 #, fuzzy
 msgid "matrix[i,j]:"
 msgstr "Matrix:"
@@ -4866,7 +4869,7 @@ msgstr "Matrix:"
 msgid "maxima's pwd is path to document"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1344
+#: ../src/wxMaximaFrame.cpp:1343
 msgid "mu"
 msgstr ""
 
@@ -4883,7 +4886,7 @@ msgstr ""
 msgid "nand"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4524
+#: ../src/wxMaxima.cpp:4536
 msgid "no"
 msgstr ""
 
@@ -4907,15 +4910,15 @@ msgstr ""
 msgid "not subset or equal"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1345
+#: ../src/wxMaximaFrame.cpp:1344
 msgid "nu"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1356
+#: ../src/wxMaximaFrame.cpp:1355
 msgid "omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1347
+#: ../src/wxMaximaFrame.cpp:1346
 msgid "omicron"
 msgstr ""
 
@@ -4928,11 +4931,11 @@ msgstr ""
 msgid "partial sign"
 msgstr "Partialbrøker"
 
-#: ../src/wxMaximaFrame.cpp:1353
+#: ../src/wxMaximaFrame.cpp:1352
 msgid "phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1348
+#: ../src/wxMaximaFrame.cpp:1347
 msgid "pi"
 msgstr ""
 
@@ -4944,11 +4947,11 @@ msgstr ""
 msgid "proportional to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1355
+#: ../src/wxMaximaFrame.cpp:1354
 msgid "psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1349
+#: ../src/wxMaximaFrame.cpp:1348
 msgid "rho"
 msgstr ""
 
@@ -4956,7 +4959,7 @@ msgstr ""
 msgid "right"
 msgstr "højre"
 
-#: ../src/wxMaximaFrame.cpp:1350
+#: ../src/wxMaximaFrame.cpp:1349
 msgid "sigma"
 msgstr ""
 
@@ -4978,7 +4981,7 @@ msgstr "Afsnitscelle"
 msgid "symmetric"
 msgstr "symmetrisk"
 
-#: ../src/wxMaximaFrame.cpp:1351
+#: ../src/wxMaximaFrame.cpp:1350
 msgid "tau"
 msgstr ""
 
@@ -4990,7 +4993,7 @@ msgstr ""
 msgid "there is no"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1340
+#: ../src/wxMaximaFrame.cpp:1339
 msgid "theta"
 msgstr ""
 
@@ -5006,13 +5009,13 @@ msgstr ""
 msgid "union"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5903
+#: ../src/wxMaxima.cpp:5918
 #, fuzzy
 msgid "unsaved"
 msgstr "[ ikke gemt ]"
 
-#: ../src/wxMaximaFrame.cpp:290 ../src/wxMaxima.cpp:2559
-#: ../src/wxMaxima.cpp:2826
+#: ../src/wxMaxima.cpp:2566 ../src/wxMaxima.cpp:2834
+#: ../src/wxMaximaFrame.cpp:289
 msgid "untitled"
 msgstr "unavngivet"
 
@@ -5021,27 +5024,27 @@ msgstr "unavngivet"
 msgid "untitled %d"
 msgstr "unavngivet"
 
-#: ../src/wxMaximaFrame.cpp:1352
+#: ../src/wxMaximaFrame.cpp:1351
 #, fuzzy
 msgid "upsilon"
 msgstr "Udtryk:"
 
-#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4538
+#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4550
 msgid "wxMaxima"
 msgstr "wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
-#: ../src/wxMaxima.cpp:5700 ../src/wxMaxima.cpp:5709 ../src/wxMaxima.cpp:5712
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaxima.cpp:5715 ../src/wxMaxima.cpp:5724
+#: ../src/wxMaxima.cpp:5727 ../src/wxMaximaFrame.cpp:287
 #, c-format
 msgid "wxMaxima %s "
 msgstr "wxMaxima %s "
 
-#: ../src/wxMaximaFrame.cpp:952
+#: ../src/wxMaximaFrame.cpp:951
 #, fuzzy
 msgid "wxMaxima &Help\tCtrl+?"
 msgstr "Maxima &Hjælp\tF1"
 
-#: ../src/wxMaximaFrame.cpp:955
+#: ../src/wxMaximaFrame.cpp:954
 #, fuzzy
 msgid "wxMaxima &Help\tF1"
 msgstr "Maxima &Hjælp\tF1"
@@ -5053,11 +5056,11 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1619
+#: ../src/wxMaxima.cpp:1624
 msgid "wxMaxima cannot open content.xml in the .wxmx zip archive "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1633
+#: ../src/wxMaxima.cpp:1638
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
@@ -5065,7 +5068,7 @@ msgstr ""
 msgid "wxMaxima configuration"
 msgstr "Indstillinger for wxMaxima"
 
-#: ../src/wxMaxima.cpp:1947
+#: ../src/wxMaxima.cpp:1952
 msgid ""
 "wxMaxima could not find Maxima!\n"
 "\n"
@@ -5077,7 +5080,7 @@ msgstr ""
 "Ændrer wxMaxima indstilliger i 'Rediger->Indstillinger'.\n"
 "Start herefter Maxima i 'Maxima->Genstart Maxima'"
 
-#: ../src/wxMaxima.cpp:2204
+#: ../src/wxMaxima.cpp:2209
 msgid ""
 "wxMaxima could not find help files.\n"
 "\n"
@@ -5087,7 +5090,7 @@ msgstr ""
 "\n"
 "Kontroller venligst installationen."
 
-#: ../src/wxMaxima.cpp:2032
+#: ../src/wxMaxima.cpp:2037
 msgid ""
 "wxMaxima could not find tip files.\n"
 "\n"
@@ -5097,7 +5100,7 @@ msgstr ""
 "\n"
 "Kontroller venligst installationen."
 
-#: ../src/wxMaxima.cpp:282
+#: ../src/wxMaxima.cpp:283
 msgid ""
 "wxMaxima could not start the server.\n"
 "\n"
@@ -5119,24 +5122,24 @@ msgstr ""
 "'%'. Hvis der er foretaget markering i dokumentet, anvendes denne markering "
 "i stedet for '%'."
 
-#: ../src/wxMaxima.cpp:2330
+#: ../src/wxMaxima.cpp:2336
 msgid "wxMaxima document"
 msgstr "wxMaxima-dokument"
 
-#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2799
+#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2807
 msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 msgstr "wxMaxima-dokument (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 
-#: ../src/wxMaxima.cpp:1455 ../src/wxMaxima.cpp:1469
+#: ../src/wxMaxima.cpp:1460 ../src/wxMaxima.cpp:1474
 msgid "wxMaxima encountered an error loading "
 msgstr "wxMaxima stødte på en fejl under indlæsning af "
 
-#: ../src/wxMaxima.cpp:4463
+#: ../src/wxMaxima.cpp:4475
 #, fuzzy
 msgid "wxMaxima icon"
 msgstr "wxMaxima-indstillinger"
 
-#: ../src/wxMaxima.cpp:4455
+#: ../src/wxMaxima.cpp:4467
 #, fuzzy
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
@@ -5145,7 +5148,7 @@ msgstr ""
 "wxMaxima er en grafisk brugerflade for computer algebra systemet MAXIMA "
 "baseret på wxWidgets."
 
-#: ../src/wxMaxima.cpp:4516
+#: ../src/wxMaxima.cpp:4528
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "Maxima based on wxWidgets."
@@ -5165,11 +5168,11 @@ msgstr ""
 msgid "x"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1346
+#: ../src/wxMaximaFrame.cpp:1345
 msgid "xi"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1643
+#: ../src/wxMaxima.cpp:1648
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
@@ -5178,12 +5181,12 @@ msgstr ""
 msgid "xor"
 msgstr "Eksporter"
 
-#: ../src/wxMaxima.cpp:4522
+#: ../src/wxMaxima.cpp:4534
 #, fuzzy
 msgid "yes"
 msgstr "Typografier"
 
-#: ../src/wxMaximaFrame.cpp:1338
+#: ../src/wxMaximaFrame.cpp:1337
 msgid "zeta"
 msgstr ""
 

--- a/locales/de.po
+++ b/locales/de.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-07 21:42+0200\n"
+"POT-Creation-Date: 2016-10-16 17:47+0900\n"
 "PO-Revision-Date: 2016-10-07 21:43+0200\n"
 "Last-Translator: Gunter Königsmann <wxMaxima@physikbuch.de>\n"
 "Language-Team: german <de@li.org>\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../src/wxMaxima.cpp:4519
+#: ../src/wxMaxima.cpp:4531
 #, c-format
 msgid ""
 "\n"
@@ -28,7 +28,7 @@ msgstr ""
 "wxWidgets: %d.%d.%d\n"
 "Unicode Unterstützung: %s"
 
-#: ../src/wxMaxima.cpp:4532
+#: ../src/wxMaxima.cpp:4544
 msgid ""
 "\n"
 "Lisp: "
@@ -36,7 +36,7 @@ msgstr ""
 "\n"
 "Lisp: "
 
-#: ../src/wxMaxima.cpp:4528
+#: ../src/wxMaxima.cpp:4540
 msgid ""
 "\n"
 "Maxima version: "
@@ -44,7 +44,7 @@ msgstr ""
 "\n"
 "Maxima Version: "
 
-#: ../src/wxMaxima.cpp:5381
+#: ../src/wxMaxima.cpp:5397
 msgid ""
 "\n"
 "Not connected to Maxima!\n"
@@ -52,7 +52,7 @@ msgstr ""
 "\n"
 "Nicht mit Maxima verbunden!\n"
 
-#: ../src/wxMaxima.cpp:4530
+#: ../src/wxMaxima.cpp:4542
 msgid ""
 "\n"
 "Not connected."
@@ -72,7 +72,7 @@ msgstr "      -l <name>"
 msgid " (Graphics) "
 msgstr " (Bild) "
 
-#: ../src/EditorCell.cpp:3045 ../src/EditorCell.cpp:3227
+#: ../src/EditorCell.cpp:3088 ../src/EditorCell.cpp:3270
 #, c-format
 msgid " ... + %i hidden lines"
 msgstr "... + %i versteckte Zeilen"
@@ -81,7 +81,7 @@ msgstr "... + %i versteckte Zeilen"
 msgid " << Expression longer than allowed by the configuration setting! >>"
 msgstr " << Ausdruck länger, als im Konfigurationsdialog erlaubt >>"
 
-#: ../src/wxMaxima.cpp:1673
+#: ../src/wxMaxima.cpp:1678
 msgid ""
 " was saved using a newer version of wxMaxima so it may not load correctly. "
 "Please update your wxMaxima."
@@ -89,7 +89,7 @@ msgstr ""
 " wurde mit einer aktuelleren wxMaxima Version gespeichert. Die Datei wird "
 "möglicherweise nicht korrekt geladen. Bitte aktualisieren Sie wxMaxima."
 
-#: ../src/wxMaxima.cpp:1665
+#: ../src/wxMaxima.cpp:1670
 msgid ""
 " was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr ""
@@ -104,64 +104,64 @@ msgstr "\"LaTeX Kopieren\" fügt Mathe-Markierung hinzu"
 msgid "\"implies\" symbol"
 msgstr "Das \"daraus folgt\"-Symbol"
 
-#: ../src/wxMaximaFrame.cpp:101
+#: ../src/wxMaximaFrame.cpp:100
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr "%i Zellen warten auf Evaluierung"
 
-#: ../src/wxMaximaFrame.cpp:773
+#: ../src/wxMaximaFrame.cpp:772
 msgid "&Algebra"
 msgstr "&Algebra"
 
-#: ../src/wxMaximaFrame.cpp:767
+#: ../src/wxMaximaFrame.cpp:766
 msgid "&Apply to List..."
 msgstr "&Auf Liste anwenden ..."
 
-#: ../src/wxMaximaFrame.cpp:964
+#: ../src/wxMaximaFrame.cpp:963
 msgid "&Apropos..."
 msgstr "&Apropos ..."
 
-#: ../src/wxMaximaFrame.cpp:478
+#: ../src/wxMaximaFrame.cpp:477
 msgid "&Batch File...\tCtrl-B"
 msgstr "&Batch-Datei laden ...\tCtrl-B"
 
-#: ../src/wxMaximaFrame.cpp:724
+#: ../src/wxMaximaFrame.cpp:723
 msgid "&Boundary Value Problem..."
 msgstr "&Randwertproblem ..."
 
-#: ../src/wxMaximaFrame.cpp:975
+#: ../src/wxMaximaFrame.cpp:974
 msgid "&Bug Report"
 msgstr "Fehler &berichten"
 
-#: ../src/wxMaximaFrame.cpp:825
+#: ../src/wxMaximaFrame.cpp:824
 msgid "&Calculus"
 msgstr "&Rechnen"
 
-#: ../src/wxMaximaFrame.cpp:876
+#: ../src/wxMaximaFrame.cpp:875
 msgid "&Canonical Form"
 msgstr "&Kanonische Form"
 
-#: ../src/wxMaximaFrame.cpp:749
+#: ../src/wxMaximaFrame.cpp:748
 msgid "&Characteristic Polynomial..."
 msgstr "&Charakteristisches Polynom ..."
 
-#: ../src/wxMaximaFrame.cpp:654
+#: ../src/wxMaximaFrame.cpp:653
 msgid "&Clear Memory"
 msgstr "&Speicher löschen"
 
-#: ../src/wxMaximaFrame.cpp:859
+#: ../src/wxMaximaFrame.cpp:858
 msgid "&Combine Factorials"
 msgstr "Fakultäten &kombinieren"
 
-#: ../src/wxMaximaFrame.cpp:902
+#: ../src/wxMaximaFrame.cpp:901
 msgid "&Complex Simplification"
 msgstr "&Komplexe Ausdrücke"
 
-#: ../src/wxMaximaFrame.cpp:822
+#: ../src/wxMaximaFrame.cpp:821
 msgid "&Continued Fraction"
 msgstr "&Kettenbruch"
 
-#: ../src/wxMaximaFrame.cpp:502
+#: ../src/wxMaximaFrame.cpp:501
 msgid "&Copy\tCtrl-C"
 msgstr "&Kopieren\tCtrl-C"
 
@@ -169,107 +169,107 @@ msgstr "&Kopieren\tCtrl-C"
 msgid "&Definite integration"
 msgstr "&Bestimmtes Integral"
 
-#: ../src/wxMaximaFrame.cpp:896
+#: ../src/wxMaximaFrame.cpp:895
 msgid "&Demoivre"
 msgstr "Als &Winkelfunktionen"
 
-#: ../src/wxMaximaFrame.cpp:752
+#: ../src/wxMaximaFrame.cpp:751
 msgid "&Determinant"
 msgstr "&Determinante"
 
-#: ../src/wxMaximaFrame.cpp:785
+#: ../src/wxMaximaFrame.cpp:784
 msgid "&Differentiate..."
 msgstr "&Differenzieren ..."
 
-#: ../src/wxMaximaFrame.cpp:543
+#: ../src/wxMaximaFrame.cpp:542
 msgid "&Edit"
 msgstr "&Bearbeiten"
 
-#: ../src/wxMaximaFrame.cpp:709
+#: ../src/wxMaximaFrame.cpp:708
 msgid "&Eliminate Variable..."
 msgstr "Variable &eliminieren ..."
 
-#: ../src/wxMaximaFrame.cpp:744
+#: ../src/wxMaximaFrame.cpp:743
 msgid "&Enter Matrix..."
 msgstr "Matrix &eingeben ..."
 
-#: ../src/wxMaximaFrame.cpp:961
+#: ../src/wxMaximaFrame.cpp:960
 msgid "&Example..."
 msgstr "B&eispiel ..."
 
-#: ../src/wxMaximaFrame.cpp:839
+#: ../src/wxMaximaFrame.cpp:838
 msgid "&Expand Expression"
 msgstr "Ausdruck &expandieren"
 
-#: ../src/wxMaximaFrame.cpp:873
+#: ../src/wxMaximaFrame.cpp:872
 msgid "&Expand Trigonometric"
 msgstr "Winkelfunktionen &expandieren"
 
-#: ../src/wxMaximaFrame.cpp:899
+#: ../src/wxMaximaFrame.cpp:898
 msgid "&Exponentialize"
 msgstr "Als &Expontialfunktionen"
 
-#: ../src/wxMaximaFrame.cpp:480
+#: ../src/wxMaximaFrame.cpp:479
 msgid "&Export..."
 msgstr "E&xportieren ..."
 
-#: ../src/wxMaximaFrame.cpp:834
+#: ../src/wxMaximaFrame.cpp:833
 msgid "&Factor Expression"
 msgstr "Ausdruck &faktorisieren"
 
-#: ../src/wxMaximaFrame.cpp:489
+#: ../src/wxMaximaFrame.cpp:488
 msgid "&File"
 msgstr "&Datei"
 
-#: ../src/wxMaximaFrame.cpp:692
+#: ../src/wxMaximaFrame.cpp:691
 msgid "&Find Root..."
 msgstr "Numerische &Nullstelle ..."
 
-#: ../src/wxMaximaFrame.cpp:738
+#: ../src/wxMaximaFrame.cpp:737
 msgid "&Generate Matrix..."
 msgstr "Matrix erzeu&gen ..."
 
-#: ../src/wxMaximaFrame.cpp:809
+#: ../src/wxMaximaFrame.cpp:808
 msgid "&Greatest Common Divisor..."
 msgstr "&GGT ..."
 
-#: ../src/wxMaximaFrame.cpp:994
+#: ../src/wxMaximaFrame.cpp:993
 msgid "&Help"
 msgstr "&Hilfe"
 
-#: ../src/wxMaximaFrame.cpp:777
+#: ../src/wxMaximaFrame.cpp:776
 msgid "&Integrate..."
 msgstr "&Integrieren ..."
 
-#: ../src/wxMaximaFrame.cpp:645
+#: ../src/wxMaximaFrame.cpp:644
 msgid "&Interrupt\tCtrl-."
 msgstr "Unter&brechen\tCtrl-."
 
-#: ../src/wxMaximaFrame.cpp:649
+#: ../src/wxMaximaFrame.cpp:648
 msgid "&Interrupt\tCtrl-G"
 msgstr "Unter&brechen\tCtrl-G"
 
-#: ../src/wxMaximaFrame.cpp:746
+#: ../src/wxMaximaFrame.cpp:745
 msgid "&Invert Matrix"
 msgstr "Matrix &invertieren"
 
-#: ../src/wxMaximaFrame.cpp:476
+#: ../src/wxMaximaFrame.cpp:475
 msgid "&Load Package...\tCtrl-L"
 msgstr "Paket &laden ...\tCtrl-L"
 
-#: ../src/wxMaximaFrame.cpp:769
+#: ../src/wxMaximaFrame.cpp:768
 msgid "&Map to List(s)..."
 msgstr "Auf Liste ab&bilden ..."
 
-#: ../src/wxMaximaFrame.cpp:684
+#: ../src/wxMaximaFrame.cpp:683
 msgid "&Maxima"
 msgstr "&Maxima"
 
-#: ../src/wxMaximaFrame.cpp:958
+#: ../src/wxMaximaFrame.cpp:957
 msgid "&Maxima help"
 msgstr "Zeige die Hilfe von Maxima"
 
-#: ../src/wxMaximaFrame.cpp:917
+#: ../src/wxMaximaFrame.cpp:916
 msgid "&Modulus Computation..."
 msgstr "Setze &Modulo ..."
 
@@ -277,7 +277,7 @@ msgstr "Setze &Modulo ..."
 msgid "&New\tCtrl-N"
 msgstr "&Neu\tCtrl-N"
 
-#: ../src/wxMaximaFrame.cpp:947
+#: ../src/wxMaximaFrame.cpp:946
 msgid "&Numeric"
 msgstr "&Numerisch"
 
@@ -293,11 +293,11 @@ msgstr "&Gosper"
 msgid "&Open\tCtrl-O"
 msgstr "&Öffnen\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:463
+#: ../src/wxMaximaFrame.cpp:462
 msgid "&Open...\tCtrl-O"
 msgstr "&Öffnen ...\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:929
+#: ../src/wxMaximaFrame.cpp:928
 msgid "&Plot"
 msgstr "&Plotten"
 
@@ -305,7 +305,7 @@ msgstr "&Plotten"
 msgid "&Power series"
 msgstr "&Potenzreihe"
 
-#: ../src/wxMaximaFrame.cpp:483
+#: ../src/wxMaximaFrame.cpp:482
 msgid "&Print...\tCtrl-P"
 msgstr "Drucken ...\tCtrl-P"
 
@@ -314,39 +314,39 @@ msgstr "Drucken ...\tCtrl-P"
 msgid "&Rational"
 msgstr "&rational"
 
-#: ../src/wxMaximaFrame.cpp:870
+#: ../src/wxMaximaFrame.cpp:869
 msgid "&Reduce Trigonometric"
 msgstr "Winkelfunktionen &reduzieren"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "&Restart Maxima"
 msgstr "&Maxima neustarten"
 
-#: ../src/wxMaximaFrame.cpp:700
+#: ../src/wxMaximaFrame.cpp:699
 msgid "&Roots of Polynomial (Real)"
 msgstr "reelle N&ullstellen eines Polynoms"
 
-#: ../src/wxMaximaFrame.cpp:472
+#: ../src/wxMaximaFrame.cpp:471
 msgid "&Save\tCtrl-S"
 msgstr "Speichern\tCtrl-S"
 
-#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:919
+#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:918
 msgid "&Simplify"
 msgstr "&Vereinfachen"
 
-#: ../src/wxMaximaFrame.cpp:829
+#: ../src/wxMaximaFrame.cpp:828
 msgid "&Simplify Expression"
 msgstr "Ausdruck &vereinfachen"
 
-#: ../src/wxMaximaFrame.cpp:856
+#: ../src/wxMaximaFrame.cpp:855
 msgid "&Simplify Factorials"
 msgstr "Fakultäten &vereinfachen"
 
-#: ../src/wxMaximaFrame.cpp:867
+#: ../src/wxMaximaFrame.cpp:866
 msgid "&Simplify Trigonometric"
 msgstr "Winkelfunktionen &vereinfachen"
 
-#: ../src/wxMaximaFrame.cpp:688
+#: ../src/wxMaximaFrame.cpp:687
 msgid "&Solve..."
 msgstr "Gleichung lö&sen ..."
 
@@ -358,11 +358,11 @@ msgstr "Be&sondere Werte"
 msgid "&Taylor series"
 msgstr "Taylorreihe"
 
-#: ../src/wxMaximaFrame.cpp:762
+#: ../src/wxMaximaFrame.cpp:761
 msgid "&Transpose Matrix"
 msgstr "Matrix &transponieren"
 
-#: ../src/wxMaximaFrame.cpp:879
+#: ../src/wxMaximaFrame.cpp:878
 msgid "&Trigonometric Simplification"
 msgstr "&Winkelfunktionen vereinfachen"
 
@@ -380,7 +380,7 @@ msgstr "(Standardsprache verwenden)"
 msgid "- Infinity"
 msgstr "- Infinity"
 
-#: ../src/wxMaxima.cpp:351
+#: ../src/wxMaxima.cpp:356
 msgid ""
 "... [suppressed additional lines since the output is longer than allowed in "
 "the configuration] "
@@ -392,16 +392,16 @@ msgstr ""
 msgid "1/2"
 msgstr "1/2"
 
-#: ../src/wxMaximaFrame.cpp:103
+#: ../src/wxMaximaFrame.cpp:102
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr "; %i ausstehende Befehle in aktueller Zelle"
 
-#: ../src/wxMaxima.cpp:4601
+#: ../src/wxMaxima.cpp:4613
 msgid "<br>Lisp: "
 msgstr "<br>Lisp: "
 
-#: ../src/wxMaxima.cpp:5487
+#: ../src/wxMaxima.cpp:5503
 msgid ""
 "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
@@ -438,11 +438,11 @@ msgstr ""
 "Zeichenbefehls ein \"wx\" angehängt wird.\n"
 "\"draw\" wird so zu \"wxdraw\", plot zu \"wxplot\" etc."
 
-#: ../src/wxMaximaFrame.cpp:1472
+#: ../src/wxMaximaFrame.cpp:1495
 msgid "A symbol from the configuration dialogue"
 msgstr "Ein Symbol aus dem Konfigurationsdialog"
 
-#: ../src/wxMaximaFrame.cpp:731
+#: ../src/wxMaximaFrame.cpp:730
 msgid "A&t Value..."
 msgstr "Rand&bedingung setzen ..."
 
@@ -450,12 +450,12 @@ msgstr "Rand&bedingung setzen ..."
 msgid "Abort evaluation on error"
 msgstr "Fehler beenden das Evaluieren"
 
-#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaxima.cpp:4603
+#: ../src/wxMaxima.cpp:4615 ../src/wxMaximaFrame.cpp:985
 msgid "About"
 msgstr "Info"
 
-#: ../src/wxMaximaFrame.cpp:987 ../src/wxMaximaFrame.cpp:990
-#: ../src/wxMaximaFrame.cpp:991
+#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaximaFrame.cpp:989
+#: ../src/wxMaximaFrame.cpp:990
 msgid "About wxMaxima"
 msgstr "Information über wxMaxima"
 
@@ -463,23 +463,23 @@ msgstr "Information über wxMaxima"
 msgid "Active cell bracket"
 msgstr "Klammern aktive Zelle"
 
-#: ../src/wxMaximaFrame.cpp:760
+#: ../src/wxMaximaFrame.cpp:759
 msgid "Ad&joint Matrix"
 msgstr "Ad&jungierte Matrix"
 
-#: ../src/wxMaximaFrame.cpp:914
+#: ../src/wxMaximaFrame.cpp:913
 msgid "Add Algebraic E&quality..."
 msgstr "Algebraische Gleichheit &hinzufügen ..."
 
-#: ../src/wxMaximaFrame.cpp:657
+#: ../src/wxMaximaFrame.cpp:656
 msgid "Add a directory to search path"
 msgstr "Ein Verzeichnis zum Suchpfad hinzufügen"
 
-#: ../src/wxMaxima.cpp:3353
+#: ../src/wxMaxima.cpp:3365
 msgid "Add dir to path:"
 msgstr "Verzeichnis zum Pfad hinzufügen"
 
-#: ../src/wxMaximaFrame.cpp:915
+#: ../src/wxMaximaFrame.cpp:914
 msgid "Add equality to the rational simplifier"
 msgstr "Gebe Vereinfacher für rationale Ausdrücke eine Gleichung"
 
@@ -487,7 +487,7 @@ msgstr "Gebe Vereinfacher für rationale Ausdrücke eine Gleichung"
 msgid "Add the .wxmx file to the HTML export"
 msgstr "Füge die .wxmx-Quellen zum HTML-Export hinzu"
 
-#: ../src/wxMaximaFrame.cpp:656
+#: ../src/wxMaximaFrame.cpp:655
 msgid "Add to &Path..."
 msgstr "Zum &Pfad hinzufügen ..."
 
@@ -531,27 +531,27 @@ msgstr "Alle Variablennamen"
 msgid "All|*"
 msgstr "Alle|*"
 
-#: ../src/wxMaximaFrame.cpp:1364
+#: ../src/wxMaximaFrame.cpp:1363
 msgid "Alpha"
 msgstr "Alpha"
 
-#: ../src/wxMaxima.cpp:3838
+#: ../src/wxMaxima.cpp:3850
 msgid "Apply"
 msgstr "Anwenden"
 
-#: ../src/wxMaximaFrame.cpp:768
+#: ../src/wxMaximaFrame.cpp:767
 msgid "Apply function to a list"
 msgstr "Funktion auf Liste anwenden"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Apropos"
 msgstr "Apropos"
 
-#: ../src/wxMaxima.cpp:3764
+#: ../src/wxMaxima.cpp:3776
 msgid "Array:"
 msgstr "Array:"
 
-#: ../src/wxMaxima.cpp:4462
+#: ../src/wxMaxima.cpp:4474
 msgid "Artwork by"
 msgstr "Bildmaterial von"
 
@@ -559,7 +559,7 @@ msgstr "Bildmaterial von"
 msgid "Ask to save untitled documents"
 msgstr "Frage nach, wenn Dokumente nicht gespeichert sind"
 
-#: ../src/wxMaxima.cpp:3650
+#: ../src/wxMaxima.cpp:3662
 msgid "At value"
 msgstr "Randwert"
 
@@ -585,11 +585,11 @@ msgstr ""
 msgid "Autosave interval (minutes, 0 means: off):"
 msgstr "Minuten zwischen automatischem Speichern (0 = aus):"
 
-#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3557
+#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3569
 msgid "BC2"
 msgstr "Randwertproblem"
 
-#: ../src/wxMaximaFrame.cpp:1272
+#: ../src/wxMaximaFrame.cpp:1271
 msgid "Barsplot..."
 msgstr "Balkendiagramm"
 
@@ -597,7 +597,7 @@ msgstr "Balkendiagramm"
 msgid "Bat files (*.bat)|*.bat|All|*"
 msgstr "Batch-Dateien (*.bat)|*.bat|Alle|*"
 
-#: ../src/wxMaxima.cpp:2943
+#: ../src/wxMaxima.cpp:2951
 msgid "Batch File"
 msgstr "Batch-Datei laden"
 
@@ -616,7 +616,7 @@ msgstr ""
 "sich nur um Änderungen innerhalb der aktuellen Zelle kümmert und den Rest "
 "des Arbeitsblattes ignoriert."
 
-#: ../src/wxMaximaFrame.cpp:1365
+#: ../src/wxMaximaFrame.cpp:1364
 msgid "Beta"
 msgstr "Beta"
 
@@ -628,11 +628,11 @@ msgstr "Skalierung der Bitmaps für den Export"
 msgid "Bold"
 msgstr "Fett"
 
-#: ../src/wxMaxima.cpp:2359
+#: ../src/wxMaxima.cpp:2366
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr "Horizontaler und Vertikaler Cursor sind gleichzeitig aktiv"
 
-#: ../src/wxMaximaFrame.cpp:1274
+#: ../src/wxMaximaFrame.cpp:1273
 msgid "Boxplot..."
 msgstr "Kursdiagramm"
 
@@ -645,17 +645,17 @@ msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr ""
 "Fehler: Textvervollständigung für eine unbekannte Kategorie aufgerufen."
 
-#: ../src/MathCtrl.cpp:2080
+#: ../src/MathCtrl.cpp:2127
 msgid "Bug: Cell left but not entered."
 msgstr "Interner Fehler: Zelle wurde verlassen, aber zuvor nie besucht."
 
-#: ../src/wxMaxima.cpp:1178
+#: ../src/wxMaxima.cpp:1183
 msgid "Bug: Found a math end marker without any start marker."
 msgstr ""
 "Interner Fehler: Habe eine Endemarkierung für Mathematik bekommen, ohne eine "
 "Startmarkierung zu finden."
 
-#: ../src/wxMaxima.cpp:1222
+#: ../src/wxMaxima.cpp:1227
 msgid "Bug: Found the end of autocompletion symbols but no beginning"
 msgstr ""
 "Interner Fehler: Habe das Ende von Symbolen für das automatische "
@@ -669,24 +669,24 @@ msgstr "Interner Fehler: Bruch ohne Nenner"
 msgid "Bug: Fraction without enumerator"
 msgstr "Interner Fehler: Bruch ohne Zähler"
 
-#: ../src/MathCtrl.cpp:2312
+#: ../src/MathCtrl.cpp:2359
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr "Interner Fehler: Habe eine Frage, aber weiß nicht, in welcher Zelle"
 
-#: ../src/MathCtrl.cpp:5839
+#: ../src/MathCtrl.cpp:5891
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of "
 "the worksheet."
 msgstr ""
 "Interner Fehler: Soll die Zelle vor dem Beginn des Arbeitsblattes ändern."
 
-#: ../src/MathCtrl.cpp:5913
+#: ../src/MathCtrl.cpp:5965
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 "Interner Fehler: Soll die Zelle vor dem Beginn des Arbeitsblattes löschen."
 
-#: ../src/MathCtrl.cpp:5882
+#: ../src/MathCtrl.cpp:5934
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
@@ -696,44 +696,44 @@ msgstr "Interner Fehler: soll den Inhalt einer Zelle ändern und sie löschen."
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
 msgstr "Interner Fehler: Eine MathCell behauptet, keine GroupCell zu besitzen."
 
-#: ../src/GroupCell.cpp:780 ../src/GroupCell.cpp:951
+#: ../src/GroupCell.cpp:781 ../src/GroupCell.cpp:952
 msgid "Bug: No image counter to write to!"
 msgstr "Interner Fehler: Habe keinen Bildzähler, den ich beschreiben könnte."
 
-#: ../src/AbsCell.cpp:193
+#: ../src/AbsCell.cpp:199
 msgid "Bug: No last cell in an absCell!"
 msgstr "Interner Fehler: Ein abs()-Kommando ohne Ende des Arguments!"
 
-#: ../src/ConjugateCell.cpp:185
+#: ../src/ConjugateCell.cpp:194
 msgid "Bug: No last cell in an conjugateCell!"
 msgstr "Interner Fehler: Ein conjugate()-Kommando ohne Ende des Arguments!"
 
-#: ../src/FracCell.cpp:471
+#: ../src/FracCell.cpp:472
 msgid "Bug: No last cell in an denominator!"
 msgstr "Interner Fehler: Bruch ohne Nenner"
 
-#: ../src/ExptCell.cpp:267
+#: ../src/ExptCell.cpp:270
 msgid "Bug: No last cell in an exponent of an exptCell!"
 msgstr "Interner Fehler: Ein exp()-Kommando ohne Ende des Arguments!"
 
-#: ../src/FracCell.cpp:459
+#: ../src/FracCell.cpp:460
 msgid "Bug: No last cell in an numerator!"
 msgstr "Interner Fehler: Bruch ohne Zähler"
 
-#: ../src/ExptCell.cpp:257
+#: ../src/ExptCell.cpp:260
 msgid "Bug: No last cell in the base of an exptCell!"
 msgstr ""
 "Interner Fehler: Kein Ende des Arguments in der Basis eines Exponenten!"
 
-#: ../src/ParenCell.cpp:534
+#: ../src/ParenCell.cpp:535
 msgid "Bug: No last cell inside a parenthesis!"
 msgstr "Interner Fehler: Kein Ende des Inhalts einer Klammer!"
 
-#: ../src/SqrtCell.cpp:312
+#: ../src/SqrtCell.cpp:317
 msgid "Bug: No last cell inside a square root!"
 msgstr "Interner Fehler: Kein Ende des Arguments einer Wurzel!"
 
-#: ../src/MathCtrl.cpp:2123
+#: ../src/MathCtrl.cpp:2170
 msgid ""
 "Bug: Start or end of merging of subsequent editing actions was requested two "
 "times in a row."
@@ -741,7 +741,7 @@ msgstr ""
 "Interner Fehler: Soll gleichzeitig zweimal mit dem Sammeln neuer Zellen "
 "beginnen oder aufhören."
 
-#: ../src/MathCtrl.cpp:2090
+#: ../src/MathCtrl.cpp:2137
 msgid "Bug: Text changed, but no active cell."
 msgstr ""
 "Interner Fehler: Text wurde geändert, aber es ist unbekannt, für welche "
@@ -753,13 +753,13 @@ msgstr ""
 "Interner Fehler: Versuche, eine nichtexistierende Zelle an eine Gruppenzelle "
 "anzuhängen."
 
-#: ../src/MathCtrl.cpp:555
+#: ../src/MathCtrl.cpp:600
 msgid "Bug: Trying to append maxima's output to a cell outside the worksheet."
 msgstr ""
 "Interner Fehler: Rückgängigmachen setzt an Zellen außerhalb des "
 "Arbeitsblattes an."
 
-#: ../src/MathCtrl.cpp:2014
+#: ../src/MathCtrl.cpp:2061
 msgid ""
 "Bug: Trying to merge individual cell adds to a region in the undo buffer but "
 "there are other cells between them."
@@ -767,7 +767,7 @@ msgstr ""
 "Interner Fehler: Versuche, die Hinzufügung von Einzelzellen zu einer Region "
 "zusammenbauen - in der es eine Lücke gibt."
 
-#: ../src/MathCtrl.cpp:6522
+#: ../src/MathCtrl.cpp:6577
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
@@ -775,31 +775,31 @@ msgstr ""
 "Fehler: Versuche, den horizontal dargestellten Cursor in einer Zelle zu "
 "platzieren."
 
-#: ../src/MathCtrl.cpp:2092
+#: ../src/MathCtrl.cpp:2139
 msgid "Bug: Trying to record a cell contents change without a cell."
 msgstr ""
 "Interner Fehler: Versuche, die Änderung des Inhalts einer Zelle zu "
 "dokumentieren, ohne die Zelle zu kennen."
 
-#: ../src/MathCtrl.cpp:1495
+#: ../src/MathCtrl.cpp:1540
 msgid "Bug: Trying to select inside a cell without having a current cell"
 msgstr ""
 "Interner Fehler: Versuche, innerhalb einer Zelle Text auszuwählen, ohne zu "
 "wissen, in welcher Zelle"
 
-#: ../src/MathCtrl.cpp:5883
+#: ../src/MathCtrl.cpp:5935
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
 "Interner Fehler: Rückgängig will Zellen ändern und gleichzeitig Zellen "
 "hinzufügen."
 
-#: ../src/MathCtrl.cpp:5844 ../src/MathCtrl.cpp:5918 ../src/MathCtrl.cpp:5952
+#: ../src/MathCtrl.cpp:5896 ../src/MathCtrl.cpp:5970 ../src/MathCtrl.cpp:6004
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
 "Interner Fehler: Rückgängigmachen setzt an Zellen außerhalb des "
 "Arbeitsblattes an."
 
-#: ../src/wxMaximaFrame.cpp:973
+#: ../src/wxMaximaFrame.cpp:972
 msgid "Build &Info"
 msgstr "&Info über Maxima"
 
@@ -816,51 +816,51 @@ msgstr ""
 "'Eingabe wertet die Zelle aus' geändert werden. Die Funktion der beiden "
 "Befehle 'Umschalt-Eingabe' und 'Eingabe' wird ausgetauscht."
 
-#: ../src/wxMaximaFrame.cpp:782
+#: ../src/wxMaximaFrame.cpp:781
 msgid "C&hange Variable..."
 msgstr "Varia&ble ersetzen ..."
 
-#: ../src/wxMaximaFrame.cpp:540
+#: ../src/wxMaximaFrame.cpp:539
 msgid "C&onfigure"
 msgstr "&Einstellungen ..."
 
-#: ../src/wxMaximaFrame.cpp:801
+#: ../src/wxMaximaFrame.cpp:800
 msgid "Calculate &Product..."
 msgstr "&Produkt berechnen ..."
 
-#: ../src/wxMaximaFrame.cpp:799
+#: ../src/wxMaximaFrame.cpp:798
 msgid "Calculate Su&m..."
 msgstr "Su&mme berechnen ..."
 
-#: ../src/wxMaximaFrame.cpp:939
+#: ../src/wxMaximaFrame.cpp:938
 msgid "Calculate bigfloat value of the last result"
 msgstr "Letztes Ergebnis als lange Gleitkommazahl"
 
-#: ../src/wxMaximaFrame.cpp:936
+#: ../src/wxMaximaFrame.cpp:935
 msgid "Calculate float value of the last result"
 msgstr "Letztes Ergebnis als Gleitkommazahl"
 
-#: ../src/wxMaxima.cpp:3971
+#: ../src/wxMaxima.cpp:3983
 msgid "Calculate modulus:"
 msgstr "Rechne modulo:"
 
-#: ../src/wxMaximaFrame.cpp:942
+#: ../src/wxMaximaFrame.cpp:941
 msgid "Calculate numeric value of the last result"
 msgstr "Letztes Ergebnis als Gleitkommazahl"
 
-#: ../src/wxMaximaFrame.cpp:802
+#: ../src/wxMaximaFrame.cpp:801
 msgid "Calculate products"
 msgstr "Produkte berechnen"
 
-#: ../src/wxMaximaFrame.cpp:800
+#: ../src/wxMaximaFrame.cpp:799
 msgid "Calculate sums"
 msgstr "Summen berechnen"
 
-#: ../src/wxMaxima.cpp:5830
+#: ../src/wxMaxima.cpp:5845
 msgid "Can not connect to the web server."
 msgstr "Keine Verbindung mit dem Webserver."
 
-#: ../src/wxMaxima.cpp:5881
+#: ../src/wxMaxima.cpp:5896
 msgid "Can not download version info."
 msgstr "Kann Information zur Version nicht laden."
 
@@ -876,15 +876,15 @@ msgstr "Kann Information zur Version nicht laden."
 #: ../src/PlotFormatWiz.cpp:48 ../src/SeriesWiz.cpp:49 ../src/SeriesWiz.cpp:51
 #: ../src/SubstituteWiz.cpp:41 ../src/SubstituteWiz.cpp:43 ../src/SumWiz.cpp:44
 #: ../src/SumWiz.cpp:46 ../src/SystemWiz.cpp:38 ../src/SystemWiz.cpp:40
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: ../src/wxMaximaFrame.cpp:126 ../src/wxMaxima.cpp:932
+#: ../src/wxMaxima.cpp:937 ../src/wxMaximaFrame.cpp:125
 msgid "Cannot start the maxima binary"
 msgstr "Kann maxima nicht starten"
 
-#: ../src/wxMaximaFrame.cpp:1217
+#: ../src/wxMaximaFrame.cpp:1216
 msgid "Canonical (tr)"
 msgstr "Trigrat"
 
@@ -892,7 +892,7 @@ msgstr "Trigrat"
 msgid "Catalan"
 msgstr "Katalanisch"
 
-#: ../src/wxMaximaFrame.cpp:638
+#: ../src/wxMaximaFrame.cpp:637
 msgid "Ce&ll"
 msgstr "Ze&llen"
 
@@ -900,41 +900,41 @@ msgstr "Ze&llen"
 msgid "Cell bracket"
 msgstr "Klammern Zelle"
 
-#: ../src/wxMaxima.cpp:5261
+#: ../src/wxMaxima.cpp:5273
 msgid "Cell ends in a backslash"
 msgstr "Zelle endet mit einem Backslash"
 
-#: ../src/wxMaximaFrame.cpp:676
+#: ../src/wxMaximaFrame.cpp:675
 msgid "Change &2d Display"
 msgstr "Format &2D Anzeige"
 
-#: ../src/wxMaximaFrame.cpp:677
+#: ../src/wxMaximaFrame.cpp:676
 msgid "Change the 2d display algorithm used to display math output"
 msgstr "Wähle ein Format für die 2D Anzeige"
 
-#: ../src/wxMaxima.cpp:3995
+#: ../src/wxMaxima.cpp:4007
 msgid "Change variable"
 msgstr "Variable ersetzen"
 
-#: ../src/wxMaximaFrame.cpp:783
+#: ../src/wxMaximaFrame.cpp:782
 msgid "Change variable in integral or sum"
 msgstr "Variable in Integral oder Summe ersetzen"
 
-#: ../src/wxMaxima.cpp:3751
+#: ../src/wxMaxima.cpp:3763
 msgid "Char poly"
 msgstr "Charakteristisches Polynom"
 
-#: ../src/wxMaximaFrame.cpp:978
+#: ../src/wxMaximaFrame.cpp:977
 msgid "Check for Updates"
 msgstr "Prüfe auf Aktualisierungen"
 
-#: ../src/wxMaximaFrame.cpp:979
+#: ../src/wxMaximaFrame.cpp:978
 msgid "Check if a newer version of wxMaxima/Maxima exist."
 msgstr ""
 "Prüfen Sie bitte, ob Sie eine aktuelle Version von wxMaxima oder Maxima "
 "erhalten können."
 
-#: ../src/wxMaximaFrame.cpp:1385
+#: ../src/wxMaximaFrame.cpp:1384
 msgid "Chi"
 msgstr "Chi"
 
@@ -955,15 +955,15 @@ msgstr "Schriftart wählen"
 msgid "Choose new plot format:"
 msgstr "Neues Plot-Format eingeben:"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710
 msgid "Classes:"
 msgstr "Klassen:"
 
-#: ../src/wxMaximaFrame.cpp:469
+#: ../src/wxMaximaFrame.cpp:468
 msgid "Close\tCtrl-W"
 msgstr "Schließen\tCtrl-W"
 
-#: ../src/wxMaximaFrame.cpp:470
+#: ../src/wxMaximaFrame.cpp:469
 msgid "Close window"
 msgstr "Schließe Fenster"
 
@@ -995,19 +995,19 @@ msgstr "Syntaxhervorhebung: Zeichenketten"
 msgid "Code highlighting: Variables"
 msgstr "Syntaxhervorhebung: Variablen"
 
-#: ../src/wxMaxima.cpp:4806
+#: ../src/wxMaxima.cpp:4818
 msgid "Col. names:"
 msgstr "Spaltennamen:"
 
-#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Columns:"
 msgstr "Spalten:"
 
-#: ../src/wxMaximaFrame.cpp:860
+#: ../src/wxMaximaFrame.cpp:859
 msgid "Combine factorials in an expression"
 msgstr "Fakultäten in einem Ausdruck kombinieren"
 
-#: ../src/wxMaxima.cpp:5293
+#: ../src/wxMaxima.cpp:5305
 msgid "Comma directly followed by a closing parenthesis"
 msgstr "Komma wird von einer schließenden Klammer gefolgt"
 
@@ -1019,23 +1019,23 @@ msgstr "x-Koordinaten durch Kommata getrennt"
 msgid "Comma separated y coordinates"
 msgstr "y-Koordinaten durch Kommata getrennt"
 
-#: ../src/MathCtrl.cpp:1030
+#: ../src/MathCtrl.cpp:1072
 msgid "Comment Selection"
 msgstr "Auswahl auskommentieren"
 
-#: ../src/wxMaximaFrame.cpp:533
+#: ../src/wxMaximaFrame.cpp:532
 msgid "Comment out the currently selected text"
 msgstr "Kommentiert den aktuell ausgewählten Text aus."
 
-#: ../src/wxMaximaFrame.cpp:532
+#: ../src/wxMaximaFrame.cpp:531
 msgid "Comment selection\tCtrl-/"
 msgstr "Auswahl auskommentieren\tCtrl-/"
 
-#: ../src/wxMaximaFrame.cpp:601
+#: ../src/wxMaximaFrame.cpp:600
 msgid "Complete Word\tCtrl-K"
 msgstr "Vervollständige Befehl\tCtrl-K"
 
-#: ../src/wxMaximaFrame.cpp:602
+#: ../src/wxMaximaFrame.cpp:601
 msgid "Complete word"
 msgstr "Vervollständige Befehl"
 
@@ -1043,36 +1043,36 @@ msgstr "Vervollständige Befehl"
 msgid "Completely stop maxima and restart it"
 msgstr "Vollständiges Beenden und Neustart von Maxima"
 
-#: ../src/wxMaximaFrame.cpp:823
+#: ../src/wxMaximaFrame.cpp:822
 msgid "Compute continued fraction of a value"
 msgstr "Kettenbruch eines Werts berechnen"
 
-#: ../src/wxMaximaFrame.cpp:761
+#: ../src/wxMaximaFrame.cpp:760
 msgid "Compute the adjoint matrix"
 msgstr "Adjungierte Matrix berechnen"
 
-#: ../src/wxMaximaFrame.cpp:750
+#: ../src/wxMaximaFrame.cpp:749
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr "Charakteristisches Polynom einer Matrix berechnen"
 
-#: ../src/wxMaximaFrame.cpp:753
+#: ../src/wxMaximaFrame.cpp:752
 msgid "Compute the determinant of a matrix"
 msgstr "Determinante einer Matrix berechnen"
 
-#: ../src/wxMaximaFrame.cpp:810
+#: ../src/wxMaximaFrame.cpp:809
 msgid "Compute the greatest common divisor"
 msgstr "Größten gemeinsamen Teiler berechnen"
 
-#: ../src/wxMaximaFrame.cpp:747
+#: ../src/wxMaximaFrame.cpp:746
 msgid "Compute the inverse of a matrix"
 msgstr "Inverse einer Matrix berechnen"
 
-#: ../src/wxMaximaFrame.cpp:813
+#: ../src/wxMaximaFrame.cpp:812
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
 "Kleinste gemeinsames Vielfache berechnen (vorher load(functs) ausführen)"
 
-#: ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4868
 msgid "Condition:"
 msgstr "Bedingung:"
 
@@ -1084,8 +1084,8 @@ msgstr "Konfigurationsdatei (*.ini)|*.ini"
 msgid "Configuration warning"
 msgstr "Konfigurationswarnung"
 
-#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:538
-#: ../src/wxMaximaFrame.cpp:541
+#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:540
 msgid "Configure wxMaxima"
 msgstr "wxMaxima konfigurieren"
 
@@ -1094,120 +1094,122 @@ msgstr "wxMaxima konfigurieren"
 msgid "Constant"
 msgstr "Konstante"
 
-#: ../src/wxMaximaFrame.cpp:844
+#: ../src/wxMaximaFrame.cpp:843
 msgid "Contract Logarithms"
 msgstr "L&ogarithmen zusammenfassen"
 
-#: ../src/wxMaximaFrame.cpp:851
+#: ../src/wxMaximaFrame.cpp:850
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr "Ersetze Binomial-, Beta- und Gammafunktionen durch Fakultäten"
 
-#: ../src/wxMaximaFrame.cpp:854
+#: ../src/wxMaximaFrame.cpp:853
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr ""
 "Ersetze Binomialfunktionen, Fakultäten und Betafunktionen durch "
 "Gammafunktionen"
 
-#: ../src/wxMaximaFrame.cpp:888
+#: ../src/wxMaximaFrame.cpp:887
 msgid "Convert complex expression to polar form"
 msgstr "Wandle komplexen Ausdruck in Polardarstellung"
 
-#: ../src/wxMaximaFrame.cpp:885
+#: ../src/wxMaximaFrame.cpp:884
 msgid "Convert complex expression to rect form"
 msgstr "Wandle komplexen Ausdruck in Standarddarstellung"
 
-#: ../src/wxMaximaFrame.cpp:897
+#: ../src/wxMaximaFrame.cpp:896
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
 "Exponentialfunktion mit imaginärem Argument in Winkelfunktion umwandeln"
 
-#: ../src/wxMaximaFrame.cpp:842
+#: ../src/wxMaximaFrame.cpp:841
 msgid "Convert logarithm of product to sum of logarithms"
 msgstr "Produkte von Logarithmen in Summe von Logarithmen umwandeln"
 
-#: ../src/wxMaximaFrame.cpp:845
+#: ../src/wxMaximaFrame.cpp:844
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "Logarithmen von Summen in Produkt von Logarithmen umwandeln"
 
-#: ../src/wxMaximaFrame.cpp:850
+#: ../src/wxMaximaFrame.cpp:849
 msgid "Convert to &Factorials"
 msgstr "In &Fakultäten umwandeln"
 
-#: ../src/wxMaximaFrame.cpp:853
+#: ../src/wxMaximaFrame.cpp:852
 msgid "Convert to &Gamma"
 msgstr "In &Gammafunktionen umwandeln"
 
-#: ../src/wxMaximaFrame.cpp:887
+#: ../src/wxMaximaFrame.cpp:886
 msgid "Convert to &Polarform"
 msgstr "&Polardarstellung"
 
-#: ../src/wxMaximaFrame.cpp:884
+#: ../src/wxMaximaFrame.cpp:883
 msgid "Convert to &Rectform"
 msgstr "&Standarddarstellung"
 
-#: ../src/wxMaximaFrame.cpp:877
+#: ../src/wxMaximaFrame.cpp:876
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr "Wandle trigonometrischen Ausdruck in eine kanonische Form"
 
-#: ../src/wxMaximaFrame.cpp:900
+#: ../src/wxMaximaFrame.cpp:899
 msgid "Convert trigonometric functions to exponential form"
 msgstr "Ersetze Winkelfunktionen durch Exponentialfunktionen"
 
-#: ../src/ToolBar.cpp:140 ../src/MathCtrl.cpp:918 ../src/MathCtrl.cpp:931
-#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1024
+#: ../src/MathCtrl.cpp:960 ../src/MathCtrl.cpp:973 ../src/MathCtrl.cpp:1019
+#: ../src/MathCtrl.cpp:1066 ../src/ToolBar.cpp:140
 msgid "Copy"
 msgstr "Kopieren"
 
-#: ../src/wxMaximaFrame.cpp:597
+#: ../src/wxMaximaFrame.cpp:596
 msgid "Copy Previous Input\tCtrl-I"
 msgstr "Kopiere letzte Eingabe\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:599
+#: ../src/wxMaximaFrame.cpp:598
 msgid "Copy Previous Output\tCtrl-U"
 msgstr "Kopiere letzte Ausgabe\tCtrl-U"
 
-#: ../src/wxMaximaFrame.cpp:514 ../src/MathCtrl.cpp:936 ../src/MathCtrl.cpp:982
+#: ../src/MathCtrl.cpp:978 ../src/MathCtrl.cpp:1024
+#: ../src/wxMaximaFrame.cpp:513
 msgid "Copy as Image"
 msgstr "Als Bild kopieren"
 
-#: ../src/wxMaximaFrame.cpp:507 ../src/MathCtrl.cpp:932 ../src/MathCtrl.cpp:978
+#: ../src/MathCtrl.cpp:974 ../src/MathCtrl.cpp:1020
+#: ../src/wxMaximaFrame.cpp:506
 msgid "Copy as LaTeX"
 msgstr "Als LaTeX kopieren"
 
-#: ../src/wxMaximaFrame.cpp:510
+#: ../src/wxMaximaFrame.cpp:509
 msgid "Copy as MathML"
 msgstr "Als MathML kopieren"
 
-#: ../src/MathCtrl.cpp:935 ../src/MathCtrl.cpp:980
+#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1022
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr "Kopiere als MathML (für Textverarbeitungen etc.)"
 
-#: ../src/wxMaximaFrame.cpp:504
+#: ../src/wxMaximaFrame.cpp:503
 msgid "Copy as Text\tCtrl-Shift-C"
 msgstr "Als Text kopieren\tCtrl-Shift-C"
 
-#: ../src/MathCtrl.cpp:933 ../src/MathCtrl.cpp:979
+#: ../src/MathCtrl.cpp:975 ../src/MathCtrl.cpp:1021
 msgid "Copy as plain text"
 msgstr "Als Text kopieren"
 
-#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:503
+#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:502
 msgid "Copy selection"
 msgstr "Auswahl kopieren"
 
-#: ../src/wxMaximaFrame.cpp:515
+#: ../src/wxMaximaFrame.cpp:514
 msgid "Copy selection from document as an image"
 msgstr "Auswahl als Bild kopieren"
 
-#: ../src/wxMaximaFrame.cpp:505
+#: ../src/wxMaximaFrame.cpp:504
 msgid "Copy selection from document as text"
 msgstr "Auswahl des Dokumentes als Text kopieren"
 
-#: ../src/wxMaximaFrame.cpp:508
+#: ../src/wxMaximaFrame.cpp:507
 msgid "Copy selection from document in LaTeX format"
 msgstr "Auswahl im LaTeX-Format kopieren"
 
-#: ../src/wxMaximaFrame.cpp:511
+#: ../src/wxMaximaFrame.cpp:510
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
@@ -1215,11 +1217,11 @@ msgstr ""
 "Kopiert den markierten Text in einem MathML-Format, das von vielen "
 "Textverarbeitungen als 2D-Formel dargestellt wird."
 
-#: ../src/wxMaximaFrame.cpp:598
+#: ../src/wxMaximaFrame.cpp:597
 msgid "Create a new cell with previous input"
 msgstr "Neue Zelle mit letzter Eingabe erzeugen."
 
-#: ../src/wxMaximaFrame.cpp:600
+#: ../src/wxMaximaFrame.cpp:599
 msgid "Create a new cell with previous output"
 msgstr "Neue Zelle mit letzter Ausgabe erzeugen."
 
@@ -1227,15 +1229,15 @@ msgstr "Neue Zelle mit letzter Ausgabe erzeugen."
 msgid "Cursor"
 msgstr "Cursor"
 
-#: ../src/ToolBar.cpp:137 ../src/MathCtrl.cpp:1023
+#: ../src/MathCtrl.cpp:1065 ../src/ToolBar.cpp:137
 msgid "Cut"
 msgstr "Ausschneiden"
 
-#: ../src/wxMaximaFrame.cpp:499
+#: ../src/wxMaximaFrame.cpp:498
 msgid "Cut\tCtrl-X"
 msgstr "Ausschneiden\tCtrl-X"
 
-#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:500
+#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:499
 msgid "Cut selection"
 msgstr "Auswahl ausschneiden"
 
@@ -1247,18 +1249,18 @@ msgstr "Tschechisch"
 msgid "Danish"
 msgstr "Dänisch"
 
-#: ../src/wxMaxima.cpp:4799 ../src/wxMaxima.cpp:4806 ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4811 ../src/wxMaxima.cpp:4818 ../src/wxMaxima.cpp:4868
 msgid "Data Matrix:"
 msgstr "Datenmatrix:"
 
-#: ../src/wxMaxima.cpp:4826
+#: ../src/wxMaxima.cpp:4838
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr "Datendatei (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698 ../src/wxMaxima.cpp:4712
-#: ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726 ../src/wxMaxima.cpp:4734
-#: ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748 ../src/wxMaxima.cpp:4755
-#: ../src/wxMaxima.cpp:4791
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710 ../src/wxMaxima.cpp:4724
+#: ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738 ../src/wxMaxima.cpp:4746
+#: ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760 ../src/wxMaxima.cpp:4767
+#: ../src/wxMaxima.cpp:4803
 msgid "Data:"
 msgstr "Daten:"
 
@@ -1266,7 +1268,7 @@ msgstr "Daten:"
 msgid "Debug: watch maxima's stdout stream"
 msgstr "Debug: Überwache den stdout-Datenstrom"
 
-#: ../src/wxMaximaFrame.cpp:820
+#: ../src/wxMaximaFrame.cpp:819
 msgid "Decompose rational function to partial fractions"
 msgstr "Partialbruchzerlegung"
 
@@ -1298,47 +1300,47 @@ msgstr ""
 "Definiert die Geschwindigkeit (in Bilder pro Sekunde), mit der Animationen "
 "standardmäßig abgespielt werden."
 
-#: ../src/wxMaxima.cpp:3403 ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3415 ../src/wxMaxima.cpp:3424
 msgid "Delete"
 msgstr "Löschen"
 
-#: ../src/wxMaximaFrame.cpp:667
+#: ../src/wxMaximaFrame.cpp:666
 msgid "Delete F&unction..."
 msgstr "F&unktion löschen ..."
 
-#: ../src/MathCtrl.cpp:939 ../src/MathCtrl.cpp:985
+#: ../src/MathCtrl.cpp:981 ../src/MathCtrl.cpp:1027
 msgid "Delete Selection"
 msgstr "Auswahl löschen"
 
-#: ../src/wxMaximaFrame.cpp:669
+#: ../src/wxMaximaFrame.cpp:668
 msgid "Delete V&ariable..."
 msgstr "V&ariable löschen ..."
 
-#: ../src/wxMaximaFrame.cpp:668
+#: ../src/wxMaximaFrame.cpp:667
 msgid "Delete a function"
 msgstr "Eine Funktion löschen"
 
-#: ../src/wxMaximaFrame.cpp:670
+#: ../src/wxMaximaFrame.cpp:669
 msgid "Delete a variable"
 msgstr "Eine Variable löschen"
 
-#: ../src/wxMaximaFrame.cpp:655
+#: ../src/wxMaximaFrame.cpp:654
 msgid "Delete all values from memory"
 msgstr "Alle Symbole aus dem Speicher löschen"
 
-#: ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3424
 msgid "Delete function(s):"
 msgstr "Lösche die Funktion(en):"
 
-#: ../src/wxMaxima.cpp:3403
+#: ../src/wxMaxima.cpp:3415
 msgid "Delete variable(s):"
 msgstr "Lösche die Variable(n):"
 
-#: ../src/wxMaximaFrame.cpp:1367
+#: ../src/wxMaximaFrame.cpp:1366
 msgid "Delta"
 msgstr "Delta"
 
-#: ../src/wxMaxima.cpp:4011
+#: ../src/wxMaxima.cpp:4023
 msgid "Denom. deg:"
 msgstr "Grad Nenner:"
 
@@ -1346,35 +1348,35 @@ msgstr "Grad Nenner:"
 msgid "Depth:"
 msgstr "Ordnung:"
 
-#: ../src/wxMaxima.cpp:3541
+#: ../src/wxMaxima.cpp:3553
 msgid "Derivative:"
 msgstr "Ableitung:"
 
-#: ../src/wxMaximaFrame.cpp:1258
+#: ../src/wxMaximaFrame.cpp:1257
 msgid "Deviation..."
 msgstr "Standardabw."
 
-#: ../src/wxMaximaFrame.cpp:816
+#: ../src/wxMaximaFrame.cpp:815
 msgid "Di&vide Polynomials..."
 msgstr "Polynome di&vidieren ..."
 
-#: ../src/wxMaximaFrame.cpp:1223
+#: ../src/wxMaximaFrame.cpp:1222
 msgid "Diff..."
 msgstr "Differenzieren ..."
 
-#: ../src/wxMaxima.cpp:4154 ../src/wxMaxima.cpp:5066
+#: ../src/wxMaxima.cpp:4166 ../src/wxMaxima.cpp:5078
 msgid "Differentiate"
 msgstr "Differenzieren"
 
-#: ../src/wxMaximaFrame.cpp:786
+#: ../src/wxMaximaFrame.cpp:785
 msgid "Differentiate expression"
 msgstr "Ausdruck differenzieren"
 
-#: ../src/MathCtrl.cpp:1001
+#: ../src/MathCtrl.cpp:1043
 msgid "Differentiate..."
 msgstr "Differenzieren ..."
 
-#: ../src/LimitWiz.cpp:37 ../src/FindReplacePane.cpp:76
+#: ../src/FindReplacePane.cpp:76 ../src/LimitWiz.cpp:37
 msgid "Direction:"
 msgstr "Richtung:"
 
@@ -1382,47 +1384,48 @@ msgstr "Richtung:"
 msgid "Discrete plot"
 msgstr "Diskreter Plot"
 
-#: ../src/wxMaximaFrame.cpp:679
+#: ../src/wxMaximaFrame.cpp:678
 msgid "Display Te&X Form"
 msgstr "Zeige Te&X Format"
 
-#: ../src/wxMaxima.cpp:3320
+#: ../src/wxMaxima.cpp:3332
 msgid "Display algorithm"
 msgstr "Darstellungmethode"
 
-#: ../src/wxMaximaFrame.cpp:680
+#: ../src/wxMaximaFrame.cpp:679
 msgid "Display last result in TeX form"
 msgstr "Zeige letztes Ergebnis in TeX Format"
 
-#: ../src/wxMaximaFrame.cpp:674
+#: ../src/wxMaximaFrame.cpp:673
 msgid "Display time used for evaluation"
 msgstr "Zeige Zeit für die Auswertung an"
 
-#: ../src/wxMaxima.cpp:4061
+#: ../src/wxMaxima.cpp:4073
 msgid "Divide"
 msgstr "Dividiere"
 
-#: ../src/MathCtrl.cpp:1032
+#: ../src/MathCtrl.cpp:1074
 msgid "Divide Cell"
 msgstr "Zelle teilen"
 
-#: ../src/wxMaximaFrame.cpp:635
+#: ../src/wxMaximaFrame.cpp:634
 msgid "Divide Cell\tCtrl-D"
 msgstr "Zelle teilen\tCtrl-D"
 
-#: ../src/wxMaximaFrame.cpp:817
+#: ../src/wxMaximaFrame.cpp:816
 msgid "Divide numbers or polynomials"
 msgstr "Dividiere Zahlen oder Polynome"
 
-#: ../src/wxMaximaFrame.cpp:636
+#: ../src/wxMaximaFrame.cpp:635
 msgid "Divide this input cell into two cells"
 msgstr "Teile diese Eingabezelle in zwei Zellen auf."
 
-#: ../src/wxMaxima.cpp:5917
-msgid "Do you want to save the changes you made in the document \""
+#: ../src/wxMaxima.cpp:5932
+#, fuzzy, c-format
+msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr "Wollen Sie Änderungen im Dokument speichern \""
 
-#: ../src/wxMaxima.cpp:1664 ../src/wxMaxima.cpp:1672
+#: ../src/wxMaxima.cpp:1669 ../src/wxMaxima.cpp:1677
 msgid "Document "
 msgstr "Dokument"
 
@@ -1444,7 +1447,7 @@ msgstr ""
 "der Bilder für sich: Dies erlaubt Versionskontroll-Systemen wie svn und git, "
 "genau zu ermitteln, welche Elemente sich geändert haben. "
 
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Don't save"
 msgstr "Nicht speichern"
 
@@ -1452,27 +1455,27 @@ msgstr "Nicht speichern"
 msgid "Down"
 msgstr "Nach unten"
 
-#: ../src/wxMaximaFrame.cpp:734
+#: ../src/wxMaximaFrame.cpp:733
 msgid "E&quations"
 msgstr "&Gleichungen"
 
-#: ../src/wxMaximaFrame.cpp:487
+#: ../src/wxMaximaFrame.cpp:486
 msgid "E&xit\tCtrl-Q"
 msgstr "B&eenden\tCtrl-Q"
 
-#: ../src/wxMaximaFrame.cpp:757
+#: ../src/wxMaximaFrame.cpp:756
 msgid "Eige&nvectors"
 msgstr "Eigen&vektoren"
 
-#: ../src/wxMaximaFrame.cpp:755
+#: ../src/wxMaximaFrame.cpp:754
 msgid "Eigen&values"
 msgstr "Eigen&werte"
 
-#: ../src/wxMaxima.cpp:3572
+#: ../src/wxMaxima.cpp:3584
 msgid "Eliminate"
 msgstr "Eliminieren"
 
-#: ../src/wxMaximaFrame.cpp:710
+#: ../src/wxMaximaFrame.cpp:709
 msgid "Eliminate a variable from a system of equations"
 msgstr "Eliminiere eine Variable aus einem Gleichungssystem"
 
@@ -1484,21 +1487,21 @@ msgstr "q.e.d. (Beweisende)"
 msgid "English"
 msgstr "Englisch"
 
-#: ../src/wxMaxima.cpp:4712 ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726
-#: ../src/wxMaxima.cpp:4734 ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748
-#: ../src/wxMaxima.cpp:4755 ../src/wxMaxima.cpp:4791 ../src/wxMaxima.cpp:4799
+#: ../src/wxMaxima.cpp:4724 ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738
+#: ../src/wxMaxima.cpp:4746 ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760
+#: ../src/wxMaxima.cpp:4767 ../src/wxMaxima.cpp:4803 ../src/wxMaxima.cpp:4811
 msgid "Enter Data"
 msgstr "Matrix eingeben"
 
-#: ../src/wxMaximaFrame.cpp:1279
+#: ../src/wxMaximaFrame.cpp:1278
 msgid "Enter Matrix..."
 msgstr "Matrix &eingeben ..."
 
-#: ../src/wxMaximaFrame.cpp:745
+#: ../src/wxMaximaFrame.cpp:744
 msgid "Enter a matrix"
 msgstr "Eine Matrix eingeben"
 
-#: ../src/wxMaxima.cpp:3962
+#: ../src/wxMaxima.cpp:3974
 msgid "Enter an equation for rational simplification:"
 msgstr "Geben Sie eine Gleichung zum Vereinfachen rationaler Ausdrücke an:"
 
@@ -1510,11 +1513,11 @@ msgstr "Geben Sie die Variablen durch Beistriche getrennt ein."
 msgid "Enter evaluates cells"
 msgstr "'Eingabe' wertet die Zelle aus"
 
-#: ../src/wxMaxima.cpp:3734
+#: ../src/wxMaxima.cpp:3746
 msgid "Enter matrix"
 msgstr "Matrix eingeben"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Enter new precision for bigfloats:"
 msgstr "Neue Genauigkeit für als Bigfloat deklarierte Zahlen eingeben:"
 
@@ -1522,11 +1525,11 @@ msgstr "Neue Genauigkeit für als Bigfloat deklarierte Zahlen eingeben:"
 msgid "Enter the path to the Maxima executable."
 msgstr "Geben Sie den Pfad zum Maxima Programm an."
 
-#: ../src/wxMaximaFrame.cpp:1368
+#: ../src/wxMaximaFrame.cpp:1367
 msgid "Epsilon"
 msgstr "Epsilon"
 
-#: ../src/wxMaxima.cpp:4208
+#: ../src/wxMaxima.cpp:4220
 msgid "Epsilon:"
 msgstr "Epsilon:"
 
@@ -1535,13 +1538,13 @@ msgstr "Epsilon:"
 msgid "Equation %d:"
 msgstr "Gleichung %d:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:3633
-#: ../src/wxMaxima.cpp:5019
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:3645
+#: ../src/wxMaxima.cpp:5031
 msgid "Equation(s):"
 msgstr "Gleichung(en):"
 
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3993
-#: ../src/wxMaxima.cpp:4807 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:4005
+#: ../src/wxMaxima.cpp:4819 ../src/wxMaxima.cpp:5045
 msgid "Equation:"
 msgstr "Gleichung:"
 
@@ -1556,76 +1559,76 @@ msgstr ""
 "können ineinander eingesetzt werden und sie werden stets in einer "
 "menschenlesbaren 2D-Form ausgegeben."
 
-#: ../src/wxMaxima.cpp:3570
+#: ../src/wxMaxima.cpp:3582
 msgid "Equations:"
 msgstr "Gleichungen:"
 
-#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1455
-#: ../src/wxMaxima.cpp:1469 ../src/wxMaxima.cpp:1620 ../src/wxMaxima.cpp:1633
-#: ../src/wxMaxima.cpp:1643 ../src/wxMaxima.cpp:1666 ../src/wxMaxima.cpp:2034
-#: ../src/wxMaxima.cpp:2206 ../src/wxMaxima.cpp:5381 ../src/wxMaxima.cpp:5830
-#: ../src/wxMaxima.cpp:5881
+#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1460
+#: ../src/wxMaxima.cpp:1474 ../src/wxMaxima.cpp:1625 ../src/wxMaxima.cpp:1638
+#: ../src/wxMaxima.cpp:1648 ../src/wxMaxima.cpp:1671 ../src/wxMaxima.cpp:2039
+#: ../src/wxMaxima.cpp:2211 ../src/wxMaxima.cpp:5397 ../src/wxMaxima.cpp:5845
+#: ../src/wxMaxima.cpp:5896
 msgid "Error"
 msgstr "Fehler"
 
-#: ../src/wxMaxima.cpp:2886 ../src/wxMaxima.cpp:2900 ../src/wxMaxima.cpp:2913
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617 ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:2894 ../src/wxMaxima.cpp:2908 ../src/wxMaxima.cpp:2921
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629 ../src/wxMaxima.cpp:3740
 msgid "Error!"
 msgstr "Fehler!"
 
-#: ../src/wxMaximaFrame.cpp:1370
+#: ../src/wxMaximaFrame.cpp:1369
 msgid "Eta"
 msgstr "Eta"
 
-#: ../src/wxMaximaFrame.cpp:909
+#: ../src/wxMaximaFrame.cpp:908
 msgid "Evaluate &Noun Forms"
 msgstr "&Noun-Formen auswerten"
 
-#: ../src/wxMaximaFrame.cpp:589
+#: ../src/wxMaximaFrame.cpp:588
 msgid "Evaluate All Cells\tCtrl-Shift-R"
 msgstr "Alle Zellen neu auswerten\tCtrl-Shift-R"
 
-#: ../src/wxMaximaFrame.cpp:587
+#: ../src/wxMaximaFrame.cpp:586
 msgid "Evaluate All Visible Cells\tCtrl-R"
 msgstr "Alle sichtbaren Zellen neu auswerten\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:585 ../src/MathCtrl.cpp:942
+#: ../src/MathCtrl.cpp:984 ../src/wxMaximaFrame.cpp:584
 msgid "Evaluate Cell(s)"
 msgstr "Zelle(n) auswerten"
 
-#: ../src/wxMaximaFrame.cpp:591
+#: ../src/wxMaximaFrame.cpp:590
 msgid "Evaluate Cells Above\tCtrl-Shift-P"
 msgstr "Zellen über dem Cursor neu auswerten\tCtrl-Shift-P"
 
-#: ../src/MathCtrl.cpp:956 ../src/MathCtrl.cpp:1051
+#: ../src/MathCtrl.cpp:998 ../src/MathCtrl.cpp:1093
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr "Evaluiere diesen Teil des Dokuments\tShift+Ctrl+Return"
 
-#: ../src/MathCtrl.cpp:961 ../src/MathCtrl.cpp:1053
+#: ../src/MathCtrl.cpp:1003 ../src/MathCtrl.cpp:1095
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr "Evaluiere dieses Kapitel\tShift+Ctrl+Return"
 
-#: ../src/MathCtrl.cpp:971 ../src/MathCtrl.cpp:1057
+#: ../src/MathCtrl.cpp:1013 ../src/MathCtrl.cpp:1099
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr "Evaluiere dieses Unterkapitel\tShift+Ctrl+Return"
 
-#: ../src/MathCtrl.cpp:966 ../src/MathCtrl.cpp:1055
+#: ../src/MathCtrl.cpp:1008 ../src/MathCtrl.cpp:1097
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr "Evaluiere dieses Unter-Unterkapitel\tShift+Ctrl+Return"
 
-#: ../src/wxMaximaFrame.cpp:586
+#: ../src/wxMaximaFrame.cpp:585
 msgid "Evaluate active or selected cell(s)"
 msgstr "Aktive oder ausgewählte Zelle(n) auswerten"
 
-#: ../src/wxMaximaFrame.cpp:590
+#: ../src/wxMaximaFrame.cpp:589
 msgid "Evaluate all cells in the document"
 msgstr "Alle Zellen im Dokument auswerten"
 
-#: ../src/wxMaximaFrame.cpp:910
+#: ../src/wxMaximaFrame.cpp:909
 msgid "Evaluate all noun forms in expression"
 msgstr "Alle Noun-Formen im Ausdruck auswerten"
 
-#: ../src/wxMaximaFrame.cpp:588
+#: ../src/wxMaximaFrame.cpp:587
 msgid "Evaluate all visible cells in the document"
 msgstr "Alle sichtbaren Zellen im Dokument auswerten"
 
@@ -1638,7 +1641,7 @@ msgstr ""
 msgid "Evaluate to point"
 msgstr "&Zellen bis hier evaluieren"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Example"
 msgstr "Beispiel"
 
@@ -1650,31 +1653,31 @@ msgstr "Mustertext"
 msgid "Examples:"
 msgstr "Beispiele:"
 
-#: ../src/wxMaximaFrame.cpp:488
+#: ../src/wxMaximaFrame.cpp:487
 msgid "Exit wxMaxima"
 msgstr "wxMaxima beenden"
 
-#: ../src/wxMaximaFrame.cpp:1214
+#: ../src/wxMaximaFrame.cpp:1213
 msgid "Expand"
 msgstr "Expandieren"
 
-#: ../src/wxMaximaFrame.cpp:1219
+#: ../src/wxMaximaFrame.cpp:1218
 msgid "Expand (tr)"
 msgstr "Trigexpand"
 
-#: ../src/MathCtrl.cpp:997
+#: ../src/MathCtrl.cpp:1039
 msgid "Expand Expression"
 msgstr "Ausdruck expandieren"
 
-#: ../src/wxMaximaFrame.cpp:841
+#: ../src/wxMaximaFrame.cpp:840
 msgid "Expand Logarithms"
 msgstr "&Logarithmen expandieren"
 
-#: ../src/wxMaximaFrame.cpp:840
+#: ../src/wxMaximaFrame.cpp:839
 msgid "Expand an expression"
 msgstr "Einen Ausdruck expandieren (ausmultiplizieren und in Terme aufspalten)"
 
-#: ../src/wxMaximaFrame.cpp:874
+#: ../src/wxMaximaFrame.cpp:873
 msgid "Expand trigonometric expression"
 msgstr "Trigonometrische Ausdrücke expandieren"
 
@@ -1682,7 +1685,7 @@ msgstr "Trigonometrische Ausdrücke expandieren"
 msgid "Expected the icon files to be found at"
 msgstr "Habe erwartet, die Icons hier zu finden:"
 
-#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2834
+#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2842
 msgid "Export"
 msgstr "Exportieren"
 
@@ -1693,31 +1696,31 @@ msgstr ""
 "Export von pdf-Animationen nach TeX. Programme, die dies nicht unterstützen, "
 "zeigen Standbilder."
 
-#: ../src/wxMaximaFrame.cpp:481
+#: ../src/wxMaximaFrame.cpp:480
 msgid "Export document to a HTML or pdfLaTeX file"
 msgstr "Exportiere Dokument als HTML oder pdfLaTex-Datei"
 
-#: ../src/wxMaximaFrame.cpp:253
+#: ../src/wxMaximaFrame.cpp:252
 msgid "Export failed."
 msgstr "Exportieren der Datei ist fehlgeschlagen!"
 
-#: ../src/wxMaximaFrame.cpp:239
+#: ../src/wxMaximaFrame.cpp:238
 msgid "Export successful."
 msgstr "Das Exportieren war erfolgreich."
 
-#: ../src/wxMaxima.cpp:2913
+#: ../src/wxMaxima.cpp:2921
 msgid "Exporting to HTML failed!"
 msgstr "Export als HTML-Datei ist fehlgeschlagen!"
 
-#: ../src/wxMaxima.cpp:2886
+#: ../src/wxMaxima.cpp:2894
 msgid "Exporting to TeX failed!"
 msgstr "Export als TeX-Datei ist fehlgeschlagen!"
 
-#: ../src/wxMaxima.cpp:2900
+#: ../src/wxMaxima.cpp:2908
 msgid "Exporting to maxima batch file failed!"
 msgstr "Export als Maxima-Bibliothek ist fehlgeschlagen!"
 
-#: ../src/wxMaximaFrame.cpp:229
+#: ../src/wxMaximaFrame.cpp:228
 msgid "Exporting..."
 msgstr "Exportieren ..."
 
@@ -1730,42 +1733,42 @@ msgid "Expression(s):"
 msgstr "Ausdruck:"
 
 #: ../src/IntegrateWiz.cpp:30 ../src/LimitWiz.cpp:27 ../src/SeriesWiz.cpp:33
-#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3648
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:4205 ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5064
+#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3660
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:4217 ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5076
 msgid "Expression:"
 msgstr "Ausdruck:"
 
-#: ../src/wxMaximaFrame.cpp:1213
+#: ../src/wxMaximaFrame.cpp:1212
 msgid "Factor"
 msgstr "Faktorisieren"
 
-#: ../src/wxMaximaFrame.cpp:836
+#: ../src/wxMaximaFrame.cpp:835
 msgid "Factor Complex"
 msgstr "Audruck faktorisieren (Komplex)"
 
-#: ../src/MathCtrl.cpp:996
+#: ../src/MathCtrl.cpp:1038
 msgid "Factor Expression"
 msgstr "Ausdruck faktorisieren"
 
-#: ../src/wxMaximaFrame.cpp:835
+#: ../src/wxMaximaFrame.cpp:834
 msgid "Factor an expression"
 msgstr "Einen Ausdruck in ein Produkt von Ausdrücken umwandeln"
 
-#: ../src/wxMaximaFrame.cpp:837
+#: ../src/wxMaximaFrame.cpp:836
 msgid "Factor an expression in Gaussian numbers"
 msgstr "Faktorisiere einen Ausdruck in komplexe Zahlen"
 
-#: ../src/wxMaximaFrame.cpp:862
+#: ../src/wxMaximaFrame.cpp:861
 msgid "Factorials and &Gamma"
 msgstr "Fakultät und &Gamma"
 
-#: ../src/wxMaxima.cpp:285
+#: ../src/wxMaxima.cpp:286
 msgid "Fatal error"
 msgstr "Fataler Fehler"
 
-#: ../src/GroupCell.cpp:1571
+#: ../src/GroupCell.cpp:1572
 #, c-format
 msgid "Figure %d:"
 msgstr "Figure %d:"
@@ -1774,20 +1777,20 @@ msgstr "Figure %d:"
 msgid "File"
 msgstr "&Datei"
 
-#: ../src/wxMaxima.cpp:1457 ../src/wxMaxima.cpp:1623 ../src/wxMaxima.cpp:1636
-#: ../src/wxMaxima.cpp:1646 ../src/wxMaxima.cpp:1668
+#: ../src/wxMaxima.cpp:1462 ../src/wxMaxima.cpp:1628 ../src/wxMaxima.cpp:1641
+#: ../src/wxMaxima.cpp:1651 ../src/wxMaxima.cpp:1673
 msgid "File could not be opened"
 msgstr "Datei kann nicht geöffnet werden"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File not found"
 msgstr "Datei nicht gefunden"
 
-#: ../src/wxMaxima.cpp:1511 ../src/wxMaxima.cpp:1729
+#: ../src/wxMaxima.cpp:1516 ../src/wxMaxima.cpp:1734
 msgid "File opened"
 msgstr "Datei geöffnet"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File you tried to open does not exist."
 msgstr "Datei existiert nicht."
 
@@ -1799,68 +1802,68 @@ msgstr "Datei:"
 msgid "Find"
 msgstr "Suchen"
 
-#: ../src/wxMaximaFrame.cpp:523
+#: ../src/wxMaximaFrame.cpp:522
 msgid "Find\tCtrl-F"
 msgstr "Suchen und Ersetzen\tCtrl-F"
 
-#: ../src/wxMaximaFrame.cpp:787
+#: ../src/wxMaximaFrame.cpp:786
 msgid "Find &Limit..."
 msgstr "Grenz&wert suchen ..."
 
-#: ../src/wxMaximaFrame.cpp:790
+#: ../src/wxMaximaFrame.cpp:789
 msgid "Find Minimum..."
 msgstr "Minimum suchen ..."
 
-#: ../src/MathCtrl.cpp:993
+#: ../src/MathCtrl.cpp:1035
 msgid "Find Root..."
 msgstr "Nullstelle suchen ..."
 
-#: ../src/wxMaximaFrame.cpp:791
+#: ../src/wxMaximaFrame.cpp:790
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr "Finde das Minimum eines Ausdrucks"
 
-#: ../src/wxMaximaFrame.cpp:788
+#: ../src/wxMaximaFrame.cpp:787
 msgid "Find a limit of an expression"
 msgstr "Grenzwert eines Ausdrucks suchen"
 
-#: ../src/wxMaximaFrame.cpp:693
+#: ../src/wxMaximaFrame.cpp:692
 msgid "Find a root of an equation on an interval"
 msgstr "Numerische Lösung einer Gleichung suchen"
 
-#: ../src/wxMaximaFrame.cpp:695
+#: ../src/wxMaximaFrame.cpp:694
 msgid "Find all roots of a polynomial"
 msgstr "Alle Nullstellen eines Polynoms suchen"
 
-#: ../src/wxMaximaFrame.cpp:698
+#: ../src/wxMaximaFrame.cpp:697
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr ""
 "Alle Nullstellen eines Polynoms mit langer Gleitkommagenauigkeit suchen"
 
-#: ../src/wxMaxima.cpp:3220
+#: ../src/wxMaxima.cpp:3215
 msgid "Find and Replace"
 msgstr "Suchen und Ersetzen"
 
-#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:523
+#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:522
 msgid "Find and replace"
 msgstr "Suchen und Ersetzen"
 
-#: ../src/wxMaximaFrame.cpp:756
+#: ../src/wxMaximaFrame.cpp:755
 msgid "Find eigenvalues of a matrix"
 msgstr "Eigenwerte einer Matrix berechnen"
 
-#: ../src/wxMaximaFrame.cpp:758
+#: ../src/wxMaximaFrame.cpp:757
 msgid "Find eigenvectors of a matrix"
 msgstr "Eigenvektoren einer Matrix berechnen"
 
-#: ../src/wxMaxima.cpp:4210
+#: ../src/wxMaxima.cpp:4222
 msgid "Find minimum"
 msgstr "Minimum suchen"
 
-#: ../src/wxMaximaFrame.cpp:701
+#: ../src/wxMaximaFrame.cpp:700
 msgid "Find real roots of a polynomial"
 msgstr "Finde die reellen Nullstellen eines Polynoms"
 
-#: ../src/wxMaxima.cpp:3493 ../src/wxMaxima.cpp:5036
+#: ../src/wxMaxima.cpp:3505 ../src/wxMaxima.cpp:5048
 msgid "Find root"
 msgstr "Nullstelle suchen"
 
@@ -1881,11 +1884,11 @@ msgstr "Neunummerierung der Ein- und Ausgabemarken beim Speichern"
 msgid "Fixed font in text controls"
 msgstr "Schriftart mit fester Breite in Texteingabefeldern"
 
-#: ../src/wxMaximaFrame.cpp:623
+#: ../src/wxMaximaFrame.cpp:622
 msgid "Fold All\tCtrl-Alt-["
 msgstr "Alles zuklappen\tCtrl-A"
 
-#: ../src/wxMaximaFrame.cpp:624
+#: ../src/wxMaximaFrame.cpp:623
 msgid "Fold all sections"
 msgstr "Alle Sektionen zuklappen"
 
@@ -1893,11 +1896,11 @@ msgstr "Alle Sektionen zuklappen"
 msgid "Follow"
 msgstr "Folge"
 
-#: ../src/ParenCell.cpp:319
+#: ../src/ParenCell.cpp:320
 msgid "Font issue: The Parenthesis sign is too small!"
 msgstr "Zeichensatzproblem: Das Klammer-Symbol ist zu klein!"
 
-#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:381
+#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:382
 msgid ""
 "Font issue: The char height is too small! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
@@ -1908,7 +1911,7 @@ msgstr ""
 "darauffolgendem Anklicken von \"Benutze jsMath-Zeichensätze\" in der "
 "Konfiguration sollte das Problem beheben."
 
-#: ../src/SqrtCell.cpp:199
+#: ../src/SqrtCell.cpp:202
 msgid ""
 "Font issue: The sqrt() sign has the size 0! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
@@ -1919,7 +1922,7 @@ msgstr ""
 "darauffolgendem Anklicken von \"Benutze jsMath-Zeichensätze\" in der "
 "Konfiguration sollte das Problem beheben."
 
-#: ../src/SqrtCell.cpp:198
+#: ../src/SqrtCell.cpp:201
 msgid "Font issue? The contents of a sqrt() has the size 0."
 msgstr "Zeichensatzproblem? Das Wurzelzeichen hat die Größe 0."
 
@@ -1950,15 +1953,15 @@ msgstr "Französisch"
 
 #: ../src/IntegrateWiz.cpp:37 ../src/Plot2dWiz.cpp:37 ../src/Plot2dWiz.cpp:47
 #: ../src/Plot2dWiz.cpp:536 ../src/Plot3dWiz.cpp:36 ../src/Plot3dWiz.cpp:45
-#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4240
+#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4252
 msgid "From:"
 msgstr "von:"
 
-#: ../src/wxMaximaFrame.cpp:576
+#: ../src/wxMaximaFrame.cpp:575
 msgid "Full Screen\tAlt-Enter"
 msgstr "Ganzer Bildschirm\tAlt-Enter"
 
-#: ../src/wxMaxima.cpp:3342
+#: ../src/wxMaxima.cpp:3354
 msgid "Function"
 msgstr "Funktion"
 
@@ -1966,32 +1969,32 @@ msgstr "Funktion"
 msgid "Function names"
 msgstr "Funktionsnamen"
 
-#: ../src/wxMaxima.cpp:3633
+#: ../src/wxMaxima.cpp:3645
 msgid "Function(s):"
 msgstr "Funktion(en):"
 
-#: ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3803
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3815
+#: ../src/wxMaxima.cpp:3848
 msgid "Function:"
 msgstr "Funktion:"
 
-#: ../src/wxMaximaFrame.cpp:904
+#: ../src/wxMaximaFrame.cpp:903
 msgid "Functions for complex simplification"
 msgstr "Funktionen zum Vereinfachen komplexer Ausdrücke"
 
-#: ../src/wxMaximaFrame.cpp:864
+#: ../src/wxMaximaFrame.cpp:863
 msgid "Functions for simplifying factorials and gamma function"
 msgstr "Funktionen zum Vereinfachen von Fakultäten und Gammafunktionen"
 
-#: ../src/wxMaximaFrame.cpp:881
+#: ../src/wxMaximaFrame.cpp:880
 msgid "Functions for simplifying trigonometric expressions"
 msgstr "Funktionen zum Vereinfachen von trigonometrischen Ausdrücken"
 
-#: ../src/wxMaxima.cpp:4046
+#: ../src/wxMaxima.cpp:4058
 msgid "GCD"
 msgstr "GGT"
 
-#: ../src/wxMaxima.cpp:5152
+#: ../src/wxMaxima.cpp:5164
 msgid "GIF image (*.gif)|*.gif"
 msgstr "GIF Bild (*.gif)|*.gif"
 
@@ -1999,31 +2002,31 @@ msgstr "GIF Bild (*.gif)|*.gif"
 msgid "Galician"
 msgstr "Galicisch"
 
-#: ../src/wxMaximaFrame.cpp:1366
+#: ../src/wxMaximaFrame.cpp:1365
 msgid "Gamma"
 msgstr "Gamma"
 
-#: ../src/wxMaximaFrame.cpp:391
+#: ../src/wxMaximaFrame.cpp:390
 msgid "General Math"
 msgstr "Allgemeine Mathematik"
 
-#: ../src/wxMaximaFrame.cpp:549
+#: ../src/wxMaximaFrame.cpp:548
 msgid "General Math\tAlt-Shift-M"
 msgstr "Allg. Mathematik\tAlt-Shift-M"
 
-#: ../src/wxMaxima.cpp:3766 ../src/wxMaxima.cpp:3785
+#: ../src/wxMaxima.cpp:3778 ../src/wxMaxima.cpp:3797
 msgid "Generate Matrix"
 msgstr "Matrix erzeugen"
 
-#: ../src/wxMaximaFrame.cpp:741
+#: ../src/wxMaximaFrame.cpp:740
 msgid "Generate Matrix from Expression..."
 msgstr "Matrix aus Ausdruck erzeugen ..."
 
-#: ../src/wxMaximaFrame.cpp:739
+#: ../src/wxMaximaFrame.cpp:738
 msgid "Generate a matrix from a 2-dimensional array"
 msgstr "Eine Matrix aus einem 2-dimensionalen Array erzeugen"
 
-#: ../src/wxMaximaFrame.cpp:742
+#: ../src/wxMaximaFrame.cpp:741
 msgid "Generate a matrix from a lambda expression"
 msgstr "Matrix aus lambda-Ausdruck erzeugen"
 
@@ -2031,39 +2034,39 @@ msgstr "Matrix aus lambda-Ausdruck erzeugen"
 msgid "German"
 msgstr "Deutsch"
 
-#: ../src/wxMaximaFrame.cpp:893
+#: ../src/wxMaximaFrame.cpp:892
 msgid "Get &Imaginary Part"
 msgstr "&Imaginärteil"
 
-#: ../src/wxMaximaFrame.cpp:793
+#: ../src/wxMaximaFrame.cpp:792
 msgid "Get &Series..."
 msgstr "Reihen&entwicklung ..."
 
-#: ../src/wxMaximaFrame.cpp:804
+#: ../src/wxMaximaFrame.cpp:803
 msgid "Get Laplace transformation of an expression"
 msgstr "Die Laplacetransformation eines Ausdrucks bestimmen"
 
-#: ../src/wxMaximaFrame.cpp:890
+#: ../src/wxMaximaFrame.cpp:889
 msgid "Get Real P&art"
 msgstr "&Realteil"
 
-#: ../src/wxMaximaFrame.cpp:807
+#: ../src/wxMaximaFrame.cpp:806
 msgid "Get inverse Laplace transformation of an expression"
 msgstr "Die inverse Laplacetransformation eines Ausdrucks bestimmen"
 
-#: ../src/wxMaximaFrame.cpp:794
+#: ../src/wxMaximaFrame.cpp:793
 msgid "Get the Taylor or power series of expression"
 msgstr "Die Taylor- oder Potenzreihe eines Ausdrucks bestimmen"
 
-#: ../src/wxMaximaFrame.cpp:894
+#: ../src/wxMaximaFrame.cpp:893
 msgid "Get the imaginary part of complex expression"
 msgstr "Imaginärteil eines komplexen Ausdrucks bestimmen"
 
-#: ../src/wxMaximaFrame.cpp:891
+#: ../src/wxMaximaFrame.cpp:890
 msgid "Get the real part of complex expression"
 msgstr "Realteil eines komplexen Ausdrucks bestimmen"
 
-#: ../src/MathCtrl.cpp:5932
+#: ../src/MathCtrl.cpp:5984
 msgid ""
 "Got a request to undo an action that involves an delete which isn't possible "
 "at this moment."
@@ -2075,11 +2078,11 @@ msgstr ""
 msgid "Greek"
 msgstr "Griechisch"
 
-#: ../src/wxMaximaFrame.cpp:356
+#: ../src/wxMaximaFrame.cpp:355
 msgid "Greek Letters"
 msgstr "Griechische Buchstaben"
 
-#: ../src/wxMaximaFrame.cpp:552
+#: ../src/wxMaximaFrame.cpp:551
 msgid "Greek Letters\tAlt-Shift-G"
 msgstr "Griechische Buchstaben\tAlt-Shift-G"
 
@@ -2091,7 +2094,7 @@ msgstr "Griechische Konstanten"
 msgid "Grid:"
 msgstr "Gitter:"
 
-#: ../src/wxMaxima.cpp:2836
+#: ../src/wxMaxima.cpp:2844
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|pdfLaTeX file (*."
 "tex)|*.tex"
@@ -2107,11 +2110,11 @@ msgstr "HTML/Textzellen: Exportiere alle Zeilenumbrüche"
 msgid "Help"
 msgstr "Hilfe"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide All Toolbars\tAlt-Shift--"
 msgstr "Alle Werkzeugleisten verbergen\tAlt-Shift--"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide all panes"
 msgstr "Alle Werkzeugleisten ausblenden"
 
@@ -2119,19 +2122,19 @@ msgstr "Alle Werkzeugleisten ausblenden"
 msgid "Highlight (dpart)"
 msgstr "Hervorgehoben"
 
-#: ../src/wxMaxima.cpp:4685
+#: ../src/wxMaxima.cpp:4697
 msgid "Histogram"
 msgstr "Histogramm"
 
-#: ../src/wxMaximaFrame.cpp:1270
+#: ../src/wxMaximaFrame.cpp:1269
 msgid "Histogram..."
 msgstr "Histogramm ..."
 
-#: ../src/wxMaximaFrame.cpp:309
+#: ../src/wxMaximaFrame.cpp:308
 msgid "History"
 msgstr "Historie der letzten Eingaben"
 
-#: ../src/wxMaximaFrame.cpp:555
+#: ../src/wxMaximaFrame.cpp:554
 msgid "History\tAlt-Shift-I"
 msgstr "Historie\tAlt-Shift-H"
 
@@ -2152,11 +2155,11 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Ungarisch"
 
-#: ../src/wxMaxima.cpp:3527
+#: ../src/wxMaxima.cpp:3539
 msgid "IC1"
 msgstr "Anfangswertproblem 1. Grades"
 
-#: ../src/wxMaxima.cpp:3543
+#: ../src/wxMaxima.cpp:3555
 msgid "IC2"
 msgstr "Anfangswertproblem 2. Grades"
 
@@ -2175,7 +2178,7 @@ msgstr ""
 "dieses Häkchen gesetzt ist, dieser Name angezeigt und nicht der mit %o "
 "beginnende Name, den maxima diesem Befehl zuweist."
 
-#: ../src/wxMaximaFrame.cpp:683
+#: ../src/wxMaximaFrame.cpp:682
 msgid ""
 "If maxima ever finishes evaluating without wxMaxima realizing this this menu "
 "item can force wxMaxima to try to send commands to maxima again."
@@ -2261,11 +2264,11 @@ msgstr ""
 "können Sie mit dem Menübefehl 'Maxima->Unterbrechen' oder 'Maxima->Maxima "
 "neustarten' die Berechnung abbrechen."
 
-#: ../src/wxMaximaFrame.cpp:1499
+#: ../src/wxMaximaFrame.cpp:1518
 msgid "Image"
 msgstr "Bild"
 
-#: ../src/wxMaxima.cpp:5644
+#: ../src/wxMaxima.cpp:5659
 msgid "Image files (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 msgstr "Bild-Dateien (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 
@@ -2308,7 +2311,7 @@ msgstr ""
 "lesbarer, wenn Exponenten hinter, nicht direkt über tiefgestelltem Text "
 "dargestellt werden. Diese Option wählt, was von beidem erwünscht ist."
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Include columns:"
 msgstr "Spalten:"
 
@@ -2327,19 +2330,19 @@ msgstr "Suche während des Tippens"
 msgid "Infinity"
 msgstr "Infinity"
 
-#: ../src/wxMaximaFrame.cpp:974
+#: ../src/wxMaximaFrame.cpp:973
 msgid "Info about Maxima build"
 msgstr "Information über Maxima Version"
 
-#: ../src/wxMaxima.cpp:4207
+#: ../src/wxMaxima.cpp:4219
 msgid "Initial Estimates:"
 msgstr "Anfangswert:"
 
-#: ../src/wxMaximaFrame.cpp:718
+#: ../src/wxMaximaFrame.cpp:717
 msgid "Initial Value Problem (&1)..."
 msgstr "Anfangswertproblem (&1) ..."
 
-#: ../src/wxMaximaFrame.cpp:721
+#: ../src/wxMaximaFrame.cpp:720
 msgid "Initial Value Problem (&2)..."
 msgstr "Anfangswertproblem (&2) ..."
 
@@ -2347,7 +2350,7 @@ msgstr "Anfangswertproblem (&2) ..."
 msgid "Input labels"
 msgstr "Eingabemarken"
 
-#: ../src/wxMaximaFrame.cpp:403
+#: ../src/wxMaximaFrame.cpp:402
 msgid "Insert"
 msgstr "Zellen Einfügen"
 
@@ -2355,95 +2358,95 @@ msgstr "Zellen Einfügen"
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr "Ein % Zeichen vor einem Operator am Anfang einer Zelle einfügen"
 
-#: ../src/wxMaximaFrame.cpp:612
+#: ../src/wxMaximaFrame.cpp:611
 msgid "Insert &Section Cell\tCtrl-3"
 msgstr "Neue &Kapitelzelle\tCtrl-3"
 
-#: ../src/wxMaximaFrame.cpp:608
+#: ../src/wxMaximaFrame.cpp:607
 msgid "Insert &Text Cell\tCtrl-1"
 msgstr "Neue &Textzelle\tCtrl-1"
 
-#: ../src/wxMaximaFrame.cpp:558
+#: ../src/wxMaximaFrame.cpp:557
 msgid "Insert Cell\tAlt-Shift-C"
 msgstr "Zellen einfügen\tAlt-Shift-C"
 
-#: ../src/wxMaxima.cpp:5642
+#: ../src/wxMaxima.cpp:5657
 msgid "Insert Image"
 msgstr "Bild einfügen"
 
-#: ../src/wxMaximaFrame.cpp:620
+#: ../src/wxMaximaFrame.cpp:619
 msgid "Insert Image..."
 msgstr "Bild einfügen ..."
 
-#: ../src/wxMaximaFrame.cpp:606
+#: ../src/wxMaximaFrame.cpp:605
 msgid "Insert Input &Cell"
 msgstr "Neue &Eingabezelle"
 
-#: ../src/wxMaximaFrame.cpp:618
+#: ../src/wxMaximaFrame.cpp:617
 msgid "Insert Page Break"
 msgstr "Seitenumbruch einfügen"
 
-#: ../src/wxMaximaFrame.cpp:614
+#: ../src/wxMaximaFrame.cpp:613
 msgid "Insert S&ubsection Cell\tCtrl-4"
 msgstr "Neue &Unterkapitelzelle\tCtrl-4"
 
-#: ../src/wxMaximaFrame.cpp:616
+#: ../src/wxMaximaFrame.cpp:615
 msgid "Insert S&ubsubsection Cell\tCtrl-5"
 msgstr "Neue &Unter-Unterkapitelzelle\tCtrl-5"
 
-#: ../src/MathCtrl.cpp:1015
+#: ../src/MathCtrl.cpp:1057
 msgid "Insert Section Cell"
 msgstr "Neue &Kapitelzelle"
 
-#: ../src/MathCtrl.cpp:1016
+#: ../src/MathCtrl.cpp:1058
 msgid "Insert Subsection Cell"
 msgstr "Neue &Unterkapitelzelle"
 
-#: ../src/MathCtrl.cpp:1017
+#: ../src/MathCtrl.cpp:1059
 msgid "Insert Subsubsection Cell"
 msgstr "Neue &Unter-Unterkapitelzelle"
 
-#: ../src/wxMaximaFrame.cpp:610
+#: ../src/wxMaximaFrame.cpp:609
 msgid "Insert T&itle Cell\tCtrl-2"
 msgstr "Neue T&itelzelle\tCtrl-2"
 
-#: ../src/MathCtrl.cpp:1013
+#: ../src/MathCtrl.cpp:1055
 msgid "Insert Text Cell"
 msgstr "Neue &Textzelle"
 
-#: ../src/MathCtrl.cpp:1014
+#: ../src/MathCtrl.cpp:1056
 msgid "Insert Title Cell"
 msgstr "Neue T&itelzelle"
 
-#: ../src/wxMaximaFrame.cpp:607
+#: ../src/wxMaximaFrame.cpp:606
 msgid "Insert a new input cell"
 msgstr "Neue Zelle für Eingabe einfügen"
 
-#: ../src/wxMaximaFrame.cpp:613
+#: ../src/wxMaximaFrame.cpp:612
 msgid "Insert a new section cell"
 msgstr "Neue Zelle für Kapitel einfügen"
 
-#: ../src/wxMaximaFrame.cpp:615
+#: ../src/wxMaximaFrame.cpp:614
 msgid "Insert a new subsection cell"
 msgstr "Neue Zelle für Unterkapitel einfügen"
 
-#: ../src/wxMaximaFrame.cpp:617
+#: ../src/wxMaximaFrame.cpp:616
 msgid "Insert a new subsubsection cell"
 msgstr "Neue Zelle für Unter-Unterkapitel einfügen"
 
-#: ../src/wxMaximaFrame.cpp:609
+#: ../src/wxMaximaFrame.cpp:608
 msgid "Insert a new text cell"
 msgstr "Neue Zelle für Text einfügen"
 
-#: ../src/wxMaximaFrame.cpp:611
+#: ../src/wxMaximaFrame.cpp:610
 msgid "Insert a new title cell"
 msgstr "Neue Zelle für Titel einfügen"
 
-#: ../src/wxMaximaFrame.cpp:619
+#: ../src/wxMaximaFrame.cpp:618
 msgid "Insert a page break"
 msgstr "Seitenumbruch einfügen"
 
-#: ../src/wxMaximaFrame.cpp:621
+#: ../src/wxMaximaFrame.cpp:620
 msgid "Insert image"
 msgstr "Bild einfügen"
 
@@ -2455,27 +2458,27 @@ msgstr "Zahlen und einzelne Buchstaben"
 msgid "Integral sign"
 msgstr "Integralzeichen"
 
-#: ../src/wxMaxima.cpp:3992
+#: ../src/wxMaxima.cpp:4004
 msgid "Integral/Sum:"
 msgstr "Integral/Summe:"
 
-#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4105 ../src/wxMaxima.cpp:5051
+#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4117 ../src/wxMaxima.cpp:5063
 msgid "Integrate"
 msgstr "Integrieren"
 
-#: ../src/wxMaxima.cpp:4091
+#: ../src/wxMaxima.cpp:4103
 msgid "Integrate (risch)"
 msgstr "Integrieren nach Risch"
 
-#: ../src/wxMaximaFrame.cpp:778
+#: ../src/wxMaximaFrame.cpp:777
 msgid "Integrate expression"
 msgstr "Ausdruck integrieren"
 
-#: ../src/wxMaximaFrame.cpp:780
+#: ../src/wxMaximaFrame.cpp:779
 msgid "Integrate expression with Risch algorithm"
 msgstr "Ausdruck mit Risch-Algorithmus integrieren"
 
-#: ../src/wxMaximaFrame.cpp:1224 ../src/MathCtrl.cpp:1000
+#: ../src/MathCtrl.cpp:1042 ../src/wxMaximaFrame.cpp:1223
 msgid "Integrate..."
 msgstr "Integrieren ..."
 
@@ -2483,7 +2486,7 @@ msgstr "Integrieren ..."
 msgid "Interrupt"
 msgstr "Unterbrechen"
 
-#: ../src/wxMaximaFrame.cpp:646 ../src/wxMaximaFrame.cpp:650
+#: ../src/wxMaximaFrame.cpp:645 ../src/wxMaximaFrame.cpp:649
 msgid "Interrupt current computation"
 msgstr "Auswertung abbrechen"
 
@@ -2505,15 +2508,15 @@ msgstr ""
 "\n"
 "Bitte geben Sie den Pfad für das Maxima-Programm erneut ein."
 
-#: ../src/wxMaxima.cpp:4137
+#: ../src/wxMaxima.cpp:4149
 msgid "Inverse Laplace"
 msgstr "Inverse Laplacetransformation"
 
-#: ../src/wxMaximaFrame.cpp:806
+#: ../src/wxMaximaFrame.cpp:805
 msgid "Inverse Laplace T&ransform..."
 msgstr "Inverse Laplacet&ransformation ..."
 
-#: ../src/wxMaximaFrame.cpp:1372
+#: ../src/wxMaximaFrame.cpp:1371
 msgid "Iota"
 msgstr "Iota"
 
@@ -2557,7 +2560,7 @@ msgstr "Japanisch"
 msgid "Kabyle"
 msgstr "Kabylisch"
 
-#: ../src/wxMaximaFrame.cpp:1373
+#: ../src/wxMaximaFrame.cpp:1372
 msgid "Kappa"
 msgstr "Kappa"
 
@@ -2566,7 +2569,7 @@ msgstr "Kappa"
 msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr "Zeige Prozentzeichen für spezielle Symbole: %e, %i, usw."
 
-#: ../src/wxMaxima.cpp:4031
+#: ../src/wxMaxima.cpp:4043
 msgid "LCM"
 msgstr "KGV"
 
@@ -2583,7 +2586,7 @@ msgstr ""
 msgid "Label width:"
 msgstr "Breite der Ein- und Ausgabemarken:"
 
-#: ../src/wxMaximaFrame.cpp:1374
+#: ../src/wxMaximaFrame.cpp:1373
 msgid "Lambda"
 msgstr "Lambda"
 
@@ -2595,11 +2598,11 @@ msgstr "Von wxMaxima verwendete Sprache."
 msgid "Language:"
 msgstr "Sprache:"
 
-#: ../src/wxMaxima.cpp:4120
+#: ../src/wxMaxima.cpp:4132
 msgid "Laplace"
 msgstr "Laplace"
 
-#: ../src/wxMaximaFrame.cpp:803
+#: ../src/wxMaximaFrame.cpp:802
 msgid "Laplace &Transform..."
 msgstr "Laplace &Transformation ..."
 
@@ -2607,15 +2610,15 @@ msgstr "Laplace &Transformation ..."
 msgid "Leads to"
 msgstr "Fürt zu"
 
-#: ../src/wxMaximaFrame.cpp:812
+#: ../src/wxMaximaFrame.cpp:811
 msgid "Least Common Multiple..."
 msgstr "KGV ..."
 
-#: ../src/wxMaxima.cpp:4809
+#: ../src/wxMaxima.cpp:4821
 msgid "Least Squares Fit"
 msgstr "Least-Squares-Fit"
 
-#: ../src/wxMaximaFrame.cpp:1266
+#: ../src/wxMaximaFrame.cpp:1265
 msgid "Least Squares Fit..."
 msgstr "Least-Squares-Fit ..."
 
@@ -2629,23 +2632,23 @@ msgstr ""
 "man jedem Verzeichnis aus zugreifen. Wo sich das Benutzerverzeichnis liegt, "
 "zeigt maxima, wenn man den Befehl maxima_userdir; eingibt. "
 
-#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4192
+#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4204
 msgid "Limit"
 msgstr "Grenzwert"
 
-#: ../src/wxMaximaFrame.cpp:1225
+#: ../src/wxMaximaFrame.cpp:1224
 msgid "Limit..."
 msgstr "Grenzwert ..."
 
-#: ../src/wxMaximaFrame.cpp:1265
+#: ../src/wxMaximaFrame.cpp:1264
 msgid "Linear Regression..."
 msgstr "Lineare Regression"
 
-#: ../src/wxMaxima.cpp:3803
+#: ../src/wxMaxima.cpp:3815
 msgid "List(s):"
 msgstr "Liste(n):"
 
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3848
 msgid "List:"
 msgstr "Liste:"
 
@@ -2653,15 +2656,15 @@ msgstr "Liste:"
 msgid "Load"
 msgstr "Laden"
 
-#: ../src/wxMaxima.cpp:2932
+#: ../src/wxMaxima.cpp:2940
 msgid "Load Package"
 msgstr "Paket laden"
 
-#: ../src/wxMaximaFrame.cpp:479
+#: ../src/wxMaximaFrame.cpp:478
 msgid "Load a Maxima file using the batch command"
 msgstr "Eine Maxima Batch-Datei laden"
 
-#: ../src/wxMaximaFrame.cpp:477
+#: ../src/wxMaximaFrame.cpp:476
 msgid "Load a Maxima package file"
 msgstr "Ein Maxima Paket laden"
 
@@ -2673,47 +2676,47 @@ msgstr "Lade Layout aus einer Datei"
 msgid "Long Right arrow"
 msgstr "Langer Pfeil nach rechts"
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Lower bound:"
 msgstr "untere Schranke:"
 
-#: ../src/wxMaximaFrame.cpp:771
+#: ../src/wxMaximaFrame.cpp:770
 msgid "Ma&p to Matrix..."
 msgstr "Auf &Matrix abbilden ..."
 
-#: ../src/wxMaximaFrame.cpp:547
+#: ../src/wxMaximaFrame.cpp:546
 msgid "Main Toolbar\tAlt-Shift-B"
 msgstr "Hauptsymbolleiste\tAlt-Shift-B"
 
-#: ../src/wxMaximaFrame.cpp:765
+#: ../src/wxMaximaFrame.cpp:764
 msgid "Make &List..."
 msgstr "&Liste erzeugen ..."
 
-#: ../src/wxMaxima.cpp:3821
+#: ../src/wxMaxima.cpp:3833
 msgid "Make list"
 msgstr "Eine Liste erzeugen"
 
-#: ../src/wxMaximaFrame.cpp:766
+#: ../src/wxMaximaFrame.cpp:765
 msgid "Make list from expression"
 msgstr "Liste aus einem Ausdruck erzeugen"
 
-#: ../src/wxMaximaFrame.cpp:907
+#: ../src/wxMaximaFrame.cpp:906
 msgid "Make substitution in expression"
 msgstr "Substitution in einem Ausdruck ausführen"
 
-#: ../src/wxMaximaFrame.cpp:682
+#: ../src/wxMaximaFrame.cpp:681
 msgid "Manually Trigger Evaluation"
 msgstr "Manueller Neubeginn des Evaluierens ."
 
-#: ../src/wxMaxima.cpp:3805
+#: ../src/wxMaxima.cpp:3817
 msgid "Map"
 msgstr "Auf Liste abbilden"
 
-#: ../src/wxMaximaFrame.cpp:770
+#: ../src/wxMaximaFrame.cpp:769
 msgid "Map function to a list"
 msgstr "Eine Funktion auf Elemente einer Liste anwenden"
 
-#: ../src/wxMaximaFrame.cpp:772
+#: ../src/wxMaximaFrame.cpp:771
 msgid "Map function to a matrix"
 msgstr "Eine Funktion auf Elemente einer Matrix anwenden"
 
@@ -2729,23 +2732,23 @@ msgstr "Automatisch passende Klammern erzeugen"
 msgid "Math font:"
 msgstr "Math. Schriftart:"
 
-#: ../src/wxMaximaFrame.cpp:374
+#: ../src/wxMaximaFrame.cpp:373
 msgid "Mathematical Symbols"
 msgstr "Mathematische Symbole"
 
-#: ../src/wxMaxima.cpp:3716
+#: ../src/wxMaxima.cpp:3728
 msgid "Matrix"
 msgstr "Matrix"
 
-#: ../src/wxMaxima.cpp:3702
+#: ../src/wxMaxima.cpp:3714
 msgid "Matrix map"
 msgstr "Auf Matrix abbilden"
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Matrix name:"
 msgstr "Matrix Name:"
 
-#: ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3749
+#: ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3761
 msgid "Matrix:"
 msgstr "Matrix"
 
@@ -2753,7 +2756,7 @@ msgstr "Matrix"
 msgid "Maxima"
 msgstr "Maxima"
 
-#: ../src/wxMaximaFrame.cpp:137
+#: ../src/wxMaximaFrame.cpp:136
 msgid "Maxima has a question"
 msgstr "Maxima hat eine Frage."
 
@@ -2761,23 +2764,23 @@ msgstr "Maxima hat eine Frage."
 msgid "Maxima input"
 msgstr "Maxima Eingabe"
 
-#: ../src/wxMaximaFrame.cpp:166
+#: ../src/wxMaximaFrame.cpp:165
 msgid "Maxima is calculating"
 msgstr "Maxima ist beim Rechnen"
 
-#: ../src/wxMaximaFrame.cpp:111
+#: ../src/wxMaximaFrame.cpp:110
 msgid "Maxima is ready for input."
 msgstr "Maxima ist bereit."
 
-#: ../src/wxMaxima.cpp:2945
+#: ../src/wxMaxima.cpp:2953
 msgid "Maxima package (*.mac)|*.mac"
 msgstr "Maxima Paket (*.mac)|*.mac"
 
-#: ../src/wxMaxima.cpp:2934
+#: ../src/wxMaxima.cpp:2942
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr "Maxima Paket (*.mac)|*.mac|Lisp Paket (*.lisp)|*.lisp|Alle|*"
 
-#: ../src/wxMaxima.cpp:1014
+#: ../src/wxMaxima.cpp:1019
 msgid "Maxima process terminated."
 msgstr "Maxima wurde beendet."
 
@@ -2789,7 +2792,7 @@ msgstr "Maxima-Programm:"
 msgid "Maxima questions"
 msgstr "Maxima Fragen"
 
-#: ../src/wxMaxima.cpp:942
+#: ../src/wxMaxima.cpp:947
 msgid "Maxima started. Waiting for connection..."
 msgstr "Maxima gestartet. Warte auf Verbindung ..."
 
@@ -2823,7 +2826,7 @@ msgstr ""
 "Variable 'a' den Wert 3 mit 'a : 3'. Der Operator ':=' definiert "
 "Funktionen,  z. B. 'f(x) := x^2'."
 
-#: ../src/wxMaxima.cpp:4597
+#: ../src/wxMaxima.cpp:4609
 msgid "Maxima version: "
 msgstr "Maxima Version: "
 
@@ -2881,39 +2884,39 @@ msgstr ""
 msgid "Maximum displayed number of digits:"
 msgstr "Maximale angezeigte Zahl an Stellen"
 
-#: ../src/wxMaximaFrame.cpp:1263
+#: ../src/wxMaximaFrame.cpp:1262
 msgid "Mean Difference Test..."
 msgstr "Zweistichprobentest ..."
 
-#: ../src/wxMaximaFrame.cpp:1262
+#: ../src/wxMaximaFrame.cpp:1261
 msgid "Mean Test..."
 msgstr "Mittelwerttest ..."
 
-#: ../src/wxMaximaFrame.cpp:1255
+#: ../src/wxMaximaFrame.cpp:1254
 msgid "Mean..."
 msgstr "Mittelwerttest ..."
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Mean:"
 msgstr "Mittelwert:"
 
-#: ../src/wxMaximaFrame.cpp:1256
+#: ../src/wxMaximaFrame.cpp:1255
 msgid "Median..."
 msgstr "Median"
 
-#: ../src/MathCtrl.cpp:945
+#: ../src/MathCtrl.cpp:987
 msgid "Merge Cells"
 msgstr "Zellen verbinden"
 
-#: ../src/wxMaximaFrame.cpp:633
+#: ../src/wxMaximaFrame.cpp:632
 msgid "Merge Cells\tCtrl-M"
 msgstr "Zellen verbinden\tCtrl-M"
 
-#: ../src/wxMaximaFrame.cpp:634
+#: ../src/wxMaximaFrame.cpp:633
 msgid "Merge the text from two input cells into one"
 msgstr "Verbinde die markierten Eingabezellen zu einer"
 
-#: ../src/wxMaxima.cpp:2668
+#: ../src/wxMaxima.cpp:2676
 msgid "Message from the stdout of Maxima: "
 msgstr "Nachricht vom stdout von wxMaxima: "
 
@@ -2921,19 +2924,19 @@ msgstr "Nachricht vom stdout von wxMaxima: "
 msgid "Method:"
 msgstr "Methode:"
 
-#: ../src/wxMaxima.cpp:5289
+#: ../src/wxMaxima.cpp:5301
 msgid "Mismatched parenthesis"
 msgstr "Nicht-zusammengehörige Klammern"
 
-#: ../src/wxMaxima.cpp:3972
+#: ../src/wxMaxima.cpp:3984
 msgid "Modulus"
 msgstr "Modulo"
 
-#: ../src/wxMaximaFrame.cpp:1375
+#: ../src/wxMaximaFrame.cpp:1374
 msgid "Mu"
 msgstr "My"
 
-#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Name:"
 msgstr "Name:"
 
@@ -2941,7 +2944,7 @@ msgstr "Name:"
 msgid "New"
 msgstr "Neu"
 
-#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
+#: ../src/wxMaximaFrame.cpp:456 ../src/wxMaximaFrame.cpp:459
 msgid "New\tCtrl-N"
 msgstr "Neu\tCtrl-N"
 
@@ -2957,11 +2960,11 @@ msgstr "Neue Zeilen: Springe zum Text"
 msgid "New value:"
 msgstr "Neuer Wert:"
 
-#: ../src/wxMaxima.cpp:3993 ../src/wxMaxima.cpp:4119 ../src/wxMaxima.cpp:4136
+#: ../src/wxMaxima.cpp:4005 ../src/wxMaxima.cpp:4131 ../src/wxMaxima.cpp:4148
 msgid "New variable:"
 msgstr "Parameter:"
 
-#: ../src/wxMaximaFrame.cpp:630
+#: ../src/wxMaximaFrame.cpp:629
 msgid "Next Command\tAlt-Down"
 msgstr "Nächster Befehl\tAlt-Herunter"
 
@@ -2969,15 +2972,15 @@ msgstr "Nächster Befehl\tAlt-Herunter"
 msgid "No"
 msgstr "Nein"
 
-#: ../src/wxMaxima.cpp:5362
+#: ../src/wxMaxima.cpp:5378
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr "Kein Dollarzeichen ($) oder Semikolon (;) am Ende eines Befehls"
 
-#: ../src/wxMaxima.cpp:3249 ../src/wxMaxima.cpp:3271
+#: ../src/wxMaxima.cpp:3260 ../src/wxMaxima.cpp:3283
 msgid "No matches found!"
 msgstr "Keine Übereinstimmung gefunden!"
 
-#: ../src/wxMaximaFrame.cpp:1264
+#: ../src/wxMaximaFrame.cpp:1263
 msgid "Normality Test..."
 msgstr "Test Normalverteilung"
 
@@ -3007,31 +3010,31 @@ msgstr ""
 msgid "Norwegian"
 msgstr "Norwegisch"
 
-#: ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:3740
 msgid "Not a valid matrix dimension!"
 msgstr "Keine gültige Dimension einer Matrix!"
 
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629
 msgid "Not a valid number of equations!"
 msgstr "Keine gültige Anzahl an Gleichungen!"
 
-#: ../src/wxMaximaFrame.cpp:197
+#: ../src/wxMaximaFrame.cpp:196
 msgid "Not connected to maxima"
 msgstr "Nicht mit Maxima verbunden"
 
-#: ../src/wxMaxima.cpp:4599
+#: ../src/wxMaxima.cpp:4611
 msgid "Not connected."
 msgstr "Nicht verbunden."
 
-#: ../src/wxMaximaFrame.cpp:1376
+#: ../src/wxMaximaFrame.cpp:1375
 msgid "Nu"
 msgstr "Ny"
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Num. deg:"
 msgstr "Grad Zähler:"
 
-#: ../src/wxMaxima.cpp:3585 ../src/wxMaxima.cpp:3609
+#: ../src/wxMaxima.cpp:3597 ../src/wxMaxima.cpp:3621
 msgid "Number of equations:"
 msgstr "Anzahl Gleichungen:"
 
@@ -3058,15 +3061,15 @@ msgstr "OK"
 msgid "Old value:"
 msgstr "Alter Wert:"
 
-#: ../src/wxMaxima.cpp:3992 ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135
+#: ../src/wxMaxima.cpp:4004 ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147
 msgid "Old variable:"
 msgstr "Variable:"
 
-#: ../src/wxMaximaFrame.cpp:1387
+#: ../src/wxMaximaFrame.cpp:1386
 msgid "Omega"
 msgstr "Omega"
 
-#: ../src/wxMaximaFrame.cpp:1378
+#: ../src/wxMaximaFrame.cpp:1377
 msgid "Omicron"
 msgstr "Omikron"
 
@@ -3086,20 +3089,20 @@ msgstr ""
 "Häkchen bei dieser Option gesetzt ist, wird sie auf den Bildschirm "
 "ausgegeben."
 
-#: ../src/wxMaxima.cpp:4763
+#: ../src/wxMaxima.cpp:4775
 msgid "One sample t-test"
 msgstr "Einstichproben t-Test"
 
-#: ../src/wxMaximaFrame.cpp:971
+#: ../src/wxMaximaFrame.cpp:970
 msgid "Online tutorials"
 msgstr "Online Tutorials"
 
 #: ../src/ConfigDialogue.cpp:656 ../src/main.cpp:347 ../src/ToolBar.cpp:119
-#: ../src/wxMaxima.cpp:2797
+#: ../src/wxMaxima.cpp:2805
 msgid "Open"
 msgstr "Öffnen"
 
-#: ../src/wxMaximaFrame.cpp:466
+#: ../src/wxMaximaFrame.cpp:465
 msgid "Open Recent"
 msgstr "Zuletzt geöffnet"
 
@@ -3107,11 +3110,11 @@ msgstr "Zuletzt geöffnet"
 msgid "Open a cell when Maxima expects input"
 msgstr "Öffne eine Zelle, wenn Maxima eine Eingabe erwartet"
 
-#: ../src/wxMaximaFrame.cpp:464
+#: ../src/wxMaximaFrame.cpp:463
 msgid "Open a document"
 msgstr "Dokument öffnen"
 
-#: ../src/wxMaximaFrame.cpp:458 ../src/wxMaximaFrame.cpp:461
+#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
 msgid "Open a new window"
 msgstr "Neues Fenster öffnen"
 
@@ -3119,11 +3122,11 @@ msgstr "Neues Fenster öffnen"
 msgid "Open document"
 msgstr "Dokument öffnen"
 
-#: ../src/wxMaxima.cpp:4824
+#: ../src/wxMaxima.cpp:4836
 msgid "Open matrix"
 msgstr "Matrix laden"
 
-#: ../src/wxMaxima.cpp:1446 ../src/wxMaxima.cpp:1518
+#: ../src/wxMaxima.cpp:1451 ../src/wxMaxima.cpp:1523
 msgid "Opening file"
 msgstr "Öffne Datei"
 
@@ -3147,11 +3150,11 @@ msgstr "Ungültige Zellen"
 msgid "Output labels"
 msgstr "Ausgabemarken"
 
-#: ../src/wxMaximaFrame.cpp:796
+#: ../src/wxMaximaFrame.cpp:795
 msgid "P&ade Approximation..."
 msgstr "P&ade-Approximation ..."
 
-#: ../src/wxMaxima.cpp:3132 ../src/wxMaxima.cpp:5133
+#: ../src/wxMaxima.cpp:3141 ../src/wxMaxima.cpp:5145
 msgid ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
 "bmp|Portable animap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X "
@@ -3161,15 +3164,15 @@ msgstr ""
 "Portable animap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X-"
 "Bixmap (*.xpm)|*.xpm"
 
-#: ../src/wxMaxima.cpp:4012
+#: ../src/wxMaxima.cpp:4024
 msgid "Pade approximation"
 msgstr "Pade-Approximation"
 
-#: ../src/wxMaximaFrame.cpp:797
+#: ../src/wxMaximaFrame.cpp:796
 msgid "Pade approximation of a Taylor series"
 msgstr "Pade-Approximation einer Taylorreihe"
 
-#: ../src/wxMaximaFrame.cpp:1500
+#: ../src/wxMaximaFrame.cpp:1519
 msgid "Pagebreak"
 msgstr "Seitenumbruch"
 
@@ -3181,19 +3184,19 @@ msgstr "Parallel"
 msgid "Parametric plot"
 msgstr "Parametrischer Plot"
 
-#: ../src/wxMaximaFrame.cpp:188
+#: ../src/wxMaximaFrame.cpp:187
 msgid "Parsing output"
 msgstr "Ausgabe analysieren"
 
-#: ../src/wxMaximaFrame.cpp:819
+#: ../src/wxMaximaFrame.cpp:818
 msgid "Partial &Fractions..."
 msgstr "Partialbruch&zerlegung ..."
 
-#: ../src/wxMaxima.cpp:4076
+#: ../src/wxMaxima.cpp:4088
 msgid "Partial fractions"
 msgstr "Partialbruchzerlegung"
 
-#: ../src/wxMaxima.cpp:1769
+#: ../src/wxMaxima.cpp:1774
 msgid "Parts of the document will not be loaded correctly!"
 msgstr "Teile des Dokuments werden nicht korrekt geladen!"
 
@@ -3205,11 +3208,11 @@ msgstr ""
 "Teile des Dokuments werden nicht korrekt geladen:\n"
 "Unbekanntes XML-Tag gefunden mit dem Name "
 
-#: ../src/ToolBar.cpp:143 ../src/MathCtrl.cpp:1010 ../src/MathCtrl.cpp:1025
+#: ../src/MathCtrl.cpp:1052 ../src/MathCtrl.cpp:1067 ../src/ToolBar.cpp:143
 msgid "Paste"
 msgstr "Einfügen"
 
-#: ../src/wxMaximaFrame.cpp:518
+#: ../src/wxMaximaFrame.cpp:517
 msgid "Paste\tCtrl-V"
 msgstr "Einfügen\tCtrl-V"
 
@@ -3217,7 +3220,7 @@ msgstr "Einfügen\tCtrl-V"
 msgid "Paste from clipboard"
 msgstr "Aus Zwischenablage einfügen"
 
-#: ../src/wxMaximaFrame.cpp:519
+#: ../src/wxMaximaFrame.cpp:518
 msgid "Paste text from clipboard"
 msgstr "Text aus Zwischenablage einfügen"
 
@@ -3225,19 +3228,19 @@ msgstr "Text aus Zwischenablage einfügen"
 msgid "Perpendicular to"
 msgstr "Senkrecht"
 
-#: ../src/wxMaximaFrame.cpp:1384
+#: ../src/wxMaximaFrame.cpp:1383
 msgid "Phi"
 msgstr "Phi"
 
-#: ../src/wxMaximaFrame.cpp:1379
+#: ../src/wxMaximaFrame.cpp:1378
 msgid "Pi"
 msgstr "Pi"
 
-#: ../src/wxMaximaFrame.cpp:1273
+#: ../src/wxMaximaFrame.cpp:1272
 msgid "Piechart..."
 msgstr "Kreisdiagramm"
 
-#: ../src/wxMaxima.cpp:1952
+#: ../src/wxMaxima.cpp:1957
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr "Bitte konfigurieren Sie wxMaxima mit 'Bearbeiten->Einstellungen'."
 
@@ -3245,52 +3248,52 @@ msgstr "Bitte konfigurieren Sie wxMaxima mit 'Bearbeiten->Einstellungen'."
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr "Bitte starten Sie wxMaxima neu, um die Änderungen zu aktivieren!"
 
-#: ../src/wxMaximaFrame.cpp:923
+#: ../src/wxMaximaFrame.cpp:922
 msgid "Plot &2d..."
 msgstr "Plot &2D ..."
 
-#: ../src/wxMaximaFrame.cpp:925
+#: ../src/wxMaximaFrame.cpp:924
 msgid "Plot &3d..."
 msgstr "Plot &3D ..."
 
-#: ../src/wxMaximaFrame.cpp:927
+#: ../src/wxMaximaFrame.cpp:926
 msgid "Plot &Format..."
 msgstr "Plot &Format ..."
 
 #: ../src/Plot2dWiz.cpp:104 ../src/Plot2dWiz.cpp:450 ../src/Plot2dWiz.cpp:464
-#: ../src/wxMaxima.cpp:4283 ../src/wxMaxima.cpp:5102
+#: ../src/wxMaxima.cpp:4295 ../src/wxMaxima.cpp:5114
 msgid "Plot 2D"
 msgstr "2D Plotten"
 
-#: ../src/wxMaximaFrame.cpp:1227
+#: ../src/wxMaximaFrame.cpp:1226
 msgid "Plot 2D..."
 msgstr "2D Plotten ..."
 
-#: ../src/MathCtrl.cpp:1003
+#: ../src/MathCtrl.cpp:1045
 msgid "Plot 2d..."
 msgstr "2D Plotten ..."
 
-#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4269 ../src/wxMaxima.cpp:5115
+#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4281 ../src/wxMaxima.cpp:5127
 msgid "Plot 3D"
 msgstr "3D Plotten"
 
-#: ../src/wxMaximaFrame.cpp:1228
+#: ../src/wxMaximaFrame.cpp:1227
 msgid "Plot 3D..."
 msgstr "3D Plotten ..."
 
-#: ../src/MathCtrl.cpp:1004
+#: ../src/MathCtrl.cpp:1046
 msgid "Plot 3d..."
 msgstr "3D Plotten ..."
 
-#: ../src/wxMaxima.cpp:4296
+#: ../src/wxMaxima.cpp:4308
 msgid "Plot format"
 msgstr "Plot-Format"
 
-#: ../src/wxMaximaFrame.cpp:924
+#: ../src/wxMaximaFrame.cpp:923
 msgid "Plot in 2 dimensions"
 msgstr "In zwei Dimensionen plotten"
 
-#: ../src/wxMaximaFrame.cpp:926
+#: ../src/wxMaximaFrame.cpp:925
 msgid "Plot in 3 dimensions"
 msgstr "In drei Dimensionen plotten"
 
@@ -3299,8 +3302,8 @@ msgid "Plot to file:"
 msgstr "Plot in Datei:"
 
 #: ../src/BC2Wiz.cpp:30 ../src/BC2Wiz.cpp:36 ../src/LimitWiz.cpp:33
-#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
-#: ../src/wxMaxima.cpp:3648
+#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
+#: ../src/wxMaxima.cpp:3660
 msgid "Point:"
 msgstr "Punkt:"
 
@@ -3308,11 +3311,11 @@ msgstr "Punkt:"
 msgid "Polish"
 msgstr "Polnisch"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 1:"
 msgstr "Polynom 1:"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 2:"
 msgstr "Polynom 2:"
 
@@ -3324,11 +3327,11 @@ msgstr "Portugiesisch (Brasilien)"
 msgid "Postscript file (*.eps)|*.eps|All|*"
 msgstr "Postscript-Datei (*.eps)|*.eps|Alle|*"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Precision"
 msgstr "Genauigkeit"
 
-#: ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:536
 msgid "Preferences...\tCtrl+,"
 msgstr "Einstellungen...\tCtrl+,"
 
@@ -3344,7 +3347,7 @@ msgstr ""
 "informiert ist, sondern auch die von externen Paketen nachgeladenen Befehle "
 "in Erfahrung bringt sowie die im aktuellen Arbeitsblatt definierten."
 
-#: ../src/wxMaximaFrame.cpp:628
+#: ../src/wxMaximaFrame.cpp:627
 msgid "Previous Command\tAlt-Up"
 msgstr "Vorheriger Befehl\tAlt-Hoch"
 
@@ -3352,11 +3355,11 @@ msgstr "Vorheriger Befehl\tAlt-Hoch"
 msgid "Print"
 msgstr "Drucken"
 
-#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:484
+#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:483
 msgid "Print document"
 msgstr "Dokument drucken"
 
-#: ../src/wxMaxima.cpp:4242
+#: ../src/wxMaxima.cpp:4254
 msgid "Product"
 msgstr "Produkt"
 
@@ -3364,35 +3367,35 @@ msgstr "Produkt"
 msgid "Product sign"
 msgstr "Produktzeichen"
 
-#: ../src/wxMaximaFrame.cpp:1386
+#: ../src/wxMaximaFrame.cpp:1385
 msgid "Psi"
 msgstr "Psi"
 
-#: ../src/wxMaximaFrame.cpp:331
+#: ../src/wxMaximaFrame.cpp:330
 msgid "Raw XML monitor"
 msgstr "XML-Anzeige"
 
-#: ../src/wxMaximaFrame.cpp:592
+#: ../src/wxMaximaFrame.cpp:591
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr "Alle Zellen des Dokuments auswerten, die über dem Cursor stehen"
 
-#: ../src/wxMaximaFrame.cpp:1278
+#: ../src/wxMaximaFrame.cpp:1277
 msgid "Read Matrix..."
 msgstr "Matrix laden ..."
 
-#: ../src/wxMaximaFrame.cpp:177
+#: ../src/wxMaximaFrame.cpp:176
 msgid "Reading Maxima output"
 msgstr "Die Ausgabe von Maxima wird gelesen"
 
-#: ../src/wxMaximaFrame.cpp:153
+#: ../src/wxMaximaFrame.cpp:152
 msgid "Ready for user input"
 msgstr "Bereit für Benutzereingabe"
 
-#: ../src/wxMaximaFrame.cpp:631
+#: ../src/wxMaximaFrame.cpp:630
 msgid "Recall next command from history"
 msgstr "Wiederhole nächsten Befehl der Historie."
 
-#: ../src/wxMaximaFrame.cpp:629
+#: ../src/wxMaximaFrame.cpp:628
 msgid "Recall previous command from history"
 msgstr "Wiederhole vorherigen Befehl der Historie."
 
@@ -3400,35 +3403,35 @@ msgstr "Wiederhole vorherigen Befehl der Historie."
 msgid "Recent files list length:"
 msgstr "Länge der Liste zuletzt geöffneter Dateien"
 
-#: ../src/wxMaximaFrame.cpp:1215
+#: ../src/wxMaximaFrame.cpp:1214
 msgid "Rectform"
 msgstr "Rectform"
 
-#: ../src/wxMaximaFrame.cpp:495
+#: ../src/wxMaximaFrame.cpp:494
 msgid "Redo\tCtrl-Y"
 msgstr "&Erneut\tCtrl-Y"
 
-#: ../src/wxMaximaFrame.cpp:496
+#: ../src/wxMaximaFrame.cpp:495
 msgid "Redo last change"
 msgstr "Letzte Änderung erneut durchführen"
 
-#: ../src/wxMaximaFrame.cpp:1220
+#: ../src/wxMaximaFrame.cpp:1219
 msgid "Reduce (tr)"
 msgstr "Trigreduce"
 
-#: ../src/wxMaximaFrame.cpp:871
+#: ../src/wxMaximaFrame.cpp:870
 msgid "Reduce trigonometric expression"
 msgstr "Versucht den Grad von trigonometrischen Ausdrücken zu veringern"
 
-#: ../src/wxMaxima.cpp:622 ../src/wxMaxima.cpp:5495
+#: ../src/wxMaxima.cpp:627 ../src/wxMaxima.cpp:5511
 msgid "Refusing to send cell to maxima: "
 msgstr "Weigere mich, die Zelle an Maxima zu senden: "
 
-#: ../src/wxMaximaFrame.cpp:594
+#: ../src/wxMaximaFrame.cpp:593
 msgid "Remove All Output"
 msgstr "Lösche alle Ausgaben"
 
-#: ../src/wxMaximaFrame.cpp:595
+#: ../src/wxMaximaFrame.cpp:594
 msgid "Remove output from input cells"
 msgstr "Lösche alle Ergebnisse der Eingabezellen"
 
@@ -3436,7 +3439,7 @@ msgstr "Lösche alle Ergebnisse der Eingabezellen"
 msgid "Replace All"
 msgstr "Alles ersetzen"
 
-#: ../src/wxMaxima.cpp:3282
+#: ../src/wxMaxima.cpp:3294
 #, c-format
 msgid "Replaced %d occurrences."
 msgstr "%d Ersetzungen ausgeführt."
@@ -3445,11 +3448,11 @@ msgstr "%d Ersetzungen ausgeführt."
 msgid "Replacement:"
 msgstr "Ersatz:"
 
-#: ../src/wxMaximaFrame.cpp:976
+#: ../src/wxMaximaFrame.cpp:975
 msgid "Report bug"
 msgstr "Einen Maxima-Fehler berichten"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "Restart Maxima"
 msgstr "Maxima wird neu gestartet"
 
@@ -3457,7 +3460,7 @@ msgstr "Maxima wird neu gestartet"
 msgid "Restart maxima"
 msgstr "Neustart von Maxima"
 
-#: ../src/MathCtrl.cpp:4442
+#: ../src/MathCtrl.cpp:4497
 msgid "Result"
 msgstr "Resultat"
 
@@ -3465,7 +3468,7 @@ msgstr "Resultat"
 msgid "Return to the cell that is currently being evaluated"
 msgstr "Zurückscrollen zu der Zelle, die derzeit evaluiert wird"
 
-#: ../src/wxMaximaFrame.cpp:1380
+#: ../src/wxMaximaFrame.cpp:1379
 msgid "Rho"
 msgstr "Rho"
 
@@ -3473,19 +3476,19 @@ msgstr "Rho"
 msgid "Right arrow"
 msgstr "Pfeil nach rechts"
 
-#: ../src/wxMaximaFrame.cpp:779
+#: ../src/wxMaximaFrame.cpp:778
 msgid "Risch Integration..."
 msgstr "Integrieren (Ri&sch) ..."
 
-#: ../src/wxMaximaFrame.cpp:694
+#: ../src/wxMaximaFrame.cpp:693
 msgid "Roots of &Polynomial"
 msgstr "Nullstellen eines &Polynoms"
 
-#: ../src/wxMaximaFrame.cpp:697
+#: ../src/wxMaximaFrame.cpp:696
 msgid "Roots of Polynomial (bfloat)"
 msgstr "Nullstellen eines Polynoms (bfloat)"
 
-#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Rows:"
 msgstr "Zeilen:"
 
@@ -3493,56 +3496,56 @@ msgstr "Zeilen:"
 msgid "Russian"
 msgstr "Russisch"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 1:"
 msgstr "Probe 1:"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 2:"
 msgstr "Probe 2:"
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Sample:"
 msgstr "Probe:"
 
 #: ../src/ConfigDialogue.cpp:781 ../src/ToolBar.cpp:122
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Save"
 msgstr "Speichern"
 
-#: ../src/MathCtrl.cpp:921
+#: ../src/MathCtrl.cpp:963
 msgid "Save Animation..."
 msgstr "Speichere Animation ..."
 
-#: ../src/wxMaxima.cpp:2565
+#: ../src/wxMaxima.cpp:2572
 msgid "Save As"
 msgstr "Speichern als"
 
-#: ../src/wxMaximaFrame.cpp:474
+#: ../src/wxMaximaFrame.cpp:473
 msgid "Save As...\tShift-Ctrl-S"
 msgstr "Speichern als ...\tShift-Ctrl-S"
 
-#: ../src/MathCtrl.cpp:919
+#: ../src/MathCtrl.cpp:961
 msgid "Save Image..."
 msgstr "Bild speichern ..."
 
-#: ../src/wxMaxima.cpp:3130
+#: ../src/wxMaxima.cpp:3139
 msgid "Save Selection to Image"
 msgstr "Auswahl als Bild speichern"
 
-#: ../src/wxMaximaFrame.cpp:528
+#: ../src/wxMaximaFrame.cpp:527
 msgid "Save Selection to Image..."
 msgstr "Auswahl als Bild speichern ..."
 
-#: ../src/wxMaxima.cpp:5150
+#: ../src/wxMaxima.cpp:5162
 msgid "Save animation to file"
 msgstr "Sichere Animation in Datei"
 
-#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:473
+#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:472
 msgid "Save document"
 msgstr "Dokument speichern"
 
-#: ../src/wxMaximaFrame.cpp:475
+#: ../src/wxMaximaFrame.cpp:474
 msgid "Save document as"
 msgstr "Dokument speichern als"
 
@@ -3566,11 +3569,11 @@ msgstr "Layout der Werkzeugleisten zwischen Sitzungen sichern"
 msgid "Save plot to file"
 msgstr "Plot in Datei speichern"
 
-#: ../src/wxMaximaFrame.cpp:529
+#: ../src/wxMaximaFrame.cpp:528
 msgid "Save selection from document to an image file"
 msgstr "Auswahl des Dokumentes in Bild-Datei speichern"
 
-#: ../src/wxMaxima.cpp:5131
+#: ../src/wxMaxima.cpp:5143
 msgid "Save selection to file"
 msgstr "Auswahl in eine Datei speichern"
 
@@ -3586,27 +3589,27 @@ msgstr "Ort und Größe des wxMaxima-Fensters speichern"
 msgid "Save wxMaxima window size/position between sessions."
 msgstr "Ort und Größe des wxMaxima-Fensters zwischen Sitzungen speichern"
 
-#: ../src/wxMaximaFrame.cpp:246
+#: ../src/wxMaximaFrame.cpp:245
 msgid "Saving failed."
 msgstr "Das Speichern ist fehlgeschlagen"
 
-#: ../src/wxMaximaFrame.cpp:222
+#: ../src/wxMaximaFrame.cpp:221
 msgid "Saving successful."
 msgstr "Das Speichern war erfolgreich."
 
-#: ../src/wxMaximaFrame.cpp:212
+#: ../src/wxMaximaFrame.cpp:211
 msgid "Saving..."
 msgstr "Speichere..."
 
-#: ../src/wxMaxima.cpp:4699
+#: ../src/wxMaxima.cpp:4711
 msgid "Scatterplot"
 msgstr "Streudiagramm"
 
-#: ../src/wxMaximaFrame.cpp:1271
+#: ../src/wxMaximaFrame.cpp:1270
 msgid "Scatterplot..."
 msgstr "Streudiagramm ..."
 
-#: ../src/wxMaximaFrame.cpp:1498
+#: ../src/wxMaximaFrame.cpp:1517
 msgid "Section"
 msgstr "Kapitel"
 
@@ -3614,8 +3617,8 @@ msgstr "Kapitel"
 msgid "Section cell"
 msgstr "Kapitelzelle"
 
-#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:292 ../src/TextCell.cpp:306
-#: ../src/TextCell.cpp:322 ../src/TextCell.cpp:334
+#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:290 ../src/TextCell.cpp:304
+#: ../src/TextCell.cpp:320 ../src/TextCell.cpp:332
 msgid ""
 "Seems like something is broken with a font. Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
@@ -3626,7 +3629,7 @@ msgstr ""
 "darauffolgendem Anklicken von \"Benutze jsMath-Zeichensätze\" in der "
 "Konfiguration sollte das Problem beheben."
 
-#: ../src/TextCell.cpp:139
+#: ../src/TextCell.cpp:137
 msgid ""
 "Seems like something is broken with the maths font. Installing http://www."
 "math.union.edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use "
@@ -3637,11 +3640,11 @@ msgstr ""
 "fonts.html mit darauffolgendem Anklicken von \"Benutze jsMath-Zeichensätze\" "
 "in der Konfiguration sollte das Problem beheben."
 
-#: ../src/MathCtrl.cpp:1011 ../src/MathCtrl.cpp:1027
+#: ../src/MathCtrl.cpp:1053 ../src/MathCtrl.cpp:1069
 msgid "Select All"
 msgstr "Alles auswählen"
 
-#: ../src/wxMaximaFrame.cpp:525
+#: ../src/wxMaximaFrame.cpp:524
 msgid "Select All\tCtrl-A"
 msgstr "Alles auswählen\tCtrl-A"
 
@@ -3649,7 +3652,7 @@ msgstr "Alles auswählen\tCtrl-A"
 msgid "Select Maxima program"
 msgstr "Maxima-Programm auswählen"
 
-#: ../src/wxMaxima.cpp:4860
+#: ../src/wxMaxima.cpp:4872
 msgid "Select Subsample"
 msgstr "Wähle Teilstichprobe"
 
@@ -3658,11 +3661,11 @@ msgstr "Wähle Teilstichprobe"
 msgid "Select a constant"
 msgstr "Eine Konstante auswählen:"
 
-#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:526
+#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:525
 msgid "Select all"
 msgstr "Alles auswählen"
 
-#: ../src/wxMaxima.cpp:3319
+#: ../src/wxMaxima.cpp:3331
 msgid "Select math display algorithm"
 msgstr "Algorithmus zum Anzeigen von Formeln auswählen"
 
@@ -3679,23 +3682,23 @@ msgstr ""
 msgid "Selection"
 msgstr "Auswahl"
 
-#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4178
+#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4190
 msgid "Series"
 msgstr "Reihen"
 
-#: ../src/wxMaximaFrame.cpp:1226
+#: ../src/wxMaximaFrame.cpp:1225
 msgid "Series..."
 msgstr "Reihen ..."
 
-#: ../src/wxMaxima.cpp:863
+#: ../src/wxMaxima.cpp:868
 msgid "Server started"
 msgstr "Server gestartet"
 
-#: ../src/wxMaximaFrame.cpp:575
+#: ../src/wxMaximaFrame.cpp:574
 msgid "Set Zoom"
 msgstr "Vergrößerung"
 
-#: ../src/wxMaximaFrame.cpp:944
+#: ../src/wxMaximaFrame.cpp:943
 msgid "Set bigfloat &Precision..."
 msgstr "Genauigkeit für als bigfloat deklarierte Fließkommazahlen setzen ..."
 
@@ -3703,11 +3706,11 @@ msgstr "Genauigkeit für als bigfloat deklarierte Fließkommazahlen setzen ..."
 msgid "Set fixed font in text controls."
 msgstr "In Eingabefeldern eine Schrift mit fester Breite verwenden."
 
-#: ../src/wxMaximaFrame.cpp:928
+#: ../src/wxMaximaFrame.cpp:927
 msgid "Set plot format"
 msgstr "Das Plot-Format einstellen"
 
-#: ../src/wxMaximaFrame.cpp:945
+#: ../src/wxMaximaFrame.cpp:944
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can "
 "be generated by entering 1.5b12 or as bfloat(1.234)"
@@ -3716,51 +3719,51 @@ msgstr ""
 "genau sind. Bigfloats können erstellt werden, indem Zahlen als 1.5b112 oder\n"
 "bfloat(1.234) eingegeben werden."
 
-#: ../src/wxMaximaFrame.cpp:569
+#: ../src/wxMaximaFrame.cpp:568
 msgid "Set zoom to 100%"
 msgstr "Setze Vergrößerung auf 100 %"
 
-#: ../src/wxMaximaFrame.cpp:570
+#: ../src/wxMaximaFrame.cpp:569
 msgid "Set zoom to 120%"
 msgstr "Setze Vergrößerung auf 120 %"
 
-#: ../src/wxMaximaFrame.cpp:571
+#: ../src/wxMaximaFrame.cpp:570
 msgid "Set zoom to 150%"
 msgstr "Setze Vergröperung auf 150 %"
 
-#: ../src/wxMaximaFrame.cpp:572
+#: ../src/wxMaximaFrame.cpp:571
 msgid "Set zoom to 200%"
 msgstr "Setze Vergrößerung auf 200 %"
 
-#: ../src/wxMaximaFrame.cpp:573
+#: ../src/wxMaximaFrame.cpp:572
 msgid "Set zoom to 300%"
 msgstr "Setze Vergrößerung auf 300 %"
 
-#: ../src/wxMaximaFrame.cpp:568
+#: ../src/wxMaximaFrame.cpp:567
 msgid "Set zoom to 80%"
 msgstr "Setze Vergrößerung auf 80 %"
 
-#: ../src/wxMaximaFrame.cpp:732
+#: ../src/wxMaximaFrame.cpp:731
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr "Bestimme Randwerte für das Lösen von GDG mit Laplacetransformation"
 
-#: ../src/wxMaximaFrame.cpp:918
+#: ../src/wxMaximaFrame.cpp:917
 msgid "Setup modulus computation"
 msgstr "Die aktuelle Restklasse angeben"
 
-#: ../src/wxMaximaFrame.cpp:662
+#: ../src/wxMaximaFrame.cpp:661
 msgid "Show &Definition..."
 msgstr "Zeige &Definition ..."
 
-#: ../src/wxMaximaFrame.cpp:660
+#: ../src/wxMaximaFrame.cpp:659
 msgid "Show &Functions"
 msgstr "Zeige &Funktionen"
 
-#: ../src/wxMaximaFrame.cpp:967
+#: ../src/wxMaximaFrame.cpp:966
 msgid "Show &Tips..."
 msgstr "Zeige &Tipp ..."
 
-#: ../src/wxMaximaFrame.cpp:665
+#: ../src/wxMaximaFrame.cpp:664
 msgid "Show &Variables"
 msgstr "Zeige &Variablen"
 
@@ -3768,43 +3771,43 @@ msgstr "Zeige &Variablen"
 msgid "Show Maxima help"
 msgstr "Zeige die Hilfe von Maxima"
 
-#: ../src/wxMaximaFrame.cpp:603
+#: ../src/wxMaximaFrame.cpp:602
 msgid "Show Template\tCtrl-Shift-K"
 msgstr "Zeige Muster\tCtrl-Shift-K"
 
-#: ../src/wxMaximaFrame.cpp:968
+#: ../src/wxMaximaFrame.cpp:967
 msgid "Show a tip"
 msgstr "Zeige einen Tipp"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Show all commands similar to:"
 msgstr "Zeige alle Befehle, die ähnlich sind zu:"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Show an example for the command:"
 msgstr "Zeige ein Beispiel für den Befehl:"
 
-#: ../src/wxMaximaFrame.cpp:962
+#: ../src/wxMaximaFrame.cpp:961
 msgid "Show an example of usage"
 msgstr "Zeige ein Anwendungsbeispiel"
 
-#: ../src/wxMaximaFrame.cpp:965
+#: ../src/wxMaximaFrame.cpp:964
 msgid "Show commands similar to"
 msgstr "Zeige ähnliche Befehle"
 
-#: ../src/wxMaximaFrame.cpp:661
+#: ../src/wxMaximaFrame.cpp:660
 msgid "Show defined functions"
 msgstr "Zeige definierte Funktionen"
 
-#: ../src/wxMaximaFrame.cpp:666
+#: ../src/wxMaximaFrame.cpp:665
 msgid "Show defined variables"
 msgstr "Zeige definierte Variablen"
 
-#: ../src/wxMaximaFrame.cpp:663
+#: ../src/wxMaximaFrame.cpp:662
 msgid "Show definition of a function"
 msgstr "Zeige die Definition einer Funktion"
 
-#: ../src/wxMaximaFrame.cpp:604
+#: ../src/wxMaximaFrame.cpp:603
 msgid "Show function template"
 msgstr "Zeige Muster der Funktion"
 
@@ -3816,7 +3819,7 @@ msgstr "Zeige lange Ausdrücke im wxMaxima Dokument."
 msgid "Show long expressions:"
 msgstr "Auch sehr lange Ausdrücke anzeigen:"
 
-#: ../src/wxMaxima.cpp:3341
+#: ../src/wxMaxima.cpp:3353
 msgid "Show the definition of function:"
 msgstr "Zeige die Definition der Funktion:"
 
@@ -3825,43 +3828,43 @@ msgstr "Zeige die Definition der Funktion:"
 msgid "Show user-defined labels instead of (%oxx)"
 msgstr "Zeige benutzerdefinierte Ausgabemarken statt (\\%oxx)"
 
-#: ../src/wxMaximaFrame.cpp:953 ../src/wxMaximaFrame.cpp:956
+#: ../src/wxMaximaFrame.cpp:952 ../src/wxMaximaFrame.cpp:955
 msgid "Show wxMaxima help"
 msgstr "Zeige die Hilfe von wxMaxima an"
 
-#: ../src/wxMaximaFrame.cpp:1381
+#: ../src/wxMaximaFrame.cpp:1380
 msgid "Sigma"
 msgstr "Sigma"
 
-#: ../src/wxMaximaFrame.cpp:1211
+#: ../src/wxMaximaFrame.cpp:1210
 msgid "Simplify"
 msgstr "Vereinfachen"
 
-#: ../src/wxMaximaFrame.cpp:831
+#: ../src/wxMaximaFrame.cpp:830
 msgid "Simplify &Radicals"
 msgstr "&Wurzeln vereinfachen"
 
-#: ../src/wxMaximaFrame.cpp:1212
+#: ../src/wxMaximaFrame.cpp:1211
 msgid "Simplify (r)"
 msgstr "Wurzelvereinf."
 
-#: ../src/wxMaximaFrame.cpp:1218
+#: ../src/wxMaximaFrame.cpp:1217
 msgid "Simplify (tr)"
 msgstr "Trigsimp"
 
-#: ../src/MathCtrl.cpp:995
+#: ../src/MathCtrl.cpp:1037
 msgid "Simplify Expression"
 msgstr "Ausdruck vereinfachen"
 
-#: ../src/wxMaximaFrame.cpp:857
+#: ../src/wxMaximaFrame.cpp:856
 msgid "Simplify an expression containing factorials"
 msgstr "Vereinfache einen Ausdruck mit Fakultäten"
 
-#: ../src/wxMaximaFrame.cpp:832
+#: ../src/wxMaximaFrame.cpp:831
 msgid "Simplify expression containing radicals"
 msgstr "Einen Wurzelausdruck vereinfachen"
 
-#: ../src/wxMaximaFrame.cpp:830
+#: ../src/wxMaximaFrame.cpp:829
 msgid "Simplify rational expression"
 msgstr "Vereinfache einen rationalen Ausdruck"
 
@@ -3869,7 +3872,7 @@ msgstr "Vereinfache einen rationalen Ausdruck"
 msgid "Simplify the sum"
 msgstr "Vereinfache die Summe"
 
-#: ../src/wxMaximaFrame.cpp:868
+#: ../src/wxMaximaFrame.cpp:867
 msgid "Simplify trigonometric expression"
 msgstr "Ausdruck mit Winkelfunktionen vereinfachen"
 
@@ -3885,87 +3888,87 @@ msgstr ""
 "das Dokument als 'wxMaxima XML Dokument' speichern müssen, wenn das Bild mit "
 "dem Dokument gesichert werden soll."
 
-#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
+#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
 msgid "Solution:"
 msgstr "Lösung:"
 
-#: ../src/wxMaxima.cpp:3461 ../src/wxMaxima.cpp:3475 ../src/wxMaxima.cpp:5020
+#: ../src/wxMaxima.cpp:3473 ../src/wxMaxima.cpp:3487 ../src/wxMaxima.cpp:5032
 msgid "Solve"
 msgstr "Gleichung lösen"
 
-#: ../src/wxMaximaFrame.cpp:706
+#: ../src/wxMaximaFrame.cpp:705
 msgid "Solve &Algebraic System..."
 msgstr "Löse &algebraisches System ..."
 
-#: ../src/wxMaximaFrame.cpp:703
+#: ../src/wxMaximaFrame.cpp:702
 msgid "Solve &Linear System..."
 msgstr "Löse &lineares System ..."
 
-#: ../src/wxMaximaFrame.cpp:714
+#: ../src/wxMaximaFrame.cpp:713
 msgid "Solve &ODE..."
 msgstr "Löse gewöhnliche Differentialgleichung ..."
 
-#: ../src/wxMaximaFrame.cpp:690
+#: ../src/wxMaximaFrame.cpp:689
 msgid "Solve (to_poly)..."
 msgstr "Gleichung lösen (to_poly_solve) ..."
 
-#: ../src/wxMaxima.cpp:3511 ../src/wxMaxima.cpp:3635
+#: ../src/wxMaxima.cpp:3523 ../src/wxMaxima.cpp:3647
 msgid "Solve ODE"
 msgstr "Löse gewöhnliche Differentialgleichung"
 
-#: ../src/wxMaximaFrame.cpp:728
+#: ../src/wxMaximaFrame.cpp:727
 msgid "Solve ODE with Lapla&ce..."
 msgstr "GDG mit Lapla&cetransformation lösen ..."
 
-#: ../src/wxMaximaFrame.cpp:1222
+#: ../src/wxMaximaFrame.cpp:1221
 msgid "Solve ODE..."
 msgstr "Löse GDG ..."
 
-#: ../src/wxMaxima.cpp:3586 ../src/wxMaxima.cpp:3597
+#: ../src/wxMaxima.cpp:3598 ../src/wxMaxima.cpp:3609
 msgid "Solve algebraic system"
 msgstr "Löse algebraisches System"
 
-#: ../src/wxMaximaFrame.cpp:707
+#: ../src/wxMaximaFrame.cpp:706
 msgid "Solve algebraic system of equations"
 msgstr "Algebraisches Gleichungssystem lösen"
 
-#: ../src/wxMaximaFrame.cpp:725
+#: ../src/wxMaximaFrame.cpp:724
 msgid "Solve boundary value problem for second degree ODE"
 msgstr "Randwertproblem für gewöhnliche DGL zweiten Grades lösen"
 
-#: ../src/wxMaximaFrame.cpp:689
+#: ../src/wxMaximaFrame.cpp:688
 msgid "Solve equation(s)"
 msgstr "Gleichung(en) lösen"
 
-#: ../src/wxMaximaFrame.cpp:691
+#: ../src/wxMaximaFrame.cpp:690
 msgid "Solve equation(s) with to_poly_solve"
 msgstr "Gleichung(en) mit to_poly_solve lösen"
 
-#: ../src/wxMaximaFrame.cpp:719
+#: ../src/wxMaximaFrame.cpp:718
 msgid "Solve initial value problem for first degree ODE"
 msgstr "Anfangswertproblem einer gewöhnlichen DGL ersten Grades lösen"
 
-#: ../src/wxMaximaFrame.cpp:722
+#: ../src/wxMaximaFrame.cpp:721
 msgid "Solve initial value problem for second degree ODE"
 msgstr "Anfangswertproblem einer gewöhnlichen DGL zweiten Grades lösen"
 
-#: ../src/wxMaxima.cpp:3610 ../src/wxMaxima.cpp:3621
+#: ../src/wxMaxima.cpp:3622 ../src/wxMaxima.cpp:3633
 msgid "Solve linear system"
 msgstr "Lineares System lösen"
 
-#: ../src/wxMaximaFrame.cpp:704
+#: ../src/wxMaximaFrame.cpp:703
 msgid "Solve linear system of equations"
 msgstr "Lineares Gleichungssystem lösen"
 
-#: ../src/wxMaximaFrame.cpp:715
+#: ../src/wxMaximaFrame.cpp:714
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr "Eine gewöhnliche DGL von höchstens zweitem Grad lösen"
 
-#: ../src/wxMaximaFrame.cpp:729
+#: ../src/wxMaximaFrame.cpp:728
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr "Gewöhnliche DGL mit Laplacetransformation lösen"
 
-#: ../src/wxMaximaFrame.cpp:1221 ../src/MathCtrl.cpp:992
+#: ../src/MathCtrl.cpp:1034 ../src/wxMaximaFrame.cpp:1220
 msgid "Solve..."
 msgstr "Gleichung lösen ..."
 
@@ -3993,7 +3996,7 @@ msgstr "Besondere Werte"
 msgid "Special constants"
 msgstr "Besondere Konstanten"
 
-#: ../src/MathCtrl.cpp:922
+#: ../src/MathCtrl.cpp:964
 msgid "Start Animation"
 msgstr "Starte Animation"
 
@@ -4013,28 +4016,28 @@ msgstr ""
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr "Beginne die Suche bereits, während das Suchwort eingegeben wird."
 
-#: ../src/wxMaxima.cpp:294
+#: ../src/wxMaxima.cpp:295
 msgid "Starting Maxima process failed"
 msgstr "Start von Maxima ist fehlgeschlagen"
 
-#: ../src/wxMaxima.cpp:928
+#: ../src/wxMaxima.cpp:933
 msgid "Starting Maxima..."
 msgstr "Maxima wird gestartet ..."
 
-#: ../src/wxMaxima.cpp:292 ../src/wxMaxima.cpp:860
+#: ../src/wxMaxima.cpp:293 ../src/wxMaxima.cpp:865
 msgid "Starting server failed"
 msgstr "Das Starten des Server ist fehlgeschlagen"
 
-#: ../src/wxMaxima.cpp:841
+#: ../src/wxMaxima.cpp:846
 #, c-format
 msgid "Starting server on port %d"
 msgstr "Der Server wird auf Port %d gestartet"
 
-#: ../src/wxMaximaFrame.cpp:342
+#: ../src/wxMaximaFrame.cpp:341
 msgid "Statistics"
 msgstr "Statistik"
 
-#: ../src/wxMaximaFrame.cpp:550
+#: ../src/wxMaximaFrame.cpp:549
 msgid "Statistics\tAlt-Shift-S"
 msgstr "Statistik\tAlt-Shift-S"
 
@@ -4050,11 +4053,11 @@ msgstr "Stil"
 msgid "Styles"
 msgstr "Schriftstile"
 
-#: ../src/wxMaximaFrame.cpp:1283
+#: ../src/wxMaximaFrame.cpp:1282
 msgid "Subsample..."
 msgstr "Teilstichprobe ..."
 
-#: ../src/wxMaximaFrame.cpp:1496
+#: ../src/wxMaximaFrame.cpp:1515
 msgid "Subsection"
 msgstr "Unterkapitel"
 
@@ -4062,20 +4065,20 @@ msgstr "Unterkapitel"
 msgid "Subsection cell"
 msgstr "Unterkapitelzelle"
 
-#: ../src/wxMaximaFrame.cpp:1216
+#: ../src/wxMaximaFrame.cpp:1215
 msgid "Subst..."
 msgstr "Substituieren ..."
 
-#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3423
-#: ../src/wxMaxima.cpp:5089
+#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3435
+#: ../src/wxMaxima.cpp:5101
 msgid "Substitute"
 msgstr "Substituieren"
 
-#: ../src/wxMaximaFrame.cpp:906 ../src/MathCtrl.cpp:998
+#: ../src/MathCtrl.cpp:1040 ../src/wxMaximaFrame.cpp:905
 msgid "Substitute..."
 msgstr "Substituieren ..."
 
-#: ../src/wxMaximaFrame.cpp:1497
+#: ../src/wxMaximaFrame.cpp:1516
 msgid "Subsubsection"
 msgstr "Unter-Unterkapitel"
 
@@ -4083,7 +4086,7 @@ msgstr "Unter-Unterkapitel"
 msgid "Subsubsection cell"
 msgstr "Unter-Unterkapitelzelle"
 
-#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4226
+#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4238
 msgid "Sum"
 msgstr "Summieren"
 
@@ -4091,35 +4094,35 @@ msgstr "Summieren"
 msgid "Sum sign"
 msgstr "Summenzeichen"
 
-#: ../src/wxMaximaFrame.cpp:553
+#: ../src/wxMaximaFrame.cpp:552
 msgid "Symbols\tAlt-Shift-Y"
 msgstr "Symbole\tAlt-Shift-Y"
 
-#: ../src/wxMaxima.cpp:4456
+#: ../src/wxMaxima.cpp:4468
 msgid "System info"
 msgstr "System Information"
 
-#: ../src/wxMaximaFrame.cpp:320
+#: ../src/wxMaximaFrame.cpp:319
 msgid "Table of Contents"
 msgstr "Inhaltsverzeichnis"
 
-#: ../src/wxMaximaFrame.cpp:556
+#: ../src/wxMaximaFrame.cpp:555
 msgid "Table of Contents\tAlt-Shift-T"
 msgstr "Inhaltsverzeichnis\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:1382
+#: ../src/wxMaximaFrame.cpp:1381
 msgid "Tau"
 msgstr "Tau"
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Taylor series:"
 msgstr "Taylorreihe:"
 
-#: ../src/wxMaxima.cpp:3963
+#: ../src/wxMaxima.cpp:3975
 msgid "Tellrat"
 msgstr "Tellrat"
 
-#: ../src/wxMaximaFrame.cpp:1494
+#: ../src/wxMaximaFrame.cpp:1513
 msgid "Text"
 msgstr "Text"
 
@@ -4173,7 +4176,7 @@ msgstr ""
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr "Die Dokumentklasse für den Export von LaTeX-Dokumenten "
 
-#: ../src/TextCell.cpp:136
+#: ../src/TextCell.cpp:134
 msgid ""
 "The letter \"X\" is of width zero. Installing http://www.math.union.edu/"
 "~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts\" in "
@@ -4197,7 +4200,7 @@ msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 "Die Anzahl der zuletzt geöffneten Dateien, die das Programm sich merken soll."
 
-#: ../src/wxMaximaFrame.cpp:959
+#: ../src/wxMaximaFrame.cpp:958
 msgid "The offline manual of maxima"
 msgstr "Das in Maxima eingebaute Handbuch"
 
@@ -4251,7 +4254,7 @@ msgstr ""
 "Webseite https://andrejv.github.io/wxmaxima/help.html, um weitere "
 "Informationen und Selbstlernkurse zu erhalten."
 
-#: ../src/SlideShowCell.cpp:332
+#: ../src/SlideShowCell.cpp:336
 msgid ""
 "There was an error during GIF export!\n"
 "\n"
@@ -4261,7 +4264,7 @@ msgstr ""
 "Stellen Sie sicher, dass ImageMagick installiert ist und wxMaxima das "
 "Konvertierungsprogramm finden kann."
 
-#: ../src/wxMaxima.cpp:442
+#: ../src/wxMaxima.cpp:447
 msgid ""
 "There was an error in generated XML!\n"
 "\n"
@@ -4271,7 +4274,7 @@ msgstr ""
 "\n"
 "Bitte berichten Sie dies als Programmfehler."
 
-#: ../src/wxMaximaFrame.cpp:1371
+#: ../src/wxMaximaFrame.cpp:1370
 msgid "Theta"
 msgstr "Theta"
 
@@ -4279,7 +4282,7 @@ msgstr "Theta"
 msgid "Ticks:"
 msgstr "Startpunkte:"
 
-#: ../src/wxMaxima.cpp:4153 ../src/wxMaxima.cpp:5065
+#: ../src/wxMaxima.cpp:4165 ../src/wxMaxima.cpp:5077
 msgid "Times:"
 msgstr "wie oft:"
 
@@ -4287,7 +4290,7 @@ msgstr "wie oft:"
 msgid "Tips not available, sorry!"
 msgstr "Tipps sind leider nicht verfügbar!"
 
-#: ../src/wxMaximaFrame.cpp:1495
+#: ../src/wxMaximaFrame.cpp:1514
 msgid "Title"
 msgstr "Titel"
 
@@ -4307,19 +4310,19 @@ msgstr ""
 "gehalten, werden alle Ebenen unterhalb der Zelle ebenfalls auf- oder "
 "zugeklappt."
 
-#: ../src/wxMaximaFrame.cpp:938
+#: ../src/wxMaximaFrame.cpp:937
 msgid "To &Bigfloat"
 msgstr "Als &lange Gleitkommazahl"
 
-#: ../src/wxMaximaFrame.cpp:935
+#: ../src/wxMaximaFrame.cpp:934
 msgid "To &Float"
 msgstr "Letztes Ergebnis als Gleitkommazahl"
 
-#: ../src/MathCtrl.cpp:990
+#: ../src/MathCtrl.cpp:1032
 msgid "To Float"
 msgstr "Letztes Ergebnis als Gleitkommazahl"
 
-#: ../src/wxMaximaFrame.cpp:941
+#: ../src/wxMaximaFrame.cpp:940
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr "Als &Zahl\tCtrl+Shift+N"
 
@@ -4362,53 +4365,53 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:41 ../src/Plot2dWiz.cpp:40 ../src/Plot2dWiz.cpp:50
 #: ../src/Plot2dWiz.cpp:539 ../src/Plot3dWiz.cpp:39 ../src/Plot3dWiz.cpp:48
-#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4241
+#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4253
 msgid "To:"
 msgstr "bis:"
 
-#: ../src/wxMaximaFrame.cpp:912
+#: ../src/wxMaximaFrame.cpp:911
 msgid "Toggle &Algebraic Flag"
 msgstr "&Algebraic ein/aus"
 
-#: ../src/wxMaximaFrame.cpp:933
+#: ../src/wxMaximaFrame.cpp:932
 msgid "Toggle &Numeric Output"
 msgstr "Flag &numer ein/aus"
 
-#: ../src/wxMaximaFrame.cpp:673
+#: ../src/wxMaximaFrame.cpp:672
 msgid "Toggle &Time Display"
 msgstr "&Zeitanzeige ein/aus"
 
-#: ../src/wxMaximaFrame.cpp:913
+#: ../src/wxMaximaFrame.cpp:912
 msgid "Toggle algebraic flag"
 msgstr "Schalte das Flag algebraic ein oder aus."
 
-#: ../src/wxMaximaFrame.cpp:577
+#: ../src/wxMaximaFrame.cpp:576
 msgid "Toggle full screen editing"
 msgstr "Ganzer Bildschirm ein-/ausschalten"
 
-#: ../src/wxMaximaFrame.cpp:934
+#: ../src/wxMaximaFrame.cpp:933
 msgid "Toggle numeric output"
 msgstr "Numerisches Berechnen ein/aus"
 
-#: ../src/wxMaxima.cpp:4464
+#: ../src/wxMaxima.cpp:4476
 msgid "Toolbar icons"
 msgstr "Werkzeugleiste Icons"
 
-#: ../src/wxMaxima.cpp:4465
+#: ../src/wxMaxima.cpp:4477
 msgid "Translated by"
 msgstr "Übersetzt von"
 
-#: ../src/wxMaximaFrame.cpp:763
+#: ../src/wxMaximaFrame.cpp:762
 msgid "Transpose a matrix"
 msgstr "Eine Matrix transponieren"
 
-#: ../src/MathCtrl.cpp:5834
+#: ../src/MathCtrl.cpp:5886
 msgid "Trying to undo an action without starting cell."
 msgstr ""
 "Versuche, eine Aktion rückgängig zu machen, ohne zu wissen, wo im "
 "Arbeitsblatt."
 
-#: ../src/MathCtrl.cpp:5901
+#: ../src/MathCtrl.cpp:5953
 msgid "Trying to undo something but the undo action is empty."
 msgstr "Soll etwas rückgängig machen, aber die Spezifikation dafür ist leer."
 
@@ -4416,11 +4419,11 @@ msgstr "Soll etwas rückgängig machen, aber die Spezifikation dafür ist leer."
 msgid "Turkish"
 msgstr "Türkisch"
 
-#: ../src/wxMaximaFrame.cpp:970
+#: ../src/wxMaximaFrame.cpp:969
 msgid "Tutorials"
 msgstr "Tutorials"
 
-#: ../src/wxMaxima.cpp:4778
+#: ../src/wxMaxima.cpp:4790
 msgid "Two sample t-test"
 msgstr "Zweistichproben t-Test"
 
@@ -4432,15 +4435,15 @@ msgstr "Gestalt:"
 msgid "Ukrainian"
 msgstr "Ukrainisch"
 
-#: ../src/wxMaxima.cpp:5356
+#: ../src/wxMaxima.cpp:5372
 msgid "Un-closed parenthesis"
 msgstr "Nicht geschlossene Klammer"
 
-#: ../src/wxMaxima.cpp:5323
+#: ../src/wxMaxima.cpp:5335
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr "; oder $, bei dem nicht alle Klammern geschlossen waren"
 
-#: ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5889
 msgid ""
 "Unable to interpret the version info I got from http://andrejv.github.io//"
 "wxmaxima/version.txt: "
@@ -4456,11 +4459,11 @@ msgstr "Unterstrichen"
 msgid "Underscore converts to subscripts:"
 msgstr "Unterstrich macht tiefgestellt:"
 
-#: ../src/wxMaximaFrame.cpp:492
+#: ../src/wxMaximaFrame.cpp:491
 msgid "Undo\tCtrl-Z"
 msgstr "&Rückgängig\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:493
+#: ../src/wxMaximaFrame.cpp:492
 msgid "Undo last change"
 msgstr "Letzte Änderung rückgängig machen"
 
@@ -4468,23 +4471,23 @@ msgstr "Letzte Änderung rückgängig machen"
 msgid "Undo limit (0 for none):"
 msgstr "Rückgängigmachbare Aktionen (0=kein Limit):"
 
-#: ../src/wxMaximaFrame.cpp:625
+#: ../src/wxMaximaFrame.cpp:624
 msgid "Unfold All\tCtrl-Alt-]"
 msgstr "Alles aufklappen\tCtrl-Alt-A"
 
-#: ../src/wxMaximaFrame.cpp:626
+#: ../src/wxMaximaFrame.cpp:625
 msgid "Unfold all folded sections"
 msgstr "Alle zugeklappten Sektionen aufklappen"
 
-#: ../src/wxMaxima.cpp:4458
+#: ../src/wxMaxima.cpp:4470
 msgid "Unicode Support"
 msgstr "Unicode Unterstützung"
 
-#: ../src/wxMaxima.cpp:5335
+#: ../src/wxMaxima.cpp:5347
 msgid "Unterminated comment."
 msgstr "Fehlende Kommentarendemarkierung"
 
-#: ../src/wxMaxima.cpp:5309
+#: ../src/wxMaxima.cpp:5321
 msgid "Unterminated string."
 msgstr "Fehlendes schließendes Anführungszeichen"
 
@@ -4492,15 +4495,15 @@ msgstr "Fehlendes schließendes Anführungszeichen"
 msgid "Up"
 msgstr "Nach oben"
 
-#: ../src/wxMaxima.cpp:5859 ../src/wxMaxima.cpp:5866 ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5874 ../src/wxMaxima.cpp:5881 ../src/wxMaxima.cpp:5889
 msgid "Upgrade"
 msgstr "Aktualisierung"
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Upper bound:"
 msgstr "obere Schranke:"
 
-#: ../src/wxMaximaFrame.cpp:1383
+#: ../src/wxMaximaFrame.cpp:1382
 msgid "Upsilon"
 msgstr "Ypsilon"
 
@@ -4551,22 +4554,22 @@ msgstr ""
 msgid "User-defined labels"
 msgstr "Benutzerdefinierte Marken"
 
-#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3525
-#: ../src/wxMaxima.cpp:3541 ../src/wxMaxima.cpp:3649
+#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3537
+#: ../src/wxMaxima.cpp:3553 ../src/wxMaxima.cpp:3661
 msgid "Value:"
 msgstr "Wert:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:5019 ../src/wxMaxima.cpp:5064
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:5031 ../src/wxMaxima.cpp:5076
 msgid "Variable(s):"
 msgstr "Variable(n):"
 
 #: ../src/IntegrateWiz.cpp:33 ../src/LimitWiz.cpp:30 ../src/Plot2dWiz.cpp:34
 #: ../src/Plot2dWiz.cpp:44 ../src/Plot2dWiz.cpp:533 ../src/Plot3dWiz.cpp:33
 #: ../src/Plot3dWiz.cpp:42 ../src/SeriesWiz.cpp:36 ../src/SumWiz.cpp:30
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3749
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3761
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5045
 msgid "Variable:"
 msgstr "Variable:"
 
@@ -4574,25 +4577,25 @@ msgstr "Variable:"
 msgid "Variables"
 msgstr "Variablen"
 
-#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3571 ../src/wxMaxima.cpp:4206
-#: ../src/wxMaxima.cpp:4807
+#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3583 ../src/wxMaxima.cpp:4218
+#: ../src/wxMaxima.cpp:4819
 msgid "Variables:"
 msgstr "Variablen:"
 
-#: ../src/wxMaximaFrame.cpp:1257
+#: ../src/wxMaximaFrame.cpp:1256
 msgid "Variance..."
 msgstr "Varianz"
 
-#: ../src/wxMaximaFrame.cpp:580
+#: ../src/wxMaximaFrame.cpp:579
 msgid "View"
 msgstr "Anzeige"
 
-#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1674 ../src/wxMaxima.cpp:1769
-#: ../src/wxMaxima.cpp:1950
+#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1679 ../src/wxMaxima.cpp:1774
+#: ../src/wxMaxima.cpp:1955
 msgid "Warning"
 msgstr "Warnung"
 
-#: ../src/wxMaximaFrame.cpp:109 ../src/wxMaximaFrame.cpp:295
+#: ../src/wxMaximaFrame.cpp:108 ../src/wxMaximaFrame.cpp:294
 msgid "Welcome to wxMaxima"
 msgstr "Willkommen bei wxMaxima"
 
@@ -4621,7 +4624,7 @@ msgstr ""
 "umgebrochen, wo er es im Arbeitsblatt wird. Ansonsten können manuelle "
 "Zeilenumbrüche durch eine leere Zeile erzeugt werden. "
 
-#: ../src/wxMaxima.cpp:2567
+#: ../src/wxMaxima.cpp:2574
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) "
 "(*.wxm)|*.wxm"
@@ -4641,7 +4644,7 @@ msgstr ""
 "Platziere Formeln, die durch \"LaTeX Kopieren\" in die Zwischenablage gelegt "
 "wurden, zwischen \\[ und \\], um TeX in den Mathematik-Modus zu versetzen."
 
-#: ../src/MathCtrl.cpp:6798
+#: ../src/MathCtrl.cpp:6856
 msgid "Wrapped search"
 msgstr "Suche wurde über das Ende des Dokuments hinweg fortgesetzt"
 
@@ -4650,15 +4653,15 @@ msgid "Write matching parenthesis in text controls."
 msgstr ""
 "Beim Öffnen einer Klammer wird automatisch eine schließende Klammer erzeugt."
 
-#: ../src/wxMaxima.cpp:4461
+#: ../src/wxMaxima.cpp:4473
 msgid "Written by"
 msgstr "Geschrieben von"
 
-#: ../src/wxMaximaFrame.cpp:557
+#: ../src/wxMaximaFrame.cpp:556
 msgid "XML Inspector"
 msgstr "XML-Inspektor"
 
-#: ../src/wxMaximaFrame.cpp:1377
+#: ../src/wxMaximaFrame.cpp:1376
 msgid "Xi"
 msgstr "Xi"
 
@@ -4731,7 +4734,7 @@ msgstr ""
 "auszuwählenden Zellen. Dies ist nützlich, wenn Sie mehrere Zellen auf einmal "
 "löschen oder auswerten wollen."
 
-#: ../src/wxMaxima.cpp:5856
+#: ../src/wxMaxima.cpp:5871
 #, c-format
 msgid ""
 "You have version %s. Current version is %s.\n"
@@ -4742,39 +4745,39 @@ msgstr ""
 "\n"
 "Wählen Sie OK, um die wxMaxima Homepage zu besuchen."
 
-#: ../src/wxMaxima.cpp:5921
+#: ../src/wxMaxima.cpp:5936
 msgid "Your changes will be lost if you don't save them."
 msgstr "Nicht gespeicherte Änderungen gehen verloren."
 
-#: ../src/wxMaxima.cpp:5866
+#: ../src/wxMaxima.cpp:5881
 msgid "Your version of wxMaxima is up to date."
 msgstr "Ihre wxMaxima Version ist aktuell."
 
-#: ../src/wxMaximaFrame.cpp:1369
+#: ../src/wxMaximaFrame.cpp:1368
 msgid "Zeta"
 msgstr "Zeta"
 
-#: ../src/wxMaximaFrame.cpp:562
+#: ../src/wxMaximaFrame.cpp:561
 msgid "Zoom &In\tCtrl-+"
 msgstr "Ver&größern\tCtrl-+"
 
-#: ../src/wxMaximaFrame.cpp:564
+#: ../src/wxMaximaFrame.cpp:563
 msgid "Zoom Ou&t\tCtrl--"
 msgstr "Verk&leinern\tCtrl--"
 
-#: ../src/wxMaximaFrame.cpp:563
+#: ../src/wxMaximaFrame.cpp:562
 msgid "Zoom in 10%"
 msgstr "Zoom in Schritten von 10 %"
 
-#: ../src/wxMaximaFrame.cpp:565
+#: ../src/wxMaximaFrame.cpp:564
 msgid "Zoom out 10%"
 msgstr "Zoom in Schritten von 10 %"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaximaFrame.cpp:287
 msgid "[ unsaved ]"
 msgstr "[ nicht gespeichert ]"
 
-#: ../src/wxMaxima.cpp:5700
+#: ../src/wxMaxima.cpp:5715
 msgid "[ unsaved* ]"
 msgstr "[ nicht gespeichert* ]"
 
@@ -4783,17 +4786,17 @@ msgstr "[ nicht gespeichert* ]"
 msgid "[%i digits]"
 msgstr "[%i Ziffern]"
 
-#: ../src/MathCtrl.cpp:4392
+#: ../src/MathCtrl.cpp:4447
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" style=\"max-width:90%%;\" >\n"
 msgstr "_%d.gif\"  alt=\"Animiertes Diagramm\" style=\"max-width:90%%;\" >\n"
 
-#: ../src/MathCtrl.cpp:4517
+#: ../src/MathCtrl.cpp:4572
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" >"
 msgstr "_%d.gif\" alt=\"Animiertes Diagramm\" style=\"max-width:90%%;\" >"
 
-#: ../src/wxMaximaFrame.cpp:1333
+#: ../src/wxMaximaFrame.cpp:1332
 msgid "alpha"
 msgstr "alpha"
 
@@ -4805,7 +4808,7 @@ msgstr "Und"
 msgid "antisymmetric"
 msgstr "schiefsymmetrisch"
 
-#: ../src/wxMaximaFrame.cpp:1334
+#: ../src/wxMaximaFrame.cpp:1333
 msgid "beta"
 msgstr "beta"
 
@@ -4849,7 +4852,7 @@ msgstr "Interner Fehler: Fehlerhaftes \"sum\"-Tag"
 msgid "bug:Invalid sup tag"
 msgstr "Interner Fehler: Fehlerhaftes \"sup\"-Tag"
 
-#: ../src/wxMaximaFrame.cpp:1354
+#: ../src/wxMaximaFrame.cpp:1353
 msgid "chi"
 msgstr "chi"
 
@@ -4862,7 +4865,7 @@ msgstr "Wählt ein Lisp, mit dem Maxima compiliert wurde, aus."
 msgid "default"
 msgstr "Standard"
 
-#: ../src/wxMaximaFrame.cpp:1336
+#: ../src/wxMaximaFrame.cpp:1335
 msgid "delta"
 msgstr "delta"
 
@@ -4874,7 +4877,7 @@ msgstr "diagonal"
 msgid "empty"
 msgstr "Leere Menge"
 
-#: ../src/wxMaximaFrame.cpp:1337
+#: ../src/wxMaximaFrame.cpp:1336
 msgid "epsilon"
 msgstr "epsilon"
 
@@ -4882,7 +4885,7 @@ msgstr "epsilon"
 msgid "equivalent"
 msgstr "Äquivalent"
 
-#: ../src/wxMaximaFrame.cpp:1339
+#: ../src/wxMaximaFrame.cpp:1338
 msgid "eta"
 msgstr "eta"
 
@@ -4903,7 +4906,7 @@ msgstr ""
 "Buchstabe ist.\n"
 "all=Alles nach einem Unterstrich wird tiefgestellt."
 
-#: ../src/wxMaximaFrame.cpp:1335
+#: ../src/wxMaximaFrame.cpp:1334
 msgid "gamma"
 msgstr "gamma"
 
@@ -4929,15 +4932,15 @@ msgstr "eingebettet"
 msgid "intersection"
 msgstr "Schnittmenge"
 
-#: ../src/wxMaximaFrame.cpp:1341
+#: ../src/wxMaximaFrame.cpp:1340
 msgid "iota"
 msgstr "iota"
 
-#: ../src/wxMaximaFrame.cpp:1342
+#: ../src/wxMaximaFrame.cpp:1341
 msgid "kappa"
 msgstr "kappa"
 
-#: ../src/wxMaximaFrame.cpp:1343
+#: ../src/wxMaximaFrame.cpp:1342
 msgid "lambda"
 msgstr "lambda"
 
@@ -4953,7 +4956,7 @@ msgstr "Kleiner oder gleich"
 msgid "logscale"
 msgstr "Logarithmische Skala"
 
-#: ../src/wxMaxima.cpp:3783
+#: ../src/wxMaxima.cpp:3795
 msgid "matrix[i,j]:"
 msgstr "Matrix"
 
@@ -4961,7 +4964,7 @@ msgstr "Matrix"
 msgid "maxima's pwd is path to document"
 msgstr "Maxima im Verzeichnis des Dokuments starten"
 
-#: ../src/wxMaximaFrame.cpp:1344
+#: ../src/wxMaximaFrame.cpp:1343
 msgid "mu"
 msgstr "my"
 
@@ -4977,7 +4980,7 @@ msgstr "Viel kleiner als"
 msgid "nand"
 msgstr "Nicht und"
 
-#: ../src/wxMaxima.cpp:4524
+#: ../src/wxMaxima.cpp:4536
 msgid "no"
 msgstr "nein"
 
@@ -5001,15 +5004,15 @@ msgstr "Nicht Untermenge von"
 msgid "not subset or equal"
 msgstr "Nicht Untermenge von oder gleich zu"
 
-#: ../src/wxMaximaFrame.cpp:1345
+#: ../src/wxMaximaFrame.cpp:1344
 msgid "nu"
 msgstr "ny"
 
-#: ../src/wxMaximaFrame.cpp:1356
+#: ../src/wxMaximaFrame.cpp:1355
 msgid "omega"
 msgstr "omega"
 
-#: ../src/wxMaximaFrame.cpp:1347
+#: ../src/wxMaximaFrame.cpp:1346
 msgid "omicron"
 msgstr "omikron"
 
@@ -5021,11 +5024,11 @@ msgstr "Oder"
 msgid "partial sign"
 msgstr "Symbol für partielle Ableitung"
 
-#: ../src/wxMaximaFrame.cpp:1353
+#: ../src/wxMaximaFrame.cpp:1352
 msgid "phi"
 msgstr "phi"
 
-#: ../src/wxMaximaFrame.cpp:1348
+#: ../src/wxMaximaFrame.cpp:1347
 msgid "pi"
 msgstr "pi"
 
@@ -5037,11 +5040,11 @@ msgstr "Plus oder Minus"
 msgid "proportional to"
 msgstr "Proportional zu"
 
-#: ../src/wxMaximaFrame.cpp:1355
+#: ../src/wxMaximaFrame.cpp:1354
 msgid "psi"
 msgstr "psi"
 
-#: ../src/wxMaximaFrame.cpp:1349
+#: ../src/wxMaximaFrame.cpp:1348
 msgid "rho"
 msgstr "rho"
 
@@ -5049,7 +5052,7 @@ msgstr "rho"
 msgid "right"
 msgstr "rechts"
 
-#: ../src/wxMaximaFrame.cpp:1350
+#: ../src/wxMaximaFrame.cpp:1349
 msgid "sigma"
 msgstr "sigma"
 
@@ -5071,7 +5074,7 @@ msgstr "Untermenge oder gleich"
 msgid "symmetric"
 msgstr "symmetrisch"
 
-#: ../src/wxMaximaFrame.cpp:1351
+#: ../src/wxMaximaFrame.cpp:1350
 msgid "tau"
 msgstr "tau"
 
@@ -5083,7 +5086,7 @@ msgstr "wie viele Megabytes soll sbcl als Heap nutzen?"
 msgid "there is no"
 msgstr "Es existiert kein"
 
-#: ../src/wxMaximaFrame.cpp:1340
+#: ../src/wxMaximaFrame.cpp:1339
 msgid "theta"
 msgstr "theta"
 
@@ -5099,12 +5102,12 @@ msgstr "Hoch 3"
 msgid "union"
 msgstr "Vereinigung"
 
-#: ../src/wxMaxima.cpp:5903
+#: ../src/wxMaxima.cpp:5918
 msgid "unsaved"
 msgstr "nicht gespeichert"
 
-#: ../src/wxMaximaFrame.cpp:290 ../src/wxMaxima.cpp:2559
-#: ../src/wxMaxima.cpp:2826
+#: ../src/wxMaxima.cpp:2566 ../src/wxMaxima.cpp:2834
+#: ../src/wxMaximaFrame.cpp:289
 msgid "untitled"
 msgstr "unbenannt"
 
@@ -5113,25 +5116,25 @@ msgstr "unbenannt"
 msgid "untitled %d"
 msgstr "unbenannt %d"
 
-#: ../src/wxMaximaFrame.cpp:1352
+#: ../src/wxMaximaFrame.cpp:1351
 msgid "upsilon"
 msgstr "ypsilon"
 
-#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4538
+#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4550
 msgid "wxMaxima"
 msgstr "wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
-#: ../src/wxMaxima.cpp:5700 ../src/wxMaxima.cpp:5709 ../src/wxMaxima.cpp:5712
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaxima.cpp:5715 ../src/wxMaxima.cpp:5724
+#: ../src/wxMaxima.cpp:5727 ../src/wxMaximaFrame.cpp:287
 #, c-format
 msgid "wxMaxima %s "
 msgstr "wxMaxima %s "
 
-#: ../src/wxMaximaFrame.cpp:952
+#: ../src/wxMaximaFrame.cpp:951
 msgid "wxMaxima &Help\tCtrl+?"
 msgstr "&Hilfe zu wxMaxima \tCtrl+?"
 
-#: ../src/wxMaximaFrame.cpp:955
+#: ../src/wxMaximaFrame.cpp:954
 msgid "wxMaxima &Help\tF1"
 msgstr "&Hilfe zu wxMaxima \tF1"
 
@@ -5146,13 +5149,13 @@ msgstr ""
 "aus. Wo das Benutzerverzeichnis liegt, wird mit dem Maxima-Befehl "
 "maxima_userdir; angezeigt. "
 
-#: ../src/wxMaxima.cpp:1619
+#: ../src/wxMaxima.cpp:1624
 msgid "wxMaxima cannot open content.xml in the .wxmx zip archive "
 msgstr ""
 "wxMaxima kann content.xml im Zip-Archiv, das die .wxmx-Datei darstellt, "
 "nicht öffnen "
 
-#: ../src/wxMaxima.cpp:1633
+#: ../src/wxMaxima.cpp:1638
 msgid "wxMaxima cannot read the xml contents of "
 msgstr "wxMaxima kann den XML-Inhalt nicht öffnen in "
 
@@ -5160,7 +5163,7 @@ msgstr "wxMaxima kann den XML-Inhalt nicht öffnen in "
 msgid "wxMaxima configuration"
 msgstr "wxMaxima Konfiguration"
 
-#: ../src/wxMaxima.cpp:1947
+#: ../src/wxMaxima.cpp:1952
 msgid ""
 "wxMaxima could not find Maxima!\n"
 "\n"
@@ -5172,7 +5175,7 @@ msgstr ""
 "Konfigurieren Sie wxMaxima mit 'Bearbeiten->Einstellungen'.\n"
 "Danach starten Sie Maxima mit 'Maxima->Maxima neustarten'."
 
-#: ../src/wxMaxima.cpp:2204
+#: ../src/wxMaxima.cpp:2209
 msgid ""
 "wxMaxima could not find help files.\n"
 "\n"
@@ -5182,7 +5185,7 @@ msgstr ""
 "\n"
 "Bitte überprüfen Sie die Installation."
 
-#: ../src/wxMaxima.cpp:2032
+#: ../src/wxMaxima.cpp:2037
 msgid ""
 "wxMaxima could not find tip files.\n"
 "\n"
@@ -5192,7 +5195,7 @@ msgstr ""
 "\n"
 "Bitte überprüfen Sie die Installation."
 
-#: ../src/wxMaxima.cpp:282
+#: ../src/wxMaxima.cpp:283
 msgid ""
 "wxMaxima could not start the server.\n"
 "\n"
@@ -5214,23 +5217,23 @@ msgstr ""
 "zum Beispiel '%' für das letzte Ergebnis. Haben Sie im Dokument einen "
 "Bereich markiert, wird dieser als Standardwert in das Eingabefeld übernommen."
 
-#: ../src/wxMaxima.cpp:2330
+#: ../src/wxMaxima.cpp:2336
 msgid "wxMaxima document"
 msgstr "wxMaxima-Dokument"
 
-#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2799
+#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2807
 msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 msgstr "wxMaxima-Dokument (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 
-#: ../src/wxMaxima.cpp:1455 ../src/wxMaxima.cpp:1469
+#: ../src/wxMaxima.cpp:1460 ../src/wxMaxima.cpp:1474
 msgid "wxMaxima encountered an error loading "
 msgstr "wxMaxima hat einen Fehler beim Laden festgestellt"
 
-#: ../src/wxMaxima.cpp:4463
+#: ../src/wxMaxima.cpp:4475
 msgid "wxMaxima icon"
 msgstr "wxMaxima Icon"
 
-#: ../src/wxMaxima.cpp:4455
+#: ../src/wxMaxima.cpp:4467
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "MAXIMA based on wxWidgets."
@@ -5238,7 +5241,7 @@ msgstr ""
 "wxMaxima ist eine wxWidgets basierte Bedienoberfläche für das Computer "
 "Algebra System Maxima."
 
-#: ../src/wxMaxima.cpp:4516
+#: ../src/wxMaxima.cpp:4528
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "Maxima based on wxWidgets."
@@ -5262,11 +5265,11 @@ msgstr ""
 msgid "x"
 msgstr "x"
 
-#: ../src/wxMaximaFrame.cpp:1346
+#: ../src/wxMaximaFrame.cpp:1345
 msgid "xi"
 msgstr "xi"
 
-#: ../src/wxMaxima.cpp:1643
+#: ../src/wxMaxima.cpp:1648
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 "In der Datei enthaltenes xml behauptet, kein wxMaxima-Arbeitsblatt zu sein. "
@@ -5275,11 +5278,11 @@ msgstr ""
 msgid "xor"
 msgstr "Exklusiv Oder"
 
-#: ../src/wxMaxima.cpp:4522
+#: ../src/wxMaxima.cpp:4534
 msgid "yes"
 msgstr "ja"
 
-#: ../src/wxMaximaFrame.cpp:1338
+#: ../src/wxMaximaFrame.cpp:1337
 msgid "zeta"
 msgstr "zeta"
 

--- a/locales/el.po
+++ b/locales/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Greek translation of wxMaxima GUI\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-07 21:42+0200\n"
+"POT-Creation-Date: 2016-10-16 17:47+0900\n"
 "PO-Revision-Date: 2010-06-04 19:46+0200\n"
 "Last-Translator: aga <akritas@uth.gr>\n"
 "Language-Team: uth <aakritas@uth.gr>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "X-Poedit-Language: Greek\n"
 "X-Poedit-Country: GREECE\n"
 
-#: ../src/wxMaxima.cpp:4519
+#: ../src/wxMaxima.cpp:4531
 #, c-format
 msgid ""
 "\n"
@@ -31,7 +31,7 @@ msgstr ""
 "wxWidgets: %d.%d.%d\n"
 "υποστήριξη Unicode: %s"
 
-#: ../src/wxMaxima.cpp:4532
+#: ../src/wxMaxima.cpp:4544
 msgid ""
 "\n"
 "Lisp: "
@@ -39,7 +39,7 @@ msgstr ""
 "\n"
 "Lisp: "
 
-#: ../src/wxMaxima.cpp:4528
+#: ../src/wxMaxima.cpp:4540
 msgid ""
 "\n"
 "Maxima version: "
@@ -47,7 +47,7 @@ msgstr ""
 "\n"
 "Έκδοση  Maxima:"
 
-#: ../src/wxMaxima.cpp:5381
+#: ../src/wxMaxima.cpp:5397
 msgid ""
 "\n"
 "Not connected to Maxima!\n"
@@ -55,7 +55,7 @@ msgstr ""
 "\n"
 "Δεν υπάρχει σύνδεση με το Maxima!\n"
 
-#: ../src/wxMaxima.cpp:4530
+#: ../src/wxMaxima.cpp:4542
 msgid ""
 "\n"
 "Not connected."
@@ -75,7 +75,7 @@ msgstr ""
 msgid " (Graphics) "
 msgstr ""
 
-#: ../src/EditorCell.cpp:3045 ../src/EditorCell.cpp:3227
+#: ../src/EditorCell.cpp:3088 ../src/EditorCell.cpp:3270
 #, c-format
 msgid " ... + %i hidden lines"
 msgstr ""
@@ -84,7 +84,7 @@ msgstr ""
 msgid " << Expression longer than allowed by the configuration setting! >>"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1673
+#: ../src/wxMaxima.cpp:1678
 msgid ""
 " was saved using a newer version of wxMaxima so it may not load correctly. "
 "Please update your wxMaxima."
@@ -92,7 +92,7 @@ msgstr ""
 "είχε αποθηκευθεί χρησιμοποιώντας μια νεότερη έκδοση του wxMaxima. Έτσι "
 "μπορεί να μην φορτωθεί σωστά.Παρακαλώ ενημερώστε το wxMaxima σας."
 
-#: ../src/wxMaxima.cpp:1665
+#: ../src/wxMaxima.cpp:1670
 msgid ""
 " was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr ""
@@ -107,64 +107,64 @@ msgstr ""
 msgid "\"implies\" symbol"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:101
+#: ../src/wxMaximaFrame.cpp:100
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:773
+#: ../src/wxMaximaFrame.cpp:772
 msgid "&Algebra"
 msgstr "Άλγεβρα"
 
-#: ../src/wxMaximaFrame.cpp:767
+#: ../src/wxMaximaFrame.cpp:766
 msgid "&Apply to List..."
 msgstr "Εφαρμογή σε λίστα..."
 
-#: ../src/wxMaximaFrame.cpp:964
+#: ../src/wxMaximaFrame.cpp:963
 msgid "&Apropos..."
 msgstr "Σχετικά..."
 
-#: ../src/wxMaximaFrame.cpp:478
+#: ../src/wxMaximaFrame.cpp:477
 msgid "&Batch File...\tCtrl-B"
 msgstr "Αρχείο Batch...\tCtrl-B"
 
-#: ../src/wxMaximaFrame.cpp:724
+#: ../src/wxMaximaFrame.cpp:723
 msgid "&Boundary Value Problem..."
 msgstr "Πρόβλημα οριακών τιμών..."
 
-#: ../src/wxMaximaFrame.cpp:975
+#: ../src/wxMaximaFrame.cpp:974
 msgid "&Bug Report"
 msgstr "Αναφορά σφάλματος"
 
-#: ../src/wxMaximaFrame.cpp:825
+#: ../src/wxMaximaFrame.cpp:824
 msgid "&Calculus"
 msgstr "Μαθηματική Ανάλυση"
 
-#: ../src/wxMaximaFrame.cpp:876
+#: ../src/wxMaximaFrame.cpp:875
 msgid "&Canonical Form"
 msgstr "Κανονική μορφή"
 
-#: ../src/wxMaximaFrame.cpp:749
+#: ../src/wxMaximaFrame.cpp:748
 msgid "&Characteristic Polynomial..."
 msgstr "Χαρακτηριστικό πολυώνυμο..."
 
-#: ../src/wxMaximaFrame.cpp:654
+#: ../src/wxMaximaFrame.cpp:653
 msgid "&Clear Memory"
 msgstr "Εκκαθάριση μνήμης"
 
-#: ../src/wxMaximaFrame.cpp:859
+#: ../src/wxMaximaFrame.cpp:858
 msgid "&Combine Factorials"
 msgstr "Συνδυασμός παραγοντικών"
 
-#: ../src/wxMaximaFrame.cpp:902
+#: ../src/wxMaximaFrame.cpp:901
 msgid "&Complex Simplification"
 msgstr "Μιγαδική απλοποίηση"
 
-#: ../src/wxMaximaFrame.cpp:822
+#: ../src/wxMaximaFrame.cpp:821
 msgid "&Continued Fraction"
 msgstr "Συνεχή κλάσματα"
 
-#: ../src/wxMaximaFrame.cpp:502
+#: ../src/wxMaximaFrame.cpp:501
 msgid "&Copy\tCtrl-C"
 msgstr "Αντιγραφή\tCtrl-C"
 
@@ -172,109 +172,109 @@ msgstr "Αντιγραφή\tCtrl-C"
 msgid "&Definite integration"
 msgstr "Ορισμένη ολοκλήρωση"
 
-#: ../src/wxMaximaFrame.cpp:896
+#: ../src/wxMaximaFrame.cpp:895
 msgid "&Demoivre"
 msgstr "Μετατροπή σε τριγωνομετρικές συναρτήσεις (Demoivre)"
 
-#: ../src/wxMaximaFrame.cpp:752
+#: ../src/wxMaximaFrame.cpp:751
 msgid "&Determinant"
 msgstr "Ορίζουσα"
 
-#: ../src/wxMaximaFrame.cpp:785
+#: ../src/wxMaximaFrame.cpp:784
 msgid "&Differentiate..."
 msgstr "Παραγώγιση..."
 
-#: ../src/wxMaximaFrame.cpp:543
+#: ../src/wxMaximaFrame.cpp:542
 msgid "&Edit"
 msgstr "Επεξεργασία"
 
-#: ../src/wxMaximaFrame.cpp:709
+#: ../src/wxMaximaFrame.cpp:708
 msgid "&Eliminate Variable..."
 msgstr "Απαλοιφή μεταβλητής..."
 
-#: ../src/wxMaximaFrame.cpp:744
+#: ../src/wxMaximaFrame.cpp:743
 msgid "&Enter Matrix..."
 msgstr "Εισαγωγή πίνακα..."
 
-#: ../src/wxMaximaFrame.cpp:961
+#: ../src/wxMaximaFrame.cpp:960
 msgid "&Example..."
 msgstr "Παράδειγμα..."
 
-#: ../src/wxMaximaFrame.cpp:839
+#: ../src/wxMaximaFrame.cpp:838
 msgid "&Expand Expression"
 msgstr "Ανάπτυξη έκφρασης"
 
-#: ../src/wxMaximaFrame.cpp:873
+#: ../src/wxMaximaFrame.cpp:872
 msgid "&Expand Trigonometric"
 msgstr "Ανάπτυξη τριγωνομετρικών παραστάσεων"
 
-#: ../src/wxMaximaFrame.cpp:899
+#: ../src/wxMaximaFrame.cpp:898
 msgid "&Exponentialize"
 msgstr "Μετατροπή σε εκθετικές συναρτήσεις"
 
-#: ../src/wxMaximaFrame.cpp:480
+#: ../src/wxMaximaFrame.cpp:479
 msgid "&Export..."
 msgstr "Εξαγωγή..."
 
-#: ../src/wxMaximaFrame.cpp:834
+#: ../src/wxMaximaFrame.cpp:833
 msgid "&Factor Expression"
 msgstr "Παραγοντοποίηση παράστασης"
 
-#: ../src/wxMaximaFrame.cpp:489
+#: ../src/wxMaximaFrame.cpp:488
 msgid "&File"
 msgstr "Αρχείο"
 
-#: ../src/wxMaximaFrame.cpp:692
+#: ../src/wxMaximaFrame.cpp:691
 msgid "&Find Root..."
 msgstr "Εύρεση Ρίζας..."
 
-#: ../src/wxMaximaFrame.cpp:738
+#: ../src/wxMaximaFrame.cpp:737
 msgid "&Generate Matrix..."
 msgstr "Δημιουργία πίνακα..."
 
-#: ../src/wxMaximaFrame.cpp:809
+#: ../src/wxMaximaFrame.cpp:808
 msgid "&Greatest Common Divisor..."
 msgstr "Μέγιστος Κοινός Διαιρέτης..."
 
-#: ../src/wxMaximaFrame.cpp:994
+#: ../src/wxMaximaFrame.cpp:993
 msgid "&Help"
 msgstr "Βοήθεια"
 
-#: ../src/wxMaximaFrame.cpp:777
+#: ../src/wxMaximaFrame.cpp:776
 msgid "&Integrate..."
 msgstr "Ολοκλήρωση..."
 
-#: ../src/wxMaximaFrame.cpp:645
+#: ../src/wxMaximaFrame.cpp:644
 msgid "&Interrupt\tCtrl-."
 msgstr "Διακοπή\tCtrl-."
 
-#: ../src/wxMaximaFrame.cpp:649
+#: ../src/wxMaximaFrame.cpp:648
 msgid "&Interrupt\tCtrl-G"
 msgstr "Διακοπή\tCtrl-G"
 
-#: ../src/wxMaximaFrame.cpp:746
+#: ../src/wxMaximaFrame.cpp:745
 msgid "&Invert Matrix"
 msgstr "Αντιστροφος πίνακας"
 
-#: ../src/wxMaximaFrame.cpp:476
+#: ../src/wxMaximaFrame.cpp:475
 msgid "&Load Package...\tCtrl-L"
 msgstr "Φόρτωση πακέτου...\tCtrl-L"
 
-#: ../src/wxMaximaFrame.cpp:769
+#: ../src/wxMaximaFrame.cpp:768
 #, fuzzy
 msgid "&Map to List(s)..."
 msgstr "Εφαρμογή στα μέλη λίστας..."
 
-#: ../src/wxMaximaFrame.cpp:684
+#: ../src/wxMaximaFrame.cpp:683
 msgid "&Maxima"
 msgstr "Maxima"
 
-#: ../src/wxMaximaFrame.cpp:958
+#: ../src/wxMaximaFrame.cpp:957
 #, fuzzy
 msgid "&Maxima help"
 msgstr "Εμφάνιση βοήθειας για το Maxima"
 
-#: ../src/wxMaximaFrame.cpp:917
+#: ../src/wxMaximaFrame.cpp:916
 msgid "&Modulus Computation..."
 msgstr "Ορισμός του modulo (για rat, κτλ)..."
 
@@ -282,7 +282,7 @@ msgstr "Ορισμός του modulo (για rat, κτλ)..."
 msgid "&New\tCtrl-N"
 msgstr "Νέο\tCtrl-N"
 
-#: ../src/wxMaximaFrame.cpp:947
+#: ../src/wxMaximaFrame.cpp:946
 msgid "&Numeric"
 msgstr "Αριθμητικοί Υπολογισμοί"
 
@@ -298,11 +298,11 @@ msgstr "Νusum"
 msgid "&Open\tCtrl-O"
 msgstr "Άνοιγμα\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:463
+#: ../src/wxMaximaFrame.cpp:462
 msgid "&Open...\tCtrl-O"
 msgstr "Άνοιγμα...\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:929
+#: ../src/wxMaximaFrame.cpp:928
 msgid "&Plot"
 msgstr "Γράφημα"
 
@@ -310,7 +310,7 @@ msgstr "Γράφημα"
 msgid "&Power series"
 msgstr "Δυναμοσειρές"
 
-#: ../src/wxMaximaFrame.cpp:483
+#: ../src/wxMaximaFrame.cpp:482
 msgid "&Print...\tCtrl-P"
 msgstr "Εκτύπωση...\tCtrl-P"
 
@@ -318,39 +318,39 @@ msgstr "Εκτύπωση...\tCtrl-P"
 msgid "&Rational"
 msgstr "Ρητός(-ή)"
 
-#: ../src/wxMaximaFrame.cpp:870
+#: ../src/wxMaximaFrame.cpp:869
 msgid "&Reduce Trigonometric"
 msgstr "Αναγωγή τριγωνομετρικών παραστάσεων"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "&Restart Maxima"
 msgstr "Επανεκκίνηση  Maxima"
 
-#: ../src/wxMaximaFrame.cpp:700
+#: ../src/wxMaximaFrame.cpp:699
 msgid "&Roots of Polynomial (Real)"
 msgstr "Ρίζες πολυωνύμου (πραγματικές)"
 
-#: ../src/wxMaximaFrame.cpp:472
+#: ../src/wxMaximaFrame.cpp:471
 msgid "&Save\tCtrl-S"
 msgstr "Αποθήκευση\tCtrl-S"
 
-#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:919
+#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:918
 msgid "&Simplify"
 msgstr "Απλοποίηση"
 
-#: ../src/wxMaximaFrame.cpp:829
+#: ../src/wxMaximaFrame.cpp:828
 msgid "&Simplify Expression"
 msgstr "Απλοποίηση έκφρασης"
 
-#: ../src/wxMaximaFrame.cpp:856
+#: ../src/wxMaximaFrame.cpp:855
 msgid "&Simplify Factorials"
 msgstr "Απλοποίηση παραγοντικών"
 
-#: ../src/wxMaximaFrame.cpp:867
+#: ../src/wxMaximaFrame.cpp:866
 msgid "&Simplify Trigonometric"
 msgstr "Απλοποίηση τριγωνομετρικών παραστάσεων"
 
-#: ../src/wxMaximaFrame.cpp:688
+#: ../src/wxMaximaFrame.cpp:687
 msgid "&Solve..."
 msgstr "Επίλυση..."
 
@@ -362,11 +362,11 @@ msgstr "Ειδικό"
 msgid "&Taylor series"
 msgstr "Σειρές Taylor"
 
-#: ../src/wxMaximaFrame.cpp:762
+#: ../src/wxMaximaFrame.cpp:761
 msgid "&Transpose Matrix"
 msgstr "Ανάστροφος πίνακας"
 
-#: ../src/wxMaximaFrame.cpp:879
+#: ../src/wxMaximaFrame.cpp:878
 msgid "&Trigonometric Simplification"
 msgstr "Τριγωνομετρική απλοποίηση"
 
@@ -384,7 +384,7 @@ msgstr "(Χρήση Προεπιλεγμένης Γλώσσας)"
 msgid "- Infinity"
 msgstr "- 'Απειρο"
 
-#: ../src/wxMaxima.cpp:351
+#: ../src/wxMaxima.cpp:356
 msgid ""
 "... [suppressed additional lines since the output is longer than allowed in "
 "the configuration] "
@@ -394,16 +394,16 @@ msgstr ""
 msgid "1/2"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:103
+#: ../src/wxMaximaFrame.cpp:102
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4601
+#: ../src/wxMaxima.cpp:4613
 msgid "<br>Lisp: "
 msgstr "<br>Lisp: "
 
-#: ../src/wxMaxima.cpp:5487
+#: ../src/wxMaxima.cpp:5503
 msgid ""
 "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
@@ -436,11 +436,11 @@ msgid ""
 "\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1472
+#: ../src/wxMaximaFrame.cpp:1495
 msgid "A symbol from the configuration dialogue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:731
+#: ../src/wxMaximaFrame.cpp:730
 msgid "A&t Value..."
 msgstr "Ορισμός οριακών τιμών..."
 
@@ -448,12 +448,12 @@ msgstr "Ορισμός οριακών τιμών..."
 msgid "Abort evaluation on error"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaxima.cpp:4603
+#: ../src/wxMaxima.cpp:4615 ../src/wxMaximaFrame.cpp:985
 msgid "About"
 msgstr "Πληροφορίες για το wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:987 ../src/wxMaximaFrame.cpp:990
-#: ../src/wxMaximaFrame.cpp:991
+#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaximaFrame.cpp:989
+#: ../src/wxMaximaFrame.cpp:990
 msgid "About wxMaxima"
 msgstr "Πληροφορίες για το wxMaxima"
 
@@ -461,23 +461,23 @@ msgstr "Πληροφορίες για το wxMaxima"
 msgid "Active cell bracket"
 msgstr "Άγκιστρο ενεργού κελιού"
 
-#: ../src/wxMaximaFrame.cpp:760
+#: ../src/wxMaximaFrame.cpp:759
 msgid "Ad&joint Matrix"
 msgstr "Προσαρτημένος πίνακας"
 
-#: ../src/wxMaximaFrame.cpp:914
+#: ../src/wxMaximaFrame.cpp:913
 msgid "Add Algebraic E&quality..."
 msgstr "Εισαγωγή αλγεβρικής ισότητας..."
 
-#: ../src/wxMaximaFrame.cpp:657
+#: ../src/wxMaximaFrame.cpp:656
 msgid "Add a directory to search path"
 msgstr "Προσθήκη καταλόγου στην διαδρομή αναζήτησης"
 
-#: ../src/wxMaxima.cpp:3353
+#: ../src/wxMaxima.cpp:3365
 msgid "Add dir to path:"
 msgstr "Προσθήκη καταλόγου στο μονοπάτι:"
 
-#: ../src/wxMaximaFrame.cpp:915
+#: ../src/wxMaximaFrame.cpp:914
 msgid "Add equality to the rational simplifier"
 msgstr "Προσθήκη ισότητας στον απλοποιητή ρητών (παραστάσεων)"
 
@@ -485,7 +485,7 @@ msgstr "Προσθήκη ισότητας στον απλοποιητή ρητώ
 msgid "Add the .wxmx file to the HTML export"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:656
+#: ../src/wxMaximaFrame.cpp:655
 msgid "Add to &Path..."
 msgstr "Προσθήκη στο μονοπάτι..."
 
@@ -526,27 +526,27 @@ msgstr "Παλιά μεταβλητή:"
 msgid "All|*"
 msgstr "Όλα|*"
 
-#: ../src/wxMaximaFrame.cpp:1364
+#: ../src/wxMaximaFrame.cpp:1363
 msgid "Alpha"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3838
+#: ../src/wxMaxima.cpp:3850
 msgid "Apply"
 msgstr "Εφαρμογή"
 
-#: ../src/wxMaximaFrame.cpp:768
+#: ../src/wxMaximaFrame.cpp:767
 msgid "Apply function to a list"
 msgstr "Εφαρμογή συνάρτησης σε μία λίστα"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Apropos"
 msgstr "Σχετικά"
 
-#: ../src/wxMaxima.cpp:3764
+#: ../src/wxMaxima.cpp:3776
 msgid "Array:"
 msgstr "Πίνακας:"
 
-#: ../src/wxMaxima.cpp:4462
+#: ../src/wxMaxima.cpp:4474
 msgid "Artwork by"
 msgstr "Υπέυθυνος γραφικών"
 
@@ -554,7 +554,7 @@ msgstr "Υπέυθυνος γραφικών"
 msgid "Ask to save untitled documents"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3650
+#: ../src/wxMaxima.cpp:3662
 msgid "At value"
 msgstr "Ορισμός οριακών τιμών"
 
@@ -575,11 +575,11 @@ msgstr ""
 msgid "Autosave interval (minutes, 0 means: off):"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3557
+#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3569
 msgid "BC2"
 msgstr "BC2"
 
-#: ../src/wxMaximaFrame.cpp:1272
+#: ../src/wxMaximaFrame.cpp:1271
 #, fuzzy
 msgid "Barsplot..."
 msgstr "Διάγραμμα ράβδων"
@@ -588,7 +588,7 @@ msgstr "Διάγραμμα ράβδων"
 msgid "Bat files (*.bat)|*.bat|All|*"
 msgstr "Αρχεία Bat  (*.bat)|*.bat|All|*"
 
-#: ../src/wxMaxima.cpp:2943
+#: ../src/wxMaxima.cpp:2951
 msgid "Batch File"
 msgstr "Αρχείο Batch"
 
@@ -601,7 +601,7 @@ msgid ""
 "cells."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1365
+#: ../src/wxMaximaFrame.cpp:1364
 msgid "Beta"
 msgstr ""
 
@@ -613,11 +613,11 @@ msgstr ""
 msgid "Bold"
 msgstr "Έντονα"
 
-#: ../src/wxMaxima.cpp:2359
+#: ../src/wxMaxima.cpp:2366
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1274
+#: ../src/wxMaximaFrame.cpp:1273
 #, fuzzy
 msgid "Boxplot..."
 msgstr "Θηκόγραμμα"
@@ -630,15 +630,15 @@ msgstr "Πλοήγηση"
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2080
+#: ../src/MathCtrl.cpp:2127
 msgid "Bug: Cell left but not entered."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1178
+#: ../src/wxMaxima.cpp:1183
 msgid "Bug: Found a math end marker without any start marker."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1222
+#: ../src/wxMaxima.cpp:1227
 msgid "Bug: Found the end of autocompletion symbols but no beginning"
 msgstr ""
 
@@ -650,22 +650,22 @@ msgstr ""
 msgid "Bug: Fraction without enumerator"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2312
+#: ../src/MathCtrl.cpp:2359
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5839
+#: ../src/MathCtrl.cpp:5891
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of "
 "the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5913
+#: ../src/MathCtrl.cpp:5965
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5882
+#: ../src/MathCtrl.cpp:5934
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
@@ -675,49 +675,49 @@ msgstr ""
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
 msgstr ""
 
-#: ../src/GroupCell.cpp:780 ../src/GroupCell.cpp:951
+#: ../src/GroupCell.cpp:781 ../src/GroupCell.cpp:952
 msgid "Bug: No image counter to write to!"
 msgstr ""
 
-#: ../src/AbsCell.cpp:193
+#: ../src/AbsCell.cpp:199
 msgid "Bug: No last cell in an absCell!"
 msgstr ""
 
-#: ../src/ConjugateCell.cpp:185
+#: ../src/ConjugateCell.cpp:194
 msgid "Bug: No last cell in an conjugateCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:471
+#: ../src/FracCell.cpp:472
 msgid "Bug: No last cell in an denominator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:267
+#: ../src/ExptCell.cpp:270
 msgid "Bug: No last cell in an exponent of an exptCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:459
+#: ../src/FracCell.cpp:460
 msgid "Bug: No last cell in an numerator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:257
+#: ../src/ExptCell.cpp:260
 msgid "Bug: No last cell in the base of an exptCell!"
 msgstr ""
 
-#: ../src/ParenCell.cpp:534
+#: ../src/ParenCell.cpp:535
 msgid "Bug: No last cell inside a parenthesis!"
 msgstr ""
 
-#: ../src/SqrtCell.cpp:312
+#: ../src/SqrtCell.cpp:317
 msgid "Bug: No last cell inside a square root!"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2123
+#: ../src/MathCtrl.cpp:2170
 msgid ""
 "Bug: Start or end of merging of subsequent editing actions was requested two "
 "times in a row."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2090
+#: ../src/MathCtrl.cpp:2137
 msgid "Bug: Text changed, but no active cell."
 msgstr ""
 
@@ -725,39 +725,39 @@ msgstr ""
 msgid "Bug: Trying to append NULL to a group cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:555
+#: ../src/MathCtrl.cpp:600
 msgid "Bug: Trying to append maxima's output to a cell outside the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2014
+#: ../src/MathCtrl.cpp:2061
 msgid ""
 "Bug: Trying to merge individual cell adds to a region in the undo buffer but "
 "there are other cells between them."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6522
+#: ../src/MathCtrl.cpp:6577
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2092
+#: ../src/MathCtrl.cpp:2139
 msgid "Bug: Trying to record a cell contents change without a cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1495
+#: ../src/MathCtrl.cpp:1540
 msgid "Bug: Trying to select inside a cell without having a current cell"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5883
+#: ../src/MathCtrl.cpp:5935
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5844 ../src/MathCtrl.cpp:5918 ../src/MathCtrl.cpp:5952
+#: ../src/MathCtrl.cpp:5896 ../src/MathCtrl.cpp:5970 ../src/MathCtrl.cpp:6004
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:973
+#: ../src/wxMaximaFrame.cpp:972
 msgid "Build &Info"
 msgstr "Πληροφορίες για το Maxima"
 
@@ -775,52 +775,52 @@ msgstr ""
 "υπολογίζει τα κελιά'. Αυτό εναλλάσει  τη λειτουργικότητα των δύο "
 "προαναφερθέντων εντολών του πληκτρολογίου."
 
-#: ../src/wxMaximaFrame.cpp:782
+#: ../src/wxMaximaFrame.cpp:781
 msgid "C&hange Variable..."
 msgstr "Αλλαγή μεταβλητής..."
 
-#: ../src/wxMaximaFrame.cpp:540
+#: ../src/wxMaximaFrame.cpp:539
 msgid "C&onfigure"
 msgstr "Ρυθμίσεις"
 
-#: ../src/wxMaximaFrame.cpp:801
+#: ../src/wxMaximaFrame.cpp:800
 msgid "Calculate &Product..."
 msgstr "Υπολογισμός γινομένου..."
 
-#: ../src/wxMaximaFrame.cpp:799
+#: ../src/wxMaximaFrame.cpp:798
 msgid "Calculate Su&m..."
 msgstr "Υπολογισμός αθροίσματος..."
 
-#: ../src/wxMaximaFrame.cpp:939
+#: ../src/wxMaximaFrame.cpp:938
 msgid "Calculate bigfloat value of the last result"
 msgstr "Υπολογισμός της τιμής του τελευταίου αποτελέσματος με bigfloat"
 
-#: ../src/wxMaximaFrame.cpp:936
+#: ../src/wxMaximaFrame.cpp:935
 msgid "Calculate float value of the last result"
 msgstr "Υπολογισμός της τιμής του τελευταίου αποτέλεσματος προσεγγιστικά"
 
-#: ../src/wxMaxima.cpp:3971
+#: ../src/wxMaxima.cpp:3983
 msgid "Calculate modulus:"
 msgstr "Υπολογισμοί  modulo ακέραιο:"
 
-#: ../src/wxMaximaFrame.cpp:942
+#: ../src/wxMaximaFrame.cpp:941
 #, fuzzy
 msgid "Calculate numeric value of the last result"
 msgstr "Υπολογισμός της τιμής του τελευταίου αποτέλεσματος προσεγγιστικά"
 
-#: ../src/wxMaximaFrame.cpp:802
+#: ../src/wxMaximaFrame.cpp:801
 msgid "Calculate products"
 msgstr "Υπολογισμός γινομένων"
 
-#: ../src/wxMaximaFrame.cpp:800
+#: ../src/wxMaximaFrame.cpp:799
 msgid "Calculate sums"
 msgstr "Υπολογισμος αθροισμάτων"
 
-#: ../src/wxMaxima.cpp:5830
+#: ../src/wxMaxima.cpp:5845
 msgid "Can not connect to the web server."
 msgstr "Η σύνδεση με τον web server δεν ήταν εφικτή."
 
-#: ../src/wxMaxima.cpp:5881
+#: ../src/wxMaxima.cpp:5896
 msgid "Can not download version info."
 msgstr ""
 
@@ -836,15 +836,15 @@ msgstr ""
 #: ../src/PlotFormatWiz.cpp:48 ../src/SeriesWiz.cpp:49 ../src/SeriesWiz.cpp:51
 #: ../src/SubstituteWiz.cpp:41 ../src/SubstituteWiz.cpp:43 ../src/SumWiz.cpp:44
 #: ../src/SumWiz.cpp:46 ../src/SystemWiz.cpp:38 ../src/SystemWiz.cpp:40
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Cancel"
 msgstr "Ακύρωση"
 
-#: ../src/wxMaximaFrame.cpp:126 ../src/wxMaxima.cpp:932
+#: ../src/wxMaxima.cpp:937 ../src/wxMaximaFrame.cpp:125
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1217
+#: ../src/wxMaximaFrame.cpp:1216
 msgid "Canonical (tr)"
 msgstr "Κανονική μορφή (τρ)"
 
@@ -853,7 +853,7 @@ msgstr "Κανονική μορφή (τρ)"
 msgid "Catalan"
 msgstr "Ιταλικά"
 
-#: ../src/wxMaximaFrame.cpp:638
+#: ../src/wxMaximaFrame.cpp:637
 msgid "Ce&ll"
 msgstr ""
 
@@ -861,41 +861,41 @@ msgstr ""
 msgid "Cell bracket"
 msgstr "Άγκιστρο κελιού"
 
-#: ../src/wxMaxima.cpp:5261
+#: ../src/wxMaxima.cpp:5273
 msgid "Cell ends in a backslash"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:676
+#: ../src/wxMaximaFrame.cpp:675
 msgid "Change &2d Display"
 msgstr "Αλλαγή 2-Δ προβολής μαθηματικών"
 
-#: ../src/wxMaximaFrame.cpp:677
+#: ../src/wxMaximaFrame.cpp:676
 msgid "Change the 2d display algorithm used to display math output"
 msgstr ""
 "Αλλαγή του 2-Δ αλγορίθμου προβολής που χρησιμοποιείται για την απεικόνιση "
 "μαθηματικών αποτελεσμάτων"
 
-#: ../src/wxMaxima.cpp:3995
+#: ../src/wxMaxima.cpp:4007
 msgid "Change variable"
 msgstr "Αλλαγή μεταβλητής"
 
-#: ../src/wxMaximaFrame.cpp:783
+#: ../src/wxMaximaFrame.cpp:782
 msgid "Change variable in integral or sum"
 msgstr "Αλλαγή μεταβλητής στο ολοκλήρωμα ή στο άθροισμα "
 
-#: ../src/wxMaxima.cpp:3751
+#: ../src/wxMaxima.cpp:3763
 msgid "Char poly"
 msgstr "Χαρακτηριστικό πολυώνυμο"
 
-#: ../src/wxMaximaFrame.cpp:978
+#: ../src/wxMaximaFrame.cpp:977
 msgid "Check for Updates"
 msgstr "Έλεγχος για ενημερώσεις"
 
-#: ../src/wxMaximaFrame.cpp:979
+#: ../src/wxMaximaFrame.cpp:978
 msgid "Check if a newer version of wxMaxima/Maxima exist."
 msgstr "Έλεγχος ύπαρξης νεότερης έκδοσης του  wxMaxima/Maxima"
 
-#: ../src/wxMaximaFrame.cpp:1385
+#: ../src/wxMaximaFrame.cpp:1384
 msgid "Chi"
 msgstr ""
 
@@ -917,16 +917,16 @@ msgstr "Επιλογή γραμματοσειράς"
 msgid "Choose new plot format:"
 msgstr "Εισαγωγή νέου τύπου σχεδίασης:"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710
 msgid "Classes:"
 msgstr "Τάξεις:"
 
-#: ../src/wxMaximaFrame.cpp:469
+#: ../src/wxMaximaFrame.cpp:468
 #, fuzzy
 msgid "Close\tCtrl-W"
 msgstr "Αντιγραφή\tCtrl-C"
 
-#: ../src/wxMaximaFrame.cpp:470
+#: ../src/wxMaximaFrame.cpp:469
 msgid "Close window"
 msgstr ""
 
@@ -958,19 +958,19 @@ msgstr ""
 msgid "Code highlighting: Variables"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4806
+#: ../src/wxMaxima.cpp:4818
 msgid "Col. names:"
 msgstr "Oνόματα στηλών:"
 
-#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Columns:"
 msgstr "Στήλες:"
 
-#: ../src/wxMaximaFrame.cpp:860
+#: ../src/wxMaximaFrame.cpp:859
 msgid "Combine factorials in an expression"
 msgstr "Συνδυασμός παραγοντικών σε μια παράσταση"
 
-#: ../src/wxMaxima.cpp:5293
+#: ../src/wxMaxima.cpp:5305
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
@@ -982,24 +982,24 @@ msgstr "Συντεταγμένες του x χωρισμένες με κόμμα
 msgid "Comma separated y coordinates"
 msgstr "Συντεταγμένες του y χωρισμένες με κόμμα"
 
-#: ../src/MathCtrl.cpp:1030
+#: ../src/MathCtrl.cpp:1072
 msgid "Comment Selection"
 msgstr "Επιλογή Σχολίων"
 
-#: ../src/wxMaximaFrame.cpp:533
+#: ../src/wxMaximaFrame.cpp:532
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:532
+#: ../src/wxMaximaFrame.cpp:531
 #, fuzzy
 msgid "Comment selection\tCtrl-/"
 msgstr "Επιλογή Σχολίων"
 
-#: ../src/wxMaximaFrame.cpp:601
+#: ../src/wxMaximaFrame.cpp:600
 msgid "Complete Word\tCtrl-K"
 msgstr "Συμπλήρωση Λέξης\tCtrl-K"
 
-#: ../src/wxMaximaFrame.cpp:602
+#: ../src/wxMaximaFrame.cpp:601
 msgid "Complete word"
 msgstr "Συμπλήρωση λέξης"
 
@@ -1007,37 +1007,37 @@ msgstr "Συμπλήρωση λέξης"
 msgid "Completely stop maxima and restart it"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:823
+#: ../src/wxMaximaFrame.cpp:822
 msgid "Compute continued fraction of a value"
 msgstr "Υπολογισμός συνεχούς κλάσματος μιας τιμής"
 
-#: ../src/wxMaximaFrame.cpp:761
+#: ../src/wxMaximaFrame.cpp:760
 msgid "Compute the adjoint matrix"
 msgstr "Υπολογισμός του προσαρτημένου πίνακα"
 
-#: ../src/wxMaximaFrame.cpp:750
+#: ../src/wxMaximaFrame.cpp:749
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr "Υπολογισμός του χαρακτηριστικού πολυωνύμου ενός πίνακα"
 
-#: ../src/wxMaximaFrame.cpp:753
+#: ../src/wxMaximaFrame.cpp:752
 msgid "Compute the determinant of a matrix"
 msgstr "Υπολογισμός ορίζουσας πίνακα"
 
-#: ../src/wxMaximaFrame.cpp:810
+#: ../src/wxMaximaFrame.cpp:809
 msgid "Compute the greatest common divisor"
 msgstr "Υπολογισμός μέγιστου κοινού διαιρέτη"
 
-#: ../src/wxMaximaFrame.cpp:747
+#: ../src/wxMaximaFrame.cpp:746
 msgid "Compute the inverse of a matrix"
 msgstr "Υπολογισμός αντιστρόφου πίνακα"
 
-#: ../src/wxMaximaFrame.cpp:813
+#: ../src/wxMaximaFrame.cpp:812
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
 "Υπολογισμός του ελαχίστου κοινού πολλαπλασίου (εκτελέστε load(functs) πριν "
 "τη χρήση)"
 
-#: ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4868
 msgid "Condition:"
 msgstr "Συνθήκη:"
 
@@ -1049,8 +1049,8 @@ msgstr "Αρχείο Config (*.ini)|*.ini"
 msgid "Configuration warning"
 msgstr "Προειδοποίηση ρύθμισης"
 
-#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:538
-#: ../src/wxMaximaFrame.cpp:541
+#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:540
 msgid "Configure wxMaxima"
 msgstr "Ρυθμίσεις του wxMaxima"
 
@@ -1059,134 +1059,136 @@ msgstr "Ρυθμίσεις του wxMaxima"
 msgid "Constant"
 msgstr "Σταθερά"
 
-#: ../src/wxMaximaFrame.cpp:844
+#: ../src/wxMaximaFrame.cpp:843
 msgid "Contract Logarithms"
 msgstr "Συστολή λογαρίθμων"
 
-#: ../src/wxMaximaFrame.cpp:851
+#: ../src/wxMaximaFrame.cpp:850
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr "Μετατροπή διωνυμικών,συναρτήσεων Βήτα και Γάμμα σε παραγοντικά"
 
-#: ../src/wxMaximaFrame.cpp:854
+#: ../src/wxMaximaFrame.cpp:853
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr ""
 "Μετατροπή διωνύμων, παραγοντικών και Βήτα συναρτήσεων σε Γάμμα συνάρτηση"
 
-#: ../src/wxMaximaFrame.cpp:888
+#: ../src/wxMaximaFrame.cpp:887
 msgid "Convert complex expression to polar form"
 msgstr "Μετατροπή μιγαδικής παράστασης σε πολική μορφή"
 
-#: ../src/wxMaximaFrame.cpp:885
+#: ../src/wxMaximaFrame.cpp:884
 msgid "Convert complex expression to rect form"
 msgstr "Μετατροπή μιγαδικών παραστάσεων σε ορθογώνιες συντεταγμένες"
 
-#: ../src/wxMaximaFrame.cpp:897
+#: ../src/wxMaximaFrame.cpp:896
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
 "Μετατροπή της εκθετικής συνάρτησης φανταστικής μεταβλητής σε τριγωνομετρική "
 "μορφή"
 
-#: ../src/wxMaximaFrame.cpp:842
+#: ../src/wxMaximaFrame.cpp:841
 msgid "Convert logarithm of product to sum of logarithms"
 msgstr "Μετατροπή λογαρίθμου γινομένου σε άθροισμα λογαρίθμων"
 
-#: ../src/wxMaximaFrame.cpp:845
+#: ../src/wxMaximaFrame.cpp:844
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "Μετατροπή αθροίσματος λογαρίθμων σε λογάριθμο γινομένου"
 
-#: ../src/wxMaximaFrame.cpp:850
+#: ../src/wxMaximaFrame.cpp:849
 msgid "Convert to &Factorials"
 msgstr "Μετατροπή σε παραγοντικά"
 
-#: ../src/wxMaximaFrame.cpp:853
+#: ../src/wxMaximaFrame.cpp:852
 msgid "Convert to &Gamma"
 msgstr "Μετατροπή σε Γάμμα"
 
-#: ../src/wxMaximaFrame.cpp:887
+#: ../src/wxMaximaFrame.cpp:886
 msgid "Convert to &Polarform"
 msgstr "Μετατροπή σε πολική μορφή"
 
-#: ../src/wxMaximaFrame.cpp:884
+#: ../src/wxMaximaFrame.cpp:883
 msgid "Convert to &Rectform"
 msgstr "Μετατροπή σε ορθογώνιες συντεταγμένες"
 
-#: ../src/wxMaximaFrame.cpp:877
+#: ../src/wxMaximaFrame.cpp:876
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr "Μετατροπή τριγωνομετρικής παράστασης σε κανονική ημιγραμμική μορφή"
 
-#: ../src/wxMaximaFrame.cpp:900
+#: ../src/wxMaximaFrame.cpp:899
 #, fuzzy
 msgid "Convert trigonometric functions to exponential form"
 msgstr "Μετατροπή τριγωνομετρικών συναρτήσεων σε εκθετική μορφή"
 
-#: ../src/ToolBar.cpp:140 ../src/MathCtrl.cpp:918 ../src/MathCtrl.cpp:931
-#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1024
+#: ../src/MathCtrl.cpp:960 ../src/MathCtrl.cpp:973 ../src/MathCtrl.cpp:1019
+#: ../src/MathCtrl.cpp:1066 ../src/ToolBar.cpp:140
 msgid "Copy"
 msgstr "Αντιγραφή"
 
-#: ../src/wxMaximaFrame.cpp:597
+#: ../src/wxMaximaFrame.cpp:596
 msgid "Copy Previous Input\tCtrl-I"
 msgstr "Αντιγραφή προηγούμενης εισαγωγής\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:599
+#: ../src/wxMaximaFrame.cpp:598
 #, fuzzy
 msgid "Copy Previous Output\tCtrl-U"
 msgstr "Αντιγραφή προηγούμενης εισαγωγής\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:514 ../src/MathCtrl.cpp:936 ../src/MathCtrl.cpp:982
+#: ../src/MathCtrl.cpp:978 ../src/MathCtrl.cpp:1024
+#: ../src/wxMaximaFrame.cpp:513
 msgid "Copy as Image"
 msgstr "Αντιγραφή ως εικόνα"
 
-#: ../src/wxMaximaFrame.cpp:507 ../src/MathCtrl.cpp:932 ../src/MathCtrl.cpp:978
+#: ../src/MathCtrl.cpp:974 ../src/MathCtrl.cpp:1020
+#: ../src/wxMaximaFrame.cpp:506
 msgid "Copy as LaTeX"
 msgstr "Αντιγραφή ως LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:510
+#: ../src/wxMaximaFrame.cpp:509
 #, fuzzy
 msgid "Copy as MathML"
 msgstr "Αντιγραφή ως εικόνα"
 
-#: ../src/MathCtrl.cpp:935 ../src/MathCtrl.cpp:980
+#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1022
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:504
+#: ../src/wxMaximaFrame.cpp:503
 msgid "Copy as Text\tCtrl-Shift-C"
 msgstr "Αντιγραφή ως κείμενο\tCtrl-Shift-C"
 
-#: ../src/MathCtrl.cpp:933 ../src/MathCtrl.cpp:979
+#: ../src/MathCtrl.cpp:975 ../src/MathCtrl.cpp:1021
 #, fuzzy
 msgid "Copy as plain text"
 msgstr "Αντιγραφή ως εικόνα"
 
-#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:503
+#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:502
 msgid "Copy selection"
 msgstr "Αντιγραφή επιλογής"
 
-#: ../src/wxMaximaFrame.cpp:515
+#: ../src/wxMaximaFrame.cpp:514
 msgid "Copy selection from document as an image"
 msgstr "Αντιγραφή επιλογής από  έγγραφο ως εικόνα"
 
-#: ../src/wxMaximaFrame.cpp:505
+#: ../src/wxMaximaFrame.cpp:504
 msgid "Copy selection from document as text"
 msgstr "Αντιγραφή επιλογής από  έγγραφο ως κείμενο"
 
-#: ../src/wxMaximaFrame.cpp:508
+#: ../src/wxMaximaFrame.cpp:507
 msgid "Copy selection from document in LaTeX format"
 msgstr "Αντιγραφή επιλογής από έγγραφο σε μορφή LaTeX "
 
-#: ../src/wxMaximaFrame.cpp:511
+#: ../src/wxMaximaFrame.cpp:510
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:598
+#: ../src/wxMaximaFrame.cpp:597
 msgid "Create a new cell with previous input"
 msgstr "Δημιουργία κελιού με την τελευταία εισαγωγή"
 
-#: ../src/wxMaximaFrame.cpp:600
+#: ../src/wxMaximaFrame.cpp:599
 #, fuzzy
 msgid "Create a new cell with previous output"
 msgstr "Δημιουργία κελιού με την τελευταία εισαγωγή"
@@ -1195,15 +1197,15 @@ msgstr "Δημιουργία κελιού με την τελευταία εισ�
 msgid "Cursor"
 msgstr "Κέρσορας"
 
-#: ../src/ToolBar.cpp:137 ../src/MathCtrl.cpp:1023
+#: ../src/MathCtrl.cpp:1065 ../src/ToolBar.cpp:137
 msgid "Cut"
 msgstr "Αποκοπή"
 
-#: ../src/wxMaximaFrame.cpp:499
+#: ../src/wxMaximaFrame.cpp:498
 msgid "Cut\tCtrl-X"
 msgstr "Αποκοπή\tCtrl-X"
 
-#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:500
+#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:499
 msgid "Cut selection"
 msgstr "Αποκοπή επιλογής"
 
@@ -1215,18 +1217,18 @@ msgstr "Τσεχικά"
 msgid "Danish"
 msgstr "Δανικά"
 
-#: ../src/wxMaxima.cpp:4799 ../src/wxMaxima.cpp:4806 ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4811 ../src/wxMaxima.cpp:4818 ../src/wxMaxima.cpp:4868
 msgid "Data Matrix:"
 msgstr "Πίνακας Δεδομένων:"
 
-#: ../src/wxMaxima.cpp:4826
+#: ../src/wxMaxima.cpp:4838
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr "Αρχείο δεδομένων (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698 ../src/wxMaxima.cpp:4712
-#: ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726 ../src/wxMaxima.cpp:4734
-#: ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748 ../src/wxMaxima.cpp:4755
-#: ../src/wxMaxima.cpp:4791
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710 ../src/wxMaxima.cpp:4724
+#: ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738 ../src/wxMaxima.cpp:4746
+#: ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760 ../src/wxMaxima.cpp:4767
+#: ../src/wxMaxima.cpp:4803
 msgid "Data:"
 msgstr "Δεδομένα:"
 
@@ -1234,7 +1236,7 @@ msgstr "Δεδομένα:"
 msgid "Debug: watch maxima's stdout stream"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:820
+#: ../src/wxMaximaFrame.cpp:819
 msgid "Decompose rational function to partial fractions"
 msgstr "Ανάλυση ρητής συνάρτησης σε μερικά κλάσματα"
 
@@ -1267,47 +1269,47 @@ msgid ""
 "with."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3403 ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3415 ../src/wxMaxima.cpp:3424
 msgid "Delete"
 msgstr "Διαγραφή"
 
-#: ../src/wxMaximaFrame.cpp:667
+#: ../src/wxMaximaFrame.cpp:666
 msgid "Delete F&unction..."
 msgstr "Διαγραφή συνάρτησης..."
 
-#: ../src/MathCtrl.cpp:939 ../src/MathCtrl.cpp:985
+#: ../src/MathCtrl.cpp:981 ../src/MathCtrl.cpp:1027
 msgid "Delete Selection"
 msgstr "Διαγραφή επιλογής"
 
-#: ../src/wxMaximaFrame.cpp:669
+#: ../src/wxMaximaFrame.cpp:668
 msgid "Delete V&ariable..."
 msgstr "Διαγραφή μεταβλητής..."
 
-#: ../src/wxMaximaFrame.cpp:668
+#: ../src/wxMaximaFrame.cpp:667
 msgid "Delete a function"
 msgstr "Διαγραφή μίας συνάρτησης"
 
-#: ../src/wxMaximaFrame.cpp:670
+#: ../src/wxMaximaFrame.cpp:669
 msgid "Delete a variable"
 msgstr "Διαγραφή μίας μεταβλητής"
 
-#: ../src/wxMaximaFrame.cpp:655
+#: ../src/wxMaximaFrame.cpp:654
 msgid "Delete all values from memory"
 msgstr "Διαγραφή όλων των τιμών από τη μνήμη"
 
-#: ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3424
 msgid "Delete function(s):"
 msgstr "Διαγραφή συνάρτησης(-σεων)"
 
-#: ../src/wxMaxima.cpp:3403
+#: ../src/wxMaxima.cpp:3415
 msgid "Delete variable(s):"
 msgstr "Διαγραφή μεταβλητής(-ών):"
 
-#: ../src/wxMaximaFrame.cpp:1367
+#: ../src/wxMaximaFrame.cpp:1366
 msgid "Delta"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4011
+#: ../src/wxMaxima.cpp:4023
 msgid "Denom. deg:"
 msgstr "Βαθμός Παρανομαστή:"
 
@@ -1315,36 +1317,36 @@ msgstr "Βαθμός Παρανομαστή:"
 msgid "Depth:"
 msgstr "Βάθος:"
 
-#: ../src/wxMaxima.cpp:3541
+#: ../src/wxMaxima.cpp:3553
 msgid "Derivative:"
 msgstr "Παράγωγος:"
 
-#: ../src/wxMaximaFrame.cpp:1258
+#: ../src/wxMaximaFrame.cpp:1257
 #, fuzzy
 msgid "Deviation..."
 msgstr "Απόκλιση"
 
-#: ../src/wxMaximaFrame.cpp:816
+#: ../src/wxMaximaFrame.cpp:815
 msgid "Di&vide Polynomials..."
 msgstr "Διαίρεση πολυωνύμων..."
 
-#: ../src/wxMaximaFrame.cpp:1223
+#: ../src/wxMaximaFrame.cpp:1222
 msgid "Diff..."
 msgstr "Παραγώγιση..."
 
-#: ../src/wxMaxima.cpp:4154 ../src/wxMaxima.cpp:5066
+#: ../src/wxMaxima.cpp:4166 ../src/wxMaxima.cpp:5078
 msgid "Differentiate"
 msgstr "Παραγώγιση"
 
-#: ../src/wxMaximaFrame.cpp:786
+#: ../src/wxMaximaFrame.cpp:785
 msgid "Differentiate expression"
 msgstr "Παραγώγιση παράστασης"
 
-#: ../src/MathCtrl.cpp:1001
+#: ../src/MathCtrl.cpp:1043
 msgid "Differentiate..."
 msgstr "Παραγώγιση..."
 
-#: ../src/LimitWiz.cpp:37 ../src/FindReplacePane.cpp:76
+#: ../src/FindReplacePane.cpp:76 ../src/LimitWiz.cpp:37
 msgid "Direction:"
 msgstr "Κατεύθυνση:"
 
@@ -1352,48 +1354,49 @@ msgstr "Κατεύθυνση:"
 msgid "Discrete plot"
 msgstr "Διακριτή σχεδίαση."
 
-#: ../src/wxMaximaFrame.cpp:679
+#: ../src/wxMaximaFrame.cpp:678
 msgid "Display Te&X Form"
 msgstr "Εμφάνιση σε μορφή TeX"
 
-#: ../src/wxMaxima.cpp:3320
+#: ../src/wxMaxima.cpp:3332
 msgid "Display algorithm"
 msgstr "Αλγόριθμος προβολής μαθηματικών"
 
-#: ../src/wxMaximaFrame.cpp:680
+#: ../src/wxMaximaFrame.cpp:679
 msgid "Display last result in TeX form"
 msgstr "Εμφάνιση τελευταίου αποτελέσματος σε μορφή TeX"
 
-#: ../src/wxMaximaFrame.cpp:674
+#: ../src/wxMaximaFrame.cpp:673
 msgid "Display time used for evaluation"
 msgstr "Εμφάνιση του χρόνου που απαιτήθηκε για τον υπολογισμό"
 
-#: ../src/wxMaxima.cpp:4061
+#: ../src/wxMaxima.cpp:4073
 msgid "Divide"
 msgstr "Διαίρεση"
 
-#: ../src/MathCtrl.cpp:1032
+#: ../src/MathCtrl.cpp:1074
 msgid "Divide Cell"
 msgstr "Διαίρεση κελιού"
 
-#: ../src/wxMaximaFrame.cpp:635
+#: ../src/wxMaximaFrame.cpp:634
 #, fuzzy
 msgid "Divide Cell\tCtrl-D"
 msgstr "Διαίρεση κελιού"
 
-#: ../src/wxMaximaFrame.cpp:817
+#: ../src/wxMaximaFrame.cpp:816
 msgid "Divide numbers or polynomials"
 msgstr "Διαίρεση αριθμών ή πολυωνύμων"
 
-#: ../src/wxMaximaFrame.cpp:636
+#: ../src/wxMaximaFrame.cpp:635
 msgid "Divide this input cell into two cells"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5917
-msgid "Do you want to save the changes you made in the document \""
+#: ../src/wxMaxima.cpp:5932
+#, c-format
+msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1664 ../src/wxMaxima.cpp:1672
+#: ../src/wxMaxima.cpp:1669 ../src/wxMaxima.cpp:1677
 msgid "Document "
 msgstr "Έγγραφο"
 
@@ -1412,7 +1415,7 @@ msgid ""
 "differences."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Don't save"
 msgstr ""
 
@@ -1420,27 +1423,27 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:734
+#: ../src/wxMaximaFrame.cpp:733
 msgid "E&quations"
 msgstr "Εξισώσεις"
 
-#: ../src/wxMaximaFrame.cpp:487
+#: ../src/wxMaximaFrame.cpp:486
 msgid "E&xit\tCtrl-Q"
 msgstr "Έξοδος\tCtrl-Q"
 
-#: ../src/wxMaximaFrame.cpp:757
+#: ../src/wxMaximaFrame.cpp:756
 msgid "Eige&nvectors"
 msgstr "Ιδιοδιανύσματα"
 
-#: ../src/wxMaximaFrame.cpp:755
+#: ../src/wxMaximaFrame.cpp:754
 msgid "Eigen&values"
 msgstr "Ιδιοτιμές"
 
-#: ../src/wxMaxima.cpp:3572
+#: ../src/wxMaxima.cpp:3584
 msgid "Eliminate"
 msgstr "Απαλειφή"
 
-#: ../src/wxMaximaFrame.cpp:710
+#: ../src/wxMaximaFrame.cpp:709
 msgid "Eliminate a variable from a system of equations"
 msgstr "Απαλειφή μεταβλητής από σύστημα εξισώσεων"
 
@@ -1452,22 +1455,22 @@ msgstr ""
 msgid "English"
 msgstr "Αγγλικά"
 
-#: ../src/wxMaxima.cpp:4712 ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726
-#: ../src/wxMaxima.cpp:4734 ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748
-#: ../src/wxMaxima.cpp:4755 ../src/wxMaxima.cpp:4791 ../src/wxMaxima.cpp:4799
+#: ../src/wxMaxima.cpp:4724 ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738
+#: ../src/wxMaxima.cpp:4746 ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760
+#: ../src/wxMaxima.cpp:4767 ../src/wxMaxima.cpp:4803 ../src/wxMaxima.cpp:4811
 #, fuzzy
 msgid "Enter Data"
 msgstr "Εισαγωγή πίνακα"
 
-#: ../src/wxMaximaFrame.cpp:1279
+#: ../src/wxMaximaFrame.cpp:1278
 msgid "Enter Matrix..."
 msgstr "Εισαγωγή πίνακα..."
 
-#: ../src/wxMaximaFrame.cpp:745
+#: ../src/wxMaximaFrame.cpp:744
 msgid "Enter a matrix"
 msgstr "Εισαγωγή πίνακα"
 
-#: ../src/wxMaxima.cpp:3962
+#: ../src/wxMaxima.cpp:3974
 msgid "Enter an equation for rational simplification:"
 msgstr "Εισαγωγή εξίσωσης για ρητή απλοποίηση:"
 
@@ -1479,11 +1482,11 @@ msgstr "Εισαγωγή λίστας μεταβλητών χωρισμένες 
 msgid "Enter evaluates cells"
 msgstr "Το Enter υπολογίζει τα κελιά"
 
-#: ../src/wxMaxima.cpp:3734
+#: ../src/wxMaxima.cpp:3746
 msgid "Enter matrix"
 msgstr "Εισαγωγή πίνακα"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 #, fuzzy
 msgid "Enter new precision for bigfloats:"
 msgstr "Εισαγωγή νέας τιμής ακρίβειας:"
@@ -1492,12 +1495,12 @@ msgstr "Εισαγωγή νέας τιμής ακρίβειας:"
 msgid "Enter the path to the Maxima executable."
 msgstr "Εισαγωγή της διαδρομής στο εκτελέσιμο αρχείο του maxima."
 
-#: ../src/wxMaximaFrame.cpp:1368
+#: ../src/wxMaximaFrame.cpp:1367
 #, fuzzy
 msgid "Epsilon"
 msgstr "Έψιλον:"
 
-#: ../src/wxMaxima.cpp:4208
+#: ../src/wxMaxima.cpp:4220
 msgid "Epsilon:"
 msgstr "Έψιλον:"
 
@@ -1506,13 +1509,13 @@ msgstr "Έψιλον:"
 msgid "Equation %d:"
 msgstr "Εξίσωση %d:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:3633
-#: ../src/wxMaxima.cpp:5019
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:3645
+#: ../src/wxMaxima.cpp:5031
 msgid "Equation(s):"
 msgstr "Εξίσωση(-εις):"
 
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3993
-#: ../src/wxMaxima.cpp:4807 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:4005
+#: ../src/wxMaxima.cpp:4819 ../src/wxMaxima.cpp:5045
 msgid "Equation:"
 msgstr "Εξίσωση:"
 
@@ -1523,79 +1526,79 @@ msgid ""
 "be introduced one into another. Also they are always printed out as 2D maths."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3570
+#: ../src/wxMaxima.cpp:3582
 msgid "Equations:"
 msgstr "Εξισώσεις:"
 
-#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1455
-#: ../src/wxMaxima.cpp:1469 ../src/wxMaxima.cpp:1620 ../src/wxMaxima.cpp:1633
-#: ../src/wxMaxima.cpp:1643 ../src/wxMaxima.cpp:1666 ../src/wxMaxima.cpp:2034
-#: ../src/wxMaxima.cpp:2206 ../src/wxMaxima.cpp:5381 ../src/wxMaxima.cpp:5830
-#: ../src/wxMaxima.cpp:5881
+#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1460
+#: ../src/wxMaxima.cpp:1474 ../src/wxMaxima.cpp:1625 ../src/wxMaxima.cpp:1638
+#: ../src/wxMaxima.cpp:1648 ../src/wxMaxima.cpp:1671 ../src/wxMaxima.cpp:2039
+#: ../src/wxMaxima.cpp:2211 ../src/wxMaxima.cpp:5397 ../src/wxMaxima.cpp:5845
+#: ../src/wxMaxima.cpp:5896
 msgid "Error"
 msgstr "Σφάλμα"
 
-#: ../src/wxMaxima.cpp:2886 ../src/wxMaxima.cpp:2900 ../src/wxMaxima.cpp:2913
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617 ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:2894 ../src/wxMaxima.cpp:2908 ../src/wxMaxima.cpp:2921
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629 ../src/wxMaxima.cpp:3740
 msgid "Error!"
 msgstr "Σφάλμα!"
 
-#: ../src/wxMaximaFrame.cpp:1370
+#: ../src/wxMaximaFrame.cpp:1369
 msgid "Eta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:909
+#: ../src/wxMaximaFrame.cpp:908
 msgid "Evaluate &Noun Forms"
 msgstr "Υπολογισμός ονοματικών μορφών"
 
-#: ../src/wxMaximaFrame.cpp:589
+#: ../src/wxMaximaFrame.cpp:588
 #, fuzzy
 msgid "Evaluate All Cells\tCtrl-Shift-R"
 msgstr "Υπολογισμός όλων των κελιών\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:587
+#: ../src/wxMaximaFrame.cpp:586
 #, fuzzy
 msgid "Evaluate All Visible Cells\tCtrl-R"
 msgstr "Υπολογισμός όλων των κελιών\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:585 ../src/MathCtrl.cpp:942
+#: ../src/MathCtrl.cpp:984 ../src/wxMaximaFrame.cpp:584
 msgid "Evaluate Cell(s)"
 msgstr "Υπολογισμός κελιού(-ιών)"
 
-#: ../src/wxMaximaFrame.cpp:591
+#: ../src/wxMaximaFrame.cpp:590
 #, fuzzy
 msgid "Evaluate Cells Above\tCtrl-Shift-P"
 msgstr "Υπολογισμός όλων των κελιών\tCtrl-R"
 
-#: ../src/MathCtrl.cpp:956 ../src/MathCtrl.cpp:1051
+#: ../src/MathCtrl.cpp:998 ../src/MathCtrl.cpp:1093
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:961 ../src/MathCtrl.cpp:1053
+#: ../src/MathCtrl.cpp:1003 ../src/MathCtrl.cpp:1095
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:971 ../src/MathCtrl.cpp:1057
+#: ../src/MathCtrl.cpp:1013 ../src/MathCtrl.cpp:1099
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:966 ../src/MathCtrl.cpp:1055
+#: ../src/MathCtrl.cpp:1008 ../src/MathCtrl.cpp:1097
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:586
+#: ../src/wxMaximaFrame.cpp:585
 msgid "Evaluate active or selected cell(s)"
 msgstr "Υπολογισμός ενεργού(-ών) ή επιλεγμένου(-ων) κελιού(-ών)"
 
-#: ../src/wxMaximaFrame.cpp:590
+#: ../src/wxMaximaFrame.cpp:589
 msgid "Evaluate all cells in the document"
 msgstr "Υπολογισμός όλων των κελιών στο έγγραφο"
 
-#: ../src/wxMaximaFrame.cpp:910
+#: ../src/wxMaximaFrame.cpp:909
 msgid "Evaluate all noun forms in expression"
 msgstr "Υπολογισμός όλων των ονοματικών μορφών στην παράσταση"
 
-#: ../src/wxMaximaFrame.cpp:588
+#: ../src/wxMaximaFrame.cpp:587
 #, fuzzy
 msgid "Evaluate all visible cells in the document"
 msgstr "Υπολογισμός όλων των κελιών στο έγγραφο"
@@ -1609,7 +1612,7 @@ msgstr ""
 msgid "Evaluate to point"
 msgstr "Υπολογισμός ονοματικών μορφών"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Example"
 msgstr "Παράδειγμα"
 
@@ -1622,31 +1625,31 @@ msgstr "Παράδειγμα κειμένου"
 msgid "Examples:"
 msgstr "Παράδειγμα"
 
-#: ../src/wxMaximaFrame.cpp:488
+#: ../src/wxMaximaFrame.cpp:487
 msgid "Exit wxMaxima"
 msgstr "Έξοδος από το wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:1214
+#: ../src/wxMaximaFrame.cpp:1213
 msgid "Expand"
 msgstr "Ανάπτυξη"
 
-#: ../src/wxMaximaFrame.cpp:1219
+#: ../src/wxMaximaFrame.cpp:1218
 msgid "Expand (tr)"
 msgstr "Ανάπτυξη (τρ)"
 
-#: ../src/MathCtrl.cpp:997
+#: ../src/MathCtrl.cpp:1039
 msgid "Expand Expression"
 msgstr "Ανάπτυξη παράστασης"
 
-#: ../src/wxMaximaFrame.cpp:841
+#: ../src/wxMaximaFrame.cpp:840
 msgid "Expand Logarithms"
 msgstr "Ανάπτυξη λογαρίθμων"
 
-#: ../src/wxMaximaFrame.cpp:840
+#: ../src/wxMaximaFrame.cpp:839
 msgid "Expand an expression"
 msgstr "Ανάπτυξη μία παράστασης"
 
-#: ../src/wxMaximaFrame.cpp:874
+#: ../src/wxMaximaFrame.cpp:873
 msgid "Expand trigonometric expression"
 msgstr "Ανάπτυξη τριγωνομετρικής παράστασης"
 
@@ -1654,7 +1657,7 @@ msgstr "Ανάπτυξη τριγωνομετρικής παράστασης"
 msgid "Expected the icon files to be found at"
 msgstr ""
 
-#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2834
+#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2842
 msgid "Export"
 msgstr "Εξαγωγή"
 
@@ -1663,33 +1666,33 @@ msgid ""
 "Export animations to TeX (Images only move if the PDF viewer supports this)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:481
+#: ../src/wxMaximaFrame.cpp:480
 msgid "Export document to a HTML or pdfLaTeX file"
 msgstr "Εξαγωγή εγγράφου σε HTML ή pdfLaTeX αρχείο"
 
-#: ../src/wxMaximaFrame.cpp:253
+#: ../src/wxMaximaFrame.cpp:252
 #, fuzzy
 msgid "Export failed."
 msgstr "Η εξαγωγή σε TeX απέτυχε"
 
-#: ../src/wxMaximaFrame.cpp:239
+#: ../src/wxMaximaFrame.cpp:238
 msgid "Export successful."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2913
+#: ../src/wxMaxima.cpp:2921
 msgid "Exporting to HTML failed!"
 msgstr "Η εξαγωγή σε HTML απέτυχε!"
 
-#: ../src/wxMaxima.cpp:2886
+#: ../src/wxMaxima.cpp:2894
 msgid "Exporting to TeX failed!"
 msgstr "Η εξαγωγή σε TeX απέτυχε"
 
-#: ../src/wxMaxima.cpp:2900
+#: ../src/wxMaxima.cpp:2908
 #, fuzzy
 msgid "Exporting to maxima batch file failed!"
 msgstr "Η εξαγωγή σε TeX απέτυχε"
 
-#: ../src/wxMaximaFrame.cpp:229
+#: ../src/wxMaximaFrame.cpp:228
 #, fuzzy
 msgid "Exporting..."
 msgstr "Εξαγωγή..."
@@ -1703,42 +1706,42 @@ msgid "Expression(s):"
 msgstr "Παράσταση(-εις):"
 
 #: ../src/IntegrateWiz.cpp:30 ../src/LimitWiz.cpp:27 ../src/SeriesWiz.cpp:33
-#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3648
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:4205 ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5064
+#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3660
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:4217 ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5076
 msgid "Expression:"
 msgstr "Παράσταση:"
 
-#: ../src/wxMaximaFrame.cpp:1213
+#: ../src/wxMaximaFrame.cpp:1212
 msgid "Factor"
 msgstr "Παραγοντοποίηση"
 
-#: ../src/wxMaximaFrame.cpp:836
+#: ../src/wxMaximaFrame.cpp:835
 msgid "Factor Complex"
 msgstr "Παραγοντοποίηση παράστασης (Μιγαδική)"
 
-#: ../src/MathCtrl.cpp:996
+#: ../src/MathCtrl.cpp:1038
 msgid "Factor Expression"
 msgstr "Παραγοντοποίηση παράστασης"
 
-#: ../src/wxMaximaFrame.cpp:835
+#: ../src/wxMaximaFrame.cpp:834
 msgid "Factor an expression"
 msgstr "Παραγοντοποίηση μιας παράστασης"
 
-#: ../src/wxMaximaFrame.cpp:837
+#: ../src/wxMaximaFrame.cpp:836
 msgid "Factor an expression in Gaussian numbers"
 msgstr "Παραγοντοποίηση παράστασης σε Γκαουσιανούς αριθμούς"
 
-#: ../src/wxMaximaFrame.cpp:862
+#: ../src/wxMaximaFrame.cpp:861
 msgid "Factorials and &Gamma"
 msgstr "Παραγοντικά και Γάμμα"
 
-#: ../src/wxMaxima.cpp:285
+#: ../src/wxMaxima.cpp:286
 msgid "Fatal error"
 msgstr "Ολέθριο σφάλμα"
 
-#: ../src/GroupCell.cpp:1571
+#: ../src/GroupCell.cpp:1572
 #, fuzzy, c-format
 msgid "Figure %d:"
 msgstr "Σχέδιο"
@@ -1747,22 +1750,22 @@ msgstr "Σχέδιο"
 msgid "File"
 msgstr "Αρχείο"
 
-#: ../src/wxMaxima.cpp:1457 ../src/wxMaxima.cpp:1623 ../src/wxMaxima.cpp:1636
-#: ../src/wxMaxima.cpp:1646 ../src/wxMaxima.cpp:1668
+#: ../src/wxMaxima.cpp:1462 ../src/wxMaxima.cpp:1628 ../src/wxMaxima.cpp:1641
+#: ../src/wxMaxima.cpp:1651 ../src/wxMaxima.cpp:1673
 #, fuzzy
 msgid "File could not be opened"
 msgstr "Το αρχείο δεν βρέθηκε"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File not found"
 msgstr "Το αρχείο δεν βρέθηκε"
 
-#: ../src/wxMaxima.cpp:1511 ../src/wxMaxima.cpp:1729
+#: ../src/wxMaxima.cpp:1516 ../src/wxMaxima.cpp:1734
 #, fuzzy
 msgid "File opened"
 msgstr "Το αρχείο δεν βρέθηκε"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File you tried to open does not exist."
 msgstr "Το αρχείο που προσπαθήσατε να ανοίξετε δεν υπάρχει"
 
@@ -1774,67 +1777,67 @@ msgstr "Αρχείο:"
 msgid "Find"
 msgstr "Εύρεση "
 
-#: ../src/wxMaximaFrame.cpp:523
+#: ../src/wxMaximaFrame.cpp:522
 msgid "Find\tCtrl-F"
 msgstr "Εύρεση \tCtrl-F"
 
-#: ../src/wxMaximaFrame.cpp:787
+#: ../src/wxMaximaFrame.cpp:786
 msgid "Find &Limit..."
 msgstr "Εύρεση ορίου..."
 
-#: ../src/wxMaximaFrame.cpp:790
+#: ../src/wxMaximaFrame.cpp:789
 msgid "Find Minimum..."
 msgstr "Εύρεση ελαχίστου..."
 
-#: ../src/MathCtrl.cpp:993
+#: ../src/MathCtrl.cpp:1035
 msgid "Find Root..."
 msgstr "Εύρεση ρίζας..."
 
-#: ../src/wxMaximaFrame.cpp:791
+#: ../src/wxMaximaFrame.cpp:790
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr "Εύρεση ενός (μη δεσμευμένου) ελαχίστου μιας παράστασης"
 
-#: ../src/wxMaximaFrame.cpp:788
+#: ../src/wxMaximaFrame.cpp:787
 msgid "Find a limit of an expression"
 msgstr "Εύρεση ορίου μιας παράστασης"
 
-#: ../src/wxMaximaFrame.cpp:693
+#: ../src/wxMaximaFrame.cpp:692
 msgid "Find a root of an equation on an interval"
 msgstr "Εύρεση ρίζας μιας εξίσωσης σε ένα διάστημα"
 
-#: ../src/wxMaximaFrame.cpp:695
+#: ../src/wxMaximaFrame.cpp:694
 msgid "Find all roots of a polynomial"
 msgstr "Εύρεση όλων των ριζών ενός πολυωνύμου"
 
-#: ../src/wxMaximaFrame.cpp:698
+#: ../src/wxMaximaFrame.cpp:697
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr "Εύρεση όλων των ριζών ενός πολυωνύμου(bfloat)"
 
-#: ../src/wxMaxima.cpp:3220
+#: ../src/wxMaxima.cpp:3215
 msgid "Find and Replace"
 msgstr "Εύρεση και Αντικατάσταση"
 
-#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:523
+#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:522
 msgid "Find and replace"
 msgstr "Εύρεση και αντικατάσταση"
 
-#: ../src/wxMaximaFrame.cpp:756
+#: ../src/wxMaximaFrame.cpp:755
 msgid "Find eigenvalues of a matrix"
 msgstr "Εύρεση ιδιοτιμών πίνακα"
 
-#: ../src/wxMaximaFrame.cpp:758
+#: ../src/wxMaximaFrame.cpp:757
 msgid "Find eigenvectors of a matrix"
 msgstr "Εύρεση ιδιοδιανυσμάτων πίνακα"
 
-#: ../src/wxMaxima.cpp:4210
+#: ../src/wxMaxima.cpp:4222
 msgid "Find minimum"
 msgstr "Εύρεση ελαχίστου"
 
-#: ../src/wxMaximaFrame.cpp:701
+#: ../src/wxMaximaFrame.cpp:700
 msgid "Find real roots of a polynomial"
 msgstr "Εύρεση πραγματικών ριζών πολυωνύμου"
 
-#: ../src/wxMaxima.cpp:3493 ../src/wxMaxima.cpp:5036
+#: ../src/wxMaxima.cpp:3505 ../src/wxMaxima.cpp:5048
 msgid "Find root"
 msgstr "Εύρεση ρίζας"
 
@@ -1857,12 +1860,12 @@ msgstr ""
 msgid "Fixed font in text controls"
 msgstr "Σταθερή γραμματοσειρά στον έλεγχο κειμένου"
 
-#: ../src/wxMaximaFrame.cpp:623
+#: ../src/wxMaximaFrame.cpp:622
 #, fuzzy
 msgid "Fold All\tCtrl-Alt-["
 msgstr "Επιλογή Όλων\tCtrl-A"
 
-#: ../src/wxMaximaFrame.cpp:624
+#: ../src/wxMaximaFrame.cpp:623
 msgid "Fold all sections"
 msgstr ""
 
@@ -1870,25 +1873,25 @@ msgstr ""
 msgid "Follow"
 msgstr ""
 
-#: ../src/ParenCell.cpp:319
+#: ../src/ParenCell.cpp:320
 msgid "Font issue: The Parenthesis sign is too small!"
 msgstr ""
 
-#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:381
+#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:382
 msgid ""
 "Font issue: The char height is too small! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:199
+#: ../src/SqrtCell.cpp:202
 msgid ""
 "Font issue: The sqrt() sign has the size 0! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:198
+#: ../src/SqrtCell.cpp:201
 msgid "Font issue? The contents of a sqrt() has the size 0."
 msgstr ""
 
@@ -1921,15 +1924,15 @@ msgstr "Γαλλικά"
 
 #: ../src/IntegrateWiz.cpp:37 ../src/Plot2dWiz.cpp:37 ../src/Plot2dWiz.cpp:47
 #: ../src/Plot2dWiz.cpp:536 ../src/Plot3dWiz.cpp:36 ../src/Plot3dWiz.cpp:45
-#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4240
+#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4252
 msgid "From:"
 msgstr "Από:"
 
-#: ../src/wxMaximaFrame.cpp:576
+#: ../src/wxMaximaFrame.cpp:575
 msgid "Full Screen\tAlt-Enter"
 msgstr "Πλήρης οθόνη\tAlt-Enter"
 
-#: ../src/wxMaxima.cpp:3342
+#: ../src/wxMaxima.cpp:3354
 msgid "Function"
 msgstr "Συνάρτηση"
 
@@ -1937,32 +1940,32 @@ msgstr "Συνάρτηση"
 msgid "Function names"
 msgstr "Ονόματα συναρτήσεων"
 
-#: ../src/wxMaxima.cpp:3633
+#: ../src/wxMaxima.cpp:3645
 msgid "Function(s):"
 msgstr "Συνάρτηση(-εις):"
 
-#: ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3803
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3815
+#: ../src/wxMaxima.cpp:3848
 msgid "Function:"
 msgstr "Συνάρτηση:"
 
-#: ../src/wxMaximaFrame.cpp:904
+#: ../src/wxMaximaFrame.cpp:903
 msgid "Functions for complex simplification"
 msgstr "Συναρτήσεις για μιγαδική απλοποίηση"
 
-#: ../src/wxMaximaFrame.cpp:864
+#: ../src/wxMaximaFrame.cpp:863
 msgid "Functions for simplifying factorials and gamma function"
 msgstr "Συναρτήσεις για απλοποίηση παραγοντικών και Γάμμα συναρτήσεων"
 
-#: ../src/wxMaximaFrame.cpp:881
+#: ../src/wxMaximaFrame.cpp:880
 msgid "Functions for simplifying trigonometric expressions"
 msgstr "Συναρτήσεις για απλοποίηση τριγωνομετρικών παραστάσεων"
 
-#: ../src/wxMaxima.cpp:4046
+#: ../src/wxMaxima.cpp:4058
 msgid "GCD"
 msgstr "ΜΚΔ"
 
-#: ../src/wxMaxima.cpp:5152
+#: ../src/wxMaxima.cpp:5164
 msgid "GIF image (*.gif)|*.gif"
 msgstr "Εικόνα GIF (*.gif)|*.gif"
 
@@ -1970,31 +1973,31 @@ msgstr "Εικόνα GIF (*.gif)|*.gif"
 msgid "Galician"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1366
+#: ../src/wxMaximaFrame.cpp:1365
 msgid "Gamma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:391
+#: ../src/wxMaximaFrame.cpp:390
 msgid "General Math"
 msgstr "Γενικά Μαθηματικά"
 
-#: ../src/wxMaximaFrame.cpp:549
+#: ../src/wxMaximaFrame.cpp:548
 msgid "General Math\tAlt-Shift-M"
 msgstr "Γενικά Μαθηματικά\tAlt-Shift-M"
 
-#: ../src/wxMaxima.cpp:3766 ../src/wxMaxima.cpp:3785
+#: ../src/wxMaxima.cpp:3778 ../src/wxMaxima.cpp:3797
 msgid "Generate Matrix"
 msgstr "Δημιουργία πίνακα"
 
-#: ../src/wxMaximaFrame.cpp:741
+#: ../src/wxMaximaFrame.cpp:740
 msgid "Generate Matrix from Expression..."
 msgstr "Δημιουργία πίνακα απο παράσταση..."
 
-#: ../src/wxMaximaFrame.cpp:739
+#: ../src/wxMaximaFrame.cpp:738
 msgid "Generate a matrix from a 2-dimensional array"
 msgstr "Δημιουργία πίνακα από 2-Δ πίνακα"
 
-#: ../src/wxMaximaFrame.cpp:742
+#: ../src/wxMaximaFrame.cpp:741
 msgid "Generate a matrix from a lambda expression"
 msgstr "Δημιουργία πίνακα από παράσταση lambda"
 
@@ -2002,39 +2005,39 @@ msgstr "Δημιουργία πίνακα από παράσταση lambda"
 msgid "German"
 msgstr "Γερμανικά"
 
-#: ../src/wxMaximaFrame.cpp:893
+#: ../src/wxMaximaFrame.cpp:892
 msgid "Get &Imaginary Part"
 msgstr "Εξαγωγή φανταστικού μέρους"
 
-#: ../src/wxMaximaFrame.cpp:793
+#: ../src/wxMaximaFrame.cpp:792
 msgid "Get &Series..."
 msgstr "Υπολογισμός σειρών..."
 
-#: ../src/wxMaximaFrame.cpp:804
+#: ../src/wxMaximaFrame.cpp:803
 msgid "Get Laplace transformation of an expression"
 msgstr "Υπολογισμός μετασχηματισμού Laplace μιας παράστασης"
 
-#: ../src/wxMaximaFrame.cpp:890
+#: ../src/wxMaximaFrame.cpp:889
 msgid "Get Real P&art"
 msgstr "Εξαγωγή πραγματικού μέρους"
 
-#: ../src/wxMaximaFrame.cpp:807
+#: ../src/wxMaximaFrame.cpp:806
 msgid "Get inverse Laplace transformation of an expression"
 msgstr "Υπολογισμός του αντίστροφου μετασχηματισμού Laplace μιας παράστασης\""
 
-#: ../src/wxMaximaFrame.cpp:794
+#: ../src/wxMaximaFrame.cpp:793
 msgid "Get the Taylor or power series of expression"
 msgstr "Υπολογισμός σειράς Taylor ή δυναμοσειράς μιας παράστασης"
 
-#: ../src/wxMaximaFrame.cpp:894
+#: ../src/wxMaximaFrame.cpp:893
 msgid "Get the imaginary part of complex expression"
 msgstr "Υπολογισμός φανταστικού μέρους μιας μιγαδικής παράστασης"
 
-#: ../src/wxMaximaFrame.cpp:891
+#: ../src/wxMaximaFrame.cpp:890
 msgid "Get the real part of complex expression"
 msgstr "Υπολογισμός πραγματικού μέρους μιας μιγαδικής παράστασης"
 
-#: ../src/MathCtrl.cpp:5932
+#: ../src/MathCtrl.cpp:5984
 msgid ""
 "Got a request to undo an action that involves an delete which isn't possible "
 "at this moment."
@@ -2044,12 +2047,12 @@ msgstr ""
 msgid "Greek"
 msgstr "Ελληνικά"
 
-#: ../src/wxMaximaFrame.cpp:356
+#: ../src/wxMaximaFrame.cpp:355
 #, fuzzy
 msgid "Greek Letters"
 msgstr "Ελληνικές σταθερές"
 
-#: ../src/wxMaximaFrame.cpp:552
+#: ../src/wxMaximaFrame.cpp:551
 #, fuzzy
 msgid "Greek Letters\tAlt-Shift-G"
 msgstr "Γενικά Μαθηματικά\tAlt-Shift-M"
@@ -2062,7 +2065,7 @@ msgstr "Ελληνικές σταθερές"
 msgid "Grid:"
 msgstr "Πλέγμα:"
 
-#: ../src/wxMaxima.cpp:2836
+#: ../src/wxMaxima.cpp:2844
 #, fuzzy
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|pdfLaTeX file (*."
@@ -2077,12 +2080,12 @@ msgstr ""
 msgid "Help"
 msgstr "Βοήθεια"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 #, fuzzy
 msgid "Hide All Toolbars\tAlt-Shift--"
 msgstr "Απόκρυψη Όλων\tAlt-Shift--"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide all panes"
 msgstr "Απόκρυψη όλων των παλετών"
 
@@ -2090,19 +2093,19 @@ msgstr "Απόκρυψη όλων των παλετών"
 msgid "Highlight (dpart)"
 msgstr "Επισήμανση (dpart)"
 
-#: ../src/wxMaxima.cpp:4685
+#: ../src/wxMaxima.cpp:4697
 msgid "Histogram"
 msgstr "Ιστόγραμμα"
 
-#: ../src/wxMaximaFrame.cpp:1270
+#: ../src/wxMaximaFrame.cpp:1269
 msgid "Histogram..."
 msgstr "Ιστόγραμμα..."
 
-#: ../src/wxMaximaFrame.cpp:309
+#: ../src/wxMaximaFrame.cpp:308
 msgid "History"
 msgstr "Ιστορικό"
 
-#: ../src/wxMaximaFrame.cpp:555
+#: ../src/wxMaximaFrame.cpp:554
 #, fuzzy
 msgid "History\tAlt-Shift-I"
 msgstr "Ιστορικό\tAlt-Shift-H"
@@ -2123,11 +2126,11 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Ουγγρικά"
 
-#: ../src/wxMaxima.cpp:3527
+#: ../src/wxMaxima.cpp:3539
 msgid "IC1"
 msgstr "IC1"
 
-#: ../src/wxMaxima.cpp:3543
+#: ../src/wxMaxima.cpp:3555
 msgid "IC2"
 msgstr "IC2"
 
@@ -2143,7 +2146,7 @@ msgid ""
 "same output cell."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:683
+#: ../src/wxMaximaFrame.cpp:682
 msgid ""
 "If maxima ever finishes evaluating without wxMaxima realizing this this menu "
 "item can force wxMaxima to try to send commands to maxima again."
@@ -2205,11 +2208,11 @@ msgstr ""
 "Αν ο υπολογισμός σας καθυστερεί πολύ, μπορείτε να δοκιμάσετε τις εντολές του "
 "μενού 'Maxima->Διακοπή' ή 'Maxima->Επανεκκίνηση Maxima'."
 
-#: ../src/wxMaximaFrame.cpp:1499
+#: ../src/wxMaximaFrame.cpp:1518
 msgid "Image"
 msgstr "Εικόνα"
 
-#: ../src/wxMaxima.cpp:5644
+#: ../src/wxMaxima.cpp:5659
 msgid "Image files (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 msgstr "Αρχεία εικόνας (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 
@@ -2236,7 +2239,7 @@ msgid ""
 "above it. Might increase readability for some fonts and short subscripts."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Include columns:"
 msgstr "Συμπεριέλαβε τις στήλες:"
 
@@ -2255,19 +2258,19 @@ msgstr ""
 msgid "Infinity"
 msgstr "Άπειρο"
 
-#: ../src/wxMaximaFrame.cpp:974
+#: ../src/wxMaximaFrame.cpp:973
 msgid "Info about Maxima build"
 msgstr "Πληροφορίες για το Maxima build"
 
-#: ../src/wxMaxima.cpp:4207
+#: ../src/wxMaxima.cpp:4219
 msgid "Initial Estimates:"
 msgstr "Αρχικές Εκτιμήσεις:"
 
-#: ../src/wxMaximaFrame.cpp:718
+#: ../src/wxMaximaFrame.cpp:717
 msgid "Initial Value Problem (&1)..."
 msgstr "Πρόβλημα αρχικών τιμών (&1)..."
 
-#: ../src/wxMaximaFrame.cpp:721
+#: ../src/wxMaximaFrame.cpp:720
 msgid "Initial Value Problem (&2)..."
 msgstr "Πρόβλημα αρχικών τιμών (&2)..."
 
@@ -2275,7 +2278,7 @@ msgstr "Πρόβλημα αρχικών τιμών (&2)..."
 msgid "Input labels"
 msgstr "Ετικέτες εισαγωγής"
 
-#: ../src/wxMaximaFrame.cpp:403
+#: ../src/wxMaximaFrame.cpp:402
 msgid "Insert"
 msgstr "Προσθήκη"
 
@@ -2283,108 +2286,108 @@ msgstr "Προσθήκη"
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:612
+#: ../src/wxMaximaFrame.cpp:611
 #, fuzzy
 msgid "Insert &Section Cell\tCtrl-3"
 msgstr "Προσθήκη κελιού &ενότητας\tF8"
 
-#: ../src/wxMaximaFrame.cpp:608
+#: ../src/wxMaximaFrame.cpp:607
 #, fuzzy
 msgid "Insert &Text Cell\tCtrl-1"
 msgstr "Προσθήκη κελιού &κειμένου\tF6"
 
-#: ../src/wxMaximaFrame.cpp:558
+#: ../src/wxMaximaFrame.cpp:557
 msgid "Insert Cell\tAlt-Shift-C"
 msgstr "Προσθήκη κελιού\tAlt-Shift-C"
 
-#: ../src/wxMaxima.cpp:5642
+#: ../src/wxMaxima.cpp:5657
 msgid "Insert Image"
 msgstr "Προσθήκη εικόνας"
 
-#: ../src/wxMaximaFrame.cpp:620
+#: ../src/wxMaximaFrame.cpp:619
 msgid "Insert Image..."
 msgstr "Προσθήκη εικόνας..."
 
-#: ../src/wxMaximaFrame.cpp:606
+#: ../src/wxMaximaFrame.cpp:605
 #, fuzzy
 msgid "Insert Input &Cell"
 msgstr "Προσθήκη κελιού εντολών"
 
-#: ../src/wxMaximaFrame.cpp:618
+#: ../src/wxMaximaFrame.cpp:617
 #, fuzzy
 msgid "Insert Page Break"
 msgstr "Προσθήκη Page Break\tF10"
 
-#: ../src/wxMaximaFrame.cpp:614
+#: ../src/wxMaximaFrame.cpp:613
 #, fuzzy
 msgid "Insert S&ubsection Cell\tCtrl-4"
 msgstr "Προσθήκη κελιού υποενότητας"
 
-#: ../src/wxMaximaFrame.cpp:616
+#: ../src/wxMaximaFrame.cpp:615
 #, fuzzy
 msgid "Insert S&ubsubsection Cell\tCtrl-5"
 msgstr "Προσθήκη κελιού υποενότητας"
 
-#: ../src/MathCtrl.cpp:1015
+#: ../src/MathCtrl.cpp:1057
 #, fuzzy
 msgid "Insert Section Cell"
 msgstr "Προσθήκη κελιού &ενότητας\tF8"
 
-#: ../src/MathCtrl.cpp:1016
+#: ../src/MathCtrl.cpp:1058
 #, fuzzy
 msgid "Insert Subsection Cell"
 msgstr "Προσθήκη κελιού υποενότητας"
 
-#: ../src/MathCtrl.cpp:1017
+#: ../src/MathCtrl.cpp:1059
 #, fuzzy
 msgid "Insert Subsubsection Cell"
 msgstr "Προσθήκη κελιού υποενότητας"
 
-#: ../src/wxMaximaFrame.cpp:610
+#: ../src/wxMaximaFrame.cpp:609
 #, fuzzy
 msgid "Insert T&itle Cell\tCtrl-2"
 msgstr "Προσθήκη κελιού τίτλου"
 
-#: ../src/MathCtrl.cpp:1013
+#: ../src/MathCtrl.cpp:1055
 #, fuzzy
 msgid "Insert Text Cell"
 msgstr "Προσθήκη κελιού &κειμένου\tF6"
 
-#: ../src/MathCtrl.cpp:1014
+#: ../src/MathCtrl.cpp:1056
 #, fuzzy
 msgid "Insert Title Cell"
 msgstr "Προσθήκη κελιού τίτλου"
 
-#: ../src/wxMaximaFrame.cpp:607
+#: ../src/wxMaximaFrame.cpp:606
 msgid "Insert a new input cell"
 msgstr "Προσθήκη νέου κελιού εντολών"
 
-#: ../src/wxMaximaFrame.cpp:613
+#: ../src/wxMaximaFrame.cpp:612
 msgid "Insert a new section cell"
 msgstr "Προσθήκη νέου κελιού ενότητας"
 
-#: ../src/wxMaximaFrame.cpp:615
+#: ../src/wxMaximaFrame.cpp:614
 msgid "Insert a new subsection cell"
 msgstr "Προσθήκη νέου κελιού υποενότητας"
 
-#: ../src/wxMaximaFrame.cpp:617
+#: ../src/wxMaximaFrame.cpp:616
 #, fuzzy
 msgid "Insert a new subsubsection cell"
 msgstr "Προσθήκη νέου κελιού υποενότητας"
 
-#: ../src/wxMaximaFrame.cpp:609
+#: ../src/wxMaximaFrame.cpp:608
 msgid "Insert a new text cell"
 msgstr "Προσθήκη νέου κελιού κειμένου"
 
-#: ../src/wxMaximaFrame.cpp:611
+#: ../src/wxMaximaFrame.cpp:610
 msgid "Insert a new title cell"
 msgstr "Προσθήκη νέου κελιού τίτλου"
 
-#: ../src/wxMaximaFrame.cpp:619
+#: ../src/wxMaximaFrame.cpp:618
 msgid "Insert a page break"
 msgstr "Προσθήκη αλλαγής σελίδας"
 
-#: ../src/wxMaximaFrame.cpp:621
+#: ../src/wxMaximaFrame.cpp:620
 msgid "Insert image"
 msgstr "Προσθήκη εικόνας"
 
@@ -2397,27 +2400,27 @@ msgstr ""
 msgid "Integral sign"
 msgstr "Ολοκλήρωση παράστασης"
 
-#: ../src/wxMaxima.cpp:3992
+#: ../src/wxMaxima.cpp:4004
 msgid "Integral/Sum:"
 msgstr "Ολοκλήρωμα/Άθροισμα:"
 
-#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4105 ../src/wxMaxima.cpp:5051
+#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4117 ../src/wxMaxima.cpp:5063
 msgid "Integrate"
 msgstr "Ολοκλήρωση"
 
-#: ../src/wxMaxima.cpp:4091
+#: ../src/wxMaxima.cpp:4103
 msgid "Integrate (risch)"
 msgstr "Ολοκλήρωση (risch)"
 
-#: ../src/wxMaximaFrame.cpp:778
+#: ../src/wxMaximaFrame.cpp:777
 msgid "Integrate expression"
 msgstr "Ολοκλήρωση παράστασης"
 
-#: ../src/wxMaximaFrame.cpp:780
+#: ../src/wxMaximaFrame.cpp:779
 msgid "Integrate expression with Risch algorithm"
 msgstr "Ολοκλήρωση παράστασης με τον αλγόριθμο Risch "
 
-#: ../src/wxMaximaFrame.cpp:1224 ../src/MathCtrl.cpp:1000
+#: ../src/MathCtrl.cpp:1042 ../src/wxMaximaFrame.cpp:1223
 msgid "Integrate..."
 msgstr "Ολοκλήρωση..."
 
@@ -2425,7 +2428,7 @@ msgstr "Ολοκλήρωση..."
 msgid "Interrupt"
 msgstr "Διακοπή"
 
-#: ../src/wxMaximaFrame.cpp:646 ../src/wxMaximaFrame.cpp:650
+#: ../src/wxMaximaFrame.cpp:645 ../src/wxMaximaFrame.cpp:649
 msgid "Interrupt current computation"
 msgstr "Διακοπή τρέχοντος υπολογισμού"
 
@@ -2445,15 +2448,15 @@ msgstr ""
 " \n"
 "Παρακαλώ δώστε ξανά την διαδρομη για το πρόγραμμα maxima ."
 
-#: ../src/wxMaxima.cpp:4137
+#: ../src/wxMaxima.cpp:4149
 msgid "Inverse Laplace"
 msgstr "Αντίστροφος Laplace"
 
-#: ../src/wxMaximaFrame.cpp:806
+#: ../src/wxMaximaFrame.cpp:805
 msgid "Inverse Laplace T&ransform..."
 msgstr "Αντίστροφος μετασχηματισμός Laplace..."
 
-#: ../src/wxMaximaFrame.cpp:1372
+#: ../src/wxMaximaFrame.cpp:1371
 msgid "Iota"
 msgstr ""
 
@@ -2487,7 +2490,7 @@ msgstr "Ιαπωνικά"
 msgid "Kabyle"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1373
+#: ../src/wxMaximaFrame.cpp:1372
 msgid "Kappa"
 msgstr ""
 
@@ -2496,7 +2499,7 @@ msgstr ""
 msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4031
+#: ../src/wxMaxima.cpp:4043
 msgid "LCM"
 msgstr "ΕΚΠ"
 
@@ -2512,7 +2515,7 @@ msgstr ""
 msgid "Label width:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1374
+#: ../src/wxMaximaFrame.cpp:1373
 msgid "Lambda"
 msgstr ""
 
@@ -2524,11 +2527,11 @@ msgstr "Γλώσσα που χρησιμοποιείται για το GUI το�
 msgid "Language:"
 msgstr "Γλώσσα:"
 
-#: ../src/wxMaxima.cpp:4120
+#: ../src/wxMaxima.cpp:4132
 msgid "Laplace"
 msgstr "Laplace"
 
-#: ../src/wxMaximaFrame.cpp:803
+#: ../src/wxMaximaFrame.cpp:802
 msgid "Laplace &Transform..."
 msgstr "Μετασχηματισμός Laplace..."
 
@@ -2536,15 +2539,15 @@ msgstr "Μετασχηματισμός Laplace..."
 msgid "Leads to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:812
+#: ../src/wxMaximaFrame.cpp:811
 msgid "Least Common Multiple..."
 msgstr "Ελάχιστο Κοινό Πολλαπλάσιο..."
 
-#: ../src/wxMaxima.cpp:4809
+#: ../src/wxMaxima.cpp:4821
 msgid "Least Squares Fit"
 msgstr "Παρεμβολή ελαχίστων τετραγώνων"
 
-#: ../src/wxMaximaFrame.cpp:1266
+#: ../src/wxMaximaFrame.cpp:1265
 msgid "Least Squares Fit..."
 msgstr "Παρεμβολή ελαχίστων τετραγώνων..."
 
@@ -2555,25 +2558,25 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4192
+#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4204
 msgid "Limit"
 msgstr "Όριο"
 
-#: ../src/wxMaximaFrame.cpp:1225
+#: ../src/wxMaximaFrame.cpp:1224
 msgid "Limit..."
 msgstr "Όριο..."
 
-#: ../src/wxMaximaFrame.cpp:1265
+#: ../src/wxMaximaFrame.cpp:1264
 #, fuzzy
 msgid "Linear Regression..."
 msgstr "Γραμμική παλινδρόμηση"
 
-#: ../src/wxMaxima.cpp:3803
+#: ../src/wxMaxima.cpp:3815
 #, fuzzy
 msgid "List(s):"
 msgstr "Λίστα:"
 
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3848
 msgid "List:"
 msgstr "Λίστα:"
 
@@ -2581,15 +2584,15 @@ msgstr "Λίστα:"
 msgid "Load"
 msgstr "Φόρτωση"
 
-#: ../src/wxMaxima.cpp:2932
+#: ../src/wxMaxima.cpp:2940
 msgid "Load Package"
 msgstr "Φόρτωση πακέτου"
 
-#: ../src/wxMaximaFrame.cpp:479
+#: ../src/wxMaximaFrame.cpp:478
 msgid "Load a Maxima file using the batch command"
 msgstr "Φόρτωση ένος αρχείου Maxima με την εντολή batch."
 
-#: ../src/wxMaximaFrame.cpp:477
+#: ../src/wxMaximaFrame.cpp:476
 msgid "Load a Maxima package file"
 msgstr "Φόρτωση αρχείου πακέτου Maxima"
 
@@ -2601,49 +2604,49 @@ msgstr "Φόρτωση στυλ από αρχείο"
 msgid "Long Right arrow"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Lower bound:"
 msgstr "Κάτω φράγμα:"
 
-#: ../src/wxMaximaFrame.cpp:771
+#: ../src/wxMaximaFrame.cpp:770
 msgid "Ma&p to Matrix..."
 msgstr "Εφαρμογή στα μέλη πίνακα..."
 
-#: ../src/wxMaximaFrame.cpp:547
+#: ../src/wxMaximaFrame.cpp:546
 #, fuzzy
 msgid "Main Toolbar\tAlt-Shift-B"
 msgstr "Γραμμή εργαλείων\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:765
+#: ../src/wxMaximaFrame.cpp:764
 msgid "Make &List..."
 msgstr "Δημιουργία λίστας..."
 
-#: ../src/wxMaxima.cpp:3821
+#: ../src/wxMaxima.cpp:3833
 msgid "Make list"
 msgstr "Δημιουργία λίστας"
 
-#: ../src/wxMaximaFrame.cpp:766
+#: ../src/wxMaximaFrame.cpp:765
 msgid "Make list from expression"
 msgstr "Δημιουργία λίστας από παράσταση"
 
-#: ../src/wxMaximaFrame.cpp:907
+#: ../src/wxMaximaFrame.cpp:906
 msgid "Make substitution in expression"
 msgstr "Αντικατάσταση σε παράσταση"
 
-#: ../src/wxMaximaFrame.cpp:682
+#: ../src/wxMaximaFrame.cpp:681
 #, fuzzy
 msgid "Manually Trigger Evaluation"
 msgstr "Εμφάνιση του χρόνου που απαιτήθηκε για τον υπολογισμό"
 
-#: ../src/wxMaxima.cpp:3805
+#: ../src/wxMaxima.cpp:3817
 msgid "Map"
 msgstr "Απεικόνιση"
 
-#: ../src/wxMaximaFrame.cpp:770
+#: ../src/wxMaximaFrame.cpp:769
 msgid "Map function to a list"
 msgstr "Εφαρμογή συνάρτησης στα μέλη λίστας"
 
-#: ../src/wxMaximaFrame.cpp:772
+#: ../src/wxMaximaFrame.cpp:771
 msgid "Map function to a matrix"
 msgstr "Εφαρμογή συνάρτησης στα μέλη πίνακα"
 
@@ -2660,23 +2663,23 @@ msgstr "Αντιστοίχιση παρενθέσεων σε έλεγχο κει
 msgid "Math font:"
 msgstr "Γραμματοσειρά Μath:"
 
-#: ../src/wxMaximaFrame.cpp:374
+#: ../src/wxMaximaFrame.cpp:373
 msgid "Mathematical Symbols"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3716
+#: ../src/wxMaxima.cpp:3728
 msgid "Matrix"
 msgstr "Πίνακας"
 
-#: ../src/wxMaxima.cpp:3702
+#: ../src/wxMaxima.cpp:3714
 msgid "Matrix map"
 msgstr "Απεικόνιση πίνακα"
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Matrix name:"
 msgstr "Όνομα πίνακα:"
 
-#: ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3749
+#: ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3761
 msgid "Matrix:"
 msgstr "Πίνακας:"
 
@@ -2685,7 +2688,7 @@ msgstr "Πίνακας:"
 msgid "Maxima"
 msgstr "Maxima"
 
-#: ../src/wxMaximaFrame.cpp:137
+#: ../src/wxMaximaFrame.cpp:136
 #, fuzzy
 msgid "Maxima has a question"
 msgstr "Ερωτήσεις για το Maxima"
@@ -2694,24 +2697,24 @@ msgstr "Ερωτήσεις για το Maxima"
 msgid "Maxima input"
 msgstr "Είσοδος Maxima"
 
-#: ../src/wxMaximaFrame.cpp:166
+#: ../src/wxMaximaFrame.cpp:165
 msgid "Maxima is calculating"
 msgstr "Το Maxima κάνει υπολογισμούς"
 
-#: ../src/wxMaximaFrame.cpp:111
+#: ../src/wxMaximaFrame.cpp:110
 #, fuzzy
 msgid "Maxima is ready for input."
 msgstr "Είσοδος Maxima"
 
-#: ../src/wxMaxima.cpp:2945
+#: ../src/wxMaxima.cpp:2953
 msgid "Maxima package (*.mac)|*.mac"
 msgstr "Πακέτο Maxima (*.mac)|*.mac"
 
-#: ../src/wxMaxima.cpp:2934
+#: ../src/wxMaxima.cpp:2942
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr "Πακέτο Maxima(*.mac)|*.mac|πακέτο Lisp (*.lisp)|*.lisp|All|*"
 
-#: ../src/wxMaxima.cpp:1014
+#: ../src/wxMaxima.cpp:1019
 msgid "Maxima process terminated."
 msgstr "Η διαδικασία Maxima τερμάτισε."
 
@@ -2723,7 +2726,7 @@ msgstr "Πρόγραμμα Maxima:"
 msgid "Maxima questions"
 msgstr "Ερωτήσεις για το Maxima"
 
-#: ../src/wxMaxima.cpp:942
+#: ../src/wxMaxima.cpp:947
 msgid "Maxima started. Waiting for connection..."
 msgstr "Το Maxima ξεκίνησε. Περιμένει για σύνδεση..."
 
@@ -2747,7 +2750,7 @@ msgstr ""
 "Το Maxima χρησιμοποιεί το ‘:’ για απόδοση τιμών σε μεταβλητές ('a : 3;') και "
 "το ‘:=’ για ορισμό συναρτήσεων ('f(x) := x^2;')."
 
-#: ../src/wxMaxima.cpp:4597
+#: ../src/wxMaxima.cpp:4609
 msgid "Maxima version: "
 msgstr "Έκδοση Maxima "
 
@@ -2784,42 +2787,42 @@ msgstr ""
 msgid "Maximum displayed number of digits:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1263
+#: ../src/wxMaximaFrame.cpp:1262
 msgid "Mean Difference Test..."
 msgstr "Τεστ μέσης διαφοράς..."
 
-#: ../src/wxMaximaFrame.cpp:1262
+#: ../src/wxMaximaFrame.cpp:1261
 msgid "Mean Test..."
 msgstr "Τεστ μέσης τιμής..."
 
-#: ../src/wxMaximaFrame.cpp:1255
+#: ../src/wxMaximaFrame.cpp:1254
 #, fuzzy
 msgid "Mean..."
 msgstr "Απεικόνιση..."
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Mean:"
 msgstr "Μέση τιμή:"
 
-#: ../src/wxMaximaFrame.cpp:1256
+#: ../src/wxMaximaFrame.cpp:1255
 #, fuzzy
 msgid "Median..."
 msgstr "Διάμεση τιμή"
 
-#: ../src/MathCtrl.cpp:945
+#: ../src/MathCtrl.cpp:987
 msgid "Merge Cells"
 msgstr "Συγχώνευση κελιών"
 
-#: ../src/wxMaximaFrame.cpp:633
+#: ../src/wxMaximaFrame.cpp:632
 #, fuzzy
 msgid "Merge Cells\tCtrl-M"
 msgstr "Συγχώνευση κελιών"
 
-#: ../src/wxMaximaFrame.cpp:634
+#: ../src/wxMaximaFrame.cpp:633
 msgid "Merge the text from two input cells into one"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2668
+#: ../src/wxMaxima.cpp:2676
 msgid "Message from the stdout of Maxima: "
 msgstr ""
 
@@ -2827,20 +2830,20 @@ msgstr ""
 msgid "Method:"
 msgstr "Μέθοδος:"
 
-#: ../src/wxMaxima.cpp:5289
+#: ../src/wxMaxima.cpp:5301
 #, fuzzy
 msgid "Mismatched parenthesis"
 msgstr "Αντιστοίχιση παρενθέσεων σε έλεγχο κειμένου"
 
-#: ../src/wxMaxima.cpp:3972
+#: ../src/wxMaxima.cpp:3984
 msgid "Modulus"
 msgstr "Modulus"
 
-#: ../src/wxMaximaFrame.cpp:1375
+#: ../src/wxMaximaFrame.cpp:1374
 msgid "Mu"
 msgstr ""
 
-#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Name:"
 msgstr "Όνομα:"
 
@@ -2848,7 +2851,7 @@ msgstr "Όνομα:"
 msgid "New"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
+#: ../src/wxMaximaFrame.cpp:456 ../src/wxMaximaFrame.cpp:459
 #, fuzzy
 msgid "New\tCtrl-N"
 msgstr "Νέο\tCtrl-N"
@@ -2866,11 +2869,11 @@ msgstr ""
 msgid "New value:"
 msgstr "Νέα τιμή:"
 
-#: ../src/wxMaxima.cpp:3993 ../src/wxMaxima.cpp:4119 ../src/wxMaxima.cpp:4136
+#: ../src/wxMaxima.cpp:4005 ../src/wxMaxima.cpp:4131 ../src/wxMaxima.cpp:4148
 msgid "New variable:"
 msgstr "Νέα μεταβλητή:"
 
-#: ../src/wxMaximaFrame.cpp:630
+#: ../src/wxMaximaFrame.cpp:629
 #, fuzzy
 msgid "Next Command\tAlt-Down"
 msgstr "Επόμενη εντολή\tAlt-Down"
@@ -2879,15 +2882,15 @@ msgstr "Επόμενη εντολή\tAlt-Down"
 msgid "No"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5362
+#: ../src/wxMaxima.cpp:5378
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3249 ../src/wxMaxima.cpp:3271
+#: ../src/wxMaxima.cpp:3260 ../src/wxMaxima.cpp:3283
 msgid "No matches found!"
 msgstr "Καμμία αντιστοίχιση δεν βρέθηκε"
 
-#: ../src/wxMaximaFrame.cpp:1264
+#: ../src/wxMaximaFrame.cpp:1263
 #, fuzzy
 msgid "Normality Test..."
 msgstr "Τεστ κανονικότητας"
@@ -2911,34 +2914,34 @@ msgstr ""
 msgid "Norwegian"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:3740
 msgid "Not a valid matrix dimension!"
 msgstr "Μη έγκυρη διάσταση πίνακα!"
 
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629
 msgid "Not a valid number of equations!"
 msgstr "Μη έγκυρος αριθμός εξισώσεων!"
 
-#: ../src/wxMaximaFrame.cpp:197
+#: ../src/wxMaximaFrame.cpp:196
 #, fuzzy
 msgid "Not connected to maxima"
 msgstr ""
 "\n"
 "Δεν υπάρχει σύνδεση με το Maxima!\n"
 
-#: ../src/wxMaxima.cpp:4599
+#: ../src/wxMaxima.cpp:4611
 msgid "Not connected."
 msgstr "Δεν είστε συνδεδεμένοι."
 
-#: ../src/wxMaximaFrame.cpp:1376
+#: ../src/wxMaximaFrame.cpp:1375
 msgid "Nu"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Num. deg:"
 msgstr "Βαθμός Αριθμητή:"
 
-#: ../src/wxMaxima.cpp:3585 ../src/wxMaxima.cpp:3609
+#: ../src/wxMaxima.cpp:3597 ../src/wxMaxima.cpp:3621
 msgid "Number of equations:"
 msgstr "Αριθμός εξισώσεων:"
 
@@ -2965,15 +2968,15 @@ msgstr "Εντάξει"
 msgid "Old value:"
 msgstr "Παλιά τιμή:"
 
-#: ../src/wxMaxima.cpp:3992 ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135
+#: ../src/wxMaxima.cpp:4004 ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147
 msgid "Old variable:"
 msgstr "Παλιά μεταβλητή:"
 
-#: ../src/wxMaximaFrame.cpp:1387
+#: ../src/wxMaximaFrame.cpp:1386
 msgid "Omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1378
+#: ../src/wxMaximaFrame.cpp:1377
 msgid "Omicron"
 msgstr ""
 
@@ -2987,20 +2990,20 @@ msgid ""
 "stream for messages."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4763
+#: ../src/wxMaxima.cpp:4775
 msgid "One sample t-test"
 msgstr "t-τεστ ενός δείγματος"
 
-#: ../src/wxMaximaFrame.cpp:971
+#: ../src/wxMaximaFrame.cpp:970
 msgid "Online tutorials"
 msgstr "Online διδακτικές παρουσιάσεις"
 
 #: ../src/ConfigDialogue.cpp:656 ../src/main.cpp:347 ../src/ToolBar.cpp:119
-#: ../src/wxMaxima.cpp:2797
+#: ../src/wxMaxima.cpp:2805
 msgid "Open"
 msgstr "Άνοιγμα"
 
-#: ../src/wxMaximaFrame.cpp:466
+#: ../src/wxMaximaFrame.cpp:465
 msgid "Open Recent"
 msgstr "Άνοιγμα πρόσφατου"
 
@@ -3008,11 +3011,11 @@ msgstr "Άνοιγμα πρόσφατου"
 msgid "Open a cell when Maxima expects input"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:464
+#: ../src/wxMaximaFrame.cpp:463
 msgid "Open a document"
 msgstr "Άνοιγμα ενός εγγράφου"
 
-#: ../src/wxMaximaFrame.cpp:458 ../src/wxMaximaFrame.cpp:461
+#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
 msgid "Open a new window"
 msgstr "Άνοιγμα νέου παραθύρου"
 
@@ -3020,11 +3023,11 @@ msgstr "Άνοιγμα νέου παραθύρου"
 msgid "Open document"
 msgstr "Άνοιγμα εγγράφου"
 
-#: ../src/wxMaxima.cpp:4824
+#: ../src/wxMaxima.cpp:4836
 msgid "Open matrix"
 msgstr "Άνοιγμα πίνακα"
 
-#: ../src/wxMaxima.cpp:1446 ../src/wxMaxima.cpp:1518
+#: ../src/wxMaxima.cpp:1451 ../src/wxMaxima.cpp:1523
 msgid "Opening file"
 msgstr "Άνοιγμα αρχείου"
 
@@ -3048,11 +3051,11 @@ msgstr "Μη ενημερωμένα κελιά"
 msgid "Output labels"
 msgstr "Ετικέτες εξόδου"
 
-#: ../src/wxMaximaFrame.cpp:796
+#: ../src/wxMaximaFrame.cpp:795
 msgid "P&ade Approximation..."
 msgstr "Προσέγγιση Pade..."
 
-#: ../src/wxMaxima.cpp:3132 ../src/wxMaxima.cpp:5133
+#: ../src/wxMaxima.cpp:3141 ../src/wxMaxima.cpp:5145
 #, fuzzy
 msgid ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
@@ -3062,15 +3065,15 @@ msgstr ""
 "Εικόνα PNG (*.png)|*.png| εικόνα JPEG (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
 "bmp|X pixmap (*.xpm)|*.xpm"
 
-#: ../src/wxMaxima.cpp:4012
+#: ../src/wxMaxima.cpp:4024
 msgid "Pade approximation"
 msgstr "Προσέγγιση Pade..."
 
-#: ../src/wxMaximaFrame.cpp:797
+#: ../src/wxMaximaFrame.cpp:796
 msgid "Pade approximation of a Taylor series"
 msgstr "Προσέγγιση Pade σειράς Taylor"
 
-#: ../src/wxMaximaFrame.cpp:1500
+#: ../src/wxMaximaFrame.cpp:1519
 msgid "Pagebreak"
 msgstr "Αλλαγή σελίδας"
 
@@ -3082,19 +3085,19 @@ msgstr ""
 msgid "Parametric plot"
 msgstr "Παραμετρικό γράφημα"
 
-#: ../src/wxMaximaFrame.cpp:188
+#: ../src/wxMaximaFrame.cpp:187
 msgid "Parsing output"
 msgstr "Συντακτική ανάλυση αποτελέσματος"
 
-#: ../src/wxMaximaFrame.cpp:819
+#: ../src/wxMaximaFrame.cpp:818
 msgid "Partial &Fractions..."
 msgstr "Μερικά κλάσματα..."
 
-#: ../src/wxMaxima.cpp:4076
+#: ../src/wxMaxima.cpp:4088
 msgid "Partial fractions"
 msgstr "Μερικά κλάσματα"
 
-#: ../src/wxMaxima.cpp:1769
+#: ../src/wxMaxima.cpp:1774
 msgid "Parts of the document will not be loaded correctly!"
 msgstr "Μέρη του εγγράφου δεν θα φορτωθούν σωστά"
 
@@ -3105,11 +3108,11 @@ msgid ""
 "Found unknown XML Tag name "
 msgstr "Μέρη του εγγράφου δεν θα φορτωθούν σωστά"
 
-#: ../src/ToolBar.cpp:143 ../src/MathCtrl.cpp:1010 ../src/MathCtrl.cpp:1025
+#: ../src/MathCtrl.cpp:1052 ../src/MathCtrl.cpp:1067 ../src/ToolBar.cpp:143
 msgid "Paste"
 msgstr "Επικόλληση"
 
-#: ../src/wxMaximaFrame.cpp:518
+#: ../src/wxMaximaFrame.cpp:517
 msgid "Paste\tCtrl-V"
 msgstr "Επικόλληση\tCtrl-V"
 
@@ -3117,7 +3120,7 @@ msgstr "Επικόλληση\tCtrl-V"
 msgid "Paste from clipboard"
 msgstr "Επικόλληση κειμένου από το πρόχειρο"
 
-#: ../src/wxMaximaFrame.cpp:519
+#: ../src/wxMaximaFrame.cpp:518
 msgid "Paste text from clipboard"
 msgstr "Επικόλληση κειμένου από το πρόχειρο"
 
@@ -3125,20 +3128,20 @@ msgstr "Επικόλληση κειμένου από το πρόχειρο"
 msgid "Perpendicular to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1384
+#: ../src/wxMaximaFrame.cpp:1383
 msgid "Phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1379
+#: ../src/wxMaximaFrame.cpp:1378
 msgid "Pi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1273
+#: ../src/wxMaximaFrame.cpp:1272
 #, fuzzy
 msgid "Piechart..."
 msgstr "Κυκλικό διάγραμμα (πίτας)"
 
-#: ../src/wxMaxima.cpp:1952
+#: ../src/wxMaxima.cpp:1957
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr ""
 "Παρακαλώ ρυθμίστε το wxMaxima μεσα απο το μενου 'Επεξεργασία->Ρυθμίσεις'."
@@ -3148,52 +3151,52 @@ msgid "Please restart wxMaxima for changes to take effect!"
 msgstr ""
 "Παρακαλώ κάντε επανεκκίνηση του wxMaxima για να ενεργοποιηθούν οι αλλαγές!"
 
-#: ../src/wxMaximaFrame.cpp:923
+#: ../src/wxMaximaFrame.cpp:922
 msgid "Plot &2d..."
 msgstr "2-Δ γράφημα..."
 
-#: ../src/wxMaximaFrame.cpp:925
+#: ../src/wxMaximaFrame.cpp:924
 msgid "Plot &3d..."
 msgstr "3-Δ γράφημα..."
 
-#: ../src/wxMaximaFrame.cpp:927
+#: ../src/wxMaximaFrame.cpp:926
 msgid "Plot &Format..."
 msgstr "Μορφή γραφήματος..."
 
 #: ../src/Plot2dWiz.cpp:104 ../src/Plot2dWiz.cpp:450 ../src/Plot2dWiz.cpp:464
-#: ../src/wxMaxima.cpp:4283 ../src/wxMaxima.cpp:5102
+#: ../src/wxMaxima.cpp:4295 ../src/wxMaxima.cpp:5114
 msgid "Plot 2D"
 msgstr "2-Δ γράφημα"
 
-#: ../src/wxMaximaFrame.cpp:1227
+#: ../src/wxMaximaFrame.cpp:1226
 msgid "Plot 2D..."
 msgstr "2-Δ γράφημα..."
 
-#: ../src/MathCtrl.cpp:1003
+#: ../src/MathCtrl.cpp:1045
 msgid "Plot 2d..."
 msgstr "2-Δ γράφημα..."
 
-#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4269 ../src/wxMaxima.cpp:5115
+#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4281 ../src/wxMaxima.cpp:5127
 msgid "Plot 3D"
 msgstr "3-Δ γράφημα"
 
-#: ../src/wxMaximaFrame.cpp:1228
+#: ../src/wxMaximaFrame.cpp:1227
 msgid "Plot 3D..."
 msgstr "3-Δ γράφημα..."
 
-#: ../src/MathCtrl.cpp:1004
+#: ../src/MathCtrl.cpp:1046
 msgid "Plot 3d..."
 msgstr "3-Δ γράφημα..."
 
-#: ../src/wxMaxima.cpp:4296
+#: ../src/wxMaxima.cpp:4308
 msgid "Plot format"
 msgstr "Μορφή γραφήματος"
 
-#: ../src/wxMaximaFrame.cpp:924
+#: ../src/wxMaximaFrame.cpp:923
 msgid "Plot in 2 dimensions"
 msgstr "Γράφημα σε 2 διαστάσεις"
 
-#: ../src/wxMaximaFrame.cpp:926
+#: ../src/wxMaximaFrame.cpp:925
 msgid "Plot in 3 dimensions"
 msgstr "Γράφημα σε 3 διαστάσεις"
 
@@ -3202,8 +3205,8 @@ msgid "Plot to file:"
 msgstr "Γράφημα σε αρχείο:"
 
 #: ../src/BC2Wiz.cpp:30 ../src/BC2Wiz.cpp:36 ../src/LimitWiz.cpp:33
-#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
-#: ../src/wxMaxima.cpp:3648
+#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
+#: ../src/wxMaxima.cpp:3660
 msgid "Point:"
 msgstr "Σημείο:"
 
@@ -3211,11 +3214,11 @@ msgstr "Σημείο:"
 msgid "Polish"
 msgstr "Πολωνικά"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 1:"
 msgstr "Πολυώνυμο 1:"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 2:"
 msgstr "Πολυώνυμο 2:"
 
@@ -3227,11 +3230,11 @@ msgstr "Πορτογαλλικά(Βραζιλίας)"
 msgid "Postscript file (*.eps)|*.eps|All|*"
 msgstr "Αρχείο Postscript (*.eps)|*.eps|All|*"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Precision"
 msgstr "Ακρίβεια"
 
-#: ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:536
 msgid "Preferences...\tCtrl+,"
 msgstr ""
 
@@ -3243,7 +3246,7 @@ msgid ""
 "packages and from functions that are defined in the current file."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:628
+#: ../src/wxMaximaFrame.cpp:627
 #, fuzzy
 msgid "Previous Command\tAlt-Up"
 msgstr "Προηγούμενη εντολή\tAlt-Up"
@@ -3252,11 +3255,11 @@ msgstr "Προηγούμενη εντολή\tAlt-Up"
 msgid "Print"
 msgstr "Εκτύπωση"
 
-#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:484
+#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:483
 msgid "Print document"
 msgstr "Εκτύπωση εγγράφου"
 
-#: ../src/wxMaxima.cpp:4242
+#: ../src/wxMaxima.cpp:4254
 msgid "Product"
 msgstr "Γινόμενο"
 
@@ -3265,36 +3268,36 @@ msgstr "Γινόμενο"
 msgid "Product sign"
 msgstr "Γινόμενο"
 
-#: ../src/wxMaximaFrame.cpp:1386
+#: ../src/wxMaximaFrame.cpp:1385
 msgid "Psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:331
+#: ../src/wxMaximaFrame.cpp:330
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:592
+#: ../src/wxMaximaFrame.cpp:591
 #, fuzzy
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr "Υπολογισμός όλων των κελιών στο έγγραφο"
 
-#: ../src/wxMaximaFrame.cpp:1278
+#: ../src/wxMaximaFrame.cpp:1277
 msgid "Read Matrix..."
 msgstr "Aνάγνωση πίνακα..."
 
-#: ../src/wxMaximaFrame.cpp:177
+#: ../src/wxMaximaFrame.cpp:176
 msgid "Reading Maxima output"
 msgstr "Διάβασμα αποτελέσματος Maxima"
 
-#: ../src/wxMaximaFrame.cpp:153
+#: ../src/wxMaximaFrame.cpp:152
 msgid "Ready for user input"
 msgstr "Έτοιμο για είσοδο από το χρήστη"
 
-#: ../src/wxMaximaFrame.cpp:631
+#: ../src/wxMaximaFrame.cpp:630
 msgid "Recall next command from history"
 msgstr "Επανάκληση επόμενης εντολής από το ιστορικό "
 
-#: ../src/wxMaximaFrame.cpp:629
+#: ../src/wxMaximaFrame.cpp:628
 msgid "Recall previous command from history"
 msgstr "Επανάκληση προηγούμενης εντολής από το ιστορικό "
 
@@ -3302,37 +3305,37 @@ msgstr "Επανάκληση προηγούμενης εντολής από το
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1215
+#: ../src/wxMaximaFrame.cpp:1214
 msgid "Rectform"
 msgstr "Καρτεσιανή μορφή"
 
-#: ../src/wxMaximaFrame.cpp:495
+#: ../src/wxMaximaFrame.cpp:494
 #, fuzzy
 msgid "Redo\tCtrl-Y"
 msgstr "Αναίρεση\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:496
+#: ../src/wxMaximaFrame.cpp:495
 #, fuzzy
 msgid "Redo last change"
 msgstr "Αναίρεση τελευταίας αλλαγής"
 
-#: ../src/wxMaximaFrame.cpp:1220
+#: ../src/wxMaximaFrame.cpp:1219
 msgid "Reduce (tr)"
 msgstr "Αναγωγή (τρ)"
 
-#: ../src/wxMaximaFrame.cpp:871
+#: ../src/wxMaximaFrame.cpp:870
 msgid "Reduce trigonometric expression"
 msgstr "Αναγωγή τριγωνομετρικής παράστασης"
 
-#: ../src/wxMaxima.cpp:622 ../src/wxMaxima.cpp:5495
+#: ../src/wxMaxima.cpp:627 ../src/wxMaxima.cpp:5511
 msgid "Refusing to send cell to maxima: "
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:594
+#: ../src/wxMaximaFrame.cpp:593
 msgid "Remove All Output"
 msgstr "Αφαίρεση όλων των αποτελεσμάτων"
 
-#: ../src/wxMaximaFrame.cpp:595
+#: ../src/wxMaximaFrame.cpp:594
 msgid "Remove output from input cells"
 msgstr "Αφαίρεση αποτελεσμάτων από τα κελιά εντολών"
 
@@ -3341,7 +3344,7 @@ msgstr "Αφαίρεση αποτελεσμάτων από τα κελιά εν�
 msgid "Replace All"
 msgstr "Επιλογή όλων"
 
-#: ../src/wxMaxima.cpp:3282
+#: ../src/wxMaxima.cpp:3294
 #, c-format
 msgid "Replaced %d occurrences."
 msgstr "Αντικατεστημένες %d εμφανίσεις"
@@ -3350,11 +3353,11 @@ msgstr "Αντικατεστημένες %d εμφανίσεις"
 msgid "Replacement:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:976
+#: ../src/wxMaximaFrame.cpp:975
 msgid "Report bug"
 msgstr "Αναφορά σφάλματος"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "Restart Maxima"
 msgstr "Επανεκίνηση του Maxima"
 
@@ -3363,7 +3366,7 @@ msgstr "Επανεκίνηση του Maxima"
 msgid "Restart maxima"
 msgstr "Επανεκίνηση του Maxima"
 
-#: ../src/MathCtrl.cpp:4442
+#: ../src/MathCtrl.cpp:4497
 msgid "Result"
 msgstr ""
 
@@ -3371,7 +3374,7 @@ msgstr ""
 msgid "Return to the cell that is currently being evaluated"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1380
+#: ../src/wxMaximaFrame.cpp:1379
 msgid "Rho"
 msgstr ""
 
@@ -3379,19 +3382,19 @@ msgstr ""
 msgid "Right arrow"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:779
+#: ../src/wxMaximaFrame.cpp:778
 msgid "Risch Integration..."
 msgstr "Ολοκλήρωση Risch..."
 
-#: ../src/wxMaximaFrame.cpp:694
+#: ../src/wxMaximaFrame.cpp:693
 msgid "Roots of &Polynomial"
 msgstr "Ρίζες πολυωνύμου"
 
-#: ../src/wxMaximaFrame.cpp:697
+#: ../src/wxMaximaFrame.cpp:696
 msgid "Roots of Polynomial (bfloat)"
 msgstr "Ρίζες πολυωνύμου (bfloat)"
 
-#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Rows:"
 msgstr "Γραμμές:"
 
@@ -3399,56 +3402,56 @@ msgstr "Γραμμές:"
 msgid "Russian"
 msgstr "Ρωσικά"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 1:"
 msgstr "Δείγμα 1:"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 2:"
 msgstr "Δείγμα 2:"
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Sample:"
 msgstr "Δείγμα:"
 
 #: ../src/ConfigDialogue.cpp:781 ../src/ToolBar.cpp:122
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Save"
 msgstr "Αποθήκευση"
 
-#: ../src/MathCtrl.cpp:921
+#: ../src/MathCtrl.cpp:963
 msgid "Save Animation..."
 msgstr "Αποθήκευση εφε κίνησης ..."
 
-#: ../src/wxMaxima.cpp:2565
+#: ../src/wxMaxima.cpp:2572
 msgid "Save As"
 msgstr "Αποθήκευση ως"
 
-#: ../src/wxMaximaFrame.cpp:474
+#: ../src/wxMaximaFrame.cpp:473
 msgid "Save As...\tShift-Ctrl-S"
 msgstr "Αποθήκευση ως...\tShift-Ctrl-S"
 
-#: ../src/MathCtrl.cpp:919
+#: ../src/MathCtrl.cpp:961
 msgid "Save Image..."
 msgstr "Αποθήκευση εικόνας..."
 
-#: ../src/wxMaxima.cpp:3130
+#: ../src/wxMaxima.cpp:3139
 msgid "Save Selection to Image"
 msgstr "Αποθήκευση επιλογής σε εικόνα"
 
-#: ../src/wxMaximaFrame.cpp:528
+#: ../src/wxMaximaFrame.cpp:527
 msgid "Save Selection to Image..."
 msgstr "Αποθήκευση επιλογής σε εικόνα..."
 
-#: ../src/wxMaxima.cpp:5150
+#: ../src/wxMaxima.cpp:5162
 msgid "Save animation to file"
 msgstr "Αποθήκευση εφε κίνησης σε αρχείο"
 
-#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:473
+#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:472
 msgid "Save document"
 msgstr "Αποθήκευση εγγράφου"
 
-#: ../src/wxMaximaFrame.cpp:475
+#: ../src/wxMaximaFrame.cpp:474
 msgid "Save document as"
 msgstr "Αποθήκευση εγγράφου ως"
 
@@ -3470,11 +3473,11 @@ msgstr "Αποθήκευση μεγέθους/θέσης παραθύρου το
 msgid "Save plot to file"
 msgstr "Αποθήκευση γραφήματος σε αρχείο"
 
-#: ../src/wxMaximaFrame.cpp:529
+#: ../src/wxMaximaFrame.cpp:528
 msgid "Save selection from document to an image file"
 msgstr "Αποθήκευση επιλογής από το έγγραφο σε ένα αρχείο εικόνας"
 
-#: ../src/wxMaxima.cpp:5131
+#: ../src/wxMaxima.cpp:5143
 msgid "Save selection to file"
 msgstr "Αποθήκευση επιλογής σε αρχείο"
 
@@ -3490,28 +3493,28 @@ msgstr "Αποθήκευση μεγέθους/θέσης παραθύρου το
 msgid "Save wxMaxima window size/position between sessions."
 msgstr "Αποθήκευση μεγέθους/θέσης παραθύρου του wxMaxima μεταξύ συνεδριών."
 
-#: ../src/wxMaximaFrame.cpp:246
+#: ../src/wxMaximaFrame.cpp:245
 #, fuzzy
 msgid "Saving failed."
 msgstr "Η εκκίνηση του εξυπηρετητή απέτυχε"
 
-#: ../src/wxMaximaFrame.cpp:222
+#: ../src/wxMaximaFrame.cpp:221
 msgid "Saving successful."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:212
+#: ../src/wxMaximaFrame.cpp:211
 msgid "Saving..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4699
+#: ../src/wxMaxima.cpp:4711
 msgid "Scatterplot"
 msgstr "Διάγραμμα διασποράς"
 
-#: ../src/wxMaximaFrame.cpp:1271
+#: ../src/wxMaximaFrame.cpp:1270
 msgid "Scatterplot..."
 msgstr "Διάγραμμα διασποράς..."
 
-#: ../src/wxMaximaFrame.cpp:1498
+#: ../src/wxMaximaFrame.cpp:1517
 msgid "Section"
 msgstr "Ενότητα"
 
@@ -3519,26 +3522,26 @@ msgstr "Ενότητα"
 msgid "Section cell"
 msgstr "Κελί ενότητας"
 
-#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:292 ../src/TextCell.cpp:306
-#: ../src/TextCell.cpp:322 ../src/TextCell.cpp:334
+#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:290 ../src/TextCell.cpp:304
+#: ../src/TextCell.cpp:320 ../src/TextCell.cpp:332
 msgid ""
 "Seems like something is broken with a font. Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/TextCell.cpp:139
+#: ../src/TextCell.cpp:137
 msgid ""
 "Seems like something is broken with the maths font. Installing http://www."
 "math.union.edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use "
 "JSmath fonts\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1011 ../src/MathCtrl.cpp:1027
+#: ../src/MathCtrl.cpp:1053 ../src/MathCtrl.cpp:1069
 msgid "Select All"
 msgstr "Επιλογή όλων"
 
-#: ../src/wxMaximaFrame.cpp:525
+#: ../src/wxMaximaFrame.cpp:524
 msgid "Select All\tCtrl-A"
 msgstr "Επιλογή Όλων\tCtrl-A"
 
@@ -3546,7 +3549,7 @@ msgstr "Επιλογή Όλων\tCtrl-A"
 msgid "Select Maxima program"
 msgstr "Επιλογή προγράμματος Maxima"
 
-#: ../src/wxMaxima.cpp:4860
+#: ../src/wxMaxima.cpp:4872
 msgid "Select Subsample"
 msgstr "Επιλογή υποδείγματος"
 
@@ -3555,11 +3558,11 @@ msgstr "Επιλογή υποδείγματος"
 msgid "Select a constant"
 msgstr "Επιλογή μιας μεταβλητής"
 
-#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:526
+#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:525
 msgid "Select all"
 msgstr "Επιλογή όλων"
 
-#: ../src/wxMaxima.cpp:3319
+#: ../src/wxMaxima.cpp:3331
 msgid "Select math display algorithm"
 msgstr "Επιλογή αλγορίθμου προβολής μαθηματικών"
 
@@ -3577,23 +3580,23 @@ msgstr ""
 msgid "Selection"
 msgstr "Επιλογή"
 
-#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4178
+#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4190
 msgid "Series"
 msgstr "Σειρές"
 
-#: ../src/wxMaximaFrame.cpp:1226
+#: ../src/wxMaximaFrame.cpp:1225
 msgid "Series..."
 msgstr "Σειρές..."
 
-#: ../src/wxMaxima.cpp:863
+#: ../src/wxMaxima.cpp:868
 msgid "Server started"
 msgstr "Ο εξυπηρετητής ξεκίνησε"
 
-#: ../src/wxMaximaFrame.cpp:575
+#: ../src/wxMaximaFrame.cpp:574
 msgid "Set Zoom"
 msgstr "Ορισμός Μεγέθυνσης"
 
-#: ../src/wxMaximaFrame.cpp:944
+#: ../src/wxMaximaFrame.cpp:943
 #, fuzzy
 msgid "Set bigfloat &Precision..."
 msgstr "Ορισμός ακρίβειας bigfloat"
@@ -3602,63 +3605,63 @@ msgstr "Ορισμός ακρίβειας bigfloat"
 msgid "Set fixed font in text controls."
 msgstr "Ορισμός σταθερού μεγέθους γραμματοσειράς στους ελέγχους κειμένου."
 
-#: ../src/wxMaximaFrame.cpp:928
+#: ../src/wxMaximaFrame.cpp:927
 msgid "Set plot format"
 msgstr "Ορισμός μορφής γραφήματος"
 
-#: ../src/wxMaximaFrame.cpp:945
+#: ../src/wxMaximaFrame.cpp:944
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can "
 "be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:569
+#: ../src/wxMaximaFrame.cpp:568
 msgid "Set zoom to 100%"
 msgstr "Ορισμός ζουμ στο 100%"
 
-#: ../src/wxMaximaFrame.cpp:570
+#: ../src/wxMaximaFrame.cpp:569
 msgid "Set zoom to 120%"
 msgstr "Ορισμός ζουμ στο 120%"
 
-#: ../src/wxMaximaFrame.cpp:571
+#: ../src/wxMaximaFrame.cpp:570
 msgid "Set zoom to 150%"
 msgstr "Ορισμός ζουμ στο 150%"
 
-#: ../src/wxMaximaFrame.cpp:572
+#: ../src/wxMaximaFrame.cpp:571
 msgid "Set zoom to 200%"
 msgstr "Ορισμός ζουμ στο 200%"
 
-#: ../src/wxMaximaFrame.cpp:573
+#: ../src/wxMaximaFrame.cpp:572
 msgid "Set zoom to 300%"
 msgstr "Ορισμός ζουμ στο 300%"
 
-#: ../src/wxMaximaFrame.cpp:568
+#: ../src/wxMaximaFrame.cpp:567
 msgid "Set zoom to 80%"
 msgstr "Ορισμός ζουμ στο 80%"
 
-#: ../src/wxMaximaFrame.cpp:732
+#: ../src/wxMaximaFrame.cpp:731
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
 "Ορισμός τιμών με την atvalues για την επίλυση ΣΔΕ με το μετασχηματισμό "
 "Laplace"
 
-#: ../src/wxMaximaFrame.cpp:918
+#: ../src/wxMaximaFrame.cpp:917
 msgid "Setup modulus computation"
 msgstr "Εγκατάσταση υπολογισμών modulo"
 
-#: ../src/wxMaximaFrame.cpp:662
+#: ../src/wxMaximaFrame.cpp:661
 msgid "Show &Definition..."
 msgstr "Εμφάνιση ορισμού..."
 
-#: ../src/wxMaximaFrame.cpp:660
+#: ../src/wxMaximaFrame.cpp:659
 msgid "Show &Functions"
 msgstr "Εμφάνιση συναρτήσεων"
 
-#: ../src/wxMaximaFrame.cpp:967
+#: ../src/wxMaximaFrame.cpp:966
 msgid "Show &Tips..."
 msgstr "Εμφάνιση συμβουλών..."
 
-#: ../src/wxMaximaFrame.cpp:665
+#: ../src/wxMaximaFrame.cpp:664
 msgid "Show &Variables"
 msgstr "Εμφάνιση  μεταβλητών"
 
@@ -3666,43 +3669,43 @@ msgstr "Εμφάνιση  μεταβλητών"
 msgid "Show Maxima help"
 msgstr "Εμφάνιση βοήθειας για το Maxima"
 
-#: ../src/wxMaximaFrame.cpp:603
+#: ../src/wxMaximaFrame.cpp:602
 msgid "Show Template\tCtrl-Shift-K"
 msgstr "Εμφάνιση προτύπου\tCtrl-Shift-K"
 
-#: ../src/wxMaximaFrame.cpp:968
+#: ../src/wxMaximaFrame.cpp:967
 msgid "Show a tip"
 msgstr "Εμφάνιση μιας συμβουλής"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Show all commands similar to:"
 msgstr "Εμφάνιση ολων των εντολών που είναι παρόμοιες με:"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Show an example for the command:"
 msgstr "Εμφάνιση ενός παραδείγματος για την εντολή:"
 
-#: ../src/wxMaximaFrame.cpp:962
+#: ../src/wxMaximaFrame.cpp:961
 msgid "Show an example of usage"
 msgstr "Εμφάνιση ενός παραδείγματος χρήσης"
 
-#: ../src/wxMaximaFrame.cpp:965
+#: ../src/wxMaximaFrame.cpp:964
 msgid "Show commands similar to"
 msgstr "Εμφάνιση εντολών παρόμοιες με"
 
-#: ../src/wxMaximaFrame.cpp:661
+#: ../src/wxMaximaFrame.cpp:660
 msgid "Show defined functions"
 msgstr "Εμφάνιση των συναρτήσεων που έχουν οριστεί"
 
-#: ../src/wxMaximaFrame.cpp:666
+#: ../src/wxMaximaFrame.cpp:665
 msgid "Show defined variables"
 msgstr "Εμφάνιση των μεταβλητών που έχουν οριστεί"
 
-#: ../src/wxMaximaFrame.cpp:663
+#: ../src/wxMaximaFrame.cpp:662
 msgid "Show definition of a function"
 msgstr "Εμφάνιση του ορισμού μίας συνάρτησης"
 
-#: ../src/wxMaximaFrame.cpp:604
+#: ../src/wxMaximaFrame.cpp:603
 msgid "Show function template"
 msgstr "Εμφάνιση συναρτήσεων"
 
@@ -3715,7 +3718,7 @@ msgstr "Εμφάνιση μεγάλων παραστάσεων στο έγγρα
 msgid "Show long expressions:"
 msgstr "Εμφάνιση μεγάλων παραστάσεων"
 
-#: ../src/wxMaxima.cpp:3341
+#: ../src/wxMaxima.cpp:3353
 msgid "Show the definition of function:"
 msgstr "Εμφάνιση ορισμού συνάρτησης:"
 
@@ -3724,44 +3727,44 @@ msgstr "Εμφάνιση ορισμού συνάρτησης:"
 msgid "Show user-defined labels instead of (%oxx)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:953 ../src/wxMaximaFrame.cpp:956
+#: ../src/wxMaximaFrame.cpp:952 ../src/wxMaximaFrame.cpp:955
 #, fuzzy
 msgid "Show wxMaxima help"
 msgstr "Εμφάνιση βοήθειας για το Maxima"
 
-#: ../src/wxMaximaFrame.cpp:1381
+#: ../src/wxMaximaFrame.cpp:1380
 msgid "Sigma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1211
+#: ../src/wxMaximaFrame.cpp:1210
 msgid "Simplify"
 msgstr "Απλοποίηση"
 
-#: ../src/wxMaximaFrame.cpp:831
+#: ../src/wxMaximaFrame.cpp:830
 msgid "Simplify &Radicals"
 msgstr "Απλοποίηση ριζικών"
 
-#: ../src/wxMaximaFrame.cpp:1212
+#: ../src/wxMaximaFrame.cpp:1211
 msgid "Simplify (r)"
 msgstr "Απλοποίηση (ρ)"
 
-#: ../src/wxMaximaFrame.cpp:1218
+#: ../src/wxMaximaFrame.cpp:1217
 msgid "Simplify (tr)"
 msgstr "Απλοποίηση (τρ)"
 
-#: ../src/MathCtrl.cpp:995
+#: ../src/MathCtrl.cpp:1037
 msgid "Simplify Expression"
 msgstr "Απλοποίηση παράστασης"
 
-#: ../src/wxMaximaFrame.cpp:857
+#: ../src/wxMaximaFrame.cpp:856
 msgid "Simplify an expression containing factorials"
 msgstr "Απλοποίηση παράστασης που περιέχει παραγοντικά"
 
-#: ../src/wxMaximaFrame.cpp:832
+#: ../src/wxMaximaFrame.cpp:831
 msgid "Simplify expression containing radicals"
 msgstr "Απλοποίηση παράστασης που περιέχει ριζικά"
 
-#: ../src/wxMaximaFrame.cpp:830
+#: ../src/wxMaximaFrame.cpp:829
 msgid "Simplify rational expression"
 msgstr "Απλοποίηση ρητής παράστασης"
 
@@ -3769,7 +3772,7 @@ msgstr "Απλοποίηση ρητής παράστασης"
 msgid "Simplify the sum"
 msgstr "Απλοποίηση αθροίσματος"
 
-#: ../src/wxMaximaFrame.cpp:868
+#: ../src/wxMaximaFrame.cpp:867
 msgid "Simplify trigonometric expression"
 msgstr "Απλοποίηση τριγωνομετρικής παράστασης"
 
@@ -3786,87 +3789,87 @@ msgstr ""
 "εικόνας...’. Σημείωστε πως πρέπει να αποθηκεύετε το έγγραφο σε μορφή "
 "'wxMaxima XML document' αν θέλετε να αποθηκευθεί η εικόνα μαζί με το έγγραφο."
 
-#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
+#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
 msgid "Solution:"
 msgstr "Λύση:"
 
-#: ../src/wxMaxima.cpp:3461 ../src/wxMaxima.cpp:3475 ../src/wxMaxima.cpp:5020
+#: ../src/wxMaxima.cpp:3473 ../src/wxMaxima.cpp:3487 ../src/wxMaxima.cpp:5032
 msgid "Solve"
 msgstr "Επίλυση"
 
-#: ../src/wxMaximaFrame.cpp:706
+#: ../src/wxMaximaFrame.cpp:705
 msgid "Solve &Algebraic System..."
 msgstr "Επίλυση αλγεβρικού συστήματος..."
 
-#: ../src/wxMaximaFrame.cpp:703
+#: ../src/wxMaximaFrame.cpp:702
 msgid "Solve &Linear System..."
 msgstr "Επίλυση γραμμικού συστήματος..."
 
-#: ../src/wxMaximaFrame.cpp:714
+#: ../src/wxMaximaFrame.cpp:713
 msgid "Solve &ODE..."
 msgstr "Επίλυση ΣΔΕ..."
 
-#: ../src/wxMaximaFrame.cpp:690
+#: ../src/wxMaximaFrame.cpp:689
 msgid "Solve (to_poly)..."
 msgstr "Επίλυση (to_poly)..."
 
-#: ../src/wxMaxima.cpp:3511 ../src/wxMaxima.cpp:3635
+#: ../src/wxMaxima.cpp:3523 ../src/wxMaxima.cpp:3647
 msgid "Solve ODE"
 msgstr "Επίλυση ΣΔΕ"
 
-#: ../src/wxMaximaFrame.cpp:728
+#: ../src/wxMaximaFrame.cpp:727
 msgid "Solve ODE with Lapla&ce..."
 msgstr "Επίλυση ΣΔΕ με Laplace..."
 
-#: ../src/wxMaximaFrame.cpp:1222
+#: ../src/wxMaximaFrame.cpp:1221
 msgid "Solve ODE..."
 msgstr "Επίλυση ΣΔΕ..."
 
-#: ../src/wxMaxima.cpp:3586 ../src/wxMaxima.cpp:3597
+#: ../src/wxMaxima.cpp:3598 ../src/wxMaxima.cpp:3609
 msgid "Solve algebraic system"
 msgstr "Επίλυση αλγεβρικού συστήματος"
 
-#: ../src/wxMaximaFrame.cpp:707
+#: ../src/wxMaximaFrame.cpp:706
 msgid "Solve algebraic system of equations"
 msgstr "Επίλυση αλγεβρικού συστήματος εξισώσεων"
 
-#: ../src/wxMaximaFrame.cpp:725
+#: ../src/wxMaximaFrame.cpp:724
 msgid "Solve boundary value problem for second degree ODE"
 msgstr "Επίλυση προβλήματος οριακών τιμών για δευτεροβάθμια ΣΔΕ"
 
-#: ../src/wxMaximaFrame.cpp:689
+#: ../src/wxMaximaFrame.cpp:688
 msgid "Solve equation(s)"
 msgstr "Επίλυση εξίσωσης(-εων)"
 
-#: ../src/wxMaximaFrame.cpp:691
+#: ../src/wxMaximaFrame.cpp:690
 msgid "Solve equation(s) with to_poly_solve"
 msgstr "Επίλυση εξίσωσης(-εων) με to_poly_solve"
 
-#: ../src/wxMaximaFrame.cpp:719
+#: ../src/wxMaximaFrame.cpp:718
 msgid "Solve initial value problem for first degree ODE"
 msgstr "Επίλυση προβλήματος αρχικών τιμών για πρωτοβάθμια ΣΔΕ"
 
-#: ../src/wxMaximaFrame.cpp:722
+#: ../src/wxMaximaFrame.cpp:721
 msgid "Solve initial value problem for second degree ODE"
 msgstr "Επίλυση προβλήματος αρχικών τιμών για δευτεροβάθμια ΣΔΕ"
 
-#: ../src/wxMaxima.cpp:3610 ../src/wxMaxima.cpp:3621
+#: ../src/wxMaxima.cpp:3622 ../src/wxMaxima.cpp:3633
 msgid "Solve linear system"
 msgstr "Επίλυση γραμμικού συστήματος"
 
-#: ../src/wxMaximaFrame.cpp:704
+#: ../src/wxMaximaFrame.cpp:703
 msgid "Solve linear system of equations"
 msgstr "Επίλυση γραμμικού συστήματος εξισώσεων"
 
-#: ../src/wxMaximaFrame.cpp:715
+#: ../src/wxMaximaFrame.cpp:714
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr "Επίλυση συνήθους διαφορικής εξίσωσης μέγιστου βαθμού 2"
 
-#: ../src/wxMaximaFrame.cpp:729
+#: ../src/wxMaximaFrame.cpp:728
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr "Επίλυση συνήθους διαφορικής εξίσωσης με μετασχηματισμό Laplace"
 
-#: ../src/wxMaximaFrame.cpp:1221 ../src/MathCtrl.cpp:992
+#: ../src/MathCtrl.cpp:1034 ../src/wxMaximaFrame.cpp:1220
 msgid "Solve..."
 msgstr "Επίλυση..."
 
@@ -3890,7 +3893,7 @@ msgstr "Ειδικός"
 msgid "Special constants"
 msgstr "Ειδικές μεταβλητές"
 
-#: ../src/MathCtrl.cpp:922
+#: ../src/MathCtrl.cpp:964
 msgid "Start Animation"
 msgstr "Εκκίνηση εφέ κίνησης"
 
@@ -3909,28 +3912,28 @@ msgstr ""
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:294
+#: ../src/wxMaxima.cpp:295
 msgid "Starting Maxima process failed"
 msgstr "Η εκκίνηση της διεργασίας Maxima απέτυχε"
 
-#: ../src/wxMaxima.cpp:928
+#: ../src/wxMaxima.cpp:933
 msgid "Starting Maxima..."
 msgstr "Εκκίνηση Maxima..."
 
-#: ../src/wxMaxima.cpp:292 ../src/wxMaxima.cpp:860
+#: ../src/wxMaxima.cpp:293 ../src/wxMaxima.cpp:865
 msgid "Starting server failed"
 msgstr "Η εκκίνηση του εξυπηρετητή απέτυχε"
 
-#: ../src/wxMaxima.cpp:841
+#: ../src/wxMaxima.cpp:846
 #, c-format
 msgid "Starting server on port %d"
 msgstr "Εκκίνηση του εξυπηρετητή στη θύρα %d"
 
-#: ../src/wxMaximaFrame.cpp:342
+#: ../src/wxMaximaFrame.cpp:341
 msgid "Statistics"
 msgstr "Στατιστική"
 
-#: ../src/wxMaximaFrame.cpp:550
+#: ../src/wxMaximaFrame.cpp:549
 msgid "Statistics\tAlt-Shift-S"
 msgstr "Στατιστική\tAlt-Shift-S"
 
@@ -3946,11 +3949,11 @@ msgstr "Στυλ"
 msgid "Styles"
 msgstr "Στυλ"
 
-#: ../src/wxMaximaFrame.cpp:1283
+#: ../src/wxMaximaFrame.cpp:1282
 msgid "Subsample..."
 msgstr "Υποδείγμα..."
 
-#: ../src/wxMaximaFrame.cpp:1496
+#: ../src/wxMaximaFrame.cpp:1515
 msgid "Subsection"
 msgstr "Υποενότητα"
 
@@ -3958,20 +3961,20 @@ msgstr "Υποενότητα"
 msgid "Subsection cell"
 msgstr "Κελί υποενότητας"
 
-#: ../src/wxMaximaFrame.cpp:1216
+#: ../src/wxMaximaFrame.cpp:1215
 msgid "Subst..."
 msgstr "Αντικατάσταση..."
 
-#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3423
-#: ../src/wxMaxima.cpp:5089
+#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3435
+#: ../src/wxMaxima.cpp:5101
 msgid "Substitute"
 msgstr "Αντικατάσταση"
 
-#: ../src/wxMaximaFrame.cpp:906 ../src/MathCtrl.cpp:998
+#: ../src/MathCtrl.cpp:1040 ../src/wxMaximaFrame.cpp:905
 msgid "Substitute..."
 msgstr "Αντικατάσταση..."
 
-#: ../src/wxMaximaFrame.cpp:1497
+#: ../src/wxMaximaFrame.cpp:1516
 #, fuzzy
 msgid "Subsubsection"
 msgstr "Υποενότητα"
@@ -3981,7 +3984,7 @@ msgstr "Υποενότητα"
 msgid "Subsubsection cell"
 msgstr "Κελί υποενότητας"
 
-#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4226
+#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4238
 msgid "Sum"
 msgstr "Άθροισμα"
 
@@ -3989,37 +3992,37 @@ msgstr "Άθροισμα"
 msgid "Sum sign"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:553
+#: ../src/wxMaximaFrame.cpp:552
 #, fuzzy
 msgid "Symbols\tAlt-Shift-Y"
 msgstr "Στατιστική\tAlt-Shift-S"
 
-#: ../src/wxMaxima.cpp:4456
+#: ../src/wxMaxima.cpp:4468
 msgid "System info"
 msgstr "Πληροφορίες συστήματος"
 
-#: ../src/wxMaximaFrame.cpp:320
+#: ../src/wxMaximaFrame.cpp:319
 msgid "Table of Contents"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:556
+#: ../src/wxMaximaFrame.cpp:555
 #, fuzzy
 msgid "Table of Contents\tAlt-Shift-T"
 msgstr "Γραμμή εργαλείων\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:1382
+#: ../src/wxMaximaFrame.cpp:1381
 msgid "Tau"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Taylor series:"
 msgstr "Σειρές Taylor:"
 
-#: ../src/wxMaxima.cpp:3963
+#: ../src/wxMaxima.cpp:3975
 msgid "Tellrat"
 msgstr "Tellrat"
 
-#: ../src/wxMaximaFrame.cpp:1494
+#: ../src/wxMaximaFrame.cpp:1513
 msgid "Text"
 msgstr "Κείμενο"
 
@@ -4067,7 +4070,7 @@ msgstr ""
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr ""
 
-#: ../src/TextCell.cpp:136
+#: ../src/TextCell.cpp:134
 msgid ""
 "The letter \"X\" is of width zero. Installing http://www.math.union.edu/"
 "~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts\" in "
@@ -4084,7 +4087,7 @@ msgstr ""
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:959
+#: ../src/wxMaximaFrame.cpp:958
 msgid "The offline manual of maxima"
 msgstr ""
 
@@ -4123,7 +4126,7 @@ msgstr ""
 "index.php/Tutorials για να βρείτε περισσότερες πληροφορίες για τη χρήση των "
 "Maxima και wxMaxima."
 
-#: ../src/SlideShowCell.cpp:332
+#: ../src/SlideShowCell.cpp:336
 msgid ""
 "There was an error during GIF export!\n"
 "\n"
@@ -4134,7 +4137,7 @@ msgstr ""
 "Βεβαιωθείτε οτι υπάρχει εγκατεστημένο το  ImageMagick και πως το wxMaxima "
 "μπορεί να βρει το πρόγραμμα μετατροπής."
 
-#: ../src/wxMaxima.cpp:442
+#: ../src/wxMaxima.cpp:447
 msgid ""
 "There was an error in generated XML!\n"
 "\n"
@@ -4142,7 +4145,7 @@ msgid ""
 msgstr ""
 "Υπήρξε σφάλμα στο δημιουργημένο XML! Παρακαλώ αναφέρετε αυτό το σφάλμα."
 
-#: ../src/wxMaximaFrame.cpp:1371
+#: ../src/wxMaximaFrame.cpp:1370
 msgid "Theta"
 msgstr ""
 
@@ -4150,7 +4153,7 @@ msgstr ""
 msgid "Ticks:"
 msgstr "Σημάνσεις:"
 
-#: ../src/wxMaxima.cpp:4153 ../src/wxMaxima.cpp:5065
+#: ../src/wxMaxima.cpp:4165 ../src/wxMaxima.cpp:5077
 msgid "Times:"
 msgstr "Φορές:"
 
@@ -4158,7 +4161,7 @@ msgstr "Φορές:"
 msgid "Tips not available, sorry!"
 msgstr "Οι συμβουλές δεν ειναι διαθέσιμες, συγνώμη!"
 
-#: ../src/wxMaximaFrame.cpp:1495
+#: ../src/wxMaximaFrame.cpp:1514
 msgid "Title"
 msgstr "Τίτλος"
 
@@ -4177,19 +4180,19 @@ msgstr ""
 "στο τετραγωνάκι που βρίσκεται δίπλα απο το κελί. Επιπλέον αν κανετε shift-"
 "κλικ, ολα τα υποεπίπεδα του κελιού επίσης θα διπλωθούν/ξεδιπλωθούν."
 
-#: ../src/wxMaximaFrame.cpp:938
+#: ../src/wxMaximaFrame.cpp:937
 msgid "To &Bigfloat"
 msgstr "Σε μεγάλο αριθμό κινητής υποδιαστολής (bigfloat)"
 
-#: ../src/wxMaximaFrame.cpp:935
+#: ../src/wxMaximaFrame.cpp:934
 msgid "To &Float"
 msgstr "Σε αριθμό κινητής υποδιαστολής"
 
-#: ../src/MathCtrl.cpp:990
+#: ../src/MathCtrl.cpp:1032
 msgid "To Float"
 msgstr "Σε αριθμό κινητής υποδιαστολής"
 
-#: ../src/wxMaximaFrame.cpp:941
+#: ../src/wxMaximaFrame.cpp:940
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr ""
 
@@ -4232,51 +4235,51 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:41 ../src/Plot2dWiz.cpp:40 ../src/Plot2dWiz.cpp:50
 #: ../src/Plot2dWiz.cpp:539 ../src/Plot3dWiz.cpp:39 ../src/Plot3dWiz.cpp:48
-#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4241
+#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4253
 msgid "To:"
 msgstr "Μέχρι:"
 
-#: ../src/wxMaximaFrame.cpp:912
+#: ../src/wxMaximaFrame.cpp:911
 msgid "Toggle &Algebraic Flag"
 msgstr "Εναλλαγή αλγεβρικής σημαίας"
 
-#: ../src/wxMaximaFrame.cpp:933
+#: ../src/wxMaximaFrame.cpp:932
 msgid "Toggle &Numeric Output"
 msgstr "Εναλλαγή μορφής αποτελεσμάτων"
 
-#: ../src/wxMaximaFrame.cpp:673
+#: ../src/wxMaximaFrame.cpp:672
 msgid "Toggle &Time Display"
 msgstr "Εναλλαγή εμφάνισης της ώρας"
 
-#: ../src/wxMaximaFrame.cpp:913
+#: ../src/wxMaximaFrame.cpp:912
 msgid "Toggle algebraic flag"
 msgstr "Εναλλαγή αλγεβρικής σημαίας"
 
-#: ../src/wxMaximaFrame.cpp:577
+#: ../src/wxMaximaFrame.cpp:576
 msgid "Toggle full screen editing"
 msgstr "Εναλλαγή επεξεργασίας πλήρης οθόνης"
 
-#: ../src/wxMaximaFrame.cpp:934
+#: ../src/wxMaximaFrame.cpp:933
 msgid "Toggle numeric output"
 msgstr "Εναλλαγή αριθμητικού αποτελέσματος"
 
-#: ../src/wxMaxima.cpp:4464
+#: ../src/wxMaxima.cpp:4476
 msgid "Toolbar icons"
 msgstr "Εικονίδια γραμμής εργαλείων"
 
-#: ../src/wxMaxima.cpp:4465
+#: ../src/wxMaxima.cpp:4477
 msgid "Translated by"
 msgstr "Μεταφρασμένο από"
 
-#: ../src/wxMaximaFrame.cpp:763
+#: ../src/wxMaximaFrame.cpp:762
 msgid "Transpose a matrix"
 msgstr "Αναστροφή πίνακα"
 
-#: ../src/MathCtrl.cpp:5834
+#: ../src/MathCtrl.cpp:5886
 msgid "Trying to undo an action without starting cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5901
+#: ../src/MathCtrl.cpp:5953
 msgid "Trying to undo something but the undo action is empty."
 msgstr ""
 
@@ -4284,11 +4287,11 @@ msgstr ""
 msgid "Turkish"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:970
+#: ../src/wxMaximaFrame.cpp:969
 msgid "Tutorials"
 msgstr "Διδακτικές παρουσιάσεις"
 
-#: ../src/wxMaxima.cpp:4778
+#: ../src/wxMaxima.cpp:4790
 msgid "Two sample t-test"
 msgstr "t-τεστ δυο δειγμάτων"
 
@@ -4300,15 +4303,15 @@ msgstr "Τύπος:"
 msgid "Ukrainian"
 msgstr "Ουκρανικά"
 
-#: ../src/wxMaxima.cpp:5356
+#: ../src/wxMaxima.cpp:5372
 msgid "Un-closed parenthesis"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5323
+#: ../src/wxMaxima.cpp:5335
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5889
 msgid ""
 "Unable to interpret the version info I got from http://andrejv.github.io//"
 "wxmaxima/version.txt: "
@@ -4322,11 +4325,11 @@ msgstr "Υπογραμμισμένος"
 msgid "Underscore converts to subscripts:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:492
+#: ../src/wxMaximaFrame.cpp:491
 msgid "Undo\tCtrl-Z"
 msgstr "Αναίρεση\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:493
+#: ../src/wxMaximaFrame.cpp:492
 msgid "Undo last change"
 msgstr "Αναίρεση τελευταίας αλλαγής"
 
@@ -4334,24 +4337,24 @@ msgstr "Αναίρεση τελευταίας αλλαγής"
 msgid "Undo limit (0 for none):"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:625
+#: ../src/wxMaximaFrame.cpp:624
 #, fuzzy
 msgid "Unfold All\tCtrl-Alt-]"
 msgstr "Επιλογή Όλων\tCtrl-A"
 
-#: ../src/wxMaximaFrame.cpp:626
+#: ../src/wxMaximaFrame.cpp:625
 msgid "Unfold all folded sections"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4458
+#: ../src/wxMaxima.cpp:4470
 msgid "Unicode Support"
 msgstr "Υποστήριξη Unicode"
 
-#: ../src/wxMaxima.cpp:5335
+#: ../src/wxMaxima.cpp:5347
 msgid "Unterminated comment."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5309
+#: ../src/wxMaxima.cpp:5321
 msgid "Unterminated string."
 msgstr ""
 
@@ -4359,15 +4362,15 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5859 ../src/wxMaxima.cpp:5866 ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5874 ../src/wxMaxima.cpp:5881 ../src/wxMaxima.cpp:5889
 msgid "Upgrade"
 msgstr "Αναβάθμιση"
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Upper bound:"
 msgstr "Άνω φράγμα:"
 
-#: ../src/wxMaximaFrame.cpp:1383
+#: ../src/wxMaximaFrame.cpp:1382
 #, fuzzy
 msgid "Upsilon"
 msgstr "Έψιλον:"
@@ -4412,22 +4415,22 @@ msgstr ""
 msgid "User-defined labels"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3525
-#: ../src/wxMaxima.cpp:3541 ../src/wxMaxima.cpp:3649
+#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3537
+#: ../src/wxMaxima.cpp:3553 ../src/wxMaxima.cpp:3661
 msgid "Value:"
 msgstr "Τιμή:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:5019 ../src/wxMaxima.cpp:5064
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:5031 ../src/wxMaxima.cpp:5076
 msgid "Variable(s):"
 msgstr "Μεταβλητή(-ές):"
 
 #: ../src/IntegrateWiz.cpp:33 ../src/LimitWiz.cpp:30 ../src/Plot2dWiz.cpp:34
 #: ../src/Plot2dWiz.cpp:44 ../src/Plot2dWiz.cpp:533 ../src/Plot3dWiz.cpp:33
 #: ../src/Plot3dWiz.cpp:42 ../src/SeriesWiz.cpp:36 ../src/SumWiz.cpp:30
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3749
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3761
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5045
 msgid "Variable:"
 msgstr "Μεταβλητή:"
 
@@ -4435,26 +4438,26 @@ msgstr "Μεταβλητή:"
 msgid "Variables"
 msgstr "Μεταβλητές"
 
-#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3571 ../src/wxMaxima.cpp:4206
-#: ../src/wxMaxima.cpp:4807
+#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3583 ../src/wxMaxima.cpp:4218
+#: ../src/wxMaxima.cpp:4819
 msgid "Variables:"
 msgstr "Μεταβλητές:"
 
-#: ../src/wxMaximaFrame.cpp:1257
+#: ../src/wxMaximaFrame.cpp:1256
 #, fuzzy
 msgid "Variance..."
 msgstr "Διακύμανση"
 
-#: ../src/wxMaximaFrame.cpp:580
+#: ../src/wxMaximaFrame.cpp:579
 msgid "View"
 msgstr ""
 
-#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1674 ../src/wxMaxima.cpp:1769
-#: ../src/wxMaxima.cpp:1950
+#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1679 ../src/wxMaxima.cpp:1774
+#: ../src/wxMaxima.cpp:1955
 msgid "Warning"
 msgstr "Προειδοποίηση"
 
-#: ../src/wxMaximaFrame.cpp:109 ../src/wxMaximaFrame.cpp:295
+#: ../src/wxMaximaFrame.cpp:108 ../src/wxMaximaFrame.cpp:294
 msgid "Welcome to wxMaxima"
 msgstr "Καλωσορίσατε στο wxMaxima"
 
@@ -4478,7 +4481,7 @@ msgid ""
 "introducing an empty line."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2567
+#: ../src/wxMaxima.cpp:2574
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) "
 "(*.wxm)|*.wxm"
@@ -4494,7 +4497,7 @@ msgid ""
 "as equation markers"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6798
+#: ../src/MathCtrl.cpp:6856
 msgid "Wrapped search"
 msgstr ""
 
@@ -4502,15 +4505,15 @@ msgstr ""
 msgid "Write matching parenthesis in text controls."
 msgstr "Εγγραφή ζεύγους παρενθέσεων στους ελέγχους κειμένου."
 
-#: ../src/wxMaxima.cpp:4461
+#: ../src/wxMaxima.cpp:4473
 msgid "Written by"
 msgstr "Γραμμένο από"
 
-#: ../src/wxMaximaFrame.cpp:557
+#: ../src/wxMaximaFrame.cpp:556
 msgid "XML Inspector"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1377
+#: ../src/wxMaximaFrame.cpp:1376
 msgid "Xi"
 msgstr ""
 
@@ -4589,7 +4592,7 @@ msgstr ""
 "επιλογή. Αυτό είναι χρήσιμο αν θέλετε να διαγράψετε ή να υπολογίσετε "
 "πολλαπλά κελιά."
 
-#: ../src/wxMaxima.cpp:5856
+#: ../src/wxMaxima.cpp:5871
 #, c-format
 msgid ""
 "You have version %s. Current version is %s.\n"
@@ -4600,41 +4603,41 @@ msgstr ""
 "\n"
 "Επιλέξτε ΟΚ ώστε να μεταβείτε στην ιστοσελίδα του wxMaxima."
 
-#: ../src/wxMaxima.cpp:5921
+#: ../src/wxMaxima.cpp:5936
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5866
+#: ../src/wxMaxima.cpp:5881
 msgid "Your version of wxMaxima is up to date."
 msgstr "Η έκδοση του wxMaxima που διαθέτετε ειναι η πιο πρόσφατη."
 
-#: ../src/wxMaximaFrame.cpp:1369
+#: ../src/wxMaximaFrame.cpp:1368
 msgid "Zeta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:562
+#: ../src/wxMaximaFrame.cpp:561
 #, fuzzy
 msgid "Zoom &In\tCtrl-+"
 msgstr "Μεγένθυση"
 
-#: ../src/wxMaximaFrame.cpp:564
+#: ../src/wxMaximaFrame.cpp:563
 #, fuzzy
 msgid "Zoom Ou&t\tCtrl--"
 msgstr "Σμίκρυνση"
 
-#: ../src/wxMaximaFrame.cpp:563
+#: ../src/wxMaximaFrame.cpp:562
 msgid "Zoom in 10%"
 msgstr "Μεγέθυνση κατά 10%"
 
-#: ../src/wxMaximaFrame.cpp:565
+#: ../src/wxMaximaFrame.cpp:564
 msgid "Zoom out 10%"
 msgstr "Σμίκρυνση κατά 10%"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaximaFrame.cpp:287
 msgid "[ unsaved ]"
 msgstr "[ δεν έχει αποθηκευθεί ]"
 
-#: ../src/wxMaxima.cpp:5700
+#: ../src/wxMaxima.cpp:5715
 msgid "[ unsaved* ]"
 msgstr "[ δεν έχει αποθηκευθεί* ]"
 
@@ -4643,17 +4646,17 @@ msgstr "[ δεν έχει αποθηκευθεί* ]"
 msgid "[%i digits]"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4392
+#: ../src/MathCtrl.cpp:4447
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" style=\"max-width:90%%;\" >\n"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4517
+#: ../src/MathCtrl.cpp:4572
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" >"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1333
+#: ../src/wxMaximaFrame.cpp:1332
 msgid "alpha"
 msgstr ""
 
@@ -4666,7 +4669,7 @@ msgstr "Ανάπτυξη"
 msgid "antisymmetric"
 msgstr "αντισυμμετρικός"
 
-#: ../src/wxMaximaFrame.cpp:1334
+#: ../src/wxMaximaFrame.cpp:1333
 msgid "beta"
 msgstr ""
 
@@ -4710,7 +4713,7 @@ msgstr ""
 msgid "bug:Invalid sup tag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1354
+#: ../src/wxMaximaFrame.cpp:1353
 msgid "chi"
 msgstr ""
 
@@ -4723,7 +4726,7 @@ msgstr ""
 msgid "default"
 msgstr "προεπιλογή"
 
-#: ../src/wxMaximaFrame.cpp:1336
+#: ../src/wxMaximaFrame.cpp:1335
 msgid "delta"
 msgstr ""
 
@@ -4735,7 +4738,7 @@ msgstr "διαγώνιος"
 msgid "empty"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1337
+#: ../src/wxMaximaFrame.cpp:1336
 #, fuzzy
 msgid "epsilon"
 msgstr "Έψιλον:"
@@ -4744,7 +4747,7 @@ msgstr "Έψιλον:"
 msgid "equivalent"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1339
+#: ../src/wxMaximaFrame.cpp:1338
 msgid "eta"
 msgstr ""
 
@@ -4760,7 +4763,7 @@ msgid ""
 "all=_ marks subscripts."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1335
+#: ../src/wxMaximaFrame.cpp:1334
 msgid "gamma"
 msgstr ""
 
@@ -4789,15 +4792,15 @@ msgstr "inline"
 msgid "intersection"
 msgstr "Κατεύθυνση:"
 
-#: ../src/wxMaximaFrame.cpp:1341
+#: ../src/wxMaximaFrame.cpp:1340
 msgid "iota"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1342
+#: ../src/wxMaximaFrame.cpp:1341
 msgid "kappa"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1343
+#: ../src/wxMaximaFrame.cpp:1342
 msgid "lambda"
 msgstr ""
 
@@ -4814,7 +4817,7 @@ msgstr "Κελί υποενότητας"
 msgid "logscale"
 msgstr "λογαριθμική κλίμακα"
 
-#: ../src/wxMaxima.cpp:3783
+#: ../src/wxMaxima.cpp:3795
 msgid "matrix[i,j]:"
 msgstr "Πίνακας[i,j]:"
 
@@ -4822,7 +4825,7 @@ msgstr "Πίνακας[i,j]:"
 msgid "maxima's pwd is path to document"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1344
+#: ../src/wxMaximaFrame.cpp:1343
 msgid "mu"
 msgstr ""
 
@@ -4839,7 +4842,7 @@ msgstr ""
 msgid "nand"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4524
+#: ../src/wxMaxima.cpp:4536
 msgid "no"
 msgstr "όχι"
 
@@ -4865,15 +4868,15 @@ msgstr ""
 msgid "not subset or equal"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1345
+#: ../src/wxMaximaFrame.cpp:1344
 msgid "nu"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1356
+#: ../src/wxMaximaFrame.cpp:1355
 msgid "omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1347
+#: ../src/wxMaximaFrame.cpp:1346
 msgid "omicron"
 msgstr ""
 
@@ -4886,11 +4889,11 @@ msgstr ""
 msgid "partial sign"
 msgstr "Μερικά κλάσματα"
 
-#: ../src/wxMaximaFrame.cpp:1353
+#: ../src/wxMaximaFrame.cpp:1352
 msgid "phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1348
+#: ../src/wxMaximaFrame.cpp:1347
 msgid "pi"
 msgstr ""
 
@@ -4902,11 +4905,11 @@ msgstr ""
 msgid "proportional to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1355
+#: ../src/wxMaximaFrame.cpp:1354
 msgid "psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1349
+#: ../src/wxMaximaFrame.cpp:1348
 msgid "rho"
 msgstr ""
 
@@ -4914,7 +4917,7 @@ msgstr ""
 msgid "right"
 msgstr "από δεξιά"
 
-#: ../src/wxMaximaFrame.cpp:1350
+#: ../src/wxMaximaFrame.cpp:1349
 msgid "sigma"
 msgstr ""
 
@@ -4936,7 +4939,7 @@ msgstr "Κελί υποενότητας"
 msgid "symmetric"
 msgstr "συμμετρικός"
 
-#: ../src/wxMaximaFrame.cpp:1351
+#: ../src/wxMaximaFrame.cpp:1350
 msgid "tau"
 msgstr ""
 
@@ -4948,7 +4951,7 @@ msgstr ""
 msgid "there is no"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1340
+#: ../src/wxMaximaFrame.cpp:1339
 msgid "theta"
 msgstr ""
 
@@ -4964,13 +4967,13 @@ msgstr ""
 msgid "union"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5903
+#: ../src/wxMaxima.cpp:5918
 #, fuzzy
 msgid "unsaved"
 msgstr "[ δεν έχει αποθηκευθεί ]"
 
-#: ../src/wxMaximaFrame.cpp:290 ../src/wxMaxima.cpp:2559
-#: ../src/wxMaxima.cpp:2826
+#: ../src/wxMaxima.cpp:2566 ../src/wxMaxima.cpp:2834
+#: ../src/wxMaximaFrame.cpp:289
 msgid "untitled"
 msgstr "ανώνυμο"
 
@@ -4979,27 +4982,27 @@ msgstr "ανώνυμο"
 msgid "untitled %d"
 msgstr "ανώνυμο"
 
-#: ../src/wxMaximaFrame.cpp:1352
+#: ../src/wxMaximaFrame.cpp:1351
 #, fuzzy
 msgid "upsilon"
 msgstr "Έψιλον:"
 
-#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4538
+#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4550
 msgid "wxMaxima"
 msgstr "wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
-#: ../src/wxMaxima.cpp:5700 ../src/wxMaxima.cpp:5709 ../src/wxMaxima.cpp:5712
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaxima.cpp:5715 ../src/wxMaxima.cpp:5724
+#: ../src/wxMaxima.cpp:5727 ../src/wxMaximaFrame.cpp:287
 #, c-format
 msgid "wxMaxima %s "
 msgstr "wxMaxima %s"
 
-#: ../src/wxMaximaFrame.cpp:952
+#: ../src/wxMaximaFrame.cpp:951
 #, fuzzy
 msgid "wxMaxima &Help\tCtrl+?"
 msgstr "Βοήθεια για το Maxima\tF1"
 
-#: ../src/wxMaximaFrame.cpp:955
+#: ../src/wxMaximaFrame.cpp:954
 #, fuzzy
 msgid "wxMaxima &Help\tF1"
 msgstr "Βοήθεια για το Maxima\tF1"
@@ -5011,11 +5014,11 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1619
+#: ../src/wxMaxima.cpp:1624
 msgid "wxMaxima cannot open content.xml in the .wxmx zip archive "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1633
+#: ../src/wxMaxima.cpp:1638
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
@@ -5023,7 +5026,7 @@ msgstr ""
 msgid "wxMaxima configuration"
 msgstr "Ρυθμίσεις του wxMaxima"
 
-#: ../src/wxMaxima.cpp:1947
+#: ../src/wxMaxima.cpp:1952
 msgid ""
 "wxMaxima could not find Maxima!\n"
 "\n"
@@ -5035,7 +5038,7 @@ msgstr ""
 "Παρακαλώ ρυθμίστε το wxMaxima από το 'Επεξεργασία->Ρυθμίσεις'. \n"
 "Μετά επανεκινήστε το Maxima με το 'Maxima->Επανεκκίνηση Maxima'."
 
-#: ../src/wxMaxima.cpp:2204
+#: ../src/wxMaxima.cpp:2209
 msgid ""
 "wxMaxima could not find help files.\n"
 "\n"
@@ -5045,7 +5048,7 @@ msgstr ""
 "\n"
 "Παρακαλώ ελέγξτε την εγκατάστασή σας."
 
-#: ../src/wxMaxima.cpp:2032
+#: ../src/wxMaxima.cpp:2037
 msgid ""
 "wxMaxima could not find tip files.\n"
 "\n"
@@ -5055,7 +5058,7 @@ msgstr ""
 "\n"
 " Παρακαλώ ελέγξτε την εγκατάστασή σας."
 
-#: ../src/wxMaxima.cpp:282
+#: ../src/wxMaxima.cpp:283
 msgid ""
 "wxMaxima could not start the server.\n"
 "\n"
@@ -5077,23 +5080,23 @@ msgstr ""
 "γραμμές εντολών μία από τις οποίες είναι το '%'. Αν έχετε κάνει μια επιλογή "
 "στο έγγραφό σας, η επιλογή αυτή θα χρησιμοποιηθεί στη θέση του '%'."
 
-#: ../src/wxMaxima.cpp:2330
+#: ../src/wxMaxima.cpp:2336
 msgid "wxMaxima document"
 msgstr "έγγραφο wxMaxima"
 
-#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2799
+#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2807
 msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 msgstr "έγγραφο wxMaxima (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 
-#: ../src/wxMaxima.cpp:1455 ../src/wxMaxima.cpp:1469
+#: ../src/wxMaxima.cpp:1460 ../src/wxMaxima.cpp:1474
 msgid "wxMaxima encountered an error loading "
 msgstr "Το wxMaxima αντιμετώπισε ένα πρόβλημα κατά την φόρτωση"
 
-#: ../src/wxMaxima.cpp:4463
+#: ../src/wxMaxima.cpp:4475
 msgid "wxMaxima icon"
 msgstr "Εικοίδιο wxMaxima"
 
-#: ../src/wxMaxima.cpp:4455
+#: ../src/wxMaxima.cpp:4467
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "MAXIMA based on wxWidgets."
@@ -5101,7 +5104,7 @@ msgstr ""
 "Το wxMaxima είναι μια γραφική διεπαφή χρήστη για το σύστημα υπολογιστικής "
 "άλγεβρας Maxima βασισμένη στα wxWidgets."
 
-#: ../src/wxMaxima.cpp:4516
+#: ../src/wxMaxima.cpp:4528
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "Maxima based on wxWidgets."
@@ -5121,11 +5124,11 @@ msgstr ""
 msgid "x"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1346
+#: ../src/wxMaximaFrame.cpp:1345
 msgid "xi"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1643
+#: ../src/wxMaxima.cpp:1648
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
@@ -5134,11 +5137,11 @@ msgstr ""
 msgid "xor"
 msgstr "Εξαγωγή"
 
-#: ../src/wxMaxima.cpp:4522
+#: ../src/wxMaxima.cpp:4534
 msgid "yes"
 msgstr "Ναι"
 
-#: ../src/wxMaximaFrame.cpp:1338
+#: ../src/wxMaximaFrame.cpp:1337
 msgid "zeta"
 msgstr ""
 

--- a/locales/en.po
+++ b/locales/en.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-07 21:42+0200\n"
+"POT-Creation-Date: 2016-10-16 17:47+0900\n"
 "PO-Revision-Date: 2015-07-04 11:28+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../src/wxMaxima.cpp:4519
+#: ../src/wxMaxima.cpp:4531
 #, c-format
 msgid ""
 "\n"
@@ -30,25 +30,25 @@ msgid ""
 "Unicode support: %s"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4532
+#: ../src/wxMaxima.cpp:4544
 msgid ""
 "\n"
 "Lisp: "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4528
+#: ../src/wxMaxima.cpp:4540
 msgid ""
 "\n"
 "Maxima version: "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5381
+#: ../src/wxMaxima.cpp:5397
 msgid ""
 "\n"
 "Not connected to Maxima!\n"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4530
+#: ../src/wxMaxima.cpp:4542
 msgid ""
 "\n"
 "Not connected."
@@ -66,7 +66,7 @@ msgstr ""
 msgid " (Graphics) "
 msgstr ""
 
-#: ../src/EditorCell.cpp:3045 ../src/EditorCell.cpp:3227
+#: ../src/EditorCell.cpp:3088 ../src/EditorCell.cpp:3270
 #, c-format
 msgid " ... + %i hidden lines"
 msgstr ""
@@ -75,13 +75,13 @@ msgstr ""
 msgid " << Expression longer than allowed by the configuration setting! >>"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1673
+#: ../src/wxMaxima.cpp:1678
 msgid ""
 " was saved using a newer version of wxMaxima so it may not load correctly. "
 "Please update your wxMaxima."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1665
+#: ../src/wxMaxima.cpp:1670
 msgid ""
 " was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr ""
@@ -94,64 +94,64 @@ msgstr ""
 msgid "\"implies\" symbol"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:101
+#: ../src/wxMaximaFrame.cpp:100
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:773
+#: ../src/wxMaximaFrame.cpp:772
 msgid "&Algebra"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:767
+#: ../src/wxMaximaFrame.cpp:766
 msgid "&Apply to List..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:964
+#: ../src/wxMaximaFrame.cpp:963
 msgid "&Apropos..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:478
+#: ../src/wxMaximaFrame.cpp:477
 msgid "&Batch File...\tCtrl-B"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:724
+#: ../src/wxMaximaFrame.cpp:723
 msgid "&Boundary Value Problem..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:975
+#: ../src/wxMaximaFrame.cpp:974
 msgid "&Bug Report"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:825
+#: ../src/wxMaximaFrame.cpp:824
 msgid "&Calculus"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:876
+#: ../src/wxMaximaFrame.cpp:875
 msgid "&Canonical Form"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:749
+#: ../src/wxMaximaFrame.cpp:748
 msgid "&Characteristic Polynomial..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:654
+#: ../src/wxMaximaFrame.cpp:653
 msgid "&Clear Memory"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:859
+#: ../src/wxMaximaFrame.cpp:858
 msgid "&Combine Factorials"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:902
+#: ../src/wxMaximaFrame.cpp:901
 msgid "&Complex Simplification"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:822
+#: ../src/wxMaximaFrame.cpp:821
 msgid "&Continued Fraction"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:502
+#: ../src/wxMaximaFrame.cpp:501
 msgid "&Copy\tCtrl-C"
 msgstr ""
 
@@ -159,107 +159,107 @@ msgstr ""
 msgid "&Definite integration"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:896
+#: ../src/wxMaximaFrame.cpp:895
 msgid "&Demoivre"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:752
+#: ../src/wxMaximaFrame.cpp:751
 msgid "&Determinant"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:785
+#: ../src/wxMaximaFrame.cpp:784
 msgid "&Differentiate..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:543
+#: ../src/wxMaximaFrame.cpp:542
 msgid "&Edit"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:709
+#: ../src/wxMaximaFrame.cpp:708
 msgid "&Eliminate Variable..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:744
+#: ../src/wxMaximaFrame.cpp:743
 msgid "&Enter Matrix..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:961
+#: ../src/wxMaximaFrame.cpp:960
 msgid "&Example..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:839
+#: ../src/wxMaximaFrame.cpp:838
 msgid "&Expand Expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:873
+#: ../src/wxMaximaFrame.cpp:872
 msgid "&Expand Trigonometric"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:899
+#: ../src/wxMaximaFrame.cpp:898
 msgid "&Exponentialize"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:480
+#: ../src/wxMaximaFrame.cpp:479
 msgid "&Export..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:834
+#: ../src/wxMaximaFrame.cpp:833
 msgid "&Factor Expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:489
+#: ../src/wxMaximaFrame.cpp:488
 msgid "&File"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:692
+#: ../src/wxMaximaFrame.cpp:691
 msgid "&Find Root..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:738
+#: ../src/wxMaximaFrame.cpp:737
 msgid "&Generate Matrix..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:809
+#: ../src/wxMaximaFrame.cpp:808
 msgid "&Greatest Common Divisor..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:994
+#: ../src/wxMaximaFrame.cpp:993
 msgid "&Help"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:777
+#: ../src/wxMaximaFrame.cpp:776
 msgid "&Integrate..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:645
+#: ../src/wxMaximaFrame.cpp:644
 msgid "&Interrupt\tCtrl-."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:649
+#: ../src/wxMaximaFrame.cpp:648
 msgid "&Interrupt\tCtrl-G"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:746
+#: ../src/wxMaximaFrame.cpp:745
 msgid "&Invert Matrix"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:476
+#: ../src/wxMaximaFrame.cpp:475
 msgid "&Load Package...\tCtrl-L"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:769
+#: ../src/wxMaximaFrame.cpp:768
 msgid "&Map to List(s)..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:684
+#: ../src/wxMaximaFrame.cpp:683
 msgid "&Maxima"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:958
+#: ../src/wxMaximaFrame.cpp:957
 msgid "&Maxima help"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:917
+#: ../src/wxMaximaFrame.cpp:916
 msgid "&Modulus Computation..."
 msgstr ""
 
@@ -267,7 +267,7 @@ msgstr ""
 msgid "&New\tCtrl-N"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:947
+#: ../src/wxMaximaFrame.cpp:946
 msgid "&Numeric"
 msgstr ""
 
@@ -283,11 +283,11 @@ msgstr ""
 msgid "&Open\tCtrl-O"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:463
+#: ../src/wxMaximaFrame.cpp:462
 msgid "&Open...\tCtrl-O"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:929
+#: ../src/wxMaximaFrame.cpp:928
 msgid "&Plot"
 msgstr ""
 
@@ -295,7 +295,7 @@ msgstr ""
 msgid "&Power series"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:483
+#: ../src/wxMaximaFrame.cpp:482
 msgid "&Print...\tCtrl-P"
 msgstr ""
 
@@ -303,39 +303,39 @@ msgstr ""
 msgid "&Rational"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:870
+#: ../src/wxMaximaFrame.cpp:869
 msgid "&Reduce Trigonometric"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "&Restart Maxima"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:700
+#: ../src/wxMaximaFrame.cpp:699
 msgid "&Roots of Polynomial (Real)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:472
+#: ../src/wxMaximaFrame.cpp:471
 msgid "&Save\tCtrl-S"
 msgstr ""
 
-#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:919
+#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:918
 msgid "&Simplify"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:829
+#: ../src/wxMaximaFrame.cpp:828
 msgid "&Simplify Expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:856
+#: ../src/wxMaximaFrame.cpp:855
 msgid "&Simplify Factorials"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:867
+#: ../src/wxMaximaFrame.cpp:866
 msgid "&Simplify Trigonometric"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:688
+#: ../src/wxMaximaFrame.cpp:687
 msgid "&Solve..."
 msgstr ""
 
@@ -347,11 +347,11 @@ msgstr ""
 msgid "&Taylor series"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:762
+#: ../src/wxMaximaFrame.cpp:761
 msgid "&Transpose Matrix"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:879
+#: ../src/wxMaximaFrame.cpp:878
 msgid "&Trigonometric Simplification"
 msgstr ""
 
@@ -369,7 +369,7 @@ msgstr ""
 msgid "- Infinity"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:351
+#: ../src/wxMaxima.cpp:356
 msgid ""
 "... [suppressed additional lines since the output is longer than allowed in "
 "the configuration] "
@@ -379,16 +379,16 @@ msgstr ""
 msgid "1/2"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:103
+#: ../src/wxMaximaFrame.cpp:102
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4601
+#: ../src/wxMaxima.cpp:4613
 msgid "<br>Lisp: "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5487
+#: ../src/wxMaxima.cpp:5503
 msgid ""
 "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
@@ -414,11 +414,11 @@ msgid ""
 "\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1472
+#: ../src/wxMaximaFrame.cpp:1495
 msgid "A symbol from the configuration dialogue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:731
+#: ../src/wxMaximaFrame.cpp:730
 msgid "A&t Value..."
 msgstr ""
 
@@ -426,12 +426,12 @@ msgstr ""
 msgid "Abort evaluation on error"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaxima.cpp:4603
+#: ../src/wxMaxima.cpp:4615 ../src/wxMaximaFrame.cpp:985
 msgid "About"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:987 ../src/wxMaximaFrame.cpp:990
-#: ../src/wxMaximaFrame.cpp:991
+#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaximaFrame.cpp:989
+#: ../src/wxMaximaFrame.cpp:990
 msgid "About wxMaxima"
 msgstr ""
 
@@ -439,23 +439,23 @@ msgstr ""
 msgid "Active cell bracket"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:760
+#: ../src/wxMaximaFrame.cpp:759
 msgid "Ad&joint Matrix"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:914
+#: ../src/wxMaximaFrame.cpp:913
 msgid "Add Algebraic E&quality..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:657
+#: ../src/wxMaximaFrame.cpp:656
 msgid "Add a directory to search path"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3353
+#: ../src/wxMaxima.cpp:3365
 msgid "Add dir to path:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:915
+#: ../src/wxMaximaFrame.cpp:914
 msgid "Add equality to the rational simplifier"
 msgstr ""
 
@@ -463,7 +463,7 @@ msgstr ""
 msgid "Add the .wxmx file to the HTML export"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:656
+#: ../src/wxMaximaFrame.cpp:655
 msgid "Add to &Path..."
 msgstr ""
 
@@ -502,27 +502,27 @@ msgstr ""
 msgid "All|*"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1364
+#: ../src/wxMaximaFrame.cpp:1363
 msgid "Alpha"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3838
+#: ../src/wxMaxima.cpp:3850
 msgid "Apply"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:768
+#: ../src/wxMaximaFrame.cpp:767
 msgid "Apply function to a list"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Apropos"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3764
+#: ../src/wxMaxima.cpp:3776
 msgid "Array:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4462
+#: ../src/wxMaxima.cpp:4474
 msgid "Artwork by"
 msgstr ""
 
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Ask to save untitled documents"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3650
+#: ../src/wxMaxima.cpp:3662
 msgid "At value"
 msgstr ""
 
@@ -551,11 +551,11 @@ msgstr ""
 msgid "Autosave interval (minutes, 0 means: off):"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3557
+#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3569
 msgid "BC2"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1272
+#: ../src/wxMaximaFrame.cpp:1271
 msgid "Barsplot..."
 msgstr ""
 
@@ -563,7 +563,7 @@ msgstr ""
 msgid "Bat files (*.bat)|*.bat|All|*"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2943
+#: ../src/wxMaxima.cpp:2951
 msgid "Batch File"
 msgstr ""
 
@@ -576,7 +576,7 @@ msgid ""
 "cells."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1365
+#: ../src/wxMaximaFrame.cpp:1364
 msgid "Beta"
 msgstr ""
 
@@ -588,11 +588,11 @@ msgstr ""
 msgid "Bold"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2359
+#: ../src/wxMaxima.cpp:2366
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1274
+#: ../src/wxMaximaFrame.cpp:1273
 msgid "Boxplot..."
 msgstr ""
 
@@ -604,15 +604,15 @@ msgstr ""
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2080
+#: ../src/MathCtrl.cpp:2127
 msgid "Bug: Cell left but not entered."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1178
+#: ../src/wxMaxima.cpp:1183
 msgid "Bug: Found a math end marker without any start marker."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1222
+#: ../src/wxMaxima.cpp:1227
 msgid "Bug: Found the end of autocompletion symbols but no beginning"
 msgstr ""
 
@@ -624,22 +624,22 @@ msgstr ""
 msgid "Bug: Fraction without enumerator"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2312
+#: ../src/MathCtrl.cpp:2359
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5839
+#: ../src/MathCtrl.cpp:5891
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of "
 "the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5913
+#: ../src/MathCtrl.cpp:5965
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5882
+#: ../src/MathCtrl.cpp:5934
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
@@ -649,49 +649,49 @@ msgstr ""
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
 msgstr ""
 
-#: ../src/GroupCell.cpp:780 ../src/GroupCell.cpp:951
+#: ../src/GroupCell.cpp:781 ../src/GroupCell.cpp:952
 msgid "Bug: No image counter to write to!"
 msgstr ""
 
-#: ../src/AbsCell.cpp:193
+#: ../src/AbsCell.cpp:199
 msgid "Bug: No last cell in an absCell!"
 msgstr ""
 
-#: ../src/ConjugateCell.cpp:185
+#: ../src/ConjugateCell.cpp:194
 msgid "Bug: No last cell in an conjugateCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:471
+#: ../src/FracCell.cpp:472
 msgid "Bug: No last cell in an denominator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:267
+#: ../src/ExptCell.cpp:270
 msgid "Bug: No last cell in an exponent of an exptCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:459
+#: ../src/FracCell.cpp:460
 msgid "Bug: No last cell in an numerator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:257
+#: ../src/ExptCell.cpp:260
 msgid "Bug: No last cell in the base of an exptCell!"
 msgstr ""
 
-#: ../src/ParenCell.cpp:534
+#: ../src/ParenCell.cpp:535
 msgid "Bug: No last cell inside a parenthesis!"
 msgstr ""
 
-#: ../src/SqrtCell.cpp:312
+#: ../src/SqrtCell.cpp:317
 msgid "Bug: No last cell inside a square root!"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2123
+#: ../src/MathCtrl.cpp:2170
 msgid ""
 "Bug: Start or end of merging of subsequent editing actions was requested two "
 "times in a row."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2090
+#: ../src/MathCtrl.cpp:2137
 msgid "Bug: Text changed, but no active cell."
 msgstr ""
 
@@ -699,39 +699,39 @@ msgstr ""
 msgid "Bug: Trying to append NULL to a group cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:555
+#: ../src/MathCtrl.cpp:600
 msgid "Bug: Trying to append maxima's output to a cell outside the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2014
+#: ../src/MathCtrl.cpp:2061
 msgid ""
 "Bug: Trying to merge individual cell adds to a region in the undo buffer but "
 "there are other cells between them."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6522
+#: ../src/MathCtrl.cpp:6577
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2092
+#: ../src/MathCtrl.cpp:2139
 msgid "Bug: Trying to record a cell contents change without a cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1495
+#: ../src/MathCtrl.cpp:1540
 msgid "Bug: Trying to select inside a cell without having a current cell"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5883
+#: ../src/MathCtrl.cpp:5935
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5844 ../src/MathCtrl.cpp:5918 ../src/MathCtrl.cpp:5952
+#: ../src/MathCtrl.cpp:5896 ../src/MathCtrl.cpp:5970 ../src/MathCtrl.cpp:6004
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:973
+#: ../src/wxMaximaFrame.cpp:972
 msgid "Build &Info"
 msgstr ""
 
@@ -743,51 +743,51 @@ msgid ""
 "two key commands."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:782
+#: ../src/wxMaximaFrame.cpp:781
 msgid "C&hange Variable..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:540
+#: ../src/wxMaximaFrame.cpp:539
 msgid "C&onfigure"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:801
+#: ../src/wxMaximaFrame.cpp:800
 msgid "Calculate &Product..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:799
+#: ../src/wxMaximaFrame.cpp:798
 msgid "Calculate Su&m..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:939
+#: ../src/wxMaximaFrame.cpp:938
 msgid "Calculate bigfloat value of the last result"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:936
+#: ../src/wxMaximaFrame.cpp:935
 msgid "Calculate float value of the last result"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3971
+#: ../src/wxMaxima.cpp:3983
 msgid "Calculate modulus:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:942
+#: ../src/wxMaximaFrame.cpp:941
 msgid "Calculate numeric value of the last result"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:802
+#: ../src/wxMaximaFrame.cpp:801
 msgid "Calculate products"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:800
+#: ../src/wxMaximaFrame.cpp:799
 msgid "Calculate sums"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5830
+#: ../src/wxMaxima.cpp:5845
 msgid "Can not connect to the web server."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5881
+#: ../src/wxMaxima.cpp:5896
 msgid "Can not download version info."
 msgstr ""
 
@@ -803,15 +803,15 @@ msgstr ""
 #: ../src/PlotFormatWiz.cpp:48 ../src/SeriesWiz.cpp:49 ../src/SeriesWiz.cpp:51
 #: ../src/SubstituteWiz.cpp:41 ../src/SubstituteWiz.cpp:43 ../src/SumWiz.cpp:44
 #: ../src/SumWiz.cpp:46 ../src/SystemWiz.cpp:38 ../src/SystemWiz.cpp:40
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Cancel"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:126 ../src/wxMaxima.cpp:932
+#: ../src/wxMaxima.cpp:937 ../src/wxMaximaFrame.cpp:125
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1217
+#: ../src/wxMaximaFrame.cpp:1216
 msgid "Canonical (tr)"
 msgstr ""
 
@@ -819,7 +819,7 @@ msgstr ""
 msgid "Catalan"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:638
+#: ../src/wxMaximaFrame.cpp:637
 msgid "Ce&ll"
 msgstr ""
 
@@ -827,39 +827,39 @@ msgstr ""
 msgid "Cell bracket"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5261
+#: ../src/wxMaxima.cpp:5273
 msgid "Cell ends in a backslash"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:676
+#: ../src/wxMaximaFrame.cpp:675
 msgid "Change &2d Display"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:677
+#: ../src/wxMaximaFrame.cpp:676
 msgid "Change the 2d display algorithm used to display math output"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3995
+#: ../src/wxMaxima.cpp:4007
 msgid "Change variable"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:783
+#: ../src/wxMaximaFrame.cpp:782
 msgid "Change variable in integral or sum"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3751
+#: ../src/wxMaxima.cpp:3763
 msgid "Char poly"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:978
+#: ../src/wxMaximaFrame.cpp:977
 msgid "Check for Updates"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:979
+#: ../src/wxMaximaFrame.cpp:978
 msgid "Check if a newer version of wxMaxima/Maxima exist."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1385
+#: ../src/wxMaximaFrame.cpp:1384
 msgid "Chi"
 msgstr ""
 
@@ -880,15 +880,15 @@ msgstr ""
 msgid "Choose new plot format:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710
 msgid "Classes:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:469
+#: ../src/wxMaximaFrame.cpp:468
 msgid "Close\tCtrl-W"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:470
+#: ../src/wxMaximaFrame.cpp:469
 msgid "Close window"
 msgstr ""
 
@@ -920,19 +920,19 @@ msgstr ""
 msgid "Code highlighting: Variables"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4806
+#: ../src/wxMaxima.cpp:4818
 msgid "Col. names:"
 msgstr ""
 
-#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Columns:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:860
+#: ../src/wxMaximaFrame.cpp:859
 msgid "Combine factorials in an expression"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5293
+#: ../src/wxMaxima.cpp:5305
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
@@ -944,23 +944,23 @@ msgstr ""
 msgid "Comma separated y coordinates"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1030
+#: ../src/MathCtrl.cpp:1072
 msgid "Comment Selection"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:533
+#: ../src/wxMaximaFrame.cpp:532
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:532
+#: ../src/wxMaximaFrame.cpp:531
 msgid "Comment selection\tCtrl-/"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:601
+#: ../src/wxMaximaFrame.cpp:600
 msgid "Complete Word\tCtrl-K"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:602
+#: ../src/wxMaximaFrame.cpp:601
 msgid "Complete word"
 msgstr ""
 
@@ -968,35 +968,35 @@ msgstr ""
 msgid "Completely stop maxima and restart it"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:823
+#: ../src/wxMaximaFrame.cpp:822
 msgid "Compute continued fraction of a value"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:761
+#: ../src/wxMaximaFrame.cpp:760
 msgid "Compute the adjoint matrix"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:750
+#: ../src/wxMaximaFrame.cpp:749
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:753
+#: ../src/wxMaximaFrame.cpp:752
 msgid "Compute the determinant of a matrix"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:810
+#: ../src/wxMaximaFrame.cpp:809
 msgid "Compute the greatest common divisor"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:747
+#: ../src/wxMaximaFrame.cpp:746
 msgid "Compute the inverse of a matrix"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:813
+#: ../src/wxMaximaFrame.cpp:812
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4868
 msgid "Condition:"
 msgstr ""
 
@@ -1008,8 +1008,8 @@ msgstr ""
 msgid "Configuration warning"
 msgstr ""
 
-#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:538
-#: ../src/wxMaximaFrame.cpp:541
+#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:540
 msgid "Configure wxMaxima"
 msgstr ""
 
@@ -1018,127 +1018,129 @@ msgstr ""
 msgid "Constant"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:844
+#: ../src/wxMaximaFrame.cpp:843
 msgid "Contract Logarithms"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:851
+#: ../src/wxMaximaFrame.cpp:850
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:854
+#: ../src/wxMaximaFrame.cpp:853
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:888
+#: ../src/wxMaximaFrame.cpp:887
 msgid "Convert complex expression to polar form"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:885
+#: ../src/wxMaximaFrame.cpp:884
 msgid "Convert complex expression to rect form"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:897
+#: ../src/wxMaximaFrame.cpp:896
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:842
+#: ../src/wxMaximaFrame.cpp:841
 msgid "Convert logarithm of product to sum of logarithms"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:845
+#: ../src/wxMaximaFrame.cpp:844
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:850
+#: ../src/wxMaximaFrame.cpp:849
 msgid "Convert to &Factorials"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:853
+#: ../src/wxMaximaFrame.cpp:852
 msgid "Convert to &Gamma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:887
+#: ../src/wxMaximaFrame.cpp:886
 msgid "Convert to &Polarform"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:884
+#: ../src/wxMaximaFrame.cpp:883
 msgid "Convert to &Rectform"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:877
+#: ../src/wxMaximaFrame.cpp:876
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:900
+#: ../src/wxMaximaFrame.cpp:899
 msgid "Convert trigonometric functions to exponential form"
 msgstr ""
 
-#: ../src/ToolBar.cpp:140 ../src/MathCtrl.cpp:918 ../src/MathCtrl.cpp:931
-#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1024
+#: ../src/MathCtrl.cpp:960 ../src/MathCtrl.cpp:973 ../src/MathCtrl.cpp:1019
+#: ../src/MathCtrl.cpp:1066 ../src/ToolBar.cpp:140
 msgid "Copy"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:597
+#: ../src/wxMaximaFrame.cpp:596
 msgid "Copy Previous Input\tCtrl-I"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:599
+#: ../src/wxMaximaFrame.cpp:598
 msgid "Copy Previous Output\tCtrl-U"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:514 ../src/MathCtrl.cpp:936 ../src/MathCtrl.cpp:982
+#: ../src/MathCtrl.cpp:978 ../src/MathCtrl.cpp:1024
+#: ../src/wxMaximaFrame.cpp:513
 msgid "Copy as Image"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:507 ../src/MathCtrl.cpp:932 ../src/MathCtrl.cpp:978
+#: ../src/MathCtrl.cpp:974 ../src/MathCtrl.cpp:1020
+#: ../src/wxMaximaFrame.cpp:506
 msgid "Copy as LaTeX"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:510
+#: ../src/wxMaximaFrame.cpp:509
 msgid "Copy as MathML"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:935 ../src/MathCtrl.cpp:980
+#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1022
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:504
+#: ../src/wxMaximaFrame.cpp:503
 msgid "Copy as Text\tCtrl-Shift-C"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:933 ../src/MathCtrl.cpp:979
+#: ../src/MathCtrl.cpp:975 ../src/MathCtrl.cpp:1021
 msgid "Copy as plain text"
 msgstr ""
 
-#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:503
+#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:502
 msgid "Copy selection"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:515
+#: ../src/wxMaximaFrame.cpp:514
 msgid "Copy selection from document as an image"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:505
+#: ../src/wxMaximaFrame.cpp:504
 msgid "Copy selection from document as text"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:508
+#: ../src/wxMaximaFrame.cpp:507
 msgid "Copy selection from document in LaTeX format"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:511
+#: ../src/wxMaximaFrame.cpp:510
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:598
+#: ../src/wxMaximaFrame.cpp:597
 msgid "Create a new cell with previous input"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:600
+#: ../src/wxMaximaFrame.cpp:599
 msgid "Create a new cell with previous output"
 msgstr ""
 
@@ -1146,15 +1148,15 @@ msgstr ""
 msgid "Cursor"
 msgstr ""
 
-#: ../src/ToolBar.cpp:137 ../src/MathCtrl.cpp:1023
+#: ../src/MathCtrl.cpp:1065 ../src/ToolBar.cpp:137
 msgid "Cut"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:499
+#: ../src/wxMaximaFrame.cpp:498
 msgid "Cut\tCtrl-X"
 msgstr ""
 
-#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:500
+#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:499
 msgid "Cut selection"
 msgstr ""
 
@@ -1166,18 +1168,18 @@ msgstr ""
 msgid "Danish"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4799 ../src/wxMaxima.cpp:4806 ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4811 ../src/wxMaxima.cpp:4818 ../src/wxMaxima.cpp:4868
 msgid "Data Matrix:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4826
+#: ../src/wxMaxima.cpp:4838
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698 ../src/wxMaxima.cpp:4712
-#: ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726 ../src/wxMaxima.cpp:4734
-#: ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748 ../src/wxMaxima.cpp:4755
-#: ../src/wxMaxima.cpp:4791
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710 ../src/wxMaxima.cpp:4724
+#: ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738 ../src/wxMaxima.cpp:4746
+#: ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760 ../src/wxMaxima.cpp:4767
+#: ../src/wxMaxima.cpp:4803
 msgid "Data:"
 msgstr ""
 
@@ -1185,7 +1187,7 @@ msgstr ""
 msgid "Debug: watch maxima's stdout stream"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:820
+#: ../src/wxMaximaFrame.cpp:819
 msgid "Decompose rational function to partial fractions"
 msgstr ""
 
@@ -1215,47 +1217,47 @@ msgid ""
 "with."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3403 ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3415 ../src/wxMaxima.cpp:3424
 msgid "Delete"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:667
+#: ../src/wxMaximaFrame.cpp:666
 msgid "Delete F&unction..."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:939 ../src/MathCtrl.cpp:985
+#: ../src/MathCtrl.cpp:981 ../src/MathCtrl.cpp:1027
 msgid "Delete Selection"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:669
+#: ../src/wxMaximaFrame.cpp:668
 msgid "Delete V&ariable..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:668
+#: ../src/wxMaximaFrame.cpp:667
 msgid "Delete a function"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:670
+#: ../src/wxMaximaFrame.cpp:669
 msgid "Delete a variable"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:655
+#: ../src/wxMaximaFrame.cpp:654
 msgid "Delete all values from memory"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3424
 msgid "Delete function(s):"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3403
+#: ../src/wxMaxima.cpp:3415
 msgid "Delete variable(s):"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1367
+#: ../src/wxMaximaFrame.cpp:1366
 msgid "Delta"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4011
+#: ../src/wxMaxima.cpp:4023
 msgid "Denom. deg:"
 msgstr ""
 
@@ -1263,35 +1265,35 @@ msgstr ""
 msgid "Depth:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3541
+#: ../src/wxMaxima.cpp:3553
 msgid "Derivative:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1258
+#: ../src/wxMaximaFrame.cpp:1257
 msgid "Deviation..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:816
+#: ../src/wxMaximaFrame.cpp:815
 msgid "Di&vide Polynomials..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1223
+#: ../src/wxMaximaFrame.cpp:1222
 msgid "Diff..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4154 ../src/wxMaxima.cpp:5066
+#: ../src/wxMaxima.cpp:4166 ../src/wxMaxima.cpp:5078
 msgid "Differentiate"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:786
+#: ../src/wxMaximaFrame.cpp:785
 msgid "Differentiate expression"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1001
+#: ../src/MathCtrl.cpp:1043
 msgid "Differentiate..."
 msgstr ""
 
-#: ../src/LimitWiz.cpp:37 ../src/FindReplacePane.cpp:76
+#: ../src/FindReplacePane.cpp:76 ../src/LimitWiz.cpp:37
 msgid "Direction:"
 msgstr ""
 
@@ -1299,47 +1301,48 @@ msgstr ""
 msgid "Discrete plot"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:679
+#: ../src/wxMaximaFrame.cpp:678
 msgid "Display Te&X Form"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3320
+#: ../src/wxMaxima.cpp:3332
 msgid "Display algorithm"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:680
+#: ../src/wxMaximaFrame.cpp:679
 msgid "Display last result in TeX form"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:674
+#: ../src/wxMaximaFrame.cpp:673
 msgid "Display time used for evaluation"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4061
+#: ../src/wxMaxima.cpp:4073
 msgid "Divide"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1032
+#: ../src/MathCtrl.cpp:1074
 msgid "Divide Cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:635
+#: ../src/wxMaximaFrame.cpp:634
 msgid "Divide Cell\tCtrl-D"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:817
+#: ../src/wxMaximaFrame.cpp:816
 msgid "Divide numbers or polynomials"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:636
+#: ../src/wxMaximaFrame.cpp:635
 msgid "Divide this input cell into two cells"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5917
-msgid "Do you want to save the changes you made in the document \""
+#: ../src/wxMaxima.cpp:5932
+#, c-format
+msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1664 ../src/wxMaxima.cpp:1672
+#: ../src/wxMaxima.cpp:1669 ../src/wxMaxima.cpp:1677
 msgid "Document "
 msgstr ""
 
@@ -1358,7 +1361,7 @@ msgid ""
 "differences."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Don't save"
 msgstr ""
 
@@ -1366,27 +1369,27 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:734
+#: ../src/wxMaximaFrame.cpp:733
 msgid "E&quations"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:487
+#: ../src/wxMaximaFrame.cpp:486
 msgid "E&xit\tCtrl-Q"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:757
+#: ../src/wxMaximaFrame.cpp:756
 msgid "Eige&nvectors"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:755
+#: ../src/wxMaximaFrame.cpp:754
 msgid "Eigen&values"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3572
+#: ../src/wxMaxima.cpp:3584
 msgid "Eliminate"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:710
+#: ../src/wxMaximaFrame.cpp:709
 msgid "Eliminate a variable from a system of equations"
 msgstr ""
 
@@ -1398,21 +1401,21 @@ msgstr ""
 msgid "English"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4712 ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726
-#: ../src/wxMaxima.cpp:4734 ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748
-#: ../src/wxMaxima.cpp:4755 ../src/wxMaxima.cpp:4791 ../src/wxMaxima.cpp:4799
+#: ../src/wxMaxima.cpp:4724 ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738
+#: ../src/wxMaxima.cpp:4746 ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760
+#: ../src/wxMaxima.cpp:4767 ../src/wxMaxima.cpp:4803 ../src/wxMaxima.cpp:4811
 msgid "Enter Data"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1279
+#: ../src/wxMaximaFrame.cpp:1278
 msgid "Enter Matrix..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:745
+#: ../src/wxMaximaFrame.cpp:744
 msgid "Enter a matrix"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3962
+#: ../src/wxMaxima.cpp:3974
 msgid "Enter an equation for rational simplification:"
 msgstr ""
 
@@ -1424,11 +1427,11 @@ msgstr ""
 msgid "Enter evaluates cells"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3734
+#: ../src/wxMaxima.cpp:3746
 msgid "Enter matrix"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Enter new precision for bigfloats:"
 msgstr ""
 
@@ -1436,11 +1439,11 @@ msgstr ""
 msgid "Enter the path to the Maxima executable."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1368
+#: ../src/wxMaximaFrame.cpp:1367
 msgid "Epsilon"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4208
+#: ../src/wxMaxima.cpp:4220
 msgid "Epsilon:"
 msgstr ""
 
@@ -1449,13 +1452,13 @@ msgstr ""
 msgid "Equation %d:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:3633
-#: ../src/wxMaxima.cpp:5019
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:3645
+#: ../src/wxMaxima.cpp:5031
 msgid "Equation(s):"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3993
-#: ../src/wxMaxima.cpp:4807 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:4005
+#: ../src/wxMaxima.cpp:4819 ../src/wxMaxima.cpp:5045
 msgid "Equation:"
 msgstr ""
 
@@ -1466,76 +1469,76 @@ msgid ""
 "be introduced one into another. Also they are always printed out as 2D maths."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3570
+#: ../src/wxMaxima.cpp:3582
 msgid "Equations:"
 msgstr ""
 
-#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1455
-#: ../src/wxMaxima.cpp:1469 ../src/wxMaxima.cpp:1620 ../src/wxMaxima.cpp:1633
-#: ../src/wxMaxima.cpp:1643 ../src/wxMaxima.cpp:1666 ../src/wxMaxima.cpp:2034
-#: ../src/wxMaxima.cpp:2206 ../src/wxMaxima.cpp:5381 ../src/wxMaxima.cpp:5830
-#: ../src/wxMaxima.cpp:5881
+#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1460
+#: ../src/wxMaxima.cpp:1474 ../src/wxMaxima.cpp:1625 ../src/wxMaxima.cpp:1638
+#: ../src/wxMaxima.cpp:1648 ../src/wxMaxima.cpp:1671 ../src/wxMaxima.cpp:2039
+#: ../src/wxMaxima.cpp:2211 ../src/wxMaxima.cpp:5397 ../src/wxMaxima.cpp:5845
+#: ../src/wxMaxima.cpp:5896
 msgid "Error"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2886 ../src/wxMaxima.cpp:2900 ../src/wxMaxima.cpp:2913
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617 ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:2894 ../src/wxMaxima.cpp:2908 ../src/wxMaxima.cpp:2921
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629 ../src/wxMaxima.cpp:3740
 msgid "Error!"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1370
+#: ../src/wxMaximaFrame.cpp:1369
 msgid "Eta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:909
+#: ../src/wxMaximaFrame.cpp:908
 msgid "Evaluate &Noun Forms"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:589
+#: ../src/wxMaximaFrame.cpp:588
 msgid "Evaluate All Cells\tCtrl-Shift-R"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:587
+#: ../src/wxMaximaFrame.cpp:586
 msgid "Evaluate All Visible Cells\tCtrl-R"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:585 ../src/MathCtrl.cpp:942
+#: ../src/MathCtrl.cpp:984 ../src/wxMaximaFrame.cpp:584
 msgid "Evaluate Cell(s)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:591
+#: ../src/wxMaximaFrame.cpp:590
 msgid "Evaluate Cells Above\tCtrl-Shift-P"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:956 ../src/MathCtrl.cpp:1051
+#: ../src/MathCtrl.cpp:998 ../src/MathCtrl.cpp:1093
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:961 ../src/MathCtrl.cpp:1053
+#: ../src/MathCtrl.cpp:1003 ../src/MathCtrl.cpp:1095
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:971 ../src/MathCtrl.cpp:1057
+#: ../src/MathCtrl.cpp:1013 ../src/MathCtrl.cpp:1099
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:966 ../src/MathCtrl.cpp:1055
+#: ../src/MathCtrl.cpp:1008 ../src/MathCtrl.cpp:1097
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:586
+#: ../src/wxMaximaFrame.cpp:585
 msgid "Evaluate active or selected cell(s)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:590
+#: ../src/wxMaximaFrame.cpp:589
 msgid "Evaluate all cells in the document"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:910
+#: ../src/wxMaximaFrame.cpp:909
 msgid "Evaluate all noun forms in expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:588
+#: ../src/wxMaximaFrame.cpp:587
 msgid "Evaluate all visible cells in the document"
 msgstr ""
 
@@ -1547,7 +1550,7 @@ msgstr ""
 msgid "Evaluate to point"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Example"
 msgstr ""
 
@@ -1559,31 +1562,31 @@ msgstr ""
 msgid "Examples:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:488
+#: ../src/wxMaximaFrame.cpp:487
 msgid "Exit wxMaxima"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1214
+#: ../src/wxMaximaFrame.cpp:1213
 msgid "Expand"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1219
+#: ../src/wxMaximaFrame.cpp:1218
 msgid "Expand (tr)"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:997
+#: ../src/MathCtrl.cpp:1039
 msgid "Expand Expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:841
+#: ../src/wxMaximaFrame.cpp:840
 msgid "Expand Logarithms"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:840
+#: ../src/wxMaximaFrame.cpp:839
 msgid "Expand an expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:874
+#: ../src/wxMaximaFrame.cpp:873
 msgid "Expand trigonometric expression"
 msgstr ""
 
@@ -1591,7 +1594,7 @@ msgstr ""
 msgid "Expected the icon files to be found at"
 msgstr ""
 
-#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2834
+#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2842
 msgid "Export"
 msgstr ""
 
@@ -1600,31 +1603,31 @@ msgid ""
 "Export animations to TeX (Images only move if the PDF viewer supports this)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:481
+#: ../src/wxMaximaFrame.cpp:480
 msgid "Export document to a HTML or pdfLaTeX file"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:253
+#: ../src/wxMaximaFrame.cpp:252
 msgid "Export failed."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:239
+#: ../src/wxMaximaFrame.cpp:238
 msgid "Export successful."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2913
+#: ../src/wxMaxima.cpp:2921
 msgid "Exporting to HTML failed!"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2886
+#: ../src/wxMaxima.cpp:2894
 msgid "Exporting to TeX failed!"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2900
+#: ../src/wxMaxima.cpp:2908
 msgid "Exporting to maxima batch file failed!"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:229
+#: ../src/wxMaximaFrame.cpp:228
 msgid "Exporting..."
 msgstr ""
 
@@ -1637,42 +1640,42 @@ msgid "Expression(s):"
 msgstr ""
 
 #: ../src/IntegrateWiz.cpp:30 ../src/LimitWiz.cpp:27 ../src/SeriesWiz.cpp:33
-#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3648
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:4205 ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5064
+#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3660
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:4217 ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5076
 msgid "Expression:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1213
+#: ../src/wxMaximaFrame.cpp:1212
 msgid "Factor"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:836
+#: ../src/wxMaximaFrame.cpp:835
 msgid "Factor Complex"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:996
+#: ../src/MathCtrl.cpp:1038
 msgid "Factor Expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:835
+#: ../src/wxMaximaFrame.cpp:834
 msgid "Factor an expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:837
+#: ../src/wxMaximaFrame.cpp:836
 msgid "Factor an expression in Gaussian numbers"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:862
+#: ../src/wxMaximaFrame.cpp:861
 msgid "Factorials and &Gamma"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:285
+#: ../src/wxMaxima.cpp:286
 msgid "Fatal error"
 msgstr ""
 
-#: ../src/GroupCell.cpp:1571
+#: ../src/GroupCell.cpp:1572
 #, c-format
 msgid "Figure %d:"
 msgstr ""
@@ -1681,20 +1684,20 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1457 ../src/wxMaxima.cpp:1623 ../src/wxMaxima.cpp:1636
-#: ../src/wxMaxima.cpp:1646 ../src/wxMaxima.cpp:1668
+#: ../src/wxMaxima.cpp:1462 ../src/wxMaxima.cpp:1628 ../src/wxMaxima.cpp:1641
+#: ../src/wxMaxima.cpp:1651 ../src/wxMaxima.cpp:1673
 msgid "File could not be opened"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File not found"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1511 ../src/wxMaxima.cpp:1729
+#: ../src/wxMaxima.cpp:1516 ../src/wxMaxima.cpp:1734
 msgid "File opened"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File you tried to open does not exist."
 msgstr ""
 
@@ -1706,67 +1709,67 @@ msgstr ""
 msgid "Find"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:523
+#: ../src/wxMaximaFrame.cpp:522
 msgid "Find\tCtrl-F"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:787
+#: ../src/wxMaximaFrame.cpp:786
 msgid "Find &Limit..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:790
+#: ../src/wxMaximaFrame.cpp:789
 msgid "Find Minimum..."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:993
+#: ../src/MathCtrl.cpp:1035
 msgid "Find Root..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:791
+#: ../src/wxMaximaFrame.cpp:790
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:788
+#: ../src/wxMaximaFrame.cpp:787
 msgid "Find a limit of an expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:693
+#: ../src/wxMaximaFrame.cpp:692
 msgid "Find a root of an equation on an interval"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:695
+#: ../src/wxMaximaFrame.cpp:694
 msgid "Find all roots of a polynomial"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:698
+#: ../src/wxMaximaFrame.cpp:697
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3220
+#: ../src/wxMaxima.cpp:3215
 msgid "Find and Replace"
 msgstr ""
 
-#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:523
+#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:522
 msgid "Find and replace"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:756
+#: ../src/wxMaximaFrame.cpp:755
 msgid "Find eigenvalues of a matrix"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:758
+#: ../src/wxMaximaFrame.cpp:757
 msgid "Find eigenvectors of a matrix"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4210
+#: ../src/wxMaxima.cpp:4222
 msgid "Find minimum"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:701
+#: ../src/wxMaximaFrame.cpp:700
 msgid "Find real roots of a polynomial"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3493 ../src/wxMaxima.cpp:5036
+#: ../src/wxMaxima.cpp:3505 ../src/wxMaxima.cpp:5048
 msgid "Find root"
 msgstr ""
 
@@ -1787,11 +1790,11 @@ msgstr ""
 msgid "Fixed font in text controls"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:623
+#: ../src/wxMaximaFrame.cpp:622
 msgid "Fold All\tCtrl-Alt-["
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:624
+#: ../src/wxMaximaFrame.cpp:623
 msgid "Fold all sections"
 msgstr ""
 
@@ -1799,25 +1802,25 @@ msgstr ""
 msgid "Follow"
 msgstr ""
 
-#: ../src/ParenCell.cpp:319
+#: ../src/ParenCell.cpp:320
 msgid "Font issue: The Parenthesis sign is too small!"
 msgstr ""
 
-#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:381
+#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:382
 msgid ""
 "Font issue: The char height is too small! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:199
+#: ../src/SqrtCell.cpp:202
 msgid ""
 "Font issue: The sqrt() sign has the size 0! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:198
+#: ../src/SqrtCell.cpp:201
 msgid "Font issue? The contents of a sqrt() has the size 0."
 msgstr ""
 
@@ -1848,15 +1851,15 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:37 ../src/Plot2dWiz.cpp:37 ../src/Plot2dWiz.cpp:47
 #: ../src/Plot2dWiz.cpp:536 ../src/Plot3dWiz.cpp:36 ../src/Plot3dWiz.cpp:45
-#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4240
+#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4252
 msgid "From:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:576
+#: ../src/wxMaximaFrame.cpp:575
 msgid "Full Screen\tAlt-Enter"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3342
+#: ../src/wxMaxima.cpp:3354
 msgid "Function"
 msgstr ""
 
@@ -1864,32 +1867,32 @@ msgstr ""
 msgid "Function names"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3633
+#: ../src/wxMaxima.cpp:3645
 msgid "Function(s):"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3803
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3815
+#: ../src/wxMaxima.cpp:3848
 msgid "Function:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:904
+#: ../src/wxMaximaFrame.cpp:903
 msgid "Functions for complex simplification"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:864
+#: ../src/wxMaximaFrame.cpp:863
 msgid "Functions for simplifying factorials and gamma function"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:881
+#: ../src/wxMaximaFrame.cpp:880
 msgid "Functions for simplifying trigonometric expressions"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4046
+#: ../src/wxMaxima.cpp:4058
 msgid "GCD"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5152
+#: ../src/wxMaxima.cpp:5164
 msgid "GIF image (*.gif)|*.gif"
 msgstr ""
 
@@ -1897,31 +1900,31 @@ msgstr ""
 msgid "Galician"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1366
+#: ../src/wxMaximaFrame.cpp:1365
 msgid "Gamma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:391
+#: ../src/wxMaximaFrame.cpp:390
 msgid "General Math"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:549
+#: ../src/wxMaximaFrame.cpp:548
 msgid "General Math\tAlt-Shift-M"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3766 ../src/wxMaxima.cpp:3785
+#: ../src/wxMaxima.cpp:3778 ../src/wxMaxima.cpp:3797
 msgid "Generate Matrix"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:741
+#: ../src/wxMaximaFrame.cpp:740
 msgid "Generate Matrix from Expression..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:739
+#: ../src/wxMaximaFrame.cpp:738
 msgid "Generate a matrix from a 2-dimensional array"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:742
+#: ../src/wxMaximaFrame.cpp:741
 msgid "Generate a matrix from a lambda expression"
 msgstr ""
 
@@ -1929,39 +1932,39 @@ msgstr ""
 msgid "German"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:893
+#: ../src/wxMaximaFrame.cpp:892
 msgid "Get &Imaginary Part"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:793
+#: ../src/wxMaximaFrame.cpp:792
 msgid "Get &Series..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:804
+#: ../src/wxMaximaFrame.cpp:803
 msgid "Get Laplace transformation of an expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:890
+#: ../src/wxMaximaFrame.cpp:889
 msgid "Get Real P&art"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:807
+#: ../src/wxMaximaFrame.cpp:806
 msgid "Get inverse Laplace transformation of an expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:794
+#: ../src/wxMaximaFrame.cpp:793
 msgid "Get the Taylor or power series of expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:894
+#: ../src/wxMaximaFrame.cpp:893
 msgid "Get the imaginary part of complex expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:891
+#: ../src/wxMaximaFrame.cpp:890
 msgid "Get the real part of complex expression"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5932
+#: ../src/MathCtrl.cpp:5984
 msgid ""
 "Got a request to undo an action that involves an delete which isn't possible "
 "at this moment."
@@ -1971,11 +1974,11 @@ msgstr ""
 msgid "Greek"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:356
+#: ../src/wxMaximaFrame.cpp:355
 msgid "Greek Letters"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:552
+#: ../src/wxMaximaFrame.cpp:551
 msgid "Greek Letters\tAlt-Shift-G"
 msgstr ""
 
@@ -1987,7 +1990,7 @@ msgstr ""
 msgid "Grid:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2836
+#: ../src/wxMaxima.cpp:2844
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|pdfLaTeX file (*."
 "tex)|*.tex"
@@ -2001,11 +2004,11 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide All Toolbars\tAlt-Shift--"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide all panes"
 msgstr "Hide all sidebars"
 
@@ -2013,19 +2016,19 @@ msgstr "Hide all sidebars"
 msgid "Highlight (dpart)"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4685
+#: ../src/wxMaxima.cpp:4697
 msgid "Histogram"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1270
+#: ../src/wxMaximaFrame.cpp:1269
 msgid "Histogram..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:309
+#: ../src/wxMaximaFrame.cpp:308
 msgid "History"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:555
+#: ../src/wxMaximaFrame.cpp:554
 msgid "History\tAlt-Shift-I"
 msgstr ""
 
@@ -2041,11 +2044,11 @@ msgstr ""
 msgid "Hungarian"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3527
+#: ../src/wxMaxima.cpp:3539
 msgid "IC1"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3543
+#: ../src/wxMaxima.cpp:3555
 msgid "IC2"
 msgstr ""
 
@@ -2061,7 +2064,7 @@ msgid ""
 "same output cell."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:683
+#: ../src/wxMaximaFrame.cpp:682
 msgid ""
 "If maxima ever finishes evaluating without wxMaxima realizing this this menu "
 "item can force wxMaxima to try to send commands to maxima again."
@@ -2121,11 +2124,11 @@ msgid ""
 ">Interrupt' or 'Maxima->Restart Maxima' menu commands."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1499
+#: ../src/wxMaximaFrame.cpp:1518
 msgid "Image"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5644
+#: ../src/wxMaxima.cpp:5659
 msgid "Image files (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 msgstr ""
 
@@ -2152,7 +2155,7 @@ msgid ""
 "above it. Might increase readability for some fonts and short subscripts."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Include columns:"
 msgstr ""
 
@@ -2171,19 +2174,19 @@ msgstr ""
 msgid "Infinity"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:974
+#: ../src/wxMaximaFrame.cpp:973
 msgid "Info about Maxima build"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4207
+#: ../src/wxMaxima.cpp:4219
 msgid "Initial Estimates:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:718
+#: ../src/wxMaximaFrame.cpp:717
 msgid "Initial Value Problem (&1)..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:721
+#: ../src/wxMaximaFrame.cpp:720
 msgid "Initial Value Problem (&2)..."
 msgstr ""
 
@@ -2191,7 +2194,7 @@ msgstr ""
 msgid "Input labels"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:403
+#: ../src/wxMaximaFrame.cpp:402
 msgid "Insert"
 msgstr ""
 
@@ -2199,95 +2202,95 @@ msgstr ""
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:612
+#: ../src/wxMaximaFrame.cpp:611
 msgid "Insert &Section Cell\tCtrl-3"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:608
+#: ../src/wxMaximaFrame.cpp:607
 msgid "Insert &Text Cell\tCtrl-1"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:558
+#: ../src/wxMaximaFrame.cpp:557
 msgid "Insert Cell\tAlt-Shift-C"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5642
+#: ../src/wxMaxima.cpp:5657
 msgid "Insert Image"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:620
+#: ../src/wxMaximaFrame.cpp:619
 msgid "Insert Image..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:606
+#: ../src/wxMaximaFrame.cpp:605
 msgid "Insert Input &Cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:618
+#: ../src/wxMaximaFrame.cpp:617
 msgid "Insert Page Break"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:614
+#: ../src/wxMaximaFrame.cpp:613
 msgid "Insert S&ubsection Cell\tCtrl-4"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:616
+#: ../src/wxMaximaFrame.cpp:615
 msgid "Insert S&ubsubsection Cell\tCtrl-5"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1015
+#: ../src/MathCtrl.cpp:1057
 msgid "Insert Section Cell"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1016
+#: ../src/MathCtrl.cpp:1058
 msgid "Insert Subsection Cell"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1017
+#: ../src/MathCtrl.cpp:1059
 msgid "Insert Subsubsection Cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:610
+#: ../src/wxMaximaFrame.cpp:609
 msgid "Insert T&itle Cell\tCtrl-2"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1013
+#: ../src/MathCtrl.cpp:1055
 msgid "Insert Text Cell"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1014
+#: ../src/MathCtrl.cpp:1056
 msgid "Insert Title Cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:607
+#: ../src/wxMaximaFrame.cpp:606
 msgid "Insert a new input cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:613
+#: ../src/wxMaximaFrame.cpp:612
 msgid "Insert a new section cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:615
+#: ../src/wxMaximaFrame.cpp:614
 msgid "Insert a new subsection cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:617
+#: ../src/wxMaximaFrame.cpp:616
 msgid "Insert a new subsubsection cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:609
+#: ../src/wxMaximaFrame.cpp:608
 msgid "Insert a new text cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:611
+#: ../src/wxMaximaFrame.cpp:610
 msgid "Insert a new title cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:619
+#: ../src/wxMaximaFrame.cpp:618
 msgid "Insert a page break"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:621
+#: ../src/wxMaximaFrame.cpp:620
 msgid "Insert image"
 msgstr ""
 
@@ -2299,27 +2302,27 @@ msgstr ""
 msgid "Integral sign"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3992
+#: ../src/wxMaxima.cpp:4004
 msgid "Integral/Sum:"
 msgstr ""
 
-#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4105 ../src/wxMaxima.cpp:5051
+#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4117 ../src/wxMaxima.cpp:5063
 msgid "Integrate"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4091
+#: ../src/wxMaxima.cpp:4103
 msgid "Integrate (risch)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:778
+#: ../src/wxMaximaFrame.cpp:777
 msgid "Integrate expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:780
+#: ../src/wxMaximaFrame.cpp:779
 msgid "Integrate expression with Risch algorithm"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1224 ../src/MathCtrl.cpp:1000
+#: ../src/MathCtrl.cpp:1042 ../src/wxMaximaFrame.cpp:1223
 msgid "Integrate..."
 msgstr ""
 
@@ -2327,7 +2330,7 @@ msgstr ""
 msgid "Interrupt"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:646 ../src/wxMaximaFrame.cpp:650
+#: ../src/wxMaximaFrame.cpp:645 ../src/wxMaximaFrame.cpp:649
 msgid "Interrupt current computation"
 msgstr ""
 
@@ -2344,15 +2347,15 @@ msgid ""
 "Please enter the path to Maxima program again."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4137
+#: ../src/wxMaxima.cpp:4149
 msgid "Inverse Laplace"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:806
+#: ../src/wxMaximaFrame.cpp:805
 msgid "Inverse Laplace T&ransform..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1372
+#: ../src/wxMaximaFrame.cpp:1371
 msgid "Iota"
 msgstr ""
 
@@ -2386,7 +2389,7 @@ msgstr ""
 msgid "Kabyle"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1373
+#: ../src/wxMaximaFrame.cpp:1372
 msgid "Kappa"
 msgstr ""
 
@@ -2395,7 +2398,7 @@ msgstr ""
 msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4031
+#: ../src/wxMaxima.cpp:4043
 msgid "LCM"
 msgstr ""
 
@@ -2411,7 +2414,7 @@ msgstr ""
 msgid "Label width:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1374
+#: ../src/wxMaximaFrame.cpp:1373
 msgid "Lambda"
 msgstr ""
 
@@ -2423,11 +2426,11 @@ msgstr ""
 msgid "Language:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4120
+#: ../src/wxMaxima.cpp:4132
 msgid "Laplace"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:803
+#: ../src/wxMaximaFrame.cpp:802
 msgid "Laplace &Transform..."
 msgstr ""
 
@@ -2435,15 +2438,15 @@ msgstr ""
 msgid "Leads to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:812
+#: ../src/wxMaximaFrame.cpp:811
 msgid "Least Common Multiple..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4809
+#: ../src/wxMaxima.cpp:4821
 msgid "Least Squares Fit"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1266
+#: ../src/wxMaximaFrame.cpp:1265
 msgid "Least Squares Fit..."
 msgstr ""
 
@@ -2454,23 +2457,23 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4192
+#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4204
 msgid "Limit"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1225
+#: ../src/wxMaximaFrame.cpp:1224
 msgid "Limit..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1265
+#: ../src/wxMaximaFrame.cpp:1264
 msgid "Linear Regression..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3803
+#: ../src/wxMaxima.cpp:3815
 msgid "List(s):"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3848
 msgid "List:"
 msgstr ""
 
@@ -2478,15 +2481,15 @@ msgstr ""
 msgid "Load"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2932
+#: ../src/wxMaxima.cpp:2940
 msgid "Load Package"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:479
+#: ../src/wxMaximaFrame.cpp:478
 msgid "Load a Maxima file using the batch command"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:477
+#: ../src/wxMaximaFrame.cpp:476
 msgid "Load a Maxima package file"
 msgstr ""
 
@@ -2498,47 +2501,47 @@ msgstr ""
 msgid "Long Right arrow"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Lower bound:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:771
+#: ../src/wxMaximaFrame.cpp:770
 msgid "Ma&p to Matrix..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:547
+#: ../src/wxMaximaFrame.cpp:546
 msgid "Main Toolbar\tAlt-Shift-B"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:765
+#: ../src/wxMaximaFrame.cpp:764
 msgid "Make &List..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3821
+#: ../src/wxMaxima.cpp:3833
 msgid "Make list"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:766
+#: ../src/wxMaximaFrame.cpp:765
 msgid "Make list from expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:907
+#: ../src/wxMaximaFrame.cpp:906
 msgid "Make substitution in expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:682
+#: ../src/wxMaximaFrame.cpp:681
 msgid "Manually Trigger Evaluation"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3805
+#: ../src/wxMaxima.cpp:3817
 msgid "Map"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:770
+#: ../src/wxMaximaFrame.cpp:769
 msgid "Map function to a list"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:772
+#: ../src/wxMaximaFrame.cpp:771
 msgid "Map function to a matrix"
 msgstr ""
 
@@ -2554,23 +2557,23 @@ msgstr ""
 msgid "Math font:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:374
+#: ../src/wxMaximaFrame.cpp:373
 msgid "Mathematical Symbols"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3716
+#: ../src/wxMaxima.cpp:3728
 msgid "Matrix"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3702
+#: ../src/wxMaxima.cpp:3714
 msgid "Matrix map"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Matrix name:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3749
+#: ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3761
 msgid "Matrix:"
 msgstr ""
 
@@ -2578,7 +2581,7 @@ msgstr ""
 msgid "Maxima"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:137
+#: ../src/wxMaximaFrame.cpp:136
 msgid "Maxima has a question"
 msgstr ""
 
@@ -2586,23 +2589,23 @@ msgstr ""
 msgid "Maxima input"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:166
+#: ../src/wxMaximaFrame.cpp:165
 msgid "Maxima is calculating"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:111
+#: ../src/wxMaximaFrame.cpp:110
 msgid "Maxima is ready for input."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2945
+#: ../src/wxMaxima.cpp:2953
 msgid "Maxima package (*.mac)|*.mac"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2934
+#: ../src/wxMaxima.cpp:2942
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1014
+#: ../src/wxMaxima.cpp:1019
 msgid "Maxima process terminated."
 msgstr ""
 
@@ -2614,7 +2617,7 @@ msgstr ""
 msgid "Maxima questions"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:942
+#: ../src/wxMaxima.cpp:947
 msgid "Maxima started. Waiting for connection..."
 msgstr ""
 
@@ -2636,7 +2639,7 @@ msgid ""
 "('f(x) := x^2;')."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4597
+#: ../src/wxMaxima.cpp:4609
 msgid "Maxima version: "
 msgstr ""
 
@@ -2673,39 +2676,39 @@ msgstr ""
 msgid "Maximum displayed number of digits:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1263
+#: ../src/wxMaximaFrame.cpp:1262
 msgid "Mean Difference Test..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1262
+#: ../src/wxMaximaFrame.cpp:1261
 msgid "Mean Test..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1255
+#: ../src/wxMaximaFrame.cpp:1254
 msgid "Mean..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Mean:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1256
+#: ../src/wxMaximaFrame.cpp:1255
 msgid "Median..."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:945
+#: ../src/MathCtrl.cpp:987
 msgid "Merge Cells"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:633
+#: ../src/wxMaximaFrame.cpp:632
 msgid "Merge Cells\tCtrl-M"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:634
+#: ../src/wxMaximaFrame.cpp:633
 msgid "Merge the text from two input cells into one"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2668
+#: ../src/wxMaxima.cpp:2676
 msgid "Message from the stdout of Maxima: "
 msgstr ""
 
@@ -2713,19 +2716,19 @@ msgstr ""
 msgid "Method:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5289
+#: ../src/wxMaxima.cpp:5301
 msgid "Mismatched parenthesis"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3972
+#: ../src/wxMaxima.cpp:3984
 msgid "Modulus"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1375
+#: ../src/wxMaximaFrame.cpp:1374
 msgid "Mu"
 msgstr ""
 
-#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Name:"
 msgstr ""
 
@@ -2733,7 +2736,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
+#: ../src/wxMaximaFrame.cpp:456 ../src/wxMaximaFrame.cpp:459
 msgid "New\tCtrl-N"
 msgstr ""
 
@@ -2749,11 +2752,11 @@ msgstr ""
 msgid "New value:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3993 ../src/wxMaxima.cpp:4119 ../src/wxMaxima.cpp:4136
+#: ../src/wxMaxima.cpp:4005 ../src/wxMaxima.cpp:4131 ../src/wxMaxima.cpp:4148
 msgid "New variable:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:630
+#: ../src/wxMaximaFrame.cpp:629
 msgid "Next Command\tAlt-Down"
 msgstr ""
 
@@ -2761,15 +2764,15 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5362
+#: ../src/wxMaxima.cpp:5378
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3249 ../src/wxMaxima.cpp:3271
+#: ../src/wxMaxima.cpp:3260 ../src/wxMaxima.cpp:3283
 msgid "No matches found!"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1264
+#: ../src/wxMaximaFrame.cpp:1263
 msgid "Normality Test..."
 msgstr ""
 
@@ -2792,31 +2795,31 @@ msgstr ""
 msgid "Norwegian"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:3740
 msgid "Not a valid matrix dimension!"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629
 msgid "Not a valid number of equations!"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:197
+#: ../src/wxMaximaFrame.cpp:196
 msgid "Not connected to maxima"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4599
+#: ../src/wxMaxima.cpp:4611
 msgid "Not connected."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1376
+#: ../src/wxMaximaFrame.cpp:1375
 msgid "Nu"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Num. deg:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3585 ../src/wxMaxima.cpp:3609
+#: ../src/wxMaxima.cpp:3597 ../src/wxMaxima.cpp:3621
 msgid "Number of equations:"
 msgstr ""
 
@@ -2843,15 +2846,15 @@ msgstr ""
 msgid "Old value:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3992 ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135
+#: ../src/wxMaxima.cpp:4004 ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147
 msgid "Old variable:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1387
+#: ../src/wxMaximaFrame.cpp:1386
 msgid "Omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1378
+#: ../src/wxMaximaFrame.cpp:1377
 msgid "Omicron"
 msgstr ""
 
@@ -2865,20 +2868,20 @@ msgid ""
 "stream for messages."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4763
+#: ../src/wxMaxima.cpp:4775
 msgid "One sample t-test"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:971
+#: ../src/wxMaximaFrame.cpp:970
 msgid "Online tutorials"
 msgstr ""
 
 #: ../src/ConfigDialogue.cpp:656 ../src/main.cpp:347 ../src/ToolBar.cpp:119
-#: ../src/wxMaxima.cpp:2797
+#: ../src/wxMaxima.cpp:2805
 msgid "Open"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:466
+#: ../src/wxMaximaFrame.cpp:465
 msgid "Open Recent"
 msgstr ""
 
@@ -2886,11 +2889,11 @@ msgstr ""
 msgid "Open a cell when Maxima expects input"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:464
+#: ../src/wxMaximaFrame.cpp:463
 msgid "Open a document"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:458 ../src/wxMaximaFrame.cpp:461
+#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
 msgid "Open a new window"
 msgstr ""
 
@@ -2898,11 +2901,11 @@ msgstr ""
 msgid "Open document"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4824
+#: ../src/wxMaxima.cpp:4836
 msgid "Open matrix"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1446 ../src/wxMaxima.cpp:1518
+#: ../src/wxMaxima.cpp:1451 ../src/wxMaxima.cpp:1523
 msgid "Opening file"
 msgstr ""
 
@@ -2926,26 +2929,26 @@ msgstr ""
 msgid "Output labels"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:796
+#: ../src/wxMaximaFrame.cpp:795
 msgid "P&ade Approximation..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3132 ../src/wxMaxima.cpp:5133
+#: ../src/wxMaxima.cpp:3141 ../src/wxMaxima.cpp:5145
 msgid ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
 "bmp|Portable animap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X "
 "pixmap (*.xpm)|*.xpm"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4012
+#: ../src/wxMaxima.cpp:4024
 msgid "Pade approximation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:797
+#: ../src/wxMaximaFrame.cpp:796
 msgid "Pade approximation of a Taylor series"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1500
+#: ../src/wxMaximaFrame.cpp:1519
 msgid "Pagebreak"
 msgstr ""
 
@@ -2957,19 +2960,19 @@ msgstr ""
 msgid "Parametric plot"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:188
+#: ../src/wxMaximaFrame.cpp:187
 msgid "Parsing output"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:819
+#: ../src/wxMaximaFrame.cpp:818
 msgid "Partial &Fractions..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4076
+#: ../src/wxMaxima.cpp:4088
 msgid "Partial fractions"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1769
+#: ../src/wxMaxima.cpp:1774
 msgid "Parts of the document will not be loaded correctly!"
 msgstr ""
 
@@ -2979,11 +2982,11 @@ msgid ""
 "Found unknown XML Tag name "
 msgstr ""
 
-#: ../src/ToolBar.cpp:143 ../src/MathCtrl.cpp:1010 ../src/MathCtrl.cpp:1025
+#: ../src/MathCtrl.cpp:1052 ../src/MathCtrl.cpp:1067 ../src/ToolBar.cpp:143
 msgid "Paste"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:518
+#: ../src/wxMaximaFrame.cpp:517
 msgid "Paste\tCtrl-V"
 msgstr ""
 
@@ -2991,7 +2994,7 @@ msgstr ""
 msgid "Paste from clipboard"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:519
+#: ../src/wxMaximaFrame.cpp:518
 msgid "Paste text from clipboard"
 msgstr ""
 
@@ -2999,19 +3002,19 @@ msgstr ""
 msgid "Perpendicular to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1384
+#: ../src/wxMaximaFrame.cpp:1383
 msgid "Phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1379
+#: ../src/wxMaximaFrame.cpp:1378
 msgid "Pi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1273
+#: ../src/wxMaximaFrame.cpp:1272
 msgid "Piechart..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1952
+#: ../src/wxMaxima.cpp:1957
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr ""
 
@@ -3019,52 +3022,52 @@ msgstr ""
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:923
+#: ../src/wxMaximaFrame.cpp:922
 msgid "Plot &2d..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:925
+#: ../src/wxMaximaFrame.cpp:924
 msgid "Plot &3d..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:927
+#: ../src/wxMaximaFrame.cpp:926
 msgid "Plot &Format..."
 msgstr ""
 
 #: ../src/Plot2dWiz.cpp:104 ../src/Plot2dWiz.cpp:450 ../src/Plot2dWiz.cpp:464
-#: ../src/wxMaxima.cpp:4283 ../src/wxMaxima.cpp:5102
+#: ../src/wxMaxima.cpp:4295 ../src/wxMaxima.cpp:5114
 msgid "Plot 2D"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1227
+#: ../src/wxMaximaFrame.cpp:1226
 msgid "Plot 2D..."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1003
+#: ../src/MathCtrl.cpp:1045
 msgid "Plot 2d..."
 msgstr ""
 
-#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4269 ../src/wxMaxima.cpp:5115
+#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4281 ../src/wxMaxima.cpp:5127
 msgid "Plot 3D"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1228
+#: ../src/wxMaximaFrame.cpp:1227
 msgid "Plot 3D..."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1004
+#: ../src/MathCtrl.cpp:1046
 msgid "Plot 3d..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4296
+#: ../src/wxMaxima.cpp:4308
 msgid "Plot format"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:924
+#: ../src/wxMaximaFrame.cpp:923
 msgid "Plot in 2 dimensions"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:926
+#: ../src/wxMaximaFrame.cpp:925
 msgid "Plot in 3 dimensions"
 msgstr ""
 
@@ -3073,8 +3076,8 @@ msgid "Plot to file:"
 msgstr ""
 
 #: ../src/BC2Wiz.cpp:30 ../src/BC2Wiz.cpp:36 ../src/LimitWiz.cpp:33
-#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
-#: ../src/wxMaxima.cpp:3648
+#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
+#: ../src/wxMaxima.cpp:3660
 msgid "Point:"
 msgstr ""
 
@@ -3082,11 +3085,11 @@ msgstr ""
 msgid "Polish"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 1:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 2:"
 msgstr ""
 
@@ -3098,11 +3101,11 @@ msgstr ""
 msgid "Postscript file (*.eps)|*.eps|All|*"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Precision"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:536
 msgid "Preferences...\tCtrl+,"
 msgstr ""
 
@@ -3114,7 +3117,7 @@ msgid ""
 "packages and from functions that are defined in the current file."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:628
+#: ../src/wxMaximaFrame.cpp:627
 msgid "Previous Command\tAlt-Up"
 msgstr ""
 
@@ -3122,11 +3125,11 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:484
+#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:483
 msgid "Print document"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4242
+#: ../src/wxMaxima.cpp:4254
 msgid "Product"
 msgstr ""
 
@@ -3134,35 +3137,35 @@ msgstr ""
 msgid "Product sign"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1386
+#: ../src/wxMaximaFrame.cpp:1385
 msgid "Psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:331
+#: ../src/wxMaximaFrame.cpp:330
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:592
+#: ../src/wxMaximaFrame.cpp:591
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1278
+#: ../src/wxMaximaFrame.cpp:1277
 msgid "Read Matrix..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:177
+#: ../src/wxMaximaFrame.cpp:176
 msgid "Reading Maxima output"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:153
+#: ../src/wxMaximaFrame.cpp:152
 msgid "Ready for user input"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:631
+#: ../src/wxMaximaFrame.cpp:630
 msgid "Recall next command from history"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:629
+#: ../src/wxMaximaFrame.cpp:628
 msgid "Recall previous command from history"
 msgstr ""
 
@@ -3170,35 +3173,35 @@ msgstr ""
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1215
+#: ../src/wxMaximaFrame.cpp:1214
 msgid "Rectform"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:495
+#: ../src/wxMaximaFrame.cpp:494
 msgid "Redo\tCtrl-Y"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:496
+#: ../src/wxMaximaFrame.cpp:495
 msgid "Redo last change"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1220
+#: ../src/wxMaximaFrame.cpp:1219
 msgid "Reduce (tr)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:871
+#: ../src/wxMaximaFrame.cpp:870
 msgid "Reduce trigonometric expression"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:622 ../src/wxMaxima.cpp:5495
+#: ../src/wxMaxima.cpp:627 ../src/wxMaxima.cpp:5511
 msgid "Refusing to send cell to maxima: "
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:594
+#: ../src/wxMaximaFrame.cpp:593
 msgid "Remove All Output"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:595
+#: ../src/wxMaximaFrame.cpp:594
 msgid "Remove output from input cells"
 msgstr ""
 
@@ -3206,7 +3209,7 @@ msgstr ""
 msgid "Replace All"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3282
+#: ../src/wxMaxima.cpp:3294
 #, c-format
 msgid "Replaced %d occurrences."
 msgstr ""
@@ -3215,11 +3218,11 @@ msgstr ""
 msgid "Replacement:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:976
+#: ../src/wxMaximaFrame.cpp:975
 msgid "Report bug"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "Restart Maxima"
 msgstr ""
 
@@ -3227,7 +3230,7 @@ msgstr ""
 msgid "Restart maxima"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4442
+#: ../src/MathCtrl.cpp:4497
 msgid "Result"
 msgstr ""
 
@@ -3235,7 +3238,7 @@ msgstr ""
 msgid "Return to the cell that is currently being evaluated"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1380
+#: ../src/wxMaximaFrame.cpp:1379
 msgid "Rho"
 msgstr ""
 
@@ -3243,19 +3246,19 @@ msgstr ""
 msgid "Right arrow"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:779
+#: ../src/wxMaximaFrame.cpp:778
 msgid "Risch Integration..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:694
+#: ../src/wxMaximaFrame.cpp:693
 msgid "Roots of &Polynomial"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:697
+#: ../src/wxMaximaFrame.cpp:696
 msgid "Roots of Polynomial (bfloat)"
 msgstr ""
 
-#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Rows:"
 msgstr ""
 
@@ -3263,56 +3266,56 @@ msgstr ""
 msgid "Russian"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 1:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 2:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Sample:"
 msgstr ""
 
 #: ../src/ConfigDialogue.cpp:781 ../src/ToolBar.cpp:122
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Save"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:921
+#: ../src/MathCtrl.cpp:963
 msgid "Save Animation..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2565
+#: ../src/wxMaxima.cpp:2572
 msgid "Save As"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:474
+#: ../src/wxMaximaFrame.cpp:473
 msgid "Save As...\tShift-Ctrl-S"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:919
+#: ../src/MathCtrl.cpp:961
 msgid "Save Image..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3130
+#: ../src/wxMaxima.cpp:3139
 msgid "Save Selection to Image"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:528
+#: ../src/wxMaximaFrame.cpp:527
 msgid "Save Selection to Image..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5150
+#: ../src/wxMaxima.cpp:5162
 msgid "Save animation to file"
 msgstr ""
 
-#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:473
+#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:472
 msgid "Save document"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:475
+#: ../src/wxMaximaFrame.cpp:474
 msgid "Save document as"
 msgstr ""
 
@@ -3334,11 +3337,11 @@ msgstr "Save the sidebar status so the next session can load it again."
 msgid "Save plot to file"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:529
+#: ../src/wxMaximaFrame.cpp:528
 msgid "Save selection from document to an image file"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5131
+#: ../src/wxMaxima.cpp:5143
 msgid "Save selection to file"
 msgstr ""
 
@@ -3354,27 +3357,27 @@ msgstr ""
 msgid "Save wxMaxima window size/position between sessions."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:246
+#: ../src/wxMaximaFrame.cpp:245
 msgid "Saving failed."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:222
+#: ../src/wxMaximaFrame.cpp:221
 msgid "Saving successful."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:212
+#: ../src/wxMaximaFrame.cpp:211
 msgid "Saving..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4699
+#: ../src/wxMaxima.cpp:4711
 msgid "Scatterplot"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1271
+#: ../src/wxMaximaFrame.cpp:1270
 msgid "Scatterplot..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1498
+#: ../src/wxMaximaFrame.cpp:1517
 msgid "Section"
 msgstr ""
 
@@ -3382,26 +3385,26 @@ msgstr ""
 msgid "Section cell"
 msgstr ""
 
-#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:292 ../src/TextCell.cpp:306
-#: ../src/TextCell.cpp:322 ../src/TextCell.cpp:334
+#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:290 ../src/TextCell.cpp:304
+#: ../src/TextCell.cpp:320 ../src/TextCell.cpp:332
 msgid ""
 "Seems like something is broken with a font. Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/TextCell.cpp:139
+#: ../src/TextCell.cpp:137
 msgid ""
 "Seems like something is broken with the maths font. Installing http://www."
 "math.union.edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use "
 "JSmath fonts\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1011 ../src/MathCtrl.cpp:1027
+#: ../src/MathCtrl.cpp:1053 ../src/MathCtrl.cpp:1069
 msgid "Select All"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:525
+#: ../src/wxMaximaFrame.cpp:524
 msgid "Select All\tCtrl-A"
 msgstr ""
 
@@ -3409,7 +3412,7 @@ msgstr ""
 msgid "Select Maxima program"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4860
+#: ../src/wxMaxima.cpp:4872
 msgid "Select Subsample"
 msgstr ""
 
@@ -3418,11 +3421,11 @@ msgstr ""
 msgid "Select a constant"
 msgstr ""
 
-#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:526
+#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:525
 msgid "Select all"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3319
+#: ../src/wxMaxima.cpp:3331
 msgid "Select math display algorithm"
 msgstr ""
 
@@ -3436,23 +3439,23 @@ msgstr ""
 msgid "Selection"
 msgstr ""
 
-#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4178
+#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4190
 msgid "Series"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1226
+#: ../src/wxMaximaFrame.cpp:1225
 msgid "Series..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:863
+#: ../src/wxMaxima.cpp:868
 msgid "Server started"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:575
+#: ../src/wxMaximaFrame.cpp:574
 msgid "Set Zoom"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:944
+#: ../src/wxMaximaFrame.cpp:943
 msgid "Set bigfloat &Precision..."
 msgstr ""
 
@@ -3460,61 +3463,61 @@ msgstr ""
 msgid "Set fixed font in text controls."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:928
+#: ../src/wxMaximaFrame.cpp:927
 msgid "Set plot format"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:945
+#: ../src/wxMaximaFrame.cpp:944
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can "
 "be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:569
+#: ../src/wxMaximaFrame.cpp:568
 msgid "Set zoom to 100%"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:570
+#: ../src/wxMaximaFrame.cpp:569
 msgid "Set zoom to 120%"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:571
+#: ../src/wxMaximaFrame.cpp:570
 msgid "Set zoom to 150%"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:572
+#: ../src/wxMaximaFrame.cpp:571
 msgid "Set zoom to 200%"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:573
+#: ../src/wxMaximaFrame.cpp:572
 msgid "Set zoom to 300%"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:568
+#: ../src/wxMaximaFrame.cpp:567
 msgid "Set zoom to 80%"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:732
+#: ../src/wxMaximaFrame.cpp:731
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:918
+#: ../src/wxMaximaFrame.cpp:917
 msgid "Setup modulus computation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:662
+#: ../src/wxMaximaFrame.cpp:661
 msgid "Show &Definition..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:660
+#: ../src/wxMaximaFrame.cpp:659
 msgid "Show &Functions"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:967
+#: ../src/wxMaximaFrame.cpp:966
 msgid "Show &Tips..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:665
+#: ../src/wxMaximaFrame.cpp:664
 msgid "Show &Variables"
 msgstr ""
 
@@ -3522,43 +3525,43 @@ msgstr ""
 msgid "Show Maxima help"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:603
+#: ../src/wxMaximaFrame.cpp:602
 msgid "Show Template\tCtrl-Shift-K"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:968
+#: ../src/wxMaximaFrame.cpp:967
 msgid "Show a tip"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Show all commands similar to:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Show an example for the command:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:962
+#: ../src/wxMaximaFrame.cpp:961
 msgid "Show an example of usage"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:965
+#: ../src/wxMaximaFrame.cpp:964
 msgid "Show commands similar to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:661
+#: ../src/wxMaximaFrame.cpp:660
 msgid "Show defined functions"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:666
+#: ../src/wxMaximaFrame.cpp:665
 msgid "Show defined variables"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:663
+#: ../src/wxMaximaFrame.cpp:662
 msgid "Show definition of a function"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:604
+#: ../src/wxMaximaFrame.cpp:603
 msgid "Show function template"
 msgstr ""
 
@@ -3570,7 +3573,7 @@ msgstr ""
 msgid "Show long expressions:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3341
+#: ../src/wxMaxima.cpp:3353
 msgid "Show the definition of function:"
 msgstr ""
 
@@ -3579,43 +3582,43 @@ msgstr ""
 msgid "Show user-defined labels instead of (%oxx)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:953 ../src/wxMaximaFrame.cpp:956
+#: ../src/wxMaximaFrame.cpp:952 ../src/wxMaximaFrame.cpp:955
 msgid "Show wxMaxima help"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1381
+#: ../src/wxMaximaFrame.cpp:1380
 msgid "Sigma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1211
+#: ../src/wxMaximaFrame.cpp:1210
 msgid "Simplify"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:831
+#: ../src/wxMaximaFrame.cpp:830
 msgid "Simplify &Radicals"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1212
+#: ../src/wxMaximaFrame.cpp:1211
 msgid "Simplify (r)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1218
+#: ../src/wxMaximaFrame.cpp:1217
 msgid "Simplify (tr)"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:995
+#: ../src/MathCtrl.cpp:1037
 msgid "Simplify Expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:857
+#: ../src/wxMaximaFrame.cpp:856
 msgid "Simplify an expression containing factorials"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:832
+#: ../src/wxMaximaFrame.cpp:831
 msgid "Simplify expression containing radicals"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:830
+#: ../src/wxMaximaFrame.cpp:829
 msgid "Simplify rational expression"
 msgstr ""
 
@@ -3623,7 +3626,7 @@ msgstr ""
 msgid "Simplify the sum"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:868
+#: ../src/wxMaximaFrame.cpp:867
 msgid "Simplify trigonometric expression"
 msgstr ""
 
@@ -3635,87 +3638,87 @@ msgid ""
 "along with your document."
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
+#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
 msgid "Solution:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3461 ../src/wxMaxima.cpp:3475 ../src/wxMaxima.cpp:5020
+#: ../src/wxMaxima.cpp:3473 ../src/wxMaxima.cpp:3487 ../src/wxMaxima.cpp:5032
 msgid "Solve"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:706
+#: ../src/wxMaximaFrame.cpp:705
 msgid "Solve &Algebraic System..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:703
+#: ../src/wxMaximaFrame.cpp:702
 msgid "Solve &Linear System..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:714
+#: ../src/wxMaximaFrame.cpp:713
 msgid "Solve &ODE..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:690
+#: ../src/wxMaximaFrame.cpp:689
 msgid "Solve (to_poly)..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3511 ../src/wxMaxima.cpp:3635
+#: ../src/wxMaxima.cpp:3523 ../src/wxMaxima.cpp:3647
 msgid "Solve ODE"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:728
+#: ../src/wxMaximaFrame.cpp:727
 msgid "Solve ODE with Lapla&ce..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1222
+#: ../src/wxMaximaFrame.cpp:1221
 msgid "Solve ODE..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3586 ../src/wxMaxima.cpp:3597
+#: ../src/wxMaxima.cpp:3598 ../src/wxMaxima.cpp:3609
 msgid "Solve algebraic system"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:707
+#: ../src/wxMaximaFrame.cpp:706
 msgid "Solve algebraic system of equations"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:725
+#: ../src/wxMaximaFrame.cpp:724
 msgid "Solve boundary value problem for second degree ODE"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:689
+#: ../src/wxMaximaFrame.cpp:688
 msgid "Solve equation(s)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:691
+#: ../src/wxMaximaFrame.cpp:690
 msgid "Solve equation(s) with to_poly_solve"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:719
+#: ../src/wxMaximaFrame.cpp:718
 msgid "Solve initial value problem for first degree ODE"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:722
+#: ../src/wxMaximaFrame.cpp:721
 msgid "Solve initial value problem for second degree ODE"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3610 ../src/wxMaxima.cpp:3621
+#: ../src/wxMaxima.cpp:3622 ../src/wxMaxima.cpp:3633
 msgid "Solve linear system"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:704
+#: ../src/wxMaximaFrame.cpp:703
 msgid "Solve linear system of equations"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:715
+#: ../src/wxMaximaFrame.cpp:714
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:729
+#: ../src/wxMaximaFrame.cpp:728
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1221 ../src/MathCtrl.cpp:992
+#: ../src/MathCtrl.cpp:1034 ../src/wxMaximaFrame.cpp:1220
 msgid "Solve..."
 msgstr ""
 
@@ -3739,7 +3742,7 @@ msgstr ""
 msgid "Special constants"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:922
+#: ../src/MathCtrl.cpp:964
 msgid "Start Animation"
 msgstr ""
 
@@ -3757,28 +3760,28 @@ msgstr ""
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:294
+#: ../src/wxMaxima.cpp:295
 msgid "Starting Maxima process failed"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:928
+#: ../src/wxMaxima.cpp:933
 msgid "Starting Maxima..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:292 ../src/wxMaxima.cpp:860
+#: ../src/wxMaxima.cpp:293 ../src/wxMaxima.cpp:865
 msgid "Starting server failed"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:841
+#: ../src/wxMaxima.cpp:846
 #, c-format
 msgid "Starting server on port %d"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:342
+#: ../src/wxMaximaFrame.cpp:341
 msgid "Statistics"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:550
+#: ../src/wxMaximaFrame.cpp:549
 msgid "Statistics\tAlt-Shift-S"
 msgstr ""
 
@@ -3794,11 +3797,11 @@ msgstr ""
 msgid "Styles"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1283
+#: ../src/wxMaximaFrame.cpp:1282
 msgid "Subsample..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1496
+#: ../src/wxMaximaFrame.cpp:1515
 msgid "Subsection"
 msgstr ""
 
@@ -3806,20 +3809,20 @@ msgstr ""
 msgid "Subsection cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1216
+#: ../src/wxMaximaFrame.cpp:1215
 msgid "Subst..."
 msgstr ""
 
-#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3423
-#: ../src/wxMaxima.cpp:5089
+#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3435
+#: ../src/wxMaxima.cpp:5101
 msgid "Substitute"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:906 ../src/MathCtrl.cpp:998
+#: ../src/MathCtrl.cpp:1040 ../src/wxMaximaFrame.cpp:905
 msgid "Substitute..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1497
+#: ../src/wxMaximaFrame.cpp:1516
 msgid "Subsubsection"
 msgstr ""
 
@@ -3827,7 +3830,7 @@ msgstr ""
 msgid "Subsubsection cell"
 msgstr ""
 
-#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4226
+#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4238
 msgid "Sum"
 msgstr ""
 
@@ -3835,35 +3838,35 @@ msgstr ""
 msgid "Sum sign"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:553
+#: ../src/wxMaximaFrame.cpp:552
 msgid "Symbols\tAlt-Shift-Y"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4456
+#: ../src/wxMaxima.cpp:4468
 msgid "System info"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:320
+#: ../src/wxMaximaFrame.cpp:319
 msgid "Table of Contents"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:556
+#: ../src/wxMaximaFrame.cpp:555
 msgid "Table of Contents\tAlt-Shift-T"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1382
+#: ../src/wxMaximaFrame.cpp:1381
 msgid "Tau"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Taylor series:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3963
+#: ../src/wxMaxima.cpp:3975
 msgid "Tellrat"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1494
+#: ../src/wxMaximaFrame.cpp:1513
 msgid "Text"
 msgstr ""
 
@@ -3908,7 +3911,7 @@ msgstr ""
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr ""
 
-#: ../src/TextCell.cpp:136
+#: ../src/TextCell.cpp:134
 msgid ""
 "The letter \"X\" is of width zero. Installing http://www.math.union.edu/"
 "~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts\" in "
@@ -3925,7 +3928,7 @@ msgstr ""
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:959
+#: ../src/wxMaximaFrame.cpp:958
 msgid "The offline manual of maxima"
 msgstr ""
 
@@ -3959,21 +3962,21 @@ msgid ""
 "find tutorials on using wxMaxima and Maxima."
 msgstr ""
 
-#: ../src/SlideShowCell.cpp:332
+#: ../src/SlideShowCell.cpp:336
 msgid ""
 "There was an error during GIF export!\n"
 "\n"
 "Make sure ImageMagick is installed and wxMaxima can find the convert program."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:442
+#: ../src/wxMaxima.cpp:447
 msgid ""
 "There was an error in generated XML!\n"
 "\n"
 "Please report this as a bug."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1371
+#: ../src/wxMaximaFrame.cpp:1370
 msgid "Theta"
 msgstr ""
 
@@ -3981,7 +3984,7 @@ msgstr ""
 msgid "Ticks:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4153 ../src/wxMaxima.cpp:5065
+#: ../src/wxMaxima.cpp:4165 ../src/wxMaxima.cpp:5077
 msgid "Times:"
 msgstr ""
 
@@ -3989,7 +3992,7 @@ msgstr ""
 msgid "Tips not available, sorry!"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1495
+#: ../src/wxMaximaFrame.cpp:1514
 msgid "Title"
 msgstr ""
 
@@ -4004,19 +4007,19 @@ msgid ""
 "all sublevels of that cell will also fold/unfold."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:938
+#: ../src/wxMaximaFrame.cpp:937
 msgid "To &Bigfloat"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:935
+#: ../src/wxMaximaFrame.cpp:934
 msgid "To &Float"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:990
+#: ../src/MathCtrl.cpp:1032
 msgid "To Float"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:941
+#: ../src/wxMaximaFrame.cpp:940
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr ""
 
@@ -4047,51 +4050,51 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:41 ../src/Plot2dWiz.cpp:40 ../src/Plot2dWiz.cpp:50
 #: ../src/Plot2dWiz.cpp:539 ../src/Plot3dWiz.cpp:39 ../src/Plot3dWiz.cpp:48
-#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4241
+#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4253
 msgid "To:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:912
+#: ../src/wxMaximaFrame.cpp:911
 msgid "Toggle &Algebraic Flag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:933
+#: ../src/wxMaximaFrame.cpp:932
 msgid "Toggle &Numeric Output"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:673
+#: ../src/wxMaximaFrame.cpp:672
 msgid "Toggle &Time Display"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:913
+#: ../src/wxMaximaFrame.cpp:912
 msgid "Toggle algebraic flag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:577
+#: ../src/wxMaximaFrame.cpp:576
 msgid "Toggle full screen editing"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:934
+#: ../src/wxMaximaFrame.cpp:933
 msgid "Toggle numeric output"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4464
+#: ../src/wxMaxima.cpp:4476
 msgid "Toolbar icons"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4465
+#: ../src/wxMaxima.cpp:4477
 msgid "Translated by"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:763
+#: ../src/wxMaximaFrame.cpp:762
 msgid "Transpose a matrix"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5834
+#: ../src/MathCtrl.cpp:5886
 msgid "Trying to undo an action without starting cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5901
+#: ../src/MathCtrl.cpp:5953
 msgid "Trying to undo something but the undo action is empty."
 msgstr ""
 
@@ -4099,11 +4102,11 @@ msgstr ""
 msgid "Turkish"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:970
+#: ../src/wxMaximaFrame.cpp:969
 msgid "Tutorials"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4778
+#: ../src/wxMaxima.cpp:4790
 msgid "Two sample t-test"
 msgstr ""
 
@@ -4115,15 +4118,15 @@ msgstr ""
 msgid "Ukrainian"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5356
+#: ../src/wxMaxima.cpp:5372
 msgid "Un-closed parenthesis"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5323
+#: ../src/wxMaxima.cpp:5335
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5889
 msgid ""
 "Unable to interpret the version info I got from http://andrejv.github.io//"
 "wxmaxima/version.txt: "
@@ -4137,11 +4140,11 @@ msgstr ""
 msgid "Underscore converts to subscripts:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:492
+#: ../src/wxMaximaFrame.cpp:491
 msgid "Undo\tCtrl-Z"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:493
+#: ../src/wxMaximaFrame.cpp:492
 msgid "Undo last change"
 msgstr ""
 
@@ -4149,23 +4152,23 @@ msgstr ""
 msgid "Undo limit (0 for none):"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:625
+#: ../src/wxMaximaFrame.cpp:624
 msgid "Unfold All\tCtrl-Alt-]"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:626
+#: ../src/wxMaximaFrame.cpp:625
 msgid "Unfold all folded sections"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4458
+#: ../src/wxMaxima.cpp:4470
 msgid "Unicode Support"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5335
+#: ../src/wxMaxima.cpp:5347
 msgid "Unterminated comment."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5309
+#: ../src/wxMaxima.cpp:5321
 msgid "Unterminated string."
 msgstr ""
 
@@ -4173,15 +4176,15 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5859 ../src/wxMaxima.cpp:5866 ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5874 ../src/wxMaxima.cpp:5881 ../src/wxMaxima.cpp:5889
 msgid "Upgrade"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Upper bound:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1383
+#: ../src/wxMaximaFrame.cpp:1382
 msgid "Upsilon"
 msgstr ""
 
@@ -4225,22 +4228,22 @@ msgstr ""
 msgid "User-defined labels"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3525
-#: ../src/wxMaxima.cpp:3541 ../src/wxMaxima.cpp:3649
+#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3537
+#: ../src/wxMaxima.cpp:3553 ../src/wxMaxima.cpp:3661
 msgid "Value:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:5019 ../src/wxMaxima.cpp:5064
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:5031 ../src/wxMaxima.cpp:5076
 msgid "Variable(s):"
 msgstr ""
 
 #: ../src/IntegrateWiz.cpp:33 ../src/LimitWiz.cpp:30 ../src/Plot2dWiz.cpp:34
 #: ../src/Plot2dWiz.cpp:44 ../src/Plot2dWiz.cpp:533 ../src/Plot3dWiz.cpp:33
 #: ../src/Plot3dWiz.cpp:42 ../src/SeriesWiz.cpp:36 ../src/SumWiz.cpp:30
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3749
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3761
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5045
 msgid "Variable:"
 msgstr ""
 
@@ -4248,25 +4251,25 @@ msgstr ""
 msgid "Variables"
 msgstr ""
 
-#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3571 ../src/wxMaxima.cpp:4206
-#: ../src/wxMaxima.cpp:4807
+#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3583 ../src/wxMaxima.cpp:4218
+#: ../src/wxMaxima.cpp:4819
 msgid "Variables:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1257
+#: ../src/wxMaximaFrame.cpp:1256
 msgid "Variance..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:580
+#: ../src/wxMaximaFrame.cpp:579
 msgid "View"
 msgstr ""
 
-#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1674 ../src/wxMaxima.cpp:1769
-#: ../src/wxMaxima.cpp:1950
+#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1679 ../src/wxMaxima.cpp:1774
+#: ../src/wxMaxima.cpp:1955
 msgid "Warning"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:109 ../src/wxMaximaFrame.cpp:295
+#: ../src/wxMaximaFrame.cpp:108 ../src/wxMaximaFrame.cpp:294
 msgid "Welcome to wxMaxima"
 msgstr ""
 
@@ -4286,7 +4289,7 @@ msgid ""
 "introducing an empty line."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2567
+#: ../src/wxMaxima.cpp:2574
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) "
 "(*.wxm)|*.wxm"
@@ -4302,7 +4305,7 @@ msgid ""
 "as equation markers"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6798
+#: ../src/MathCtrl.cpp:6856
 msgid "Wrapped search"
 msgstr ""
 
@@ -4310,15 +4313,15 @@ msgstr ""
 msgid "Write matching parenthesis in text controls."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4461
+#: ../src/wxMaxima.cpp:4473
 msgid "Written by"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:557
+#: ../src/wxMaximaFrame.cpp:556
 msgid "XML Inspector"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1377
+#: ../src/wxMaximaFrame.cpp:1376
 msgid "Xi"
 msgstr ""
 
@@ -4369,7 +4372,7 @@ msgid ""
 "cells."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5856
+#: ../src/wxMaxima.cpp:5871
 #, c-format
 msgid ""
 "You have version %s. Current version is %s.\n"
@@ -4377,39 +4380,39 @@ msgid ""
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5921
+#: ../src/wxMaxima.cpp:5936
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5866
+#: ../src/wxMaxima.cpp:5881
 msgid "Your version of wxMaxima is up to date."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1369
+#: ../src/wxMaximaFrame.cpp:1368
 msgid "Zeta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:562
+#: ../src/wxMaximaFrame.cpp:561
 msgid "Zoom &In\tCtrl-+"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:564
+#: ../src/wxMaximaFrame.cpp:563
 msgid "Zoom Ou&t\tCtrl--"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:563
+#: ../src/wxMaximaFrame.cpp:562
 msgid "Zoom in 10%"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:565
+#: ../src/wxMaximaFrame.cpp:564
 msgid "Zoom out 10%"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaximaFrame.cpp:287
 msgid "[ unsaved ]"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5700
+#: ../src/wxMaxima.cpp:5715
 msgid "[ unsaved* ]"
 msgstr ""
 
@@ -4418,17 +4421,17 @@ msgstr ""
 msgid "[%i digits]"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4392
+#: ../src/MathCtrl.cpp:4447
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" style=\"max-width:90%%;\" >\n"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4517
+#: ../src/MathCtrl.cpp:4572
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" >"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1333
+#: ../src/wxMaximaFrame.cpp:1332
 msgid "alpha"
 msgstr ""
 
@@ -4440,7 +4443,7 @@ msgstr ""
 msgid "antisymmetric"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1334
+#: ../src/wxMaximaFrame.cpp:1333
 msgid "beta"
 msgstr ""
 
@@ -4484,7 +4487,7 @@ msgstr ""
 msgid "bug:Invalid sup tag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1354
+#: ../src/wxMaximaFrame.cpp:1353
 msgid "chi"
 msgstr ""
 
@@ -4497,7 +4500,7 @@ msgstr ""
 msgid "default"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1336
+#: ../src/wxMaximaFrame.cpp:1335
 msgid "delta"
 msgstr ""
 
@@ -4509,7 +4512,7 @@ msgstr ""
 msgid "empty"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1337
+#: ../src/wxMaximaFrame.cpp:1336
 msgid "epsilon"
 msgstr ""
 
@@ -4517,7 +4520,7 @@ msgstr ""
 msgid "equivalent"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1339
+#: ../src/wxMaximaFrame.cpp:1338
 msgid "eta"
 msgstr ""
 
@@ -4533,7 +4536,7 @@ msgid ""
 "all=_ marks subscripts."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1335
+#: ../src/wxMaximaFrame.cpp:1334
 msgid "gamma"
 msgstr ""
 
@@ -4559,15 +4562,15 @@ msgstr ""
 msgid "intersection"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1341
+#: ../src/wxMaximaFrame.cpp:1340
 msgid "iota"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1342
+#: ../src/wxMaximaFrame.cpp:1341
 msgid "kappa"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1343
+#: ../src/wxMaximaFrame.cpp:1342
 msgid "lambda"
 msgstr ""
 
@@ -4583,7 +4586,7 @@ msgstr ""
 msgid "logscale"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3783
+#: ../src/wxMaxima.cpp:3795
 msgid "matrix[i,j]:"
 msgstr ""
 
@@ -4591,7 +4594,7 @@ msgstr ""
 msgid "maxima's pwd is path to document"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1344
+#: ../src/wxMaximaFrame.cpp:1343
 msgid "mu"
 msgstr ""
 
@@ -4607,7 +4610,7 @@ msgstr ""
 msgid "nand"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4524
+#: ../src/wxMaxima.cpp:4536
 msgid "no"
 msgstr ""
 
@@ -4631,15 +4634,15 @@ msgstr ""
 msgid "not subset or equal"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1345
+#: ../src/wxMaximaFrame.cpp:1344
 msgid "nu"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1356
+#: ../src/wxMaximaFrame.cpp:1355
 msgid "omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1347
+#: ../src/wxMaximaFrame.cpp:1346
 msgid "omicron"
 msgstr ""
 
@@ -4651,11 +4654,11 @@ msgstr ""
 msgid "partial sign"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1353
+#: ../src/wxMaximaFrame.cpp:1352
 msgid "phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1348
+#: ../src/wxMaximaFrame.cpp:1347
 msgid "pi"
 msgstr ""
 
@@ -4667,11 +4670,11 @@ msgstr ""
 msgid "proportional to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1355
+#: ../src/wxMaximaFrame.cpp:1354
 msgid "psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1349
+#: ../src/wxMaximaFrame.cpp:1348
 msgid "rho"
 msgstr ""
 
@@ -4679,7 +4682,7 @@ msgstr ""
 msgid "right"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1350
+#: ../src/wxMaximaFrame.cpp:1349
 msgid "sigma"
 msgstr ""
 
@@ -4699,7 +4702,7 @@ msgstr ""
 msgid "symmetric"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1351
+#: ../src/wxMaximaFrame.cpp:1350
 msgid "tau"
 msgstr ""
 
@@ -4711,7 +4714,7 @@ msgstr ""
 msgid "there is no"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1340
+#: ../src/wxMaximaFrame.cpp:1339
 msgid "theta"
 msgstr ""
 
@@ -4727,12 +4730,12 @@ msgstr ""
 msgid "union"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5903
+#: ../src/wxMaxima.cpp:5918
 msgid "unsaved"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:290 ../src/wxMaxima.cpp:2559
-#: ../src/wxMaxima.cpp:2826
+#: ../src/wxMaxima.cpp:2566 ../src/wxMaxima.cpp:2834
+#: ../src/wxMaximaFrame.cpp:289
 msgid "untitled"
 msgstr ""
 
@@ -4741,25 +4744,25 @@ msgstr ""
 msgid "untitled %d"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1352
+#: ../src/wxMaximaFrame.cpp:1351
 msgid "upsilon"
 msgstr ""
 
-#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4538
+#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4550
 msgid "wxMaxima"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
-#: ../src/wxMaxima.cpp:5700 ../src/wxMaxima.cpp:5709 ../src/wxMaxima.cpp:5712
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaxima.cpp:5715 ../src/wxMaxima.cpp:5724
+#: ../src/wxMaxima.cpp:5727 ../src/wxMaximaFrame.cpp:287
 #, c-format
 msgid "wxMaxima %s "
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:952
+#: ../src/wxMaximaFrame.cpp:951
 msgid "wxMaxima &Help\tCtrl+?"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:955
+#: ../src/wxMaximaFrame.cpp:954
 msgid "wxMaxima &Help\tF1"
 msgstr ""
 
@@ -4770,11 +4773,11 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1619
+#: ../src/wxMaxima.cpp:1624
 msgid "wxMaxima cannot open content.xml in the .wxmx zip archive "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1633
+#: ../src/wxMaxima.cpp:1638
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
@@ -4782,7 +4785,7 @@ msgstr ""
 msgid "wxMaxima configuration"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1947
+#: ../src/wxMaxima.cpp:1952
 msgid ""
 "wxMaxima could not find Maxima!\n"
 "\n"
@@ -4790,21 +4793,21 @@ msgid ""
 "Then start Maxima with 'Maxima->Restart Maxima'."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2204
+#: ../src/wxMaxima.cpp:2209
 msgid ""
 "wxMaxima could not find help files.\n"
 "\n"
 "Please check your installation."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2032
+#: ../src/wxMaxima.cpp:2037
 msgid ""
 "wxMaxima could not find tip files.\n"
 "\n"
 "Please check your installation."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:282
+#: ../src/wxMaxima.cpp:283
 msgid ""
 "wxMaxima could not start the server.\n"
 "\n"
@@ -4819,29 +4822,29 @@ msgid ""
 "instead of '%'."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2330
+#: ../src/wxMaxima.cpp:2336
 msgid "wxMaxima document"
 msgstr ""
 
-#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2799
+#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2807
 msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1455 ../src/wxMaxima.cpp:1469
+#: ../src/wxMaxima.cpp:1460 ../src/wxMaxima.cpp:1474
 msgid "wxMaxima encountered an error loading "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4463
+#: ../src/wxMaxima.cpp:4475
 msgid "wxMaxima icon"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4455
+#: ../src/wxMaxima.cpp:4467
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "MAXIMA based on wxWidgets."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4516
+#: ../src/wxMaxima.cpp:4528
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "Maxima based on wxWidgets."
@@ -4859,11 +4862,11 @@ msgstr ""
 msgid "x"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1346
+#: ../src/wxMaximaFrame.cpp:1345
 msgid "xi"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1643
+#: ../src/wxMaxima.cpp:1648
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
@@ -4871,11 +4874,11 @@ msgstr ""
 msgid "xor"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4522
+#: ../src/wxMaxima.cpp:4534
 msgid "yes"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1338
+#: ../src/wxMaximaFrame.cpp:1337
 msgid "zeta"
 msgstr ""
 

--- a/locales/es.po
+++ b/locales/es.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: es\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-07 21:42+0200\n"
+"POT-Creation-Date: 2016-10-16 17:47+0900\n"
 "PO-Revision-Date: 2007-08-02 17:05+0200\n"
 "Last-Translator: Mario Rodriguez <mario@edu.xunta.es>\n"
 "Language-Team:  <es@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../src/wxMaxima.cpp:4519
+#: ../src/wxMaxima.cpp:4531
 #, c-format
 msgid ""
 "\n"
@@ -31,7 +31,7 @@ msgstr ""
 "wxWidgets: %d.%d.%d\n"
 "Soporte unicode: %s"
 
-#: ../src/wxMaxima.cpp:4532
+#: ../src/wxMaxima.cpp:4544
 msgid ""
 "\n"
 "Lisp: "
@@ -39,7 +39,7 @@ msgstr ""
 "\n"
 "Lisp: "
 
-#: ../src/wxMaxima.cpp:4528
+#: ../src/wxMaxima.cpp:4540
 msgid ""
 "\n"
 "Maxima version: "
@@ -47,7 +47,7 @@ msgstr ""
 "\n"
 "Versión de Maxima: "
 
-#: ../src/wxMaxima.cpp:5381
+#: ../src/wxMaxima.cpp:5397
 msgid ""
 "\n"
 "Not connected to Maxima!\n"
@@ -55,7 +55,7 @@ msgstr ""
 "\n"
 "¡No conectado a Maxima!\n"
 
-#: ../src/wxMaxima.cpp:4530
+#: ../src/wxMaxima.cpp:4542
 msgid ""
 "\n"
 "Not connected."
@@ -76,7 +76,7 @@ msgstr "      -l <name>"
 msgid " (Graphics) "
 msgstr " (Gráficos) "
 
-#: ../src/EditorCell.cpp:3045 ../src/EditorCell.cpp:3227
+#: ../src/EditorCell.cpp:3088 ../src/EditorCell.cpp:3270
 #, c-format
 msgid " ... + %i hidden lines"
 msgstr ""
@@ -88,7 +88,7 @@ msgstr ""
 "...[suprimidas líneas adicionales; resultado mayor del indicado en "
 "configuración]"
 
-#: ../src/wxMaxima.cpp:1673
+#: ../src/wxMaxima.cpp:1678
 msgid ""
 " was saved using a newer version of wxMaxima so it may not load correctly. "
 "Please update your wxMaxima."
@@ -96,7 +96,7 @@ msgstr ""
 " fue guardado con una versión más actualizada de wxMaxima, por lo que es "
 "posible que no se cargue correctamente. Por favor, actualice wxMaxima."
 
-#: ../src/wxMaxima.cpp:1665
+#: ../src/wxMaxima.cpp:1670
 msgid ""
 " was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr ""
@@ -111,64 +111,64 @@ msgstr "\"Copiar LaTeX\" añade marcadores de ecuaciones"
 msgid "\"implies\" symbol"
 msgstr "símbolo \"implica\""
 
-#: ../src/wxMaximaFrame.cpp:101
+#: ../src/wxMaximaFrame.cpp:100
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr "celdas %i en la cola de evaluación"
 
-#: ../src/wxMaximaFrame.cpp:773
+#: ../src/wxMaximaFrame.cpp:772
 msgid "&Algebra"
 msgstr "Álge&bra"
 
-#: ../src/wxMaximaFrame.cpp:767
+#: ../src/wxMaximaFrame.cpp:766
 msgid "&Apply to List..."
 msgstr "&Aplicar a lista"
 
-#: ../src/wxMaximaFrame.cpp:964
+#: ../src/wxMaximaFrame.cpp:963
 msgid "&Apropos..."
 msgstr "&A propósito"
 
-#: ../src/wxMaximaFrame.cpp:478
+#: ../src/wxMaximaFrame.cpp:477
 msgid "&Batch File...\tCtrl-B"
 msgstr "Archivo por &lotes\tCtrl-B"
 
-#: ../src/wxMaximaFrame.cpp:724
+#: ../src/wxMaximaFrame.cpp:723
 msgid "&Boundary Value Problem..."
 msgstr "Pro&blema de contorno"
 
-#: ../src/wxMaximaFrame.cpp:975
+#: ../src/wxMaximaFrame.cpp:974
 msgid "&Bug Report"
 msgstr "Informar de e&rror"
 
-#: ../src/wxMaximaFrame.cpp:825
+#: ../src/wxMaximaFrame.cpp:824
 msgid "&Calculus"
 msgstr "A&nálisis"
 
-#: ../src/wxMaximaFrame.cpp:876
+#: ../src/wxMaximaFrame.cpp:875
 msgid "&Canonical Form"
 msgstr "Forma &canónica"
 
-#: ../src/wxMaximaFrame.cpp:749
+#: ../src/wxMaximaFrame.cpp:748
 msgid "&Characteristic Polynomial..."
 msgstr "Polinomio &característico"
 
-#: ../src/wxMaximaFrame.cpp:654
+#: ../src/wxMaximaFrame.cpp:653
 msgid "&Clear Memory"
 msgstr "&Limpiar memoria"
 
-#: ../src/wxMaximaFrame.cpp:859
+#: ../src/wxMaximaFrame.cpp:858
 msgid "&Combine Factorials"
 msgstr "&Combinar factoriales"
 
-#: ../src/wxMaximaFrame.cpp:902
+#: ../src/wxMaximaFrame.cpp:901
 msgid "&Complex Simplification"
 msgstr "Simplificación &compleja"
 
-#: ../src/wxMaximaFrame.cpp:822
+#: ../src/wxMaximaFrame.cpp:821
 msgid "&Continued Fraction"
 msgstr "Fracción contin&ua"
 
-#: ../src/wxMaximaFrame.cpp:502
+#: ../src/wxMaximaFrame.cpp:501
 msgid "&Copy\tCtrl-C"
 msgstr "&Copiar\tCtrl-C"
 
@@ -176,107 +176,107 @@ msgstr "&Copiar\tCtrl-C"
 msgid "&Definite integration"
 msgstr "Integración &definida"
 
-#: ../src/wxMaximaFrame.cpp:896
+#: ../src/wxMaximaFrame.cpp:895
 msgid "&Demoivre"
 msgstr "&Demoivre"
 
-#: ../src/wxMaximaFrame.cpp:752
+#: ../src/wxMaximaFrame.cpp:751
 msgid "&Determinant"
 msgstr "&Determinante"
 
-#: ../src/wxMaximaFrame.cpp:785
+#: ../src/wxMaximaFrame.cpp:784
 msgid "&Differentiate..."
 msgstr "&Derivar"
 
-#: ../src/wxMaximaFrame.cpp:543
+#: ../src/wxMaximaFrame.cpp:542
 msgid "&Edit"
 msgstr "&Editar"
 
-#: ../src/wxMaximaFrame.cpp:709
+#: ../src/wxMaximaFrame.cpp:708
 msgid "&Eliminate Variable..."
 msgstr "Eliminar &variable"
 
-#: ../src/wxMaximaFrame.cpp:744
+#: ../src/wxMaximaFrame.cpp:743
 msgid "&Enter Matrix..."
 msgstr "&Introducir matriz"
 
-#: ../src/wxMaximaFrame.cpp:961
+#: ../src/wxMaximaFrame.cpp:960
 msgid "&Example..."
 msgstr "&Ejemplo"
 
-#: ../src/wxMaximaFrame.cpp:839
+#: ../src/wxMaximaFrame.cpp:838
 msgid "&Expand Expression"
 msgstr "&Expandir expresión"
 
-#: ../src/wxMaximaFrame.cpp:873
+#: ../src/wxMaximaFrame.cpp:872
 msgid "&Expand Trigonometric"
 msgstr "Expandir &trigonometría"
 
-#: ../src/wxMaximaFrame.cpp:899
+#: ../src/wxMaximaFrame.cpp:898
 msgid "&Exponentialize"
 msgstr "Expo&nencializar"
 
-#: ../src/wxMaximaFrame.cpp:480
+#: ../src/wxMaximaFrame.cpp:479
 msgid "&Export..."
 msgstr "&Exportar"
 
-#: ../src/wxMaximaFrame.cpp:834
+#: ../src/wxMaximaFrame.cpp:833
 msgid "&Factor Expression"
 msgstr "&Factorizar expresión"
 
-#: ../src/wxMaximaFrame.cpp:489
+#: ../src/wxMaximaFrame.cpp:488
 msgid "&File"
 msgstr "&Archivo"
 
-#: ../src/wxMaximaFrame.cpp:692
+#: ../src/wxMaximaFrame.cpp:691
 msgid "&Find Root..."
 msgstr "C&alcular raíz"
 
-#: ../src/wxMaximaFrame.cpp:738
+#: ../src/wxMaximaFrame.cpp:737
 msgid "&Generate Matrix..."
 msgstr "&Generar matriz"
 
-#: ../src/wxMaximaFrame.cpp:809
+#: ../src/wxMaximaFrame.cpp:808
 msgid "&Greatest Common Divisor..."
 msgstr "Má&ximo común divisor"
 
-#: ../src/wxMaximaFrame.cpp:994
+#: ../src/wxMaximaFrame.cpp:993
 msgid "&Help"
 msgstr "A&yuda"
 
-#: ../src/wxMaximaFrame.cpp:777
+#: ../src/wxMaximaFrame.cpp:776
 msgid "&Integrate..."
 msgstr "&Integrar"
 
-#: ../src/wxMaximaFrame.cpp:645
+#: ../src/wxMaximaFrame.cpp:644
 msgid "&Interrupt\tCtrl-."
 msgstr "&Interrumpir\tCtrl-."
 
-#: ../src/wxMaximaFrame.cpp:649
+#: ../src/wxMaximaFrame.cpp:648
 msgid "&Interrupt\tCtrl-G"
 msgstr "&Interrumpir\tCtrl-G"
 
-#: ../src/wxMaximaFrame.cpp:746
+#: ../src/wxMaximaFrame.cpp:745
 msgid "&Invert Matrix"
 msgstr "In&vertir matriz"
 
-#: ../src/wxMaximaFrame.cpp:476
+#: ../src/wxMaximaFrame.cpp:475
 msgid "&Load Package...\tCtrl-L"
 msgstr "Cargar &paquete\tCtrl-L"
 
-#: ../src/wxMaximaFrame.cpp:769
+#: ../src/wxMaximaFrame.cpp:768
 msgid "&Map to List(s)..."
 msgstr "Distribui&r sobre lista"
 
-#: ../src/wxMaximaFrame.cpp:684
+#: ../src/wxMaximaFrame.cpp:683
 msgid "&Maxima"
 msgstr "&Maxima"
 
-#: ../src/wxMaximaFrame.cpp:958
+#: ../src/wxMaximaFrame.cpp:957
 msgid "&Maxima help"
 msgstr "Ayuda de Maxima"
 
-#: ../src/wxMaximaFrame.cpp:917
+#: ../src/wxMaximaFrame.cpp:916
 msgid "&Modulus Computation..."
 msgstr "Cálculo del &módulo"
 
@@ -284,7 +284,7 @@ msgstr "Cálculo del &módulo"
 msgid "&New\tCtrl-N"
 msgstr "&Nuevo\tCtrl-N"
 
-#: ../src/wxMaximaFrame.cpp:947
+#: ../src/wxMaximaFrame.cpp:946
 msgid "&Numeric"
 msgstr "N&umérico"
 
@@ -300,11 +300,11 @@ msgstr "&Nusum"
 msgid "&Open\tCtrl-O"
 msgstr "&Abrir\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:463
+#: ../src/wxMaximaFrame.cpp:462
 msgid "&Open...\tCtrl-O"
 msgstr "&Abrir...\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:929
+#: ../src/wxMaximaFrame.cpp:928
 msgid "&Plot"
 msgstr "&Gráficos"
 
@@ -312,7 +312,7 @@ msgstr "&Gráficos"
 msgid "&Power series"
 msgstr "Serie de &potencias"
 
-#: ../src/wxMaximaFrame.cpp:483
+#: ../src/wxMaximaFrame.cpp:482
 msgid "&Print...\tCtrl-P"
 msgstr "&Imprimir...\tCtrl-P"
 
@@ -320,39 +320,39 @@ msgstr "&Imprimir...\tCtrl-P"
 msgid "&Rational"
 msgstr "&Racional"
 
-#: ../src/wxMaximaFrame.cpp:870
+#: ../src/wxMaximaFrame.cpp:869
 msgid "&Reduce Trigonometric"
 msgstr "R&educir trigonometría"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "&Restart Maxima"
 msgstr "&Reiniciar Maxima"
 
-#: ../src/wxMaximaFrame.cpp:700
+#: ../src/wxMaximaFrame.cpp:699
 msgid "&Roots of Polynomial (Real)"
 msgstr "Raíces reales de un polino&mio"
 
-#: ../src/wxMaximaFrame.cpp:472
+#: ../src/wxMaximaFrame.cpp:471
 msgid "&Save\tCtrl-S"
 msgstr "&Guardar\tCtrl-S"
 
-#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:919
+#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:918
 msgid "&Simplify"
 msgstr "&Simplificar"
 
-#: ../src/wxMaximaFrame.cpp:829
+#: ../src/wxMaximaFrame.cpp:828
 msgid "&Simplify Expression"
 msgstr "&Simplificar expresión"
 
-#: ../src/wxMaximaFrame.cpp:856
+#: ../src/wxMaximaFrame.cpp:855
 msgid "&Simplify Factorials"
 msgstr "&Simplificar factoriales"
 
-#: ../src/wxMaximaFrame.cpp:867
+#: ../src/wxMaximaFrame.cpp:866
 msgid "&Simplify Trigonometric"
 msgstr "&Simplificar trigonometría"
 
-#: ../src/wxMaximaFrame.cpp:688
+#: ../src/wxMaximaFrame.cpp:687
 msgid "&Solve..."
 msgstr "&Resolver"
 
@@ -364,11 +364,11 @@ msgstr "Especial"
 msgid "&Taylor series"
 msgstr "Serie de Taylor"
 
-#: ../src/wxMaximaFrame.cpp:762
+#: ../src/wxMaximaFrame.cpp:761
 msgid "&Transpose Matrix"
 msgstr "&Trasponer matriz"
 
-#: ../src/wxMaximaFrame.cpp:879
+#: ../src/wxMaximaFrame.cpp:878
 msgid "&Trigonometric Simplification"
 msgstr "Simplificación &trigonométrica"
 
@@ -386,7 +386,7 @@ msgstr "(Usar idioma predeterminado)"
 msgid "- Infinity"
 msgstr "- Infinito"
 
-#: ../src/wxMaxima.cpp:351
+#: ../src/wxMaxima.cpp:356
 msgid ""
 "... [suppressed additional lines since the output is longer than allowed in "
 "the configuration] "
@@ -398,16 +398,16 @@ msgstr ""
 msgid "1/2"
 msgstr "1/2"
 
-#: ../src/wxMaximaFrame.cpp:103
+#: ../src/wxMaximaFrame.cpp:102
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4601
+#: ../src/wxMaxima.cpp:4613
 msgid "<br>Lisp: "
 msgstr "<br>Lisp: "
 
-#: ../src/wxMaxima.cpp:5487
+#: ../src/wxMaxima.cpp:5503
 msgid ""
 "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
@@ -440,12 +440,12 @@ msgid ""
 "\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1472
+#: ../src/wxMaximaFrame.cpp:1495
 #, fuzzy
 msgid "A symbol from the configuration dialogue"
 msgstr "Un símbolo del diálogo de configuración"
 
-#: ../src/wxMaximaFrame.cpp:731
+#: ../src/wxMaximaFrame.cpp:730
 msgid "A&t Value..."
 msgstr "&Condición inicial"
 
@@ -453,12 +453,12 @@ msgstr "&Condición inicial"
 msgid "Abort evaluation on error"
 msgstr "Interrupción de cálculo debido a error"
 
-#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaxima.cpp:4603
+#: ../src/wxMaxima.cpp:4615 ../src/wxMaximaFrame.cpp:985
 msgid "About"
 msgstr "A&cerca de..."
 
-#: ../src/wxMaximaFrame.cpp:987 ../src/wxMaximaFrame.cpp:990
-#: ../src/wxMaximaFrame.cpp:991
+#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaximaFrame.cpp:989
+#: ../src/wxMaximaFrame.cpp:990
 msgid "About wxMaxima"
 msgstr "Acerca de wxMaxima"
 
@@ -466,23 +466,23 @@ msgstr "Acerca de wxMaxima"
 msgid "Active cell bracket"
 msgstr "Corchete de celda activa"
 
-#: ../src/wxMaximaFrame.cpp:760
+#: ../src/wxMaximaFrame.cpp:759
 msgid "Ad&joint Matrix"
 msgstr "Matriz ad&junta"
 
-#: ../src/wxMaximaFrame.cpp:914
+#: ../src/wxMaximaFrame.cpp:913
 msgid "Add Algebraic E&quality..."
 msgstr "Añadir &igualdad algebraica"
 
-#: ../src/wxMaximaFrame.cpp:657
+#: ../src/wxMaximaFrame.cpp:656
 msgid "Add a directory to search path"
 msgstr "Añadir directorio a la ruta de búsqueda"
 
-#: ../src/wxMaxima.cpp:3353
+#: ../src/wxMaxima.cpp:3365
 msgid "Add dir to path:"
 msgstr "Añadir dir a la ruta:"
 
-#: ../src/wxMaximaFrame.cpp:915
+#: ../src/wxMaximaFrame.cpp:914
 msgid "Add equality to the rational simplifier"
 msgstr "Añadir igualdad al simplificador racional"
 
@@ -490,7 +490,7 @@ msgstr "Añadir igualdad al simplificador racional"
 msgid "Add the .wxmx file to the HTML export"
 msgstr "Añadir archivo .wxmx a la exportación HTML"
 
-#: ../src/wxMaximaFrame.cpp:656
+#: ../src/wxMaximaFrame.cpp:655
 msgid "Add to &Path..."
 msgstr "Aña&dir a la ruta"
 
@@ -532,27 +532,27 @@ msgstr "Nombres de todas las variables"
 msgid "All|*"
 msgstr "Todos|*"
 
-#: ../src/wxMaximaFrame.cpp:1364
+#: ../src/wxMaximaFrame.cpp:1363
 msgid "Alpha"
 msgstr "Alfa"
 
-#: ../src/wxMaxima.cpp:3838
+#: ../src/wxMaxima.cpp:3850
 msgid "Apply"
 msgstr "Aplicar"
 
-#: ../src/wxMaximaFrame.cpp:768
+#: ../src/wxMaximaFrame.cpp:767
 msgid "Apply function to a list"
 msgstr "Aplicar función a lista"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Apropos"
 msgstr "A propósito"
 
-#: ../src/wxMaxima.cpp:3764
+#: ../src/wxMaxima.cpp:3776
 msgid "Array:"
 msgstr "Array:"
 
-#: ../src/wxMaxima.cpp:4462
+#: ../src/wxMaxima.cpp:4474
 msgid "Artwork by"
 msgstr "Arte por"
 
@@ -560,7 +560,7 @@ msgstr "Arte por"
 msgid "Ask to save untitled documents"
 msgstr "Preguntar para guardar documentos no titulados"
 
-#: ../src/wxMaxima.cpp:3650
+#: ../src/wxMaxima.cpp:3662
 msgid "At value"
 msgstr "Condición inicial"
 
@@ -588,11 +588,11 @@ msgstr ""
 msgid "Autosave interval (minutes, 0 means: off):"
 msgstr "Intervalo de autoguardado (minutos, 0 significa desactivado)"
 
-#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3557
+#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3569
 msgid "BC2"
 msgstr "BC2"
 
-#: ../src/wxMaximaFrame.cpp:1272
+#: ../src/wxMaximaFrame.cpp:1271
 msgid "Barsplot..."
 msgstr "Diagrama de barras"
 
@@ -600,7 +600,7 @@ msgstr "Diagrama de barras"
 msgid "Bat files (*.bat)|*.bat|All|*"
 msgstr "Archivos bat (*.bat)|*.bat|Todos|*"
 
-#: ../src/wxMaxima.cpp:2943
+#: ../src/wxMaxima.cpp:2951
 msgid "Batch File"
 msgstr "Archivo por lotes"
 
@@ -618,7 +618,7 @@ msgstr ""
 "restringida a celdas. Pulsando Ctrl+Z dentro de una celda permite hacer "
 "cambios que solo afectan a ella misma."
 
-#: ../src/wxMaximaFrame.cpp:1365
+#: ../src/wxMaximaFrame.cpp:1364
 msgid "Beta"
 msgstr "Beta"
 
@@ -631,11 +631,11 @@ msgstr "Escala bitmap para exportar"
 msgid "Bold"
 msgstr "Bastardilla"
 
-#: ../src/wxMaxima.cpp:2359
+#: ../src/wxMaxima.cpp:2366
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr "Cursores horizontal y vertical activos al mismo tiempo"
 
-#: ../src/wxMaximaFrame.cpp:1274
+#: ../src/wxMaximaFrame.cpp:1273
 msgid "Boxplot..."
 msgstr "Diagrama de cajas"
 
@@ -647,15 +647,15 @@ msgstr "Navegar"
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr "Fallo: autocompleción solicitada para elemento desconocido."
 
-#: ../src/MathCtrl.cpp:2080
+#: ../src/MathCtrl.cpp:2127
 msgid "Bug: Cell left but not entered."
 msgstr "Fallo: celda abandonada sin haber entrado."
 
-#: ../src/wxMaxima.cpp:1178
+#: ../src/wxMaxima.cpp:1183
 msgid "Bug: Found a math end marker without any start marker."
 msgstr "Fallo: encontrado marcador final sin marcador de inicio."
 
-#: ../src/wxMaxima.cpp:1222
+#: ../src/wxMaxima.cpp:1227
 msgid "Bug: Found the end of autocompletion symbols but no beginning"
 msgstr "Fallo: encontrado fin de autocompleción sin inicio"
 
@@ -667,11 +667,11 @@ msgstr ""
 msgid "Bug: Fraction without enumerator"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2312
+#: ../src/MathCtrl.cpp:2359
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr "Fallo: pregunta sin celda asociada"
 
-#: ../src/MathCtrl.cpp:5839
+#: ../src/MathCtrl.cpp:5891
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of "
 "the worksheet."
@@ -679,14 +679,14 @@ msgstr ""
 "Fallo: Se ha solicitado cambiar el contenido de una celda por encima del "
 "comienzo de la hoja de trabajo."
 
-#: ../src/MathCtrl.cpp:5913
+#: ../src/MathCtrl.cpp:5965
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 "Fallo: Se ha solicitado eliminar el contenido de una celda por encima del "
 "comienzo de la hoja de trabajo."
 
-#: ../src/MathCtrl.cpp:5882
+#: ../src/MathCtrl.cpp:5934
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
@@ -698,43 +698,43 @@ msgstr ""
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
 msgstr "Fallo: celda sin grupo al que pertenecer"
 
-#: ../src/GroupCell.cpp:780 ../src/GroupCell.cpp:951
+#: ../src/GroupCell.cpp:781 ../src/GroupCell.cpp:952
 msgid "Bug: No image counter to write to!"
 msgstr ""
 
-#: ../src/AbsCell.cpp:193
+#: ../src/AbsCell.cpp:199
 msgid "Bug: No last cell in an absCell!"
 msgstr ""
 
-#: ../src/ConjugateCell.cpp:185
+#: ../src/ConjugateCell.cpp:194
 msgid "Bug: No last cell in an conjugateCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:471
+#: ../src/FracCell.cpp:472
 msgid "Bug: No last cell in an denominator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:267
+#: ../src/ExptCell.cpp:270
 msgid "Bug: No last cell in an exponent of an exptCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:459
+#: ../src/FracCell.cpp:460
 msgid "Bug: No last cell in an numerator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:257
+#: ../src/ExptCell.cpp:260
 msgid "Bug: No last cell in the base of an exptCell!"
 msgstr ""
 
-#: ../src/ParenCell.cpp:534
+#: ../src/ParenCell.cpp:535
 msgid "Bug: No last cell inside a parenthesis!"
 msgstr ""
 
-#: ../src/SqrtCell.cpp:312
+#: ../src/SqrtCell.cpp:317
 msgid "Bug: No last cell inside a square root!"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2123
+#: ../src/MathCtrl.cpp:2170
 msgid ""
 "Bug: Start or end of merging of subsequent editing actions was requested two "
 "times in a row."
@@ -742,7 +742,7 @@ msgstr ""
 "Fallo: Se ha solicitado dos veces en una fila el inicio y final de pegado de "
 "acciones de edición."
 
-#: ../src/MathCtrl.cpp:2090
+#: ../src/MathCtrl.cpp:2137
 msgid "Bug: Text changed, but no active cell."
 msgstr "Fallo: Texto cambiado sin celda activa."
 
@@ -750,13 +750,13 @@ msgstr "Fallo: Texto cambiado sin celda activa."
 msgid "Bug: Trying to append NULL to a group cell."
 msgstr "Fallo: Intento de añadir NULL a un grupo de celdas."
 
-#: ../src/MathCtrl.cpp:555
+#: ../src/MathCtrl.cpp:600
 msgid "Bug: Trying to append maxima's output to a cell outside the worksheet."
 msgstr ""
 "Fallo: Intento de añadir el resultado de Maxima a una celda fuera de la hoja "
 "de trabajo."
 
-#: ../src/MathCtrl.cpp:2014
+#: ../src/MathCtrl.cpp:2061
 msgid ""
 "Bug: Trying to merge individual cell adds to a region in the undo buffer but "
 "there are other cells between them."
@@ -764,32 +764,32 @@ msgstr ""
 "Fallo: Intento de unir celdas individuales en una región del búffer de "
 "deshacer, pero no hay otras celdas entre ellas."
 
-#: ../src/MathCtrl.cpp:6522
+#: ../src/MathCtrl.cpp:6577
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
 "Fallo: intento de mover cursor horizontal dentro de un grupo de celdas."
 
-#: ../src/MathCtrl.cpp:2092
+#: ../src/MathCtrl.cpp:2139
 msgid "Bug: Trying to record a cell contents change without a cell."
 msgstr ""
 "Fallo: Intento de guardar el cambio del contenido de una celda sin celda."
 
-#: ../src/MathCtrl.cpp:1495
+#: ../src/MathCtrl.cpp:1540
 msgid "Bug: Trying to select inside a cell without having a current cell"
 msgstr "Fallo: Intento de selección no válida del contenido de una celda."
 
-#: ../src/MathCtrl.cpp:5883
+#: ../src/MathCtrl.cpp:5935
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr "Fallo: Acción de deshacer."
 
-#: ../src/MathCtrl.cpp:5844 ../src/MathCtrl.cpp:5918 ../src/MathCtrl.cpp:5952
+#: ../src/MathCtrl.cpp:5896 ../src/MathCtrl.cpp:5970 ../src/MathCtrl.cpp:6004
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
 "Fallo: Solicitud de deshacer para una celda fuera da la hoja de trabajo."
 
-#: ../src/wxMaximaFrame.cpp:973
+#: ../src/wxMaximaFrame.cpp:972
 msgid "Build &Info"
 msgstr "Crear info"
 
@@ -806,51 +806,51 @@ msgstr ""
 "puede cambiar en 'Editar->Preferencias' seleccionando 'Tecla retorno evalúa "
 "celdas', con lo que se intercambiarán los roles de estas teclas."
 
-#: ../src/wxMaximaFrame.cpp:782
+#: ../src/wxMaximaFrame.cpp:781
 msgid "C&hange Variable..."
 msgstr "C&ambiar variable"
 
-#: ../src/wxMaximaFrame.cpp:540
+#: ../src/wxMaximaFrame.cpp:539
 msgid "C&onfigure"
 msgstr "&Preferencias"
 
-#: ../src/wxMaximaFrame.cpp:801
+#: ../src/wxMaximaFrame.cpp:800
 msgid "Calculate &Product..."
 msgstr "&Calcular producto"
 
-#: ../src/wxMaximaFrame.cpp:799
+#: ../src/wxMaximaFrame.cpp:798
 msgid "Calculate Su&m..."
 msgstr "Calcular su&ma"
 
-#: ../src/wxMaximaFrame.cpp:939
+#: ../src/wxMaximaFrame.cpp:938
 msgid "Calculate bigfloat value of the last result"
 msgstr "Formato real grande de la última expresión"
 
-#: ../src/wxMaximaFrame.cpp:936
+#: ../src/wxMaximaFrame.cpp:935
 msgid "Calculate float value of the last result"
 msgstr "Formato real de la última expresión"
 
-#: ../src/wxMaxima.cpp:3971
+#: ../src/wxMaxima.cpp:3983
 msgid "Calculate modulus:"
 msgstr "Calcular módulo:"
 
-#: ../src/wxMaximaFrame.cpp:942
+#: ../src/wxMaximaFrame.cpp:941
 msgid "Calculate numeric value of the last result"
 msgstr "Calcula el valor numérico del último resultado"
 
-#: ../src/wxMaximaFrame.cpp:802
+#: ../src/wxMaximaFrame.cpp:801
 msgid "Calculate products"
 msgstr "Calcular productos"
 
-#: ../src/wxMaximaFrame.cpp:800
+#: ../src/wxMaximaFrame.cpp:799
 msgid "Calculate sums"
 msgstr "Calcular sumas"
 
-#: ../src/wxMaxima.cpp:5830
+#: ../src/wxMaxima.cpp:5845
 msgid "Can not connect to the web server."
 msgstr "No se puede acceder al servidor web."
 
-#: ../src/wxMaxima.cpp:5881
+#: ../src/wxMaxima.cpp:5896
 msgid "Can not download version info."
 msgstr "No se puede descargar la versión."
 
@@ -866,15 +866,15 @@ msgstr "No se puede descargar la versión."
 #: ../src/PlotFormatWiz.cpp:48 ../src/SeriesWiz.cpp:49 ../src/SeriesWiz.cpp:51
 #: ../src/SubstituteWiz.cpp:41 ../src/SubstituteWiz.cpp:43 ../src/SumWiz.cpp:44
 #: ../src/SumWiz.cpp:46 ../src/SystemWiz.cpp:38 ../src/SystemWiz.cpp:40
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../src/wxMaximaFrame.cpp:126 ../src/wxMaxima.cpp:932
+#: ../src/wxMaxima.cpp:937 ../src/wxMaximaFrame.cpp:125
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1217
+#: ../src/wxMaximaFrame.cpp:1216
 msgid "Canonical (tr)"
 msgstr "Canónico (tr)"
 
@@ -882,7 +882,7 @@ msgstr "Canónico (tr)"
 msgid "Catalan"
 msgstr "Catalán"
 
-#: ../src/wxMaximaFrame.cpp:638
+#: ../src/wxMaximaFrame.cpp:637
 msgid "Ce&ll"
 msgstr "Ce&lda"
 
@@ -890,41 +890,41 @@ msgstr "Ce&lda"
 msgid "Cell bracket"
 msgstr "Corchete de celda"
 
-#: ../src/wxMaxima.cpp:5261
+#: ../src/wxMaxima.cpp:5273
 msgid "Cell ends in a backslash"
 msgstr "Celda termina en barra invertida"
 
-#: ../src/wxMaximaFrame.cpp:676
+#: ../src/wxMaximaFrame.cpp:675
 msgid "Change &2d Display"
 msgstr "Cambiar pantalla &2D"
 
-#: ../src/wxMaximaFrame.cpp:677
+#: ../src/wxMaximaFrame.cpp:676
 msgid "Change the 2d display algorithm used to display math output"
 msgstr ""
 "Cambiar el algoritmo empleado para mostrar la salida matemática en la "
 "pantalla 2D."
 
-#: ../src/wxMaxima.cpp:3995
+#: ../src/wxMaxima.cpp:4007
 msgid "Change variable"
 msgstr "Cambiar variable"
 
-#: ../src/wxMaximaFrame.cpp:783
+#: ../src/wxMaximaFrame.cpp:782
 msgid "Change variable in integral or sum"
 msgstr "Cambiar variable en integral o suma"
 
-#: ../src/wxMaxima.cpp:3751
+#: ../src/wxMaxima.cpp:3763
 msgid "Char poly"
 msgstr "Polinomio característico"
 
-#: ../src/wxMaximaFrame.cpp:978
+#: ../src/wxMaximaFrame.cpp:977
 msgid "Check for Updates"
 msgstr "Comprueba actualizaciones"
 
-#: ../src/wxMaximaFrame.cpp:979
+#: ../src/wxMaximaFrame.cpp:978
 msgid "Check if a newer version of wxMaxima/Maxima exist."
 msgstr "Comprueba si existe nueva versión de wxMaxima/Maxima."
 
-#: ../src/wxMaximaFrame.cpp:1385
+#: ../src/wxMaximaFrame.cpp:1384
 msgid "Chi"
 msgstr "Ji"
 
@@ -945,15 +945,15 @@ msgstr "Elegir fuente"
 msgid "Choose new plot format:"
 msgstr "Elegir un nuevo formato de gráficos:"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710
 msgid "Classes:"
 msgstr "Clases:"
 
-#: ../src/wxMaximaFrame.cpp:469
+#: ../src/wxMaximaFrame.cpp:468
 msgid "Close\tCtrl-W"
 msgstr "&Cerrar\tCtrl-W"
 
-#: ../src/wxMaximaFrame.cpp:470
+#: ../src/wxMaximaFrame.cpp:469
 msgid "Close window"
 msgstr "Cerrar ventana"
 
@@ -985,19 +985,19 @@ msgstr "Resaltado de código: Cadenas de texto"
 msgid "Code highlighting: Variables"
 msgstr "Resaltado de código: Variables"
 
-#: ../src/wxMaxima.cpp:4806
+#: ../src/wxMaxima.cpp:4818
 msgid "Col. names:"
 msgstr "Nombres col.:"
 
-#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Columns:"
 msgstr "Columnas:"
 
-#: ../src/wxMaximaFrame.cpp:860
+#: ../src/wxMaximaFrame.cpp:859
 msgid "Combine factorials in an expression"
 msgstr "Combinar factoriales en una expresión"
 
-#: ../src/wxMaxima.cpp:5293
+#: ../src/wxMaxima.cpp:5305
 msgid "Comma directly followed by a closing parenthesis"
 msgstr "Coma seguida de paréntesis que cierra"
 
@@ -1009,23 +1009,23 @@ msgstr "Coordenadas x separadas por comas."
 msgid "Comma separated y coordinates"
 msgstr "Coordenadas y separadas por comas."
 
-#: ../src/MathCtrl.cpp:1030
+#: ../src/MathCtrl.cpp:1072
 msgid "Comment Selection"
 msgstr "Comentar selección"
 
-#: ../src/wxMaximaFrame.cpp:533
+#: ../src/wxMaximaFrame.cpp:532
 msgid "Comment out the currently selected text"
 msgstr "Descomentar el texto seleccionado"
 
-#: ../src/wxMaximaFrame.cpp:532
+#: ../src/wxMaximaFrame.cpp:531
 msgid "Comment selection\tCtrl-/"
 msgstr "Comentar selección\tCtrl-/"
 
-#: ../src/wxMaximaFrame.cpp:601
+#: ../src/wxMaximaFrame.cpp:600
 msgid "Complete Word\tCtrl-K"
 msgstr "&Autocompletar\tCtrl-K"
 
-#: ../src/wxMaximaFrame.cpp:602
+#: ../src/wxMaximaFrame.cpp:601
 msgid "Complete word"
 msgstr "Autocompletar"
 
@@ -1033,35 +1033,35 @@ msgstr "Autocompletar"
 msgid "Completely stop maxima and restart it"
 msgstr "Parar completamente Maxima y arrancar de nuevo"
 
-#: ../src/wxMaximaFrame.cpp:823
+#: ../src/wxMaximaFrame.cpp:822
 msgid "Compute continued fraction of a value"
 msgstr "Calcular fracción continua de un valor"
 
-#: ../src/wxMaximaFrame.cpp:761
+#: ../src/wxMaximaFrame.cpp:760
 msgid "Compute the adjoint matrix"
 msgstr "Calcula la matriz adjunta"
 
-#: ../src/wxMaximaFrame.cpp:750
+#: ../src/wxMaximaFrame.cpp:749
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr "Calcula el polinomio característico de una matriz"
 
-#: ../src/wxMaximaFrame.cpp:753
+#: ../src/wxMaximaFrame.cpp:752
 msgid "Compute the determinant of a matrix"
 msgstr "Calcular el determinante de una matriz"
 
-#: ../src/wxMaximaFrame.cpp:810
+#: ../src/wxMaximaFrame.cpp:809
 msgid "Compute the greatest common divisor"
 msgstr "Calcular el máximo común divisor"
 
-#: ../src/wxMaximaFrame.cpp:747
+#: ../src/wxMaximaFrame.cpp:746
 msgid "Compute the inverse of a matrix"
 msgstr "Calcular la inversa de una matriz"
 
-#: ../src/wxMaximaFrame.cpp:813
+#: ../src/wxMaximaFrame.cpp:812
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr "Calcular el mínimo común múltiplo (cargar(funciones) antes de usar)"
 
-#: ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4868
 msgid "Condition:"
 msgstr "Condición"
 
@@ -1073,8 +1073,8 @@ msgstr "Fichero de configuración (*.ini)|*.ini"
 msgid "Configuration warning"
 msgstr "Advertencia sobre configuración"
 
-#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:538
-#: ../src/wxMaximaFrame.cpp:541
+#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:540
 msgid "Configure wxMaxima"
 msgstr "Configurar wxMaxima"
 
@@ -1083,130 +1083,132 @@ msgstr "Configurar wxMaxima"
 msgid "Constant"
 msgstr "Constante"
 
-#: ../src/wxMaximaFrame.cpp:844
+#: ../src/wxMaximaFrame.cpp:843
 msgid "Contract Logarithms"
 msgstr "C&ontraer logaritmos"
 
-#: ../src/wxMaximaFrame.cpp:851
+#: ../src/wxMaximaFrame.cpp:850
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr "Convertir binomiales, funciones beta y gamma a factoriales"
 
-#: ../src/wxMaximaFrame.cpp:854
+#: ../src/wxMaximaFrame.cpp:853
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr "Convertir binomiales, funciones factoriales  y beta a función gamma"
 
-#: ../src/wxMaximaFrame.cpp:888
+#: ../src/wxMaximaFrame.cpp:887
 msgid "Convert complex expression to polar form"
 msgstr "Convertir expresión compleja a forma polar"
 
-#: ../src/wxMaximaFrame.cpp:885
+#: ../src/wxMaximaFrame.cpp:884
 msgid "Convert complex expression to rect form"
 msgstr "Convertir expresión compleja a forma cartesiana"
 
-#: ../src/wxMaximaFrame.cpp:897
+#: ../src/wxMaximaFrame.cpp:896
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
 "Convertir función exponencial de argumento imaginario a forma trigonométrica"
 
-#: ../src/wxMaximaFrame.cpp:842
+#: ../src/wxMaximaFrame.cpp:841
 msgid "Convert logarithm of product to sum of logarithms"
 msgstr "Convertir logaritmo de un producto en suma de logaritmos"
 
-#: ../src/wxMaximaFrame.cpp:845
+#: ../src/wxMaximaFrame.cpp:844
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "Convertir suma de logaritmos en logaritmo de un producto"
 
-#: ../src/wxMaximaFrame.cpp:850
+#: ../src/wxMaximaFrame.cpp:849
 msgid "Convert to &Factorials"
 msgstr "Convertir a &factoriales"
 
-#: ../src/wxMaximaFrame.cpp:853
+#: ../src/wxMaximaFrame.cpp:852
 msgid "Convert to &Gamma"
 msgstr "Convertir a &gamma"
 
-#: ../src/wxMaximaFrame.cpp:887
+#: ../src/wxMaximaFrame.cpp:886
 msgid "Convert to &Polarform"
 msgstr "Convertir a forma &polar"
 
-#: ../src/wxMaximaFrame.cpp:884
+#: ../src/wxMaximaFrame.cpp:883
 msgid "Convert to &Rectform"
 msgstr "Convertir a forma &cartesiana"
 
-#: ../src/wxMaximaFrame.cpp:877
+#: ../src/wxMaximaFrame.cpp:876
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr "Convertir expresión trigonométrica a forma canónica casi lineal"
 
-#: ../src/wxMaximaFrame.cpp:900
+#: ../src/wxMaximaFrame.cpp:899
 msgid "Convert trigonometric functions to exponential form"
 msgstr "Convertir funciones trigonométricas a forma exponencial"
 
-#: ../src/ToolBar.cpp:140 ../src/MathCtrl.cpp:918 ../src/MathCtrl.cpp:931
-#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1024
+#: ../src/MathCtrl.cpp:960 ../src/MathCtrl.cpp:973 ../src/MathCtrl.cpp:1019
+#: ../src/MathCtrl.cpp:1066 ../src/ToolBar.cpp:140
 msgid "Copy"
 msgstr "Copiar"
 
-#: ../src/wxMaximaFrame.cpp:597
+#: ../src/wxMaximaFrame.cpp:596
 msgid "Copy Previous Input\tCtrl-I"
 msgstr "&Copiar entrada anterior\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:599
+#: ../src/wxMaximaFrame.cpp:598
 msgid "Copy Previous Output\tCtrl-U"
 msgstr "&Copiar resultado anterior\tCtrl-U"
 
-#: ../src/wxMaximaFrame.cpp:514 ../src/MathCtrl.cpp:936 ../src/MathCtrl.cpp:982
+#: ../src/MathCtrl.cpp:978 ../src/MathCtrl.cpp:1024
+#: ../src/wxMaximaFrame.cpp:513
 msgid "Copy as Image"
 msgstr "Copiar como imagen"
 
-#: ../src/wxMaximaFrame.cpp:507 ../src/MathCtrl.cpp:932 ../src/MathCtrl.cpp:978
+#: ../src/MathCtrl.cpp:974 ../src/MathCtrl.cpp:1020
+#: ../src/wxMaximaFrame.cpp:506
 msgid "Copy as LaTeX"
 msgstr "Copiar como &LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:510
+#: ../src/wxMaximaFrame.cpp:509
 #, fuzzy
 msgid "Copy as MathML"
 msgstr "Copiar como imagen"
 
-#: ../src/MathCtrl.cpp:935 ../src/MathCtrl.cpp:980
+#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1022
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:504
+#: ../src/wxMaximaFrame.cpp:503
 msgid "Copy as Text\tCtrl-Shift-C"
 msgstr "Copiar como &texto\tCtrl-Shift-C"
 
-#: ../src/MathCtrl.cpp:933 ../src/MathCtrl.cpp:979
+#: ../src/MathCtrl.cpp:975 ../src/MathCtrl.cpp:1021
 #, fuzzy
 msgid "Copy as plain text"
 msgstr "Copiar como imagen"
 
-#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:503
+#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:502
 msgid "Copy selection"
 msgstr "Copiar selección"
 
-#: ../src/wxMaximaFrame.cpp:515
+#: ../src/wxMaximaFrame.cpp:514
 msgid "Copy selection from document as an image"
 msgstr "Copiar selección del documento como imagen"
 
-#: ../src/wxMaximaFrame.cpp:505
+#: ../src/wxMaximaFrame.cpp:504
 msgid "Copy selection from document as text"
 msgstr "Copiar selección del documento en formato texto"
 
-#: ../src/wxMaximaFrame.cpp:508
+#: ../src/wxMaximaFrame.cpp:507
 msgid "Copy selection from document in LaTeX format"
 msgstr "Copiar selección del documento en formato LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:511
+#: ../src/wxMaximaFrame.cpp:510
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:598
+#: ../src/wxMaximaFrame.cpp:597
 msgid "Create a new cell with previous input"
 msgstr "Crear una nueva celda con la entrada anterior"
 
-#: ../src/wxMaximaFrame.cpp:600
+#: ../src/wxMaximaFrame.cpp:599
 msgid "Create a new cell with previous output"
 msgstr "Crear una nueva celda con el resultado anterior"
 
@@ -1214,15 +1216,15 @@ msgstr "Crear una nueva celda con el resultado anterior"
 msgid "Cursor"
 msgstr "Cursor"
 
-#: ../src/ToolBar.cpp:137 ../src/MathCtrl.cpp:1023
+#: ../src/MathCtrl.cpp:1065 ../src/ToolBar.cpp:137
 msgid "Cut"
 msgstr "Cortar"
 
-#: ../src/wxMaximaFrame.cpp:499
+#: ../src/wxMaximaFrame.cpp:498
 msgid "Cut\tCtrl-X"
 msgstr "Co&rtar\tCtrl-X"
 
-#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:500
+#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:499
 msgid "Cut selection"
 msgstr "Cortar selección"
 
@@ -1234,18 +1236,18 @@ msgstr "Checo"
 msgid "Danish"
 msgstr "Danés"
 
-#: ../src/wxMaxima.cpp:4799 ../src/wxMaxima.cpp:4806 ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4811 ../src/wxMaxima.cpp:4818 ../src/wxMaxima.cpp:4868
 msgid "Data Matrix:"
 msgstr "Matriz de datos:"
 
-#: ../src/wxMaxima.cpp:4826
+#: ../src/wxMaxima.cpp:4838
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr "Archivo de datos (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698 ../src/wxMaxima.cpp:4712
-#: ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726 ../src/wxMaxima.cpp:4734
-#: ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748 ../src/wxMaxima.cpp:4755
-#: ../src/wxMaxima.cpp:4791
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710 ../src/wxMaxima.cpp:4724
+#: ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738 ../src/wxMaxima.cpp:4746
+#: ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760 ../src/wxMaxima.cpp:4767
+#: ../src/wxMaxima.cpp:4803
 msgid "Data:"
 msgstr "Datos:"
 
@@ -1254,7 +1256,7 @@ msgstr "Datos:"
 msgid "Debug: watch maxima's stdout stream"
 msgstr "Depurado: mirar el flujo de salida de Maxima"
 
-#: ../src/wxMaximaFrame.cpp:820
+#: ../src/wxMaximaFrame.cpp:819
 msgid "Decompose rational function to partial fractions"
 msgstr "Descomponer función racional en fracciones simples"
 
@@ -1285,47 +1287,47 @@ msgid ""
 "with."
 msgstr "Definir la frecuencia de imágenes para la reproducción de animaciones."
 
-#: ../src/wxMaxima.cpp:3403 ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3415 ../src/wxMaxima.cpp:3424
 msgid "Delete"
 msgstr "Borrar"
 
-#: ../src/wxMaximaFrame.cpp:667
+#: ../src/wxMaximaFrame.cpp:666
 msgid "Delete F&unction..."
 msgstr "Borrar f&unción"
 
-#: ../src/MathCtrl.cpp:939 ../src/MathCtrl.cpp:985
+#: ../src/MathCtrl.cpp:981 ../src/MathCtrl.cpp:1027
 msgid "Delete Selection"
 msgstr "Borrar selección"
 
-#: ../src/wxMaximaFrame.cpp:669
+#: ../src/wxMaximaFrame.cpp:668
 msgid "Delete V&ariable..."
 msgstr "Borrar v&ariable"
 
-#: ../src/wxMaximaFrame.cpp:668
+#: ../src/wxMaximaFrame.cpp:667
 msgid "Delete a function"
 msgstr "Borrar una función"
 
-#: ../src/wxMaximaFrame.cpp:670
+#: ../src/wxMaximaFrame.cpp:669
 msgid "Delete a variable"
 msgstr "Borrar una variable"
 
-#: ../src/wxMaximaFrame.cpp:655
+#: ../src/wxMaximaFrame.cpp:654
 msgid "Delete all values from memory"
 msgstr "Eliminar todas las variables de la memoria"
 
-#: ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3424
 msgid "Delete function(s):"
 msgstr "Borrar función(es):"
 
-#: ../src/wxMaxima.cpp:3403
+#: ../src/wxMaxima.cpp:3415
 msgid "Delete variable(s):"
 msgstr "Borrar variable(s):"
 
-#: ../src/wxMaximaFrame.cpp:1367
+#: ../src/wxMaximaFrame.cpp:1366
 msgid "Delta"
 msgstr "Delta"
 
-#: ../src/wxMaxima.cpp:4011
+#: ../src/wxMaxima.cpp:4023
 msgid "Denom. deg:"
 msgstr "denom deg:"
 
@@ -1333,35 +1335,35 @@ msgstr "denom deg:"
 msgid "Depth:"
 msgstr "profundidad:"
 
-#: ../src/wxMaxima.cpp:3541
+#: ../src/wxMaxima.cpp:3553
 msgid "Derivative:"
 msgstr "Derivada:"
 
-#: ../src/wxMaximaFrame.cpp:1258
+#: ../src/wxMaximaFrame.cpp:1257
 msgid "Deviation..."
 msgstr "Desviación"
 
-#: ../src/wxMaximaFrame.cpp:816
+#: ../src/wxMaximaFrame.cpp:815
 msgid "Di&vide Polynomials..."
 msgstr "Di&vidir polinomios"
 
-#: ../src/wxMaximaFrame.cpp:1223
+#: ../src/wxMaximaFrame.cpp:1222
 msgid "Diff..."
 msgstr "Derivar"
 
-#: ../src/wxMaxima.cpp:4154 ../src/wxMaxima.cpp:5066
+#: ../src/wxMaxima.cpp:4166 ../src/wxMaxima.cpp:5078
 msgid "Differentiate"
 msgstr "Derivar"
 
-#: ../src/wxMaximaFrame.cpp:786
+#: ../src/wxMaximaFrame.cpp:785
 msgid "Differentiate expression"
 msgstr "Derivar expresión"
 
-#: ../src/MathCtrl.cpp:1001
+#: ../src/MathCtrl.cpp:1043
 msgid "Differentiate..."
 msgstr "Derivar"
 
-#: ../src/LimitWiz.cpp:37 ../src/FindReplacePane.cpp:76
+#: ../src/FindReplacePane.cpp:76 ../src/LimitWiz.cpp:37
 msgid "Direction:"
 msgstr "Dirección:"
 
@@ -1369,48 +1371,49 @@ msgstr "Dirección:"
 msgid "Discrete plot"
 msgstr "Gráfico discreto"
 
-#: ../src/wxMaximaFrame.cpp:679
+#: ../src/wxMaximaFrame.cpp:678
 msgid "Display Te&X Form"
 msgstr "Mostrar formato Te&X"
 
-#: ../src/wxMaxima.cpp:3320
+#: ../src/wxMaxima.cpp:3332
 msgid "Display algorithm"
 msgstr "Mostrar algoritmo"
 
-#: ../src/wxMaximaFrame.cpp:680
+#: ../src/wxMaximaFrame.cpp:679
 msgid "Display last result in TeX form"
 msgstr "Mostrar último resultado en formato TeX"
 
-#: ../src/wxMaximaFrame.cpp:674
+#: ../src/wxMaximaFrame.cpp:673
 msgid "Display time used for evaluation"
 msgstr "Mostrar tiempo de ejecución"
 
-#: ../src/wxMaxima.cpp:4061
+#: ../src/wxMaxima.cpp:4073
 msgid "Divide"
 msgstr "Dividir"
 
-#: ../src/MathCtrl.cpp:1032
+#: ../src/MathCtrl.cpp:1074
 msgid "Divide Cell"
 msgstr "Dividir celda"
 
-#: ../src/wxMaximaFrame.cpp:635
+#: ../src/wxMaximaFrame.cpp:634
 #, fuzzy
 msgid "Divide Cell\tCtrl-D"
 msgstr "Dividir celda"
 
-#: ../src/wxMaximaFrame.cpp:817
+#: ../src/wxMaximaFrame.cpp:816
 msgid "Divide numbers or polynomials"
 msgstr "Dividir números o polinomios"
 
-#: ../src/wxMaximaFrame.cpp:636
+#: ../src/wxMaximaFrame.cpp:635
 msgid "Divide this input cell into two cells"
 msgstr "Dividir esta celda de entrada en dos celdas"
 
-#: ../src/wxMaxima.cpp:5917
-msgid "Do you want to save the changes you made in the document \""
+#: ../src/wxMaxima.cpp:5932
+#, fuzzy, c-format
+msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr "¿Quiere guardar los cambios hechos al documento \""
 
-#: ../src/wxMaxima.cpp:1664 ../src/wxMaxima.cpp:1672
+#: ../src/wxMaxima.cpp:1669 ../src/wxMaxima.cpp:1677
 msgid "Document "
 msgstr "Documento"
 
@@ -1432,7 +1435,7 @@ msgstr ""
 "dificulta a los sistemas de control de versiones (git, svn) detectar "
 "diferencias de forma efectiva."
 
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Don't save"
 msgstr "No guardar"
 
@@ -1440,27 +1443,27 @@ msgstr "No guardar"
 msgid "Down"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:734
+#: ../src/wxMaximaFrame.cpp:733
 msgid "E&quations"
 msgstr "E&cuaciones"
 
-#: ../src/wxMaximaFrame.cpp:487
+#: ../src/wxMaximaFrame.cpp:486
 msgid "E&xit\tCtrl-Q"
 msgstr "&Salir\tCtrl-Q"
 
-#: ../src/wxMaximaFrame.cpp:757
+#: ../src/wxMaximaFrame.cpp:756
 msgid "Eige&nvectors"
 msgstr "Vectores &propios"
 
-#: ../src/wxMaximaFrame.cpp:755
+#: ../src/wxMaximaFrame.cpp:754
 msgid "Eigen&values"
 msgstr "Va&lores propios"
 
-#: ../src/wxMaxima.cpp:3572
+#: ../src/wxMaxima.cpp:3584
 msgid "Eliminate"
 msgstr "Eliminar"
 
-#: ../src/wxMaximaFrame.cpp:710
+#: ../src/wxMaximaFrame.cpp:709
 msgid "Eliminate a variable from a system of equations"
 msgstr "Eliminar una variable de un sistema de ecuaciones"
 
@@ -1472,21 +1475,21 @@ msgstr "Fin de prueba"
 msgid "English"
 msgstr "Inglés"
 
-#: ../src/wxMaxima.cpp:4712 ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726
-#: ../src/wxMaxima.cpp:4734 ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748
-#: ../src/wxMaxima.cpp:4755 ../src/wxMaxima.cpp:4791 ../src/wxMaxima.cpp:4799
+#: ../src/wxMaxima.cpp:4724 ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738
+#: ../src/wxMaxima.cpp:4746 ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760
+#: ../src/wxMaxima.cpp:4767 ../src/wxMaxima.cpp:4803 ../src/wxMaxima.cpp:4811
 msgid "Enter Data"
 msgstr "Introducir datos"
 
-#: ../src/wxMaximaFrame.cpp:1279
+#: ../src/wxMaximaFrame.cpp:1278
 msgid "Enter Matrix..."
 msgstr "Introducir matriz"
 
-#: ../src/wxMaximaFrame.cpp:745
+#: ../src/wxMaximaFrame.cpp:744
 msgid "Enter a matrix"
 msgstr "Introducir una matriz"
 
-#: ../src/wxMaxima.cpp:3962
+#: ../src/wxMaxima.cpp:3974
 msgid "Enter an equation for rational simplification:"
 msgstr "Introducir una ecuación para simplificación racional:"
 
@@ -1498,11 +1501,11 @@ msgstr "Introducir una lista de variables separadas por comas."
 msgid "Enter evaluates cells"
 msgstr "Tecla retorno evalúa celdas"
 
-#: ../src/wxMaxima.cpp:3734
+#: ../src/wxMaxima.cpp:3746
 msgid "Enter matrix"
 msgstr "Introducir matriz"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Enter new precision for bigfloats:"
 msgstr "Precisión para bigfloats:"
 
@@ -1510,11 +1513,11 @@ msgstr "Precisión para bigfloats:"
 msgid "Enter the path to the Maxima executable."
 msgstr "Introducir la ruta al ejecutable Maxima."
 
-#: ../src/wxMaximaFrame.cpp:1368
+#: ../src/wxMaximaFrame.cpp:1367
 msgid "Epsilon"
 msgstr "Épsilon"
 
-#: ../src/wxMaxima.cpp:4208
+#: ../src/wxMaxima.cpp:4220
 msgid "Epsilon:"
 msgstr "Épsilon:"
 
@@ -1523,13 +1526,13 @@ msgstr "Épsilon:"
 msgid "Equation %d:"
 msgstr "Ecuación %d:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:3633
-#: ../src/wxMaxima.cpp:5019
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:3645
+#: ../src/wxMaxima.cpp:5031
 msgid "Equation(s):"
 msgstr "Ecuación:"
 
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3993
-#: ../src/wxMaxima.cpp:4807 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:4005
+#: ../src/wxMaxima.cpp:4819 ../src/wxMaxima.cpp:5045
 msgid "Equation:"
 msgstr "Ecuación:"
 
@@ -1540,77 +1543,77 @@ msgid ""
 "be introduced one into another. Also they are always printed out as 2D maths."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3570
+#: ../src/wxMaxima.cpp:3582
 msgid "Equations:"
 msgstr "Ecuaciones:"
 
-#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1455
-#: ../src/wxMaxima.cpp:1469 ../src/wxMaxima.cpp:1620 ../src/wxMaxima.cpp:1633
-#: ../src/wxMaxima.cpp:1643 ../src/wxMaxima.cpp:1666 ../src/wxMaxima.cpp:2034
-#: ../src/wxMaxima.cpp:2206 ../src/wxMaxima.cpp:5381 ../src/wxMaxima.cpp:5830
-#: ../src/wxMaxima.cpp:5881
+#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1460
+#: ../src/wxMaxima.cpp:1474 ../src/wxMaxima.cpp:1625 ../src/wxMaxima.cpp:1638
+#: ../src/wxMaxima.cpp:1648 ../src/wxMaxima.cpp:1671 ../src/wxMaxima.cpp:2039
+#: ../src/wxMaxima.cpp:2211 ../src/wxMaxima.cpp:5397 ../src/wxMaxima.cpp:5845
+#: ../src/wxMaxima.cpp:5896
 msgid "Error"
 msgstr "Error"
 
-#: ../src/wxMaxima.cpp:2886 ../src/wxMaxima.cpp:2900 ../src/wxMaxima.cpp:2913
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617 ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:2894 ../src/wxMaxima.cpp:2908 ../src/wxMaxima.cpp:2921
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629 ../src/wxMaxima.cpp:3740
 msgid "Error!"
 msgstr "¡Error!"
 
-#: ../src/wxMaximaFrame.cpp:1370
+#: ../src/wxMaximaFrame.cpp:1369
 msgid "Eta"
 msgstr "Eta"
 
-#: ../src/wxMaximaFrame.cpp:909
+#: ../src/wxMaximaFrame.cpp:908
 msgid "Evaluate &Noun Forms"
 msgstr "Evaluar formas &nominales"
 
-#: ../src/wxMaximaFrame.cpp:589
+#: ../src/wxMaximaFrame.cpp:588
 msgid "Evaluate All Cells\tCtrl-Shift-R"
 msgstr "Evaluar t&odas las celdas\tCtrl-Shift-R"
 
-#: ../src/wxMaximaFrame.cpp:587
+#: ../src/wxMaximaFrame.cpp:586
 msgid "Evaluate All Visible Cells\tCtrl-R"
 msgstr "Evaluar t&odas las celdas visibles\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:585 ../src/MathCtrl.cpp:942
+#: ../src/MathCtrl.cpp:984 ../src/wxMaximaFrame.cpp:584
 msgid "Evaluate Cell(s)"
 msgstr "E&valuar celda(s)"
 
-#: ../src/wxMaximaFrame.cpp:591
+#: ../src/wxMaximaFrame.cpp:590
 #, fuzzy
 msgid "Evaluate Cells Above\tCtrl-Shift-P"
 msgstr "Evaluar celdas superiores\tCtrl-Shift-P"
 
-#: ../src/MathCtrl.cpp:956 ../src/MathCtrl.cpp:1051
+#: ../src/MathCtrl.cpp:998 ../src/MathCtrl.cpp:1093
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr "Evaluar parte\tShift+Ctrl+Enter"
 
-#: ../src/MathCtrl.cpp:961 ../src/MathCtrl.cpp:1053
+#: ../src/MathCtrl.cpp:1003 ../src/MathCtrl.cpp:1095
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr "Evaluar sección\tShift+Ctrl+Enter"
 
-#: ../src/MathCtrl.cpp:971 ../src/MathCtrl.cpp:1057
+#: ../src/MathCtrl.cpp:1013 ../src/MathCtrl.cpp:1099
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr "Evaluar sub-subsección\tShift+Ctrl+Enter"
 
-#: ../src/MathCtrl.cpp:966 ../src/MathCtrl.cpp:1055
+#: ../src/MathCtrl.cpp:1008 ../src/MathCtrl.cpp:1097
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr "Evaluar subsección\tShift+Ctrl+Enter"
 
-#: ../src/wxMaximaFrame.cpp:586
+#: ../src/wxMaximaFrame.cpp:585
 msgid "Evaluate active or selected cell(s)"
 msgstr "Evaluar celdas activas o seleccionadas"
 
-#: ../src/wxMaximaFrame.cpp:590
+#: ../src/wxMaximaFrame.cpp:589
 msgid "Evaluate all cells in the document"
 msgstr "Evaluar todas las celdas del documento"
 
-#: ../src/wxMaximaFrame.cpp:910
+#: ../src/wxMaximaFrame.cpp:909
 msgid "Evaluate all noun forms in expression"
 msgstr "Evaluar todas las formas nominales en una expresión"
 
-#: ../src/wxMaximaFrame.cpp:588
+#: ../src/wxMaximaFrame.cpp:587
 msgid "Evaluate all visible cells in the document"
 msgstr "Evaluar todas las celdas visibles del documento"
 
@@ -1622,7 +1625,7 @@ msgstr "Evaluar el fichero desde el comienzo hasta la celda sobre el cursor"
 msgid "Evaluate to point"
 msgstr "Evaluar hasta el punto"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Example"
 msgstr "Ejemplo"
 
@@ -1634,31 +1637,31 @@ msgstr "Texto de ejemplo"
 msgid "Examples:"
 msgstr "Ejemplos:"
 
-#: ../src/wxMaximaFrame.cpp:488
+#: ../src/wxMaximaFrame.cpp:487
 msgid "Exit wxMaxima"
 msgstr "Salir de wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:1214
+#: ../src/wxMaximaFrame.cpp:1213
 msgid "Expand"
 msgstr "Expandir"
 
-#: ../src/wxMaximaFrame.cpp:1219
+#: ../src/wxMaximaFrame.cpp:1218
 msgid "Expand (tr)"
 msgstr "Expandir (tr)"
 
-#: ../src/MathCtrl.cpp:997
+#: ../src/MathCtrl.cpp:1039
 msgid "Expand Expression"
 msgstr "Expandir expresión"
 
-#: ../src/wxMaximaFrame.cpp:841
+#: ../src/wxMaximaFrame.cpp:840
 msgid "Expand Logarithms"
 msgstr "Ex&pandir logaritmos"
 
-#: ../src/wxMaximaFrame.cpp:840
+#: ../src/wxMaximaFrame.cpp:839
 msgid "Expand an expression"
 msgstr "Expandir una expresión"
 
-#: ../src/wxMaximaFrame.cpp:874
+#: ../src/wxMaximaFrame.cpp:873
 msgid "Expand trigonometric expression"
 msgstr "Expandir expresión trigonométrica"
 
@@ -1666,7 +1669,7 @@ msgstr "Expandir expresión trigonométrica"
 msgid "Expected the icon files to be found at"
 msgstr "Ubicación de iconos de archivos en"
 
-#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2834
+#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2842
 msgid "Export"
 msgstr "&Exportar"
 
@@ -1677,31 +1680,31 @@ msgstr ""
 "Exportar animaciones a TeX (las imágenes tendrán movimiento solo si el visor "
 "PDF lo admite)"
 
-#: ../src/wxMaximaFrame.cpp:481
+#: ../src/wxMaximaFrame.cpp:480
 msgid "Export document to a HTML or pdfLaTeX file"
 msgstr "Exportar documento a archivo HTML o pdfLaTeX"
 
-#: ../src/wxMaximaFrame.cpp:253
+#: ../src/wxMaximaFrame.cpp:252
 msgid "Export failed."
 msgstr "Falló la exportación"
 
-#: ../src/wxMaximaFrame.cpp:239
+#: ../src/wxMaximaFrame.cpp:238
 msgid "Export successful."
 msgstr "Exportación realizada."
 
-#: ../src/wxMaxima.cpp:2913
+#: ../src/wxMaxima.cpp:2921
 msgid "Exporting to HTML failed!"
 msgstr "¡Falló la exportación a HTML!"
 
-#: ../src/wxMaxima.cpp:2886
+#: ../src/wxMaxima.cpp:2894
 msgid "Exporting to TeX failed!"
 msgstr "¡Falló la exportación a TeX!"
 
-#: ../src/wxMaxima.cpp:2900
+#: ../src/wxMaxima.cpp:2908
 msgid "Exporting to maxima batch file failed!"
 msgstr "Falló la exportación a fichero por lotes"
 
-#: ../src/wxMaximaFrame.cpp:229
+#: ../src/wxMaximaFrame.cpp:228
 msgid "Exporting..."
 msgstr "Exportando..."
 
@@ -1714,42 +1717,42 @@ msgid "Expression(s):"
 msgstr "Expresión(es):"
 
 #: ../src/IntegrateWiz.cpp:30 ../src/LimitWiz.cpp:27 ../src/SeriesWiz.cpp:33
-#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3648
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:4205 ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5064
+#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3660
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:4217 ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5076
 msgid "Expression:"
 msgstr "Expresión:"
 
-#: ../src/wxMaximaFrame.cpp:1213
+#: ../src/wxMaximaFrame.cpp:1212
 msgid "Factor"
 msgstr "Factorizar"
 
-#: ../src/wxMaximaFrame.cpp:836
+#: ../src/wxMaximaFrame.cpp:835
 msgid "Factor Complex"
 msgstr "Factorizar comple&jo"
 
-#: ../src/MathCtrl.cpp:996
+#: ../src/MathCtrl.cpp:1038
 msgid "Factor Expression"
 msgstr "Factorizar expresión"
 
-#: ../src/wxMaximaFrame.cpp:835
+#: ../src/wxMaximaFrame.cpp:834
 msgid "Factor an expression"
 msgstr "Factorizar una expresión"
 
-#: ../src/wxMaximaFrame.cpp:837
+#: ../src/wxMaximaFrame.cpp:836
 msgid "Factor an expression in Gaussian numbers"
 msgstr "Factorizar una expresión en números gausianos"
 
-#: ../src/wxMaximaFrame.cpp:862
+#: ../src/wxMaximaFrame.cpp:861
 msgid "Factorials and &Gamma"
 msgstr "Factoriales y &gamma"
 
-#: ../src/wxMaxima.cpp:285
+#: ../src/wxMaxima.cpp:286
 msgid "Fatal error"
 msgstr "Error fatal"
 
-#: ../src/GroupCell.cpp:1571
+#: ../src/GroupCell.cpp:1572
 #, c-format
 msgid "Figure %d:"
 msgstr "Figura %d:"
@@ -1758,20 +1761,20 @@ msgstr "Figura %d:"
 msgid "File"
 msgstr "Archivo"
 
-#: ../src/wxMaxima.cpp:1457 ../src/wxMaxima.cpp:1623 ../src/wxMaxima.cpp:1636
-#: ../src/wxMaxima.cpp:1646 ../src/wxMaxima.cpp:1668
+#: ../src/wxMaxima.cpp:1462 ../src/wxMaxima.cpp:1628 ../src/wxMaxima.cpp:1641
+#: ../src/wxMaxima.cpp:1651 ../src/wxMaxima.cpp:1673
 msgid "File could not be opened"
 msgstr "Archivo no se pudo abrir"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File not found"
 msgstr "Archivo no encontrado"
 
-#: ../src/wxMaxima.cpp:1511 ../src/wxMaxima.cpp:1729
+#: ../src/wxMaxima.cpp:1516 ../src/wxMaxima.cpp:1734
 msgid "File opened"
 msgstr "Archivo abierto"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File you tried to open does not exist."
 msgstr "El archivo a abrir no existe."
 
@@ -1783,67 +1786,67 @@ msgstr "Archivo"
 msgid "Find"
 msgstr "Buscar"
 
-#: ../src/wxMaximaFrame.cpp:523
+#: ../src/wxMaximaFrame.cpp:522
 msgid "Find\tCtrl-F"
 msgstr "&Buscar\tCtrl-F"
 
-#: ../src/wxMaximaFrame.cpp:787
+#: ../src/wxMaximaFrame.cpp:786
 msgid "Find &Limit..."
 msgstr "Calcular &límite"
 
-#: ../src/wxMaximaFrame.cpp:790
+#: ../src/wxMaximaFrame.cpp:789
 msgid "Find Minimum..."
 msgstr "Calcular mínim&o"
 
-#: ../src/MathCtrl.cpp:993
+#: ../src/MathCtrl.cpp:1035
 msgid "Find Root..."
 msgstr "Calcular raíz..."
 
-#: ../src/wxMaximaFrame.cpp:791
+#: ../src/wxMaximaFrame.cpp:790
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr "Calcular mínimo (sin restricciones) de una expresión"
 
-#: ../src/wxMaximaFrame.cpp:788
+#: ../src/wxMaximaFrame.cpp:787
 msgid "Find a limit of an expression"
 msgstr "Calcular el límite de una expresión"
 
-#: ../src/wxMaximaFrame.cpp:693
+#: ../src/wxMaximaFrame.cpp:692
 msgid "Find a root of an equation on an interval"
 msgstr "Calcular una raíz de una ecuación en un intervalo"
 
-#: ../src/wxMaximaFrame.cpp:695
+#: ../src/wxMaximaFrame.cpp:694
 msgid "Find all roots of a polynomial"
 msgstr "Calcular todas las raíces de un polinomio"
 
-#: ../src/wxMaximaFrame.cpp:698
+#: ../src/wxMaximaFrame.cpp:697
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr "Calcular todas las raíces reales de un polinomio"
 
-#: ../src/wxMaxima.cpp:3220
+#: ../src/wxMaxima.cpp:3215
 msgid "Find and Replace"
 msgstr "Buscar y sustituir"
 
-#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:523
+#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:522
 msgid "Find and replace"
 msgstr "Buscar y sustituir"
 
-#: ../src/wxMaximaFrame.cpp:756
+#: ../src/wxMaximaFrame.cpp:755
 msgid "Find eigenvalues of a matrix"
 msgstr "Calcular los valores propios de una matriz"
 
-#: ../src/wxMaximaFrame.cpp:758
+#: ../src/wxMaximaFrame.cpp:757
 msgid "Find eigenvectors of a matrix"
 msgstr "Calcular los vectores propios de una matriz"
 
-#: ../src/wxMaxima.cpp:4210
+#: ../src/wxMaxima.cpp:4222
 msgid "Find minimum"
 msgstr "Calcular mínimo"
 
-#: ../src/wxMaximaFrame.cpp:701
+#: ../src/wxMaximaFrame.cpp:700
 msgid "Find real roots of a polynomial"
 msgstr "Calcular las raíces reales de un polinomio"
 
-#: ../src/wxMaxima.cpp:3493 ../src/wxMaxima.cpp:5036
+#: ../src/wxMaxima.cpp:3505 ../src/wxMaxima.cpp:5048
 msgid "Find root"
 msgstr "Calcular raíz"
 
@@ -1866,11 +1869,11 @@ msgstr "Ajustar los índices de orden (%i y %o) antes de guardar"
 msgid "Fixed font in text controls"
 msgstr "Fuente proporcional en controles de texto"
 
-#: ../src/wxMaximaFrame.cpp:623
+#: ../src/wxMaximaFrame.cpp:622
 msgid "Fold All\tCtrl-Alt-["
 msgstr "Ocultar todo\tCtrl-Alt-["
 
-#: ../src/wxMaximaFrame.cpp:624
+#: ../src/wxMaximaFrame.cpp:623
 msgid "Fold all sections"
 msgstr "Ocultar todas las secciones"
 
@@ -1878,11 +1881,11 @@ msgstr "Ocultar todas las secciones"
 msgid "Follow"
 msgstr "Seguir"
 
-#: ../src/ParenCell.cpp:319
+#: ../src/ParenCell.cpp:320
 msgid "Font issue: The Parenthesis sign is too small!"
 msgstr "Problema tipográfico: paréntesis demasiado pequeño"
 
-#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:381
+#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:382
 msgid ""
 "Font issue: The char height is too small! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
@@ -1893,7 +1896,7 @@ msgstr ""
 "comprobando \"Use JSmath fonts\" en el diálogo de configuración debería "
 "resolver el problema."
 
-#: ../src/SqrtCell.cpp:199
+#: ../src/SqrtCell.cpp:202
 msgid ""
 "Font issue: The sqrt() sign has the size 0! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
@@ -1904,7 +1907,7 @@ msgstr ""
 "\"Use JSmath fonts\" en el diálogo de configuración debería resolver el "
 "problema."
 
-#: ../src/SqrtCell.cpp:198
+#: ../src/SqrtCell.cpp:201
 msgid "Font issue? The contents of a sqrt() has the size 0."
 msgstr "Problema tipográfico: el contenido de sqrt() tiene tamaño 0."
 
@@ -1935,15 +1938,15 @@ msgstr "Francés"
 
 #: ../src/IntegrateWiz.cpp:37 ../src/Plot2dWiz.cpp:37 ../src/Plot2dWiz.cpp:47
 #: ../src/Plot2dWiz.cpp:536 ../src/Plot3dWiz.cpp:36 ../src/Plot3dWiz.cpp:45
-#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4240
+#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4252
 msgid "From:"
 msgstr "Desde:"
 
-#: ../src/wxMaximaFrame.cpp:576
+#: ../src/wxMaximaFrame.cpp:575
 msgid "Full Screen\tAlt-Enter"
 msgstr "P&antalla completa\tAlt-Retorno"
 
-#: ../src/wxMaxima.cpp:3342
+#: ../src/wxMaxima.cpp:3354
 msgid "Function"
 msgstr "Función"
 
@@ -1951,32 +1954,32 @@ msgstr "Función"
 msgid "Function names"
 msgstr "Nombres de funciones"
 
-#: ../src/wxMaxima.cpp:3633
+#: ../src/wxMaxima.cpp:3645
 msgid "Function(s):"
 msgstr "Función"
 
-#: ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3803
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3815
+#: ../src/wxMaxima.cpp:3848
 msgid "Function:"
 msgstr "Función:"
 
-#: ../src/wxMaximaFrame.cpp:904
+#: ../src/wxMaximaFrame.cpp:903
 msgid "Functions for complex simplification"
 msgstr "Funciones para la simplificación compleja"
 
-#: ../src/wxMaximaFrame.cpp:864
+#: ../src/wxMaximaFrame.cpp:863
 msgid "Functions for simplifying factorials and gamma function"
 msgstr "Funciones para simplificar factoriales y función gamma"
 
-#: ../src/wxMaximaFrame.cpp:881
+#: ../src/wxMaximaFrame.cpp:880
 msgid "Functions for simplifying trigonometric expressions"
 msgstr "Funciones para simplificar expresiones trigonométricas"
 
-#: ../src/wxMaxima.cpp:4046
+#: ../src/wxMaxima.cpp:4058
 msgid "GCD"
 msgstr "MCD"
 
-#: ../src/wxMaxima.cpp:5152
+#: ../src/wxMaxima.cpp:5164
 msgid "GIF image (*.gif)|*.gif"
 msgstr "Imagen GIF (*.gif)|*.gif"
 
@@ -1984,31 +1987,31 @@ msgstr "Imagen GIF (*.gif)|*.gif"
 msgid "Galician"
 msgstr "Gallego"
 
-#: ../src/wxMaximaFrame.cpp:1366
+#: ../src/wxMaximaFrame.cpp:1365
 msgid "Gamma"
 msgstr "Gamma"
 
-#: ../src/wxMaximaFrame.cpp:391
+#: ../src/wxMaximaFrame.cpp:390
 msgid "General Math"
 msgstr "Matemáticas generales"
 
-#: ../src/wxMaximaFrame.cpp:549
+#: ../src/wxMaximaFrame.cpp:548
 msgid "General Math\tAlt-Shift-M"
 msgstr "&Matemáticas generales\tAlt-Shift-M"
 
-#: ../src/wxMaxima.cpp:3766 ../src/wxMaxima.cpp:3785
+#: ../src/wxMaxima.cpp:3778 ../src/wxMaxima.cpp:3797
 msgid "Generate Matrix"
 msgstr "Generar matriz"
 
-#: ../src/wxMaximaFrame.cpp:741
+#: ../src/wxMaximaFrame.cpp:740
 msgid "Generate Matrix from Expression..."
 msgstr "&Generar matriz a partir de expresión"
 
-#: ../src/wxMaximaFrame.cpp:739
+#: ../src/wxMaximaFrame.cpp:738
 msgid "Generate a matrix from a 2-dimensional array"
 msgstr "Generar una matriz a partir de una tabla de 2 dimensiones"
 
-#: ../src/wxMaximaFrame.cpp:742
+#: ../src/wxMaximaFrame.cpp:741
 msgid "Generate a matrix from a lambda expression"
 msgstr "Generar una matriz a partir de una expresión lambda"
 
@@ -2016,39 +2019,39 @@ msgstr "Generar una matriz a partir de una expresión lambda"
 msgid "German"
 msgstr "Alemán"
 
-#: ../src/wxMaximaFrame.cpp:893
+#: ../src/wxMaximaFrame.cpp:892
 msgid "Get &Imaginary Part"
 msgstr "Calcular parte &imaginaria"
 
-#: ../src/wxMaximaFrame.cpp:793
+#: ../src/wxMaximaFrame.cpp:792
 msgid "Get &Series..."
 msgstr "Calcular &serie"
 
-#: ../src/wxMaximaFrame.cpp:804
+#: ../src/wxMaximaFrame.cpp:803
 msgid "Get Laplace transformation of an expression"
 msgstr "Calcular la transformada de Laplace de una expresión"
 
-#: ../src/wxMaximaFrame.cpp:890
+#: ../src/wxMaximaFrame.cpp:889
 msgid "Get Real P&art"
 msgstr "Calcular parte &real"
 
-#: ../src/wxMaximaFrame.cpp:807
+#: ../src/wxMaximaFrame.cpp:806
 msgid "Get inverse Laplace transformation of an expression"
 msgstr "Calcular la transformada inversa de Laplace de una expresión"
 
-#: ../src/wxMaximaFrame.cpp:794
+#: ../src/wxMaximaFrame.cpp:793
 msgid "Get the Taylor or power series of expression"
 msgstr "Calcular el desarrollo de Taylor o serie de potencias de la expresión"
 
-#: ../src/wxMaximaFrame.cpp:894
+#: ../src/wxMaximaFrame.cpp:893
 msgid "Get the imaginary part of complex expression"
 msgstr "Calcular la parte imaginaria de una expresión compleja"
 
-#: ../src/wxMaximaFrame.cpp:891
+#: ../src/wxMaximaFrame.cpp:890
 msgid "Get the real part of complex expression"
 msgstr "Calcular la parte real de una expresión compleja"
 
-#: ../src/MathCtrl.cpp:5932
+#: ../src/MathCtrl.cpp:5984
 msgid ""
 "Got a request to undo an action that involves an delete which isn't possible "
 "at this moment."
@@ -2060,12 +2063,12 @@ msgstr ""
 msgid "Greek"
 msgstr "Griego"
 
-#: ../src/wxMaximaFrame.cpp:356
+#: ../src/wxMaximaFrame.cpp:355
 #, fuzzy
 msgid "Greek Letters"
 msgstr "Letras griegas"
 
-#: ../src/wxMaximaFrame.cpp:552
+#: ../src/wxMaximaFrame.cpp:551
 #, fuzzy
 msgid "Greek Letters\tAlt-Shift-G"
 msgstr "Letras griegas\tAlt-Shift-G"
@@ -2078,7 +2081,7 @@ msgstr "Constantes griegas"
 msgid "Grid:"
 msgstr "Cuadrícula:"
 
-#: ../src/wxMaxima.cpp:2836
+#: ../src/wxMaxima.cpp:2844
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|pdfLaTeX file (*."
 "tex)|*.tex"
@@ -2094,11 +2097,11 @@ msgstr "Celdas HTML/Texto: Exportar todos los saltos de línea"
 msgid "Help"
 msgstr "A&yuda"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide All Toolbars\tAlt-Shift--"
 msgstr "Ocultar todas las barras de herramientas\tAlt-Shift--"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide all panes"
 msgstr "Ocultar todos los paneles"
 
@@ -2106,19 +2109,19 @@ msgstr "Ocultar todos los paneles"
 msgid "Highlight (dpart)"
 msgstr "Resaltado"
 
-#: ../src/wxMaxima.cpp:4685
+#: ../src/wxMaxima.cpp:4697
 msgid "Histogram"
 msgstr "Histograma"
 
-#: ../src/wxMaximaFrame.cpp:1270
+#: ../src/wxMaximaFrame.cpp:1269
 msgid "Histogram..."
 msgstr "Histograma"
 
-#: ../src/wxMaximaFrame.cpp:309
+#: ../src/wxMaximaFrame.cpp:308
 msgid "History"
 msgstr "Historia"
 
-#: ../src/wxMaximaFrame.cpp:555
+#: ../src/wxMaximaFrame.cpp:554
 msgid "History\tAlt-Shift-I"
 msgstr "Historia\tAlt-Shift-I"
 
@@ -2138,11 +2141,11 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: ../src/wxMaxima.cpp:3527
+#: ../src/wxMaxima.cpp:3539
 msgid "IC1"
 msgstr "IC1"
 
-#: ../src/wxMaxima.cpp:3543
+#: ../src/wxMaxima.cpp:3555
 msgid "IC2"
 msgstr "IC2"
 
@@ -2160,7 +2163,7 @@ msgstr ""
 "Si una instrucción empieza con una etiqueta seguida de : wxMaxima mostrará "
 "esta etiqueta en lugar de la etiqueta %o por defecto de Maxima."
 
-#: ../src/wxMaximaFrame.cpp:683
+#: ../src/wxMaximaFrame.cpp:682
 msgid ""
 "If maxima ever finishes evaluating without wxMaxima realizing this this menu "
 "item can force wxMaxima to try to send commands to maxima again."
@@ -2238,11 +2241,11 @@ msgstr ""
 "Si un cálculo dura mucho tiempo, se puede parar seleccionando 'Maxima-"
 ">Interrumpir' o 'Maxima->Reiniciar Maxima' en el menú."
 
-#: ../src/wxMaximaFrame.cpp:1499
+#: ../src/wxMaximaFrame.cpp:1518
 msgid "Image"
 msgstr "Imagen"
 
-#: ../src/wxMaxima.cpp:5644
+#: ../src/wxMaxima.cpp:5659
 msgid "Image files (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 msgstr "Archivos gráficos (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 
@@ -2272,7 +2275,7 @@ msgstr ""
 "de colocarlos encima de ellas. Puede facilitar la lectura con algunas "
 "fuentes."
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Include columns:"
 msgstr "Incluir columnas:"
 
@@ -2291,19 +2294,19 @@ msgstr ""
 msgid "Infinity"
 msgstr "Infinito"
 
-#: ../src/wxMaximaFrame.cpp:974
+#: ../src/wxMaximaFrame.cpp:973
 msgid "Info about Maxima build"
 msgstr "Información sobre la compilación de Maxima"
 
-#: ../src/wxMaxima.cpp:4207
+#: ../src/wxMaxima.cpp:4219
 msgid "Initial Estimates:"
 msgstr "Estimadores iniciales:"
 
-#: ../src/wxMaximaFrame.cpp:718
+#: ../src/wxMaximaFrame.cpp:717
 msgid "Initial Value Problem (&1)..."
 msgstr "Problema de valor inicial (&1)"
 
-#: ../src/wxMaximaFrame.cpp:721
+#: ../src/wxMaximaFrame.cpp:720
 msgid "Initial Value Problem (&2)..."
 msgstr "Problema de valor inicial (&2)"
 
@@ -2311,7 +2314,7 @@ msgstr "Problema de valor inicial (&2)"
 msgid "Input labels"
 msgstr "Introducir etiquetas"
 
-#: ../src/wxMaximaFrame.cpp:403
+#: ../src/wxMaximaFrame.cpp:402
 msgid "Insert"
 msgstr "Insertar"
 
@@ -2319,95 +2322,95 @@ msgstr "Insertar"
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr "Insertar % antes de un operador al inicio de una celda"
 
-#: ../src/wxMaximaFrame.cpp:612
+#: ../src/wxMaximaFrame.cpp:611
 msgid "Insert &Section Cell\tCtrl-3"
 msgstr "Nueva celda de &sección\tCtrl-3"
 
-#: ../src/wxMaximaFrame.cpp:608
+#: ../src/wxMaximaFrame.cpp:607
 msgid "Insert &Text Cell\tCtrl-1"
 msgstr "Nueva celda de te&xto\tCtrl-1"
 
-#: ../src/wxMaximaFrame.cpp:558
+#: ../src/wxMaximaFrame.cpp:557
 msgid "Insert Cell\tAlt-Shift-C"
 msgstr "In&sertar celda\tAlt-Shift-C"
 
-#: ../src/wxMaxima.cpp:5642
+#: ../src/wxMaxima.cpp:5657
 msgid "Insert Image"
 msgstr "Insertar imagen"
 
-#: ../src/wxMaximaFrame.cpp:620
+#: ../src/wxMaximaFrame.cpp:619
 msgid "Insert Image..."
 msgstr "I&nsertar imagen"
 
-#: ../src/wxMaximaFrame.cpp:606
+#: ../src/wxMaximaFrame.cpp:605
 msgid "Insert Input &Cell"
 msgstr "Nueva celda de &entrada"
 
-#: ../src/wxMaximaFrame.cpp:618
+#: ../src/wxMaximaFrame.cpp:617
 msgid "Insert Page Break"
 msgstr "Salto de página"
 
-#: ../src/wxMaximaFrame.cpp:614
+#: ../src/wxMaximaFrame.cpp:613
 msgid "Insert S&ubsection Cell\tCtrl-4"
 msgstr "Nueva celda de s&ubsección\tCtrl-4"
 
-#: ../src/wxMaximaFrame.cpp:616
+#: ../src/wxMaximaFrame.cpp:615
 msgid "Insert S&ubsubsection Cell\tCtrl-5"
 msgstr "Insertar celda de subsubsección\tCtrl-5"
 
-#: ../src/MathCtrl.cpp:1015
+#: ../src/MathCtrl.cpp:1057
 msgid "Insert Section Cell"
 msgstr "Nueva celda de &sección\tF8"
 
-#: ../src/MathCtrl.cpp:1016
+#: ../src/MathCtrl.cpp:1058
 msgid "Insert Subsection Cell"
 msgstr "Nueva celda de subsección"
 
-#: ../src/MathCtrl.cpp:1017
+#: ../src/MathCtrl.cpp:1059
 msgid "Insert Subsubsection Cell"
 msgstr "Insertar celda de subsubsección"
 
-#: ../src/wxMaximaFrame.cpp:610
+#: ../src/wxMaximaFrame.cpp:609
 msgid "Insert T&itle Cell\tCtrl-2"
 msgstr "Nueva celda de &título\tCtrl-2"
 
-#: ../src/MathCtrl.cpp:1013
+#: ../src/MathCtrl.cpp:1055
 msgid "Insert Text Cell"
 msgstr "Nueva celda de texto"
 
-#: ../src/MathCtrl.cpp:1014
+#: ../src/MathCtrl.cpp:1056
 msgid "Insert Title Cell"
 msgstr "Nueva celda de título"
 
-#: ../src/wxMaximaFrame.cpp:607
+#: ../src/wxMaximaFrame.cpp:606
 msgid "Insert a new input cell"
 msgstr "Nueva celda de entrada"
 
-#: ../src/wxMaximaFrame.cpp:613
+#: ../src/wxMaximaFrame.cpp:612
 msgid "Insert a new section cell"
 msgstr "Nueva celda de sección"
 
-#: ../src/wxMaximaFrame.cpp:615
+#: ../src/wxMaximaFrame.cpp:614
 msgid "Insert a new subsection cell"
 msgstr "Nueva celda de subsección"
 
-#: ../src/wxMaximaFrame.cpp:617
+#: ../src/wxMaximaFrame.cpp:616
 msgid "Insert a new subsubsection cell"
 msgstr "Insertar nueva celda de subsubsección"
 
-#: ../src/wxMaximaFrame.cpp:609
+#: ../src/wxMaximaFrame.cpp:608
 msgid "Insert a new text cell"
 msgstr "Nueva celda de texto"
 
-#: ../src/wxMaximaFrame.cpp:611
+#: ../src/wxMaximaFrame.cpp:610
 msgid "Insert a new title cell"
 msgstr "Nueva celda de título"
 
-#: ../src/wxMaximaFrame.cpp:619
+#: ../src/wxMaximaFrame.cpp:618
 msgid "Insert a page break"
 msgstr "Salto de página"
 
-#: ../src/wxMaximaFrame.cpp:621
+#: ../src/wxMaximaFrame.cpp:620
 msgid "Insert image"
 msgstr "Insertar imagen"
 
@@ -2419,27 +2422,27 @@ msgstr "Enteros y letras"
 msgid "Integral sign"
 msgstr "Símbolo integral"
 
-#: ../src/wxMaxima.cpp:3992
+#: ../src/wxMaxima.cpp:4004
 msgid "Integral/Sum:"
 msgstr "Integral/suma:"
 
-#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4105 ../src/wxMaxima.cpp:5051
+#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4117 ../src/wxMaxima.cpp:5063
 msgid "Integrate"
 msgstr "Integrar"
 
-#: ../src/wxMaxima.cpp:4091
+#: ../src/wxMaxima.cpp:4103
 msgid "Integrate (risch)"
 msgstr "Integrar (risch)"
 
-#: ../src/wxMaximaFrame.cpp:778
+#: ../src/wxMaximaFrame.cpp:777
 msgid "Integrate expression"
 msgstr "Integrar expresión"
 
-#: ../src/wxMaximaFrame.cpp:780
+#: ../src/wxMaximaFrame.cpp:779
 msgid "Integrate expression with Risch algorithm"
 msgstr "Integrar expresión con algoritmo Risch"
 
-#: ../src/wxMaximaFrame.cpp:1224 ../src/MathCtrl.cpp:1000
+#: ../src/MathCtrl.cpp:1042 ../src/wxMaximaFrame.cpp:1223
 msgid "Integrate..."
 msgstr "Integrar"
 
@@ -2447,7 +2450,7 @@ msgstr "Integrar"
 msgid "Interrupt"
 msgstr "Interrumpir"
 
-#: ../src/wxMaximaFrame.cpp:646 ../src/wxMaximaFrame.cpp:650
+#: ../src/wxMaximaFrame.cpp:645 ../src/wxMaximaFrame.cpp:649
 msgid "Interrupt current computation"
 msgstr "Interrumpir el cálculo actual"
 
@@ -2469,15 +2472,15 @@ msgstr ""
 "\n"
 "Por favor, introduzca de nuevo la ruta al programa Maxima."
 
-#: ../src/wxMaxima.cpp:4137
+#: ../src/wxMaxima.cpp:4149
 msgid "Inverse Laplace"
 msgstr "Laplace inversa"
 
-#: ../src/wxMaximaFrame.cpp:806
+#: ../src/wxMaximaFrame.cpp:805
 msgid "Inverse Laplace T&ransform..."
 msgstr "Trans&formada inversa de Laplace"
 
-#: ../src/wxMaximaFrame.cpp:1372
+#: ../src/wxMaximaFrame.cpp:1371
 msgid "Iota"
 msgstr "Iota"
 
@@ -2515,7 +2518,7 @@ msgstr "Japonés"
 msgid "Kabyle"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1373
+#: ../src/wxMaximaFrame.cpp:1372
 msgid "Kappa"
 msgstr "Kappa"
 
@@ -2524,7 +2527,7 @@ msgstr "Kappa"
 msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr "Mantener el símbolo porcentual en constantes especiales: %e, %i, etc."
 
-#: ../src/wxMaxima.cpp:4031
+#: ../src/wxMaxima.cpp:4043
 msgid "LCM"
 msgstr "MCM"
 
@@ -2543,7 +2546,7 @@ msgstr ""
 msgid "Label width:"
 msgstr "Ancho de etiqueta"
 
-#: ../src/wxMaximaFrame.cpp:1374
+#: ../src/wxMaximaFrame.cpp:1373
 msgid "Lambda"
 msgstr "Lambda"
 
@@ -2555,11 +2558,11 @@ msgstr "Idioma usado en la interfaz de usuario de wxMaxima."
 msgid "Language:"
 msgstr "Idioma:"
 
-#: ../src/wxMaxima.cpp:4120
+#: ../src/wxMaxima.cpp:4132
 msgid "Laplace"
 msgstr "Laplace"
 
-#: ../src/wxMaximaFrame.cpp:803
+#: ../src/wxMaximaFrame.cpp:802
 msgid "Laplace &Transform..."
 msgstr "&Transformada de Laplace"
 
@@ -2568,15 +2571,15 @@ msgstr "&Transformada de Laplace"
 msgid "Leads to"
 msgstr "tiende a:"
 
-#: ../src/wxMaximaFrame.cpp:812
+#: ../src/wxMaximaFrame.cpp:811
 msgid "Least Common Multiple..."
 msgstr "Mí&nimo común múltiplo"
 
-#: ../src/wxMaxima.cpp:4809
+#: ../src/wxMaxima.cpp:4821
 msgid "Least Squares Fit"
 msgstr "Ajuste por mínimos cuadrados"
 
-#: ../src/wxMaximaFrame.cpp:1266
+#: ../src/wxMaximaFrame.cpp:1265
 msgid "Least Squares Fit..."
 msgstr "Ajuste por mínimos cuadrados"
 
@@ -2591,23 +2594,23 @@ msgstr ""
 "directorio en el que se encuentren, si este se guarda en la variable "
 "maxima_userdir"
 
-#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4192
+#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4204
 msgid "Limit"
 msgstr "Límite"
 
-#: ../src/wxMaximaFrame.cpp:1225
+#: ../src/wxMaximaFrame.cpp:1224
 msgid "Limit..."
 msgstr "Límite"
 
-#: ../src/wxMaximaFrame.cpp:1265
+#: ../src/wxMaximaFrame.cpp:1264
 msgid "Linear Regression..."
 msgstr "Regresión lineal"
 
-#: ../src/wxMaxima.cpp:3803
+#: ../src/wxMaxima.cpp:3815
 msgid "List(s):"
 msgstr "Lista(s):"
 
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3848
 msgid "List:"
 msgstr "Lista:"
 
@@ -2615,15 +2618,15 @@ msgstr "Lista:"
 msgid "Load"
 msgstr "Cargar"
 
-#: ../src/wxMaxima.cpp:2932
+#: ../src/wxMaxima.cpp:2940
 msgid "Load Package"
 msgstr "Cargar paquete"
 
-#: ../src/wxMaximaFrame.cpp:479
+#: ../src/wxMaximaFrame.cpp:478
 msgid "Load a Maxima file using the batch command"
 msgstr "Cargar un archivo Maxima usando el comando batch"
 
-#: ../src/wxMaximaFrame.cpp:477
+#: ../src/wxMaximaFrame.cpp:476
 msgid "Load a Maxima package file"
 msgstr "Cargar un paquete Maxima"
 
@@ -2635,48 +2638,48 @@ msgstr "Leer estilo desde un archivo"
 msgid "Long Right arrow"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Lower bound:"
 msgstr "Cota inferior:"
 
-#: ../src/wxMaximaFrame.cpp:771
+#: ../src/wxMaximaFrame.cpp:770
 msgid "Ma&p to Matrix..."
 msgstr "Distribuir sobre &matriz"
 
-#: ../src/wxMaximaFrame.cpp:547
+#: ../src/wxMaximaFrame.cpp:546
 msgid "Main Toolbar\tAlt-Shift-B"
 msgstr "Barra de herramientas principal\tAlt-Shift-B"
 
-#: ../src/wxMaximaFrame.cpp:765
+#: ../src/wxMaximaFrame.cpp:764
 msgid "Make &List..."
 msgstr "Construir &lista"
 
-#: ../src/wxMaxima.cpp:3821
+#: ../src/wxMaxima.cpp:3833
 msgid "Make list"
 msgstr "Construir lista"
 
-#: ../src/wxMaximaFrame.cpp:766
+#: ../src/wxMaximaFrame.cpp:765
 msgid "Make list from expression"
 msgstr "Construir una lista a partir de una expresión"
 
-#: ../src/wxMaximaFrame.cpp:907
+#: ../src/wxMaximaFrame.cpp:906
 msgid "Make substitution in expression"
 msgstr "Hacer una sustitución en una expresión"
 
-#: ../src/wxMaximaFrame.cpp:682
+#: ../src/wxMaximaFrame.cpp:681
 #, fuzzy
 msgid "Manually Trigger Evaluation"
 msgstr "Inicio manual de la evaluación"
 
-#: ../src/wxMaxima.cpp:3805
+#: ../src/wxMaxima.cpp:3817
 msgid "Map"
 msgstr "Aplicar"
 
-#: ../src/wxMaximaFrame.cpp:770
+#: ../src/wxMaximaFrame.cpp:769
 msgid "Map function to a list"
 msgstr "Aplicar función a una lista"
 
-#: ../src/wxMaximaFrame.cpp:772
+#: ../src/wxMaximaFrame.cpp:771
 msgid "Map function to a matrix"
 msgstr "Aplicar una función a una matriz"
 
@@ -2693,23 +2696,23 @@ msgstr "Hacer coincidir paréntesis en los controles de texto"
 msgid "Math font:"
 msgstr "Fuente matemática:"
 
-#: ../src/wxMaximaFrame.cpp:374
+#: ../src/wxMaximaFrame.cpp:373
 msgid "Mathematical Symbols"
 msgstr "Símbolos matemáticos"
 
-#: ../src/wxMaxima.cpp:3716
+#: ../src/wxMaxima.cpp:3728
 msgid "Matrix"
 msgstr "Matriz"
 
-#: ../src/wxMaxima.cpp:3702
+#: ../src/wxMaxima.cpp:3714
 msgid "Matrix map"
 msgstr "Aplicar matriz"
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Matrix name:"
 msgstr "Nombre de matriz:"
 
-#: ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3749
+#: ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3761
 msgid "Matrix:"
 msgstr "Matriz:"
 
@@ -2717,7 +2720,7 @@ msgstr "Matriz:"
 msgid "Maxima"
 msgstr "Maxima"
 
-#: ../src/wxMaximaFrame.cpp:137
+#: ../src/wxMaximaFrame.cpp:136
 #, fuzzy
 msgid "Maxima has a question"
 msgstr "Pregunta Maxima"
@@ -2726,24 +2729,24 @@ msgstr "Pregunta Maxima"
 msgid "Maxima input"
 msgstr "Entrada Maxima"
 
-#: ../src/wxMaximaFrame.cpp:166
+#: ../src/wxMaximaFrame.cpp:165
 msgid "Maxima is calculating"
 msgstr "Maxima está calculando"
 
-#: ../src/wxMaximaFrame.cpp:111
+#: ../src/wxMaximaFrame.cpp:110
 #, fuzzy
 msgid "Maxima is ready for input."
 msgstr "Entrada Maxima"
 
-#: ../src/wxMaxima.cpp:2945
+#: ../src/wxMaxima.cpp:2953
 msgid "Maxima package (*.mac)|*.mac"
 msgstr "Paquete de Maxima (*.mac)|*.mac"
 
-#: ../src/wxMaxima.cpp:2934
+#: ../src/wxMaxima.cpp:2942
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr "Paquete Maxima (*.mac)|*.mac|Paquete Lisp (*.lisp)|*.lisp|Todos|*"
 
-#: ../src/wxMaxima.cpp:1014
+#: ../src/wxMaxima.cpp:1019
 msgid "Maxima process terminated."
 msgstr "Proceso de Maxima terminado."
 
@@ -2755,7 +2758,7 @@ msgstr "Programa Maxima:"
 msgid "Maxima questions"
 msgstr "Opciones de Maxima"
 
-#: ../src/wxMaxima.cpp:942
+#: ../src/wxMaxima.cpp:947
 msgid "Maxima started. Waiting for connection..."
 msgstr "Maxima iniciado. Esperando la conexión..."
 
@@ -2787,7 +2790,7 @@ msgstr ""
 "Maxima utiliza ':' para asignar un valor a una variable ('a : 3;') y ':=' "
 "para definir funciones ('f(x) := x^2;')."
 
-#: ../src/wxMaxima.cpp:4597
+#: ../src/wxMaxima.cpp:4609
 msgid "Maxima version: "
 msgstr "Versión de Maxima: "
 
@@ -2824,40 +2827,40 @@ msgstr ""
 msgid "Maximum displayed number of digits:"
 msgstr "Número máximo de dígitos a mostrar:"
 
-#: ../src/wxMaximaFrame.cpp:1263
+#: ../src/wxMaximaFrame.cpp:1262
 msgid "Mean Difference Test..."
 msgstr "Test diferencia de medias"
 
-#: ../src/wxMaximaFrame.cpp:1262
+#: ../src/wxMaximaFrame.cpp:1261
 msgid "Mean Test..."
 msgstr "Test medias"
 
-#: ../src/wxMaximaFrame.cpp:1255
+#: ../src/wxMaximaFrame.cpp:1254
 msgid "Mean..."
 msgstr "Media"
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Mean:"
 msgstr "Media:"
 
-#: ../src/wxMaximaFrame.cpp:1256
+#: ../src/wxMaximaFrame.cpp:1255
 msgid "Median..."
 msgstr "Mediana"
 
-#: ../src/MathCtrl.cpp:945
+#: ../src/MathCtrl.cpp:987
 msgid "Merge Cells"
 msgstr "Unir celdas"
 
-#: ../src/wxMaximaFrame.cpp:633
+#: ../src/wxMaximaFrame.cpp:632
 #, fuzzy
 msgid "Merge Cells\tCtrl-M"
 msgstr "Unir celdas"
 
-#: ../src/wxMaximaFrame.cpp:634
+#: ../src/wxMaximaFrame.cpp:633
 msgid "Merge the text from two input cells into one"
 msgstr "Unir el texto de dos celdas de entrada en una sola"
 
-#: ../src/wxMaxima.cpp:2668
+#: ../src/wxMaxima.cpp:2676
 msgid "Message from the stdout of Maxima: "
 msgstr "Mensaje de la salida estándar de Maxima: "
 
@@ -2865,19 +2868,19 @@ msgstr "Mensaje de la salida estándar de Maxima: "
 msgid "Method:"
 msgstr "Método:"
 
-#: ../src/wxMaxima.cpp:5289
+#: ../src/wxMaxima.cpp:5301
 msgid "Mismatched parenthesis"
 msgstr "Paréntesis no pareados"
 
-#: ../src/wxMaxima.cpp:3972
+#: ../src/wxMaxima.cpp:3984
 msgid "Modulus"
 msgstr "Módulo"
 
-#: ../src/wxMaximaFrame.cpp:1375
+#: ../src/wxMaximaFrame.cpp:1374
 msgid "Mu"
 msgstr ""
 
-#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Name:"
 msgstr "Nombre"
 
@@ -2885,7 +2888,7 @@ msgstr "Nombre"
 msgid "New"
 msgstr "Nuevo"
 
-#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
+#: ../src/wxMaximaFrame.cpp:456 ../src/wxMaximaFrame.cpp:459
 msgid "New\tCtrl-N"
 msgstr "Nuevo\tCtrl-N"
 
@@ -2901,11 +2904,11 @@ msgstr ""
 msgid "New value:"
 msgstr "Nuevo valor:"
 
-#: ../src/wxMaxima.cpp:3993 ../src/wxMaxima.cpp:4119 ../src/wxMaxima.cpp:4136
+#: ../src/wxMaxima.cpp:4005 ../src/wxMaxima.cpp:4131 ../src/wxMaxima.cpp:4148
 msgid "New variable:"
 msgstr "Nueva variable:"
 
-#: ../src/wxMaximaFrame.cpp:630
+#: ../src/wxMaximaFrame.cpp:629
 msgid "Next Command\tAlt-Down"
 msgstr "Siguiente instrucción\tAlt-Abajo"
 
@@ -2913,16 +2916,16 @@ msgstr "Siguiente instrucción\tAlt-Abajo"
 msgid "No"
 msgstr "No"
 
-#: ../src/wxMaxima.cpp:5362
+#: ../src/wxMaxima.cpp:5378
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 "No hay símbolo de dólar ($) ni de punto y coma (;) al final de la instrucción"
 
-#: ../src/wxMaxima.cpp:3249 ../src/wxMaxima.cpp:3271
+#: ../src/wxMaxima.cpp:3260 ../src/wxMaxima.cpp:3283
 msgid "No matches found!"
 msgstr "¡No se encontraron coincidencias!"
 
-#: ../src/wxMaximaFrame.cpp:1264
+#: ../src/wxMaximaFrame.cpp:1263
 msgid "Normality Test..."
 msgstr "Test de normalidad"
 
@@ -2953,31 +2956,31 @@ msgstr ""
 msgid "Norwegian"
 msgstr "Noruego"
 
-#: ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:3740
 msgid "Not a valid matrix dimension!"
 msgstr "¡La dimensión de la matriz no es válida!"
 
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629
 msgid "Not a valid number of equations!"
 msgstr "¡El número de ecuaciones es incorrecto!"
 
-#: ../src/wxMaximaFrame.cpp:197
+#: ../src/wxMaximaFrame.cpp:196
 msgid "Not connected to maxima"
 msgstr "No conectado a Maxima"
 
-#: ../src/wxMaxima.cpp:4599
+#: ../src/wxMaxima.cpp:4611
 msgid "Not connected."
 msgstr "No conectado."
 
-#: ../src/wxMaximaFrame.cpp:1376
+#: ../src/wxMaximaFrame.cpp:1375
 msgid "Nu"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Num. deg:"
 msgstr "num deg:"
 
-#: ../src/wxMaxima.cpp:3585 ../src/wxMaxima.cpp:3609
+#: ../src/wxMaxima.cpp:3597 ../src/wxMaxima.cpp:3621
 msgid "Number of equations:"
 msgstr "Número de ecuaciones:"
 
@@ -3004,15 +3007,15 @@ msgstr "Aceptar"
 msgid "Old value:"
 msgstr "Valor antiguo:"
 
-#: ../src/wxMaxima.cpp:3992 ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135
+#: ../src/wxMaxima.cpp:4004 ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147
 msgid "Old variable:"
 msgstr "Variable antigua:"
 
-#: ../src/wxMaximaFrame.cpp:1387
+#: ../src/wxMaximaFrame.cpp:1386
 msgid "Omega"
 msgstr "Omega"
 
-#: ../src/wxMaximaFrame.cpp:1378
+#: ../src/wxMaximaFrame.cpp:1377
 msgid "Omicron"
 msgstr ""
 
@@ -3029,20 +3032,20 @@ msgstr ""
 "necesita enviar mensajes por la salida estándar, pero sí el Lisp que "
 "funciona en segundo plano."
 
-#: ../src/wxMaxima.cpp:4763
+#: ../src/wxMaxima.cpp:4775
 msgid "One sample t-test"
 msgstr "Test t para una muestra"
 
-#: ../src/wxMaximaFrame.cpp:971
+#: ../src/wxMaximaFrame.cpp:970
 msgid "Online tutorials"
 msgstr "Tutoriales en línea"
 
 #: ../src/ConfigDialogue.cpp:656 ../src/main.cpp:347 ../src/ToolBar.cpp:119
-#: ../src/wxMaxima.cpp:2797
+#: ../src/wxMaxima.cpp:2805
 msgid "Open"
 msgstr "Abrir"
 
-#: ../src/wxMaximaFrame.cpp:466
+#: ../src/wxMaximaFrame.cpp:465
 msgid "Open Recent"
 msgstr "Abrir sesión &reciente"
 
@@ -3050,11 +3053,11 @@ msgstr "Abrir sesión &reciente"
 msgid "Open a cell when Maxima expects input"
 msgstr "Abrir una celda cuando Maxima espera una entrada"
 
-#: ../src/wxMaximaFrame.cpp:464
+#: ../src/wxMaximaFrame.cpp:463
 msgid "Open a document"
 msgstr "Abrir un documento"
 
-#: ../src/wxMaximaFrame.cpp:458 ../src/wxMaximaFrame.cpp:461
+#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
 msgid "Open a new window"
 msgstr "Abrir nueva ventana"
 
@@ -3062,11 +3065,11 @@ msgstr "Abrir nueva ventana"
 msgid "Open document"
 msgstr "Abrir documento"
 
-#: ../src/wxMaxima.cpp:4824
+#: ../src/wxMaxima.cpp:4836
 msgid "Open matrix"
 msgstr "Abrir matriz"
 
-#: ../src/wxMaxima.cpp:1446 ../src/wxMaxima.cpp:1518
+#: ../src/wxMaxima.cpp:1451 ../src/wxMaxima.cpp:1523
 msgid "Opening file"
 msgstr "Abriendo archivo"
 
@@ -3090,11 +3093,11 @@ msgstr "Celdas obsoletas"
 msgid "Output labels"
 msgstr "Etiquetas de salida"
 
-#: ../src/wxMaximaFrame.cpp:796
+#: ../src/wxMaximaFrame.cpp:795
 msgid "P&ade Approximation..."
 msgstr "Aproximación de &Padé"
 
-#: ../src/wxMaxima.cpp:3132 ../src/wxMaxima.cpp:5133
+#: ../src/wxMaxima.cpp:3141 ../src/wxMaxima.cpp:5145
 msgid ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
 "bmp|Portable animap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X "
@@ -3104,15 +3107,15 @@ msgstr ""
 "bmp|Portable any map (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X "
 "pixmap (*.xpm)|*.xpm"
 
-#: ../src/wxMaxima.cpp:4012
+#: ../src/wxMaxima.cpp:4024
 msgid "Pade approximation"
 msgstr "Aproximación de Padé"
 
-#: ../src/wxMaximaFrame.cpp:797
+#: ../src/wxMaximaFrame.cpp:796
 msgid "Pade approximation of a Taylor series"
 msgstr "Aproximación de Padé de una serie de Taylor"
 
-#: ../src/wxMaximaFrame.cpp:1500
+#: ../src/wxMaximaFrame.cpp:1519
 msgid "Pagebreak"
 msgstr "Salto de página"
 
@@ -3124,19 +3127,19 @@ msgstr "Paralelo a"
 msgid "Parametric plot"
 msgstr "Gráfico paramétrico"
 
-#: ../src/wxMaximaFrame.cpp:188
+#: ../src/wxMaximaFrame.cpp:187
 msgid "Parsing output"
 msgstr "Analizando salida"
 
-#: ../src/wxMaximaFrame.cpp:819
+#: ../src/wxMaximaFrame.cpp:818
 msgid "Partial &Fractions..."
 msgstr "Fraccion&es simples"
 
-#: ../src/wxMaxima.cpp:4076
+#: ../src/wxMaxima.cpp:4088
 msgid "Partial fractions"
 msgstr "Fracciones simples"
 
-#: ../src/wxMaxima.cpp:1769
+#: ../src/wxMaxima.cpp:1774
 msgid "Parts of the document will not be loaded correctly!"
 msgstr "¡Lectura del documento parcialmente correcta!"
 
@@ -3149,11 +3152,11 @@ msgstr ""
 "¡Lectura del documento parcialmente correcta!\n"
 "Se encontró etiqueta XML desconocida"
 
-#: ../src/ToolBar.cpp:143 ../src/MathCtrl.cpp:1010 ../src/MathCtrl.cpp:1025
+#: ../src/MathCtrl.cpp:1052 ../src/MathCtrl.cpp:1067 ../src/ToolBar.cpp:143
 msgid "Paste"
 msgstr "Pegar"
 
-#: ../src/wxMaximaFrame.cpp:518
+#: ../src/wxMaximaFrame.cpp:517
 msgid "Paste\tCtrl-V"
 msgstr "Pe&gar\tCtrl-V"
 
@@ -3161,7 +3164,7 @@ msgstr "Pe&gar\tCtrl-V"
 msgid "Paste from clipboard"
 msgstr "Pegar desde el portapapeles"
 
-#: ../src/wxMaximaFrame.cpp:519
+#: ../src/wxMaximaFrame.cpp:518
 msgid "Paste text from clipboard"
 msgstr "Pegar texto desde el portapapeles"
 
@@ -3169,19 +3172,19 @@ msgstr "Pegar texto desde el portapapeles"
 msgid "Perpendicular to"
 msgstr "Perpendicular a"
 
-#: ../src/wxMaximaFrame.cpp:1384
+#: ../src/wxMaximaFrame.cpp:1383
 msgid "Phi"
 msgstr "Fi"
 
-#: ../src/wxMaximaFrame.cpp:1379
+#: ../src/wxMaximaFrame.cpp:1378
 msgid "Pi"
 msgstr "Pi"
 
-#: ../src/wxMaximaFrame.cpp:1273
+#: ../src/wxMaximaFrame.cpp:1272
 msgid "Piechart..."
 msgstr "Diagrama de sectores"
 
-#: ../src/wxMaxima.cpp:1952
+#: ../src/wxMaxima.cpp:1957
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr "Configure wxMaxima con 'Editar->Configurar'."
 
@@ -3189,52 +3192,52 @@ msgstr "Configure wxMaxima con 'Editar->Configurar'."
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr "Reinicie wxMaxima para que los cambios tengan efecto"
 
-#: ../src/wxMaximaFrame.cpp:923
+#: ../src/wxMaximaFrame.cpp:922
 msgid "Plot &2d..."
 msgstr "Gráficos &2D"
 
-#: ../src/wxMaximaFrame.cpp:925
+#: ../src/wxMaximaFrame.cpp:924
 msgid "Plot &3d..."
 msgstr "Gráficos &3D"
 
-#: ../src/wxMaximaFrame.cpp:927
+#: ../src/wxMaximaFrame.cpp:926
 msgid "Plot &Format..."
 msgstr "&Formato de gráficos"
 
 #: ../src/Plot2dWiz.cpp:104 ../src/Plot2dWiz.cpp:450 ../src/Plot2dWiz.cpp:464
-#: ../src/wxMaxima.cpp:4283 ../src/wxMaxima.cpp:5102
+#: ../src/wxMaxima.cpp:4295 ../src/wxMaxima.cpp:5114
 msgid "Plot 2D"
 msgstr "Gráficos 2D"
 
-#: ../src/wxMaximaFrame.cpp:1227
+#: ../src/wxMaximaFrame.cpp:1226
 msgid "Plot 2D..."
 msgstr "Gráficos 2D"
 
-#: ../src/MathCtrl.cpp:1003
+#: ../src/MathCtrl.cpp:1045
 msgid "Plot 2d..."
 msgstr "Gráficos 2D"
 
-#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4269 ../src/wxMaxima.cpp:5115
+#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4281 ../src/wxMaxima.cpp:5127
 msgid "Plot 3D"
 msgstr "Gráficos 3D"
 
-#: ../src/wxMaximaFrame.cpp:1228
+#: ../src/wxMaximaFrame.cpp:1227
 msgid "Plot 3D..."
 msgstr "Gráficos 3D"
 
-#: ../src/MathCtrl.cpp:1004
+#: ../src/MathCtrl.cpp:1046
 msgid "Plot 3d..."
 msgstr "Gráficos 3D"
 
-#: ../src/wxMaxima.cpp:4296
+#: ../src/wxMaxima.cpp:4308
 msgid "Plot format"
 msgstr "Formato de los gráficos"
 
-#: ../src/wxMaximaFrame.cpp:924
+#: ../src/wxMaximaFrame.cpp:923
 msgid "Plot in 2 dimensions"
 msgstr "Gráfico en 2 dimensiones"
 
-#: ../src/wxMaximaFrame.cpp:926
+#: ../src/wxMaximaFrame.cpp:925
 msgid "Plot in 3 dimensions"
 msgstr "Gráfico en 3 dimensiones"
 
@@ -3243,8 +3246,8 @@ msgid "Plot to file:"
 msgstr "Gráfico al archivo:"
 
 #: ../src/BC2Wiz.cpp:30 ../src/BC2Wiz.cpp:36 ../src/LimitWiz.cpp:33
-#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
-#: ../src/wxMaxima.cpp:3648
+#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
+#: ../src/wxMaxima.cpp:3660
 msgid "Point:"
 msgstr "Punto:"
 
@@ -3252,11 +3255,11 @@ msgstr "Punto:"
 msgid "Polish"
 msgstr "Polaco"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 1:"
 msgstr "Polinomio 1:"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 2:"
 msgstr "Polinomio 2:"
 
@@ -3268,11 +3271,11 @@ msgstr "Portugués (Brasileño)"
 msgid "Postscript file (*.eps)|*.eps|All|*"
 msgstr "Archivo postscript (*.eps)|*.eps|Todos|*"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Precision"
 msgstr "Precisión"
 
-#: ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:536
 msgid "Preferences...\tCtrl+,"
 msgstr "Preferencias...\tCtrl+,"
 
@@ -3284,7 +3287,7 @@ msgid ""
 "packages and from functions that are defined in the current file."
 msgstr "Pulsando Ctrl+Space o Ctrl+Tab se inicia la autocompleción."
 
-#: ../src/wxMaximaFrame.cpp:628
+#: ../src/wxMaximaFrame.cpp:627
 msgid "Previous Command\tAlt-Up"
 msgstr "Instrucción anterior\tAlt-Arriba"
 
@@ -3292,11 +3295,11 @@ msgstr "Instrucción anterior\tAlt-Arriba"
 msgid "Print"
 msgstr "Imprimir"
 
-#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:484
+#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:483
 msgid "Print document"
 msgstr "Imprimir documento"
 
-#: ../src/wxMaxima.cpp:4242
+#: ../src/wxMaxima.cpp:4254
 msgid "Product"
 msgstr "Producto"
 
@@ -3304,35 +3307,35 @@ msgstr "Producto"
 msgid "Product sign"
 msgstr "Símbolo de producto"
 
-#: ../src/wxMaximaFrame.cpp:1386
+#: ../src/wxMaximaFrame.cpp:1385
 msgid "Psi"
 msgstr "Psi"
 
-#: ../src/wxMaximaFrame.cpp:331
+#: ../src/wxMaximaFrame.cpp:330
 msgid "Raw XML monitor"
 msgstr "Monitor XML"
 
-#: ../src/wxMaximaFrame.cpp:592
+#: ../src/wxMaximaFrame.cpp:591
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr "Evaluar todas las celdas por encima del cursor"
 
-#: ../src/wxMaximaFrame.cpp:1278
+#: ../src/wxMaximaFrame.cpp:1277
 msgid "Read Matrix..."
 msgstr "Leer matriz"
 
-#: ../src/wxMaximaFrame.cpp:177
+#: ../src/wxMaximaFrame.cpp:176
 msgid "Reading Maxima output"
 msgstr "Leyendo salida de Maxima"
 
-#: ../src/wxMaximaFrame.cpp:153
+#: ../src/wxMaximaFrame.cpp:152
 msgid "Ready for user input"
 msgstr "Preparado para la entrada de usuario"
 
-#: ../src/wxMaximaFrame.cpp:631
+#: ../src/wxMaximaFrame.cpp:630
 msgid "Recall next command from history"
 msgstr "Llamar a la siguiente instrucción del historial"
 
-#: ../src/wxMaximaFrame.cpp:629
+#: ../src/wxMaximaFrame.cpp:628
 msgid "Recall previous command from history"
 msgstr "Llamar a la instrucción anterior del historial"
 
@@ -3340,35 +3343,35 @@ msgstr "Llamar a la instrucción anterior del historial"
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1215
+#: ../src/wxMaximaFrame.cpp:1214
 msgid "Rectform"
 msgstr "Forma cartesiana"
 
-#: ../src/wxMaximaFrame.cpp:495
+#: ../src/wxMaximaFrame.cpp:494
 msgid "Redo\tCtrl-Y"
 msgstr "Rehacer\tCtrl-Y"
 
-#: ../src/wxMaximaFrame.cpp:496
+#: ../src/wxMaximaFrame.cpp:495
 msgid "Redo last change"
 msgstr "Rehacer último cambio"
 
-#: ../src/wxMaximaFrame.cpp:1220
+#: ../src/wxMaximaFrame.cpp:1219
 msgid "Reduce (tr)"
 msgstr "Reducir (tr)"
 
-#: ../src/wxMaximaFrame.cpp:871
+#: ../src/wxMaximaFrame.cpp:870
 msgid "Reduce trigonometric expression"
 msgstr "Simplificar expresión trigonométrica"
 
-#: ../src/wxMaxima.cpp:622 ../src/wxMaxima.cpp:5495
+#: ../src/wxMaxima.cpp:627 ../src/wxMaxima.cpp:5511
 msgid "Refusing to send cell to maxima: "
 msgstr "Rechazado enviar una celda a Maxima: "
 
-#: ../src/wxMaximaFrame.cpp:594
+#: ../src/wxMaximaFrame.cpp:593
 msgid "Remove All Output"
 msgstr "&Borrar todos los resultados"
 
-#: ../src/wxMaximaFrame.cpp:595
+#: ../src/wxMaximaFrame.cpp:594
 msgid "Remove output from input cells"
 msgstr "Borrar resultados de las celdas de entrada"
 
@@ -3377,7 +3380,7 @@ msgstr "Borrar resultados de las celdas de entrada"
 msgid "Replace All"
 msgstr "Seleccionar todo"
 
-#: ../src/wxMaxima.cpp:3282
+#: ../src/wxMaxima.cpp:3294
 #, c-format
 msgid "Replaced %d occurrences."
 msgstr "Reemplazadas %d coincidencias."
@@ -3386,11 +3389,11 @@ msgstr "Reemplazadas %d coincidencias."
 msgid "Replacement:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:976
+#: ../src/wxMaximaFrame.cpp:975
 msgid "Report bug"
 msgstr "Informar de error"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "Restart Maxima"
 msgstr "Reiniciar maxima"
 
@@ -3398,7 +3401,7 @@ msgstr "Reiniciar maxima"
 msgid "Restart maxima"
 msgstr "Reiniciar Maxima"
 
-#: ../src/MathCtrl.cpp:4442
+#: ../src/MathCtrl.cpp:4497
 msgid "Result"
 msgstr "Resultado"
 
@@ -3406,7 +3409,7 @@ msgstr "Resultado"
 msgid "Return to the cell that is currently being evaluated"
 msgstr "Volver a la celda que se está evaluando actualmente"
 
-#: ../src/wxMaximaFrame.cpp:1380
+#: ../src/wxMaximaFrame.cpp:1379
 msgid "Rho"
 msgstr "Ro"
 
@@ -3414,19 +3417,19 @@ msgstr "Ro"
 msgid "Right arrow"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:779
+#: ../src/wxMaximaFrame.cpp:778
 msgid "Risch Integration..."
 msgstr "Integración &Risch"
 
-#: ../src/wxMaximaFrame.cpp:694
+#: ../src/wxMaximaFrame.cpp:693
 msgid "Roots of &Polynomial"
 msgstr "Raíces de un &polinomio"
 
-#: ../src/wxMaximaFrame.cpp:697
+#: ../src/wxMaximaFrame.cpp:696
 msgid "Roots of Polynomial (bfloat)"
 msgstr "Raíces reales &grandes de un polinomio"
 
-#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Rows:"
 msgstr "Filas:"
 
@@ -3434,56 +3437,56 @@ msgstr "Filas:"
 msgid "Russian"
 msgstr "Ruso"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 1:"
 msgstr "Ejemplo 1:"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 2:"
 msgstr "Ejemplo 2:"
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Sample:"
 msgstr "Muestra:"
 
 #: ../src/ConfigDialogue.cpp:781 ../src/ToolBar.cpp:122
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Save"
 msgstr "Guardar"
 
-#: ../src/MathCtrl.cpp:921
+#: ../src/MathCtrl.cpp:963
 msgid "Save Animation..."
 msgstr "Guardar animación"
 
-#: ../src/wxMaxima.cpp:2565
+#: ../src/wxMaxima.cpp:2572
 msgid "Save As"
 msgstr "Guardar como"
 
-#: ../src/wxMaximaFrame.cpp:474
+#: ../src/wxMaximaFrame.cpp:473
 msgid "Save As...\tShift-Ctrl-S"
 msgstr "Guardar &como\tShift-Ctrl-S"
 
-#: ../src/MathCtrl.cpp:919
+#: ../src/MathCtrl.cpp:961
 msgid "Save Image..."
 msgstr "Guardar imagen..."
 
-#: ../src/wxMaxima.cpp:3130
+#: ../src/wxMaxima.cpp:3139
 msgid "Save Selection to Image"
 msgstr "Guardar selección en imagen"
 
-#: ../src/wxMaximaFrame.cpp:528
+#: ../src/wxMaximaFrame.cpp:527
 msgid "Save Selection to Image..."
 msgstr "G&uardar selección en imagen"
 
-#: ../src/wxMaxima.cpp:5150
+#: ../src/wxMaxima.cpp:5162
 msgid "Save animation to file"
 msgstr "Guardar animación en fichero"
 
-#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:473
+#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:472
 msgid "Save document"
 msgstr "Guardar documento"
 
-#: ../src/wxMaximaFrame.cpp:475
+#: ../src/wxMaximaFrame.cpp:474
 msgid "Save document as"
 msgstr "Guardar documento como"
 
@@ -3507,11 +3510,11 @@ msgstr "Guardar disposición de paneles entre sesiones."
 msgid "Save plot to file"
 msgstr "Guardar gráfico en un archivo"
 
-#: ../src/wxMaximaFrame.cpp:529
+#: ../src/wxMaximaFrame.cpp:528
 msgid "Save selection from document to an image file"
 msgstr "Copiar selección del documento a imagen"
 
-#: ../src/wxMaxima.cpp:5131
+#: ../src/wxMaxima.cpp:5143
 msgid "Save selection to file"
 msgstr "Guardar selección en un archivo"
 
@@ -3527,27 +3530,27 @@ msgstr "Guardar el tamaño/posición de la ventana de wxMaxima"
 msgid "Save wxMaxima window size/position between sessions."
 msgstr "Guardar tamaño/posición de la ventana de wxMaxima entre sesiones."
 
-#: ../src/wxMaximaFrame.cpp:246
+#: ../src/wxMaximaFrame.cpp:245
 msgid "Saving failed."
 msgstr "Fallo al guardar"
 
-#: ../src/wxMaximaFrame.cpp:222
+#: ../src/wxMaximaFrame.cpp:221
 msgid "Saving successful."
 msgstr "Guardado correcto."
 
-#: ../src/wxMaximaFrame.cpp:212
+#: ../src/wxMaximaFrame.cpp:211
 msgid "Saving..."
 msgstr "Guardando..."
 
-#: ../src/wxMaxima.cpp:4699
+#: ../src/wxMaxima.cpp:4711
 msgid "Scatterplot"
 msgstr "Diagrama dispersión"
 
-#: ../src/wxMaximaFrame.cpp:1271
+#: ../src/wxMaximaFrame.cpp:1270
 msgid "Scatterplot..."
 msgstr "Diagrama dispersión"
 
-#: ../src/wxMaximaFrame.cpp:1498
+#: ../src/wxMaximaFrame.cpp:1517
 msgid "Section"
 msgstr "Sección"
 
@@ -3555,8 +3558,8 @@ msgstr "Sección"
 msgid "Section cell"
 msgstr "Celda de sección"
 
-#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:292 ../src/TextCell.cpp:306
-#: ../src/TextCell.cpp:322 ../src/TextCell.cpp:334
+#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:290 ../src/TextCell.cpp:304
+#: ../src/TextCell.cpp:320 ../src/TextCell.cpp:332
 msgid ""
 "Seems like something is broken with a font. Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
@@ -3566,7 +3569,7 @@ msgstr ""
 "~dpvc/jsmath/download/jsMath-fonts.html y comprobando \"Use JSmath fonts\" "
 "en el diálogo de configuración debería resolver el problema."
 
-#: ../src/TextCell.cpp:139
+#: ../src/TextCell.cpp:137
 msgid ""
 "Seems like something is broken with the maths font. Installing http://www."
 "math.union.edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use "
@@ -3576,11 +3579,11 @@ msgstr ""
 "union.edu/~dpvc/jsmath/download/jsMath-fonts.html y comprobando \"Use JSmath "
 "fonts\" en el diálogo de configuración debería resolver el problema."
 
-#: ../src/MathCtrl.cpp:1011 ../src/MathCtrl.cpp:1027
+#: ../src/MathCtrl.cpp:1053 ../src/MathCtrl.cpp:1069
 msgid "Select All"
 msgstr "Seleccionar todo"
 
-#: ../src/wxMaximaFrame.cpp:525
+#: ../src/wxMaximaFrame.cpp:524
 msgid "Select All\tCtrl-A"
 msgstr "&Seleccionar todo\tCtrl-A"
 
@@ -3588,7 +3591,7 @@ msgstr "&Seleccionar todo\tCtrl-A"
 msgid "Select Maxima program"
 msgstr "Seleccionar el programa Maxima"
 
-#: ../src/wxMaxima.cpp:4860
+#: ../src/wxMaxima.cpp:4872
 msgid "Select Subsample"
 msgstr "Seleccionar submuestra"
 
@@ -3597,11 +3600,11 @@ msgstr "Seleccionar submuestra"
 msgid "Select a constant"
 msgstr "Seleccionar una constante"
 
-#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:526
+#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:525
 msgid "Select all"
 msgstr "Seleccionar todo"
 
-#: ../src/wxMaxima.cpp:3319
+#: ../src/wxMaxima.cpp:3331
 msgid "Select math display algorithm"
 msgstr "Seleccionar el algoritmo de salida matemática"
 
@@ -3618,23 +3621,23 @@ msgstr ""
 msgid "Selection"
 msgstr "Selección"
 
-#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4178
+#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4190
 msgid "Series"
 msgstr "Serie"
 
-#: ../src/wxMaximaFrame.cpp:1226
+#: ../src/wxMaximaFrame.cpp:1225
 msgid "Series..."
 msgstr "Serie"
 
-#: ../src/wxMaxima.cpp:863
+#: ../src/wxMaxima.cpp:868
 msgid "Server started"
 msgstr "Servidor iniciado"
 
-#: ../src/wxMaximaFrame.cpp:575
+#: ../src/wxMaximaFrame.cpp:574
 msgid "Set Zoom"
 msgstr "Establecer au&mento"
 
-#: ../src/wxMaximaFrame.cpp:944
+#: ../src/wxMaximaFrame.cpp:943
 msgid "Set bigfloat &Precision..."
 msgstr "Establecer la precisión bigfloat"
 
@@ -3642,11 +3645,11 @@ msgstr "Establecer la precisión bigfloat"
 msgid "Set fixed font in text controls."
 msgstr "Establecer fuente fija en los controles de texto."
 
-#: ../src/wxMaximaFrame.cpp:928
+#: ../src/wxMaximaFrame.cpp:927
 msgid "Set plot format"
 msgstr "Establecer el formato de los gráficos"
 
-#: ../src/wxMaximaFrame.cpp:945
+#: ../src/wxMaximaFrame.cpp:944
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can "
 "be generated by entering 1.5b12 or as bfloat(1.234)"
@@ -3654,53 +3657,53 @@ msgstr ""
 "Ajustar la precisión de los números que se define como bigfloat. Tales "
 "números se pueden generar escribiendo 1.5b12 o bfloat(1.234)"
 
-#: ../src/wxMaximaFrame.cpp:569
+#: ../src/wxMaximaFrame.cpp:568
 msgid "Set zoom to 100%"
 msgstr "Establecer ampliación a 100%"
 
-#: ../src/wxMaximaFrame.cpp:570
+#: ../src/wxMaximaFrame.cpp:569
 msgid "Set zoom to 120%"
 msgstr "Establecer ampliación a 120%"
 
-#: ../src/wxMaximaFrame.cpp:571
+#: ../src/wxMaximaFrame.cpp:570
 msgid "Set zoom to 150%"
 msgstr "Establecer ampliación a 150%"
 
-#: ../src/wxMaximaFrame.cpp:572
+#: ../src/wxMaximaFrame.cpp:571
 msgid "Set zoom to 200%"
 msgstr "Establecer ampliación a 200%"
 
-#: ../src/wxMaximaFrame.cpp:573
+#: ../src/wxMaximaFrame.cpp:572
 msgid "Set zoom to 300%"
 msgstr "Establecer ampliación a 300%"
 
-#: ../src/wxMaximaFrame.cpp:568
+#: ../src/wxMaximaFrame.cpp:567
 msgid "Set zoom to 80%"
 msgstr "Establecer disminución a 80%"
 
-#: ../src/wxMaximaFrame.cpp:732
+#: ../src/wxMaximaFrame.cpp:731
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
 "Establecer condiciones iniciales para resolver EDO mediante la transformada "
 "de Laplace"
 
-#: ../src/wxMaximaFrame.cpp:918
+#: ../src/wxMaximaFrame.cpp:917
 msgid "Setup modulus computation"
 msgstr "Configurar cálculo de módulo"
 
-#: ../src/wxMaximaFrame.cpp:662
+#: ../src/wxMaximaFrame.cpp:661
 msgid "Show &Definition..."
 msgstr "Mostrar &definición"
 
-#: ../src/wxMaximaFrame.cpp:660
+#: ../src/wxMaximaFrame.cpp:659
 msgid "Show &Functions"
 msgstr "Mostrar &funciones"
 
-#: ../src/wxMaximaFrame.cpp:967
+#: ../src/wxMaximaFrame.cpp:966
 msgid "Show &Tips..."
 msgstr "Mostrar &sugerencias"
 
-#: ../src/wxMaximaFrame.cpp:665
+#: ../src/wxMaximaFrame.cpp:664
 msgid "Show &Variables"
 msgstr "Mostrar &variables"
 
@@ -3708,43 +3711,43 @@ msgstr "Mostrar &variables"
 msgid "Show Maxima help"
 msgstr "Mostrar la ayuda de Maxima"
 
-#: ../src/wxMaximaFrame.cpp:603
+#: ../src/wxMaximaFrame.cpp:602
 msgid "Show Template\tCtrl-Shift-K"
 msgstr "&Mostrar plantilla\tCtrl-Shift-K"
 
-#: ../src/wxMaximaFrame.cpp:968
+#: ../src/wxMaximaFrame.cpp:967
 msgid "Show a tip"
 msgstr "Mostrar una sugerencia"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Show all commands similar to:"
 msgstr "Mostrar todos los comandos similares a:"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Show an example for the command:"
 msgstr "Mostrar un ejemplo para el comando:"
 
-#: ../src/wxMaximaFrame.cpp:962
+#: ../src/wxMaximaFrame.cpp:961
 msgid "Show an example of usage"
 msgstr "Mostrar un ejemplo de uso"
 
-#: ../src/wxMaximaFrame.cpp:965
+#: ../src/wxMaximaFrame.cpp:964
 msgid "Show commands similar to"
 msgstr "Mostrar comandos similares a"
 
-#: ../src/wxMaximaFrame.cpp:661
+#: ../src/wxMaximaFrame.cpp:660
 msgid "Show defined functions"
 msgstr "Mostrar las funciones definidas"
 
-#: ../src/wxMaximaFrame.cpp:666
+#: ../src/wxMaximaFrame.cpp:665
 msgid "Show defined variables"
 msgstr "Mostrar las variables definidas"
 
-#: ../src/wxMaximaFrame.cpp:663
+#: ../src/wxMaximaFrame.cpp:662
 msgid "Show definition of a function"
 msgstr "Mostrar la definición de una función"
 
-#: ../src/wxMaximaFrame.cpp:604
+#: ../src/wxMaximaFrame.cpp:603
 msgid "Show function template"
 msgstr "Mostrar plantilla de función"
 
@@ -3757,7 +3760,7 @@ msgstr "Mostrar expresiones largas en el documento de wxMaxima."
 msgid "Show long expressions:"
 msgstr "Mostrar expresiones largas"
 
-#: ../src/wxMaxima.cpp:3341
+#: ../src/wxMaxima.cpp:3353
 msgid "Show the definition of function:"
 msgstr "Mostrar la definición de la función:"
 
@@ -3766,43 +3769,43 @@ msgstr "Mostrar la definición de la función:"
 msgid "Show user-defined labels instead of (%oxx)"
 msgstr "Mostrar etiquetas definidas por el usuario en lugar de (%oxx)"
 
-#: ../src/wxMaximaFrame.cpp:953 ../src/wxMaximaFrame.cpp:956
+#: ../src/wxMaximaFrame.cpp:952 ../src/wxMaximaFrame.cpp:955
 msgid "Show wxMaxima help"
 msgstr "Ayuda de wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:1381
+#: ../src/wxMaximaFrame.cpp:1380
 msgid "Sigma"
 msgstr "Sigma"
 
-#: ../src/wxMaximaFrame.cpp:1211
+#: ../src/wxMaximaFrame.cpp:1210
 msgid "Simplify"
 msgstr "Simplificar"
 
-#: ../src/wxMaximaFrame.cpp:831
+#: ../src/wxMaximaFrame.cpp:830
 msgid "Simplify &Radicals"
 msgstr "Simplificar &radicales"
 
-#: ../src/wxMaximaFrame.cpp:1212
+#: ../src/wxMaximaFrame.cpp:1211
 msgid "Simplify (r)"
 msgstr "Simplificar (r)"
 
-#: ../src/wxMaximaFrame.cpp:1218
+#: ../src/wxMaximaFrame.cpp:1217
 msgid "Simplify (tr)"
 msgstr "Simplificar(tr)"
 
-#: ../src/MathCtrl.cpp:995
+#: ../src/MathCtrl.cpp:1037
 msgid "Simplify Expression"
 msgstr "Simplificar expresión"
 
-#: ../src/wxMaximaFrame.cpp:857
+#: ../src/wxMaximaFrame.cpp:856
 msgid "Simplify an expression containing factorials"
 msgstr "Simplificar una expresión que contiene factoriales"
 
-#: ../src/wxMaximaFrame.cpp:832
+#: ../src/wxMaximaFrame.cpp:831
 msgid "Simplify expression containing radicals"
 msgstr "Simplificar una expresión que contiene radicales"
 
-#: ../src/wxMaximaFrame.cpp:830
+#: ../src/wxMaximaFrame.cpp:829
 msgid "Simplify rational expression"
 msgstr "Simplificar expresión racional"
 
@@ -3810,7 +3813,7 @@ msgstr "Simplificar expresión racional"
 msgid "Simplify the sum"
 msgstr "Simplificar la suma"
 
-#: ../src/wxMaximaFrame.cpp:868
+#: ../src/wxMaximaFrame.cpp:867
 msgid "Simplify trigonometric expression"
 msgstr "Simplificar una expresión trigonométrica"
 
@@ -3826,88 +3829,88 @@ msgstr ""
 "guardar el documento en formato 'Documento xml wxMaxima' si quiere que se "
 "almacene la imagen junto con el resto del documento."
 
-#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
+#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
 msgid "Solution:"
 msgstr "Solución:"
 
-#: ../src/wxMaxima.cpp:3461 ../src/wxMaxima.cpp:3475 ../src/wxMaxima.cpp:5020
+#: ../src/wxMaxima.cpp:3473 ../src/wxMaxima.cpp:3487 ../src/wxMaxima.cpp:5032
 msgid "Solve"
 msgstr "Resolver"
 
-#: ../src/wxMaximaFrame.cpp:706
+#: ../src/wxMaximaFrame.cpp:705
 msgid "Solve &Algebraic System..."
 msgstr "Reso&lver sistema algebraico"
 
-#: ../src/wxMaximaFrame.cpp:703
+#: ../src/wxMaximaFrame.cpp:702
 msgid "Solve &Linear System..."
 msgstr "Resolver &sistema lineal"
 
-#: ../src/wxMaximaFrame.cpp:714
+#: ../src/wxMaximaFrame.cpp:713
 msgid "Solve &ODE..."
 msgstr "Resolver &EDO"
 
-#: ../src/wxMaximaFrame.cpp:690
+#: ../src/wxMaximaFrame.cpp:689
 msgid "Solve (to_poly)..."
 msgstr "Res&olver (to_poly)"
 
-#: ../src/wxMaxima.cpp:3511 ../src/wxMaxima.cpp:3635
+#: ../src/wxMaxima.cpp:3523 ../src/wxMaxima.cpp:3647
 msgid "Solve ODE"
 msgstr "Resolver EDO"
 
-#: ../src/wxMaximaFrame.cpp:728
+#: ../src/wxMaximaFrame.cpp:727
 msgid "Solve ODE with Lapla&ce..."
 msgstr "Resolver E&DO con Laplace"
 
-#: ../src/wxMaximaFrame.cpp:1222
+#: ../src/wxMaximaFrame.cpp:1221
 msgid "Solve ODE..."
 msgstr "Resolver EDO"
 
-#: ../src/wxMaxima.cpp:3586 ../src/wxMaxima.cpp:3597
+#: ../src/wxMaxima.cpp:3598 ../src/wxMaxima.cpp:3609
 msgid "Solve algebraic system"
 msgstr "Resolver sistema algebraico"
 
-#: ../src/wxMaximaFrame.cpp:707
+#: ../src/wxMaximaFrame.cpp:706
 msgid "Solve algebraic system of equations"
 msgstr "Resolver sistema algebraico de ecuaciones"
 
-#: ../src/wxMaximaFrame.cpp:725
+#: ../src/wxMaximaFrame.cpp:724
 msgid "Solve boundary value problem for second degree ODE"
 msgstr "Resolver problema de contorno para una EDO de segundo orden"
 
-#: ../src/wxMaximaFrame.cpp:689
+#: ../src/wxMaximaFrame.cpp:688
 msgid "Solve equation(s)"
 msgstr "Resolver ecuación(s)"
 
-#: ../src/wxMaximaFrame.cpp:691
+#: ../src/wxMaximaFrame.cpp:690
 msgid "Solve equation(s) with to_poly_solve"
 msgstr "Resolver ecuación con to_poly_solve"
 
-#: ../src/wxMaximaFrame.cpp:719
+#: ../src/wxMaximaFrame.cpp:718
 msgid "Solve initial value problem for first degree ODE"
 msgstr "Resolver problema de valor inicial para EDO de primer orden"
 
-#: ../src/wxMaximaFrame.cpp:722
+#: ../src/wxMaximaFrame.cpp:721
 msgid "Solve initial value problem for second degree ODE"
 msgstr "Resolver problema de valor inicial para EDO de segundo orden"
 
-#: ../src/wxMaxima.cpp:3610 ../src/wxMaxima.cpp:3621
+#: ../src/wxMaxima.cpp:3622 ../src/wxMaxima.cpp:3633
 msgid "Solve linear system"
 msgstr "Resolver sistema lineal"
 
-#: ../src/wxMaximaFrame.cpp:704
+#: ../src/wxMaximaFrame.cpp:703
 msgid "Solve linear system of equations"
 msgstr "Resolver sistema de ecuaciones lineales"
 
-#: ../src/wxMaximaFrame.cpp:715
+#: ../src/wxMaximaFrame.cpp:714
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr "Resolver ecuación diferencial ordinaria de orden máximo 2"
 
-#: ../src/wxMaximaFrame.cpp:729
+#: ../src/wxMaximaFrame.cpp:728
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
 "Resolver  ecuaciones diferenciales ordinarias con la transformada de Laplace"
 
-#: ../src/wxMaximaFrame.cpp:1221 ../src/MathCtrl.cpp:992
+#: ../src/MathCtrl.cpp:1034 ../src/wxMaximaFrame.cpp:1220
 msgid "Solve..."
 msgstr "Resolver"
 
@@ -3934,7 +3937,7 @@ msgstr "Especial"
 msgid "Special constants"
 msgstr "Constantes especiales"
 
-#: ../src/MathCtrl.cpp:922
+#: ../src/MathCtrl.cpp:964
 msgid "Start Animation"
 msgstr "Comenzar animación"
 
@@ -3954,28 +3957,28 @@ msgstr ""
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:294
+#: ../src/wxMaxima.cpp:295
 msgid "Starting Maxima process failed"
 msgstr "Falló el inicio de Maxima"
 
-#: ../src/wxMaxima.cpp:928
+#: ../src/wxMaxima.cpp:933
 msgid "Starting Maxima..."
 msgstr "Iniciando Maxima..."
 
-#: ../src/wxMaxima.cpp:292 ../src/wxMaxima.cpp:860
+#: ../src/wxMaxima.cpp:293 ../src/wxMaxima.cpp:865
 msgid "Starting server failed"
 msgstr "El inicio del servidor ha fallado"
 
-#: ../src/wxMaxima.cpp:841
+#: ../src/wxMaxima.cpp:846
 #, c-format
 msgid "Starting server on port %d"
 msgstr "Iniciando servidor en el puerto %d"
 
-#: ../src/wxMaximaFrame.cpp:342
+#: ../src/wxMaximaFrame.cpp:341
 msgid "Statistics"
 msgstr "Estadística"
 
-#: ../src/wxMaximaFrame.cpp:550
+#: ../src/wxMaximaFrame.cpp:549
 msgid "Statistics\tAlt-Shift-S"
 msgstr "&Estadística\tAlt-Shift-S"
 
@@ -3991,11 +3994,11 @@ msgstr "Estilo"
 msgid "Styles"
 msgstr "Estilos"
 
-#: ../src/wxMaximaFrame.cpp:1283
+#: ../src/wxMaximaFrame.cpp:1282
 msgid "Subsample..."
 msgstr "Submuestra"
 
-#: ../src/wxMaximaFrame.cpp:1496
+#: ../src/wxMaximaFrame.cpp:1515
 msgid "Subsection"
 msgstr "Subsección"
 
@@ -4003,20 +4006,20 @@ msgstr "Subsección"
 msgid "Subsection cell"
 msgstr "Celda de subsección"
 
-#: ../src/wxMaximaFrame.cpp:1216
+#: ../src/wxMaximaFrame.cpp:1215
 msgid "Subst..."
 msgstr "S&ustituir"
 
-#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3423
-#: ../src/wxMaxima.cpp:5089
+#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3435
+#: ../src/wxMaxima.cpp:5101
 msgid "Substitute"
 msgstr "Sustituir"
 
-#: ../src/wxMaximaFrame.cpp:906 ../src/MathCtrl.cpp:998
+#: ../src/MathCtrl.cpp:1040 ../src/wxMaximaFrame.cpp:905
 msgid "Substitute..."
 msgstr "Sustituir"
 
-#: ../src/wxMaximaFrame.cpp:1497
+#: ../src/wxMaximaFrame.cpp:1516
 msgid "Subsubsection"
 msgstr "Subsubsección"
 
@@ -4024,7 +4027,7 @@ msgstr "Subsubsección"
 msgid "Subsubsection cell"
 msgstr "Celda de subsubsección"
 
-#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4226
+#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4238
 msgid "Sum"
 msgstr "Suma"
 
@@ -4032,36 +4035,36 @@ msgstr "Suma"
 msgid "Sum sign"
 msgstr "Símbolo de suma"
 
-#: ../src/wxMaximaFrame.cpp:553
+#: ../src/wxMaximaFrame.cpp:552
 msgid "Symbols\tAlt-Shift-Y"
 msgstr "Símbolos\tAlt-Shift-Y"
 
-#: ../src/wxMaxima.cpp:4456
+#: ../src/wxMaxima.cpp:4468
 msgid "System info"
 msgstr "Información del sistema"
 
-#: ../src/wxMaximaFrame.cpp:320
+#: ../src/wxMaximaFrame.cpp:319
 msgid "Table of Contents"
 msgstr "Tabla de contenido"
 
-#: ../src/wxMaximaFrame.cpp:556
+#: ../src/wxMaximaFrame.cpp:555
 #, fuzzy
 msgid "Table of Contents\tAlt-Shift-T"
 msgstr "Tabla de contenidos\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:1382
+#: ../src/wxMaximaFrame.cpp:1381
 msgid "Tau"
 msgstr "Tau"
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Taylor series:"
 msgstr "Serie de Taylor:"
 
-#: ../src/wxMaxima.cpp:3963
+#: ../src/wxMaxima.cpp:3975
 msgid "Tellrat"
 msgstr "Tellrat"
 
-#: ../src/wxMaximaFrame.cpp:1494
+#: ../src/wxMaximaFrame.cpp:1513
 msgid "Text"
 msgstr "Texto"
 
@@ -4110,7 +4113,7 @@ msgstr ""
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr "La clase de documento que utilizará LaTeX para nuestros documentos."
 
-#: ../src/TextCell.cpp:136
+#: ../src/TextCell.cpp:134
 msgid ""
 "The letter \"X\" is of width zero. Installing http://www.math.union.edu/"
 "~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts\" in "
@@ -4130,7 +4133,7 @@ msgstr ""
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:959
+#: ../src/wxMaximaFrame.cpp:958
 msgid "The offline manual of maxima"
 msgstr "Manual de Maxima fuera de línea"
 
@@ -4169,7 +4172,7 @@ msgstr ""
 "andrejv.github.com/wxmaxima/help.html para más información sobre cómo "
 "utilizar wxMaxima y Maxima."
 
-#: ../src/SlideShowCell.cpp:332
+#: ../src/SlideShowCell.cpp:336
 msgid ""
 "There was an error during GIF export!\n"
 "\n"
@@ -4180,7 +4183,7 @@ msgstr ""
 "Asegúrese que ImageMagick está instalado y que wxMaxima tiene acceso al "
 "programa convert."
 
-#: ../src/wxMaxima.cpp:442
+#: ../src/wxMaxima.cpp:447
 msgid ""
 "There was an error in generated XML!\n"
 "\n"
@@ -4190,7 +4193,7 @@ msgstr ""
 "\n"
 "Por favor, informe de ésto como un error."
 
-#: ../src/wxMaximaFrame.cpp:1371
+#: ../src/wxMaximaFrame.cpp:1370
 msgid "Theta"
 msgstr "Theta"
 
@@ -4198,7 +4201,7 @@ msgstr "Theta"
 msgid "Ticks:"
 msgstr "Graduaciones:"
 
-#: ../src/wxMaxima.cpp:4153 ../src/wxMaxima.cpp:5065
+#: ../src/wxMaxima.cpp:4165 ../src/wxMaxima.cpp:5077
 msgid "Times:"
 msgstr "Veces:"
 
@@ -4206,7 +4209,7 @@ msgstr "Veces:"
 msgid "Tips not available, sorry!"
 msgstr "Sugerencia no disponible, lo sentimos"
 
-#: ../src/wxMaximaFrame.cpp:1495
+#: ../src/wxMaximaFrame.cpp:1514
 msgid "Title"
 msgstr "Título"
 
@@ -4225,19 +4228,19 @@ msgstr ""
 "cuadrado contiguo a la celda. Si al mismo tiempo se pulsa 'Mayúsculas', "
 "todas los subniveles serán plegados/desplegados."
 
-#: ../src/wxMaximaFrame.cpp:938
+#: ../src/wxMaximaFrame.cpp:937
 msgid "To &Bigfloat"
 msgstr "A real grande (&bigfloat)"
 
-#: ../src/wxMaximaFrame.cpp:935
+#: ../src/wxMaximaFrame.cpp:934
 msgid "To &Float"
 msgstr "A &real"
 
-#: ../src/MathCtrl.cpp:990
+#: ../src/MathCtrl.cpp:1032
 msgid "To Float"
 msgstr "A real"
 
-#: ../src/wxMaximaFrame.cpp:941
+#: ../src/wxMaximaFrame.cpp:940
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr "A numérico\tCtrl+Shift+N"
 
@@ -4279,51 +4282,51 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:41 ../src/Plot2dWiz.cpp:40 ../src/Plot2dWiz.cpp:50
 #: ../src/Plot2dWiz.cpp:539 ../src/Plot3dWiz.cpp:39 ../src/Plot3dWiz.cpp:48
-#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4241
+#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4253
 msgid "To:"
 msgstr "Hasta:"
 
-#: ../src/wxMaximaFrame.cpp:912
+#: ../src/wxMaximaFrame.cpp:911
 msgid "Toggle &Algebraic Flag"
 msgstr "Conmutar álge&bra"
 
-#: ../src/wxMaximaFrame.cpp:933
+#: ../src/wxMaximaFrame.cpp:932
 msgid "Toggle &Numeric Output"
 msgstr "Conmutar salida &numérica"
 
-#: ../src/wxMaximaFrame.cpp:673
+#: ../src/wxMaximaFrame.cpp:672
 msgid "Toggle &Time Display"
 msgstr "Conmutar pantalla de &tiempo"
 
-#: ../src/wxMaximaFrame.cpp:913
+#: ../src/wxMaximaFrame.cpp:912
 msgid "Toggle algebraic flag"
 msgstr "Conmutar álge&bra"
 
-#: ../src/wxMaximaFrame.cpp:577
+#: ../src/wxMaximaFrame.cpp:576
 msgid "Toggle full screen editing"
 msgstr "Conmutar edición de pantalla completa"
 
-#: ../src/wxMaximaFrame.cpp:934
+#: ../src/wxMaximaFrame.cpp:933
 msgid "Toggle numeric output"
 msgstr "Conmutar salida numérica"
 
-#: ../src/wxMaxima.cpp:4464
+#: ../src/wxMaxima.cpp:4476
 msgid "Toolbar icons"
 msgstr "Iconos de la barra de herramientas"
 
-#: ../src/wxMaxima.cpp:4465
+#: ../src/wxMaxima.cpp:4477
 msgid "Translated by"
 msgstr "Traducido por"
 
-#: ../src/wxMaximaFrame.cpp:763
+#: ../src/wxMaximaFrame.cpp:762
 msgid "Transpose a matrix"
 msgstr "Trasponer una matriz"
 
-#: ../src/MathCtrl.cpp:5834
+#: ../src/MathCtrl.cpp:5886
 msgid "Trying to undo an action without starting cell."
 msgstr "Intentando deshacer una acción sin celda de comienzo."
 
-#: ../src/MathCtrl.cpp:5901
+#: ../src/MathCtrl.cpp:5953
 msgid "Trying to undo something but the undo action is empty."
 msgstr "Intentando deshacer una acción que no existe."
 
@@ -4331,11 +4334,11 @@ msgstr "Intentando deshacer una acción que no existe."
 msgid "Turkish"
 msgstr "Turco"
 
-#: ../src/wxMaximaFrame.cpp:970
+#: ../src/wxMaximaFrame.cpp:969
 msgid "Tutorials"
 msgstr "&Tutoriales"
 
-#: ../src/wxMaxima.cpp:4778
+#: ../src/wxMaxima.cpp:4790
 msgid "Two sample t-test"
 msgstr "Test t de dos muestras"
 
@@ -4347,15 +4350,15 @@ msgstr "Tipo:"
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: ../src/wxMaxima.cpp:5356
+#: ../src/wxMaxima.cpp:5372
 msgid "Un-closed parenthesis"
 msgstr "Paréntesis no cerrado"
 
-#: ../src/wxMaxima.cpp:5323
+#: ../src/wxMaxima.cpp:5335
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr "Paréntesis mal pareado o ha escrito ; o $ antes de tiempo"
 
-#: ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5889
 msgid ""
 "Unable to interpret the version info I got from http://andrejv.github.io//"
 "wxmaxima/version.txt: "
@@ -4372,11 +4375,11 @@ msgstr "Subrayado"
 msgid "Underscore converts to subscripts:"
 msgstr "Guión bajo convierte a subíndices"
 
-#: ../src/wxMaximaFrame.cpp:492
+#: ../src/wxMaximaFrame.cpp:491
 msgid "Undo\tCtrl-Z"
 msgstr "D&eshacer\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:493
+#: ../src/wxMaximaFrame.cpp:492
 msgid "Undo last change"
 msgstr "Deshacer último cambio"
 
@@ -4385,23 +4388,23 @@ msgstr "Deshacer último cambio"
 msgid "Undo limit (0 for none):"
 msgstr "Límite de deshacer (0 para ninguno)"
 
-#: ../src/wxMaximaFrame.cpp:625
+#: ../src/wxMaximaFrame.cpp:624
 msgid "Unfold All\tCtrl-Alt-]"
 msgstr "Desplegar todo\tCtrl-Alt-]"
 
-#: ../src/wxMaximaFrame.cpp:626
+#: ../src/wxMaximaFrame.cpp:625
 msgid "Unfold all folded sections"
 msgstr "Desplegar todas las secciones"
 
-#: ../src/wxMaxima.cpp:4458
+#: ../src/wxMaxima.cpp:4470
 msgid "Unicode Support"
 msgstr "Soporte Unicode"
 
-#: ../src/wxMaxima.cpp:5335
+#: ../src/wxMaxima.cpp:5347
 msgid "Unterminated comment."
 msgstr "Comentario sin terminar"
 
-#: ../src/wxMaxima.cpp:5309
+#: ../src/wxMaxima.cpp:5321
 msgid "Unterminated string."
 msgstr "Cadena de texto sin terminar."
 
@@ -4409,15 +4412,15 @@ msgstr "Cadena de texto sin terminar."
 msgid "Up"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5859 ../src/wxMaxima.cpp:5866 ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5874 ../src/wxMaxima.cpp:5881 ../src/wxMaxima.cpp:5889
 msgid "Upgrade"
 msgstr "Actualizar"
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Upper bound:"
 msgstr "Cota superior:"
 
-#: ../src/wxMaximaFrame.cpp:1383
+#: ../src/wxMaximaFrame.cpp:1382
 #, fuzzy
 msgid "Upsilon"
 msgstr "Épsilon"
@@ -4465,22 +4468,22 @@ msgstr ""
 msgid "User-defined labels"
 msgstr "Etiquetas definidas por el usuario"
 
-#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3525
-#: ../src/wxMaxima.cpp:3541 ../src/wxMaxima.cpp:3649
+#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3537
+#: ../src/wxMaxima.cpp:3553 ../src/wxMaxima.cpp:3661
 msgid "Value:"
 msgstr "Valor:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:5019 ../src/wxMaxima.cpp:5064
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:5031 ../src/wxMaxima.cpp:5076
 msgid "Variable(s):"
 msgstr "Incógnita(s):"
 
 #: ../src/IntegrateWiz.cpp:33 ../src/LimitWiz.cpp:30 ../src/Plot2dWiz.cpp:34
 #: ../src/Plot2dWiz.cpp:44 ../src/Plot2dWiz.cpp:533 ../src/Plot3dWiz.cpp:33
 #: ../src/Plot3dWiz.cpp:42 ../src/SeriesWiz.cpp:36 ../src/SumWiz.cpp:30
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3749
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3761
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5045
 msgid "Variable:"
 msgstr "Variable:"
 
@@ -4488,25 +4491,25 @@ msgstr "Variable:"
 msgid "Variables"
 msgstr "Variables"
 
-#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3571 ../src/wxMaxima.cpp:4206
-#: ../src/wxMaxima.cpp:4807
+#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3583 ../src/wxMaxima.cpp:4218
+#: ../src/wxMaxima.cpp:4819
 msgid "Variables:"
 msgstr "Variables:"
 
-#: ../src/wxMaximaFrame.cpp:1257
+#: ../src/wxMaximaFrame.cpp:1256
 msgid "Variance..."
 msgstr "Varianza"
 
-#: ../src/wxMaximaFrame.cpp:580
+#: ../src/wxMaximaFrame.cpp:579
 msgid "View"
 msgstr "Ver"
 
-#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1674 ../src/wxMaxima.cpp:1769
-#: ../src/wxMaxima.cpp:1950
+#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1679 ../src/wxMaxima.cpp:1774
+#: ../src/wxMaxima.cpp:1955
 msgid "Warning"
 msgstr "Aviso"
 
-#: ../src/wxMaximaFrame.cpp:109 ../src/wxMaximaFrame.cpp:295
+#: ../src/wxMaximaFrame.cpp:108 ../src/wxMaximaFrame.cpp:294
 msgid "Welcome to wxMaxima"
 msgstr "Bienvenido a wxMaxima"
 
@@ -4532,7 +4535,7 @@ msgstr ""
 "puntos que en la hoja de trabajo. Si la opción no se activa, los saltos de "
 "línea se pueden hacer manualmente introduciendo una línea en blanco."
 
-#: ../src/wxMaxima.cpp:2567
+#: ../src/wxMaxima.cpp:2574
 #, fuzzy
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) "
@@ -4551,7 +4554,7 @@ msgstr ""
 "Envuelve ecuaciones exportadas con \"copiar como LaTeX\" entre \\[ and \\] "
 "como marcadores de ecuaciones"
 
-#: ../src/MathCtrl.cpp:6798
+#: ../src/MathCtrl.cpp:6856
 msgid "Wrapped search"
 msgstr ""
 
@@ -4559,15 +4562,15 @@ msgstr ""
 msgid "Write matching parenthesis in text controls."
 msgstr "Escribir paréntesis coincidentes en los controles de texto."
 
-#: ../src/wxMaxima.cpp:4461
+#: ../src/wxMaxima.cpp:4473
 msgid "Written by"
 msgstr "Escrito por"
 
-#: ../src/wxMaximaFrame.cpp:557
+#: ../src/wxMaximaFrame.cpp:556
 msgid "XML Inspector"
 msgstr "Inspector XML"
 
-#: ../src/wxMaximaFrame.cpp:1377
+#: ../src/wxMaximaFrame.cpp:1376
 msgid "Xi"
 msgstr "Xi"
 
@@ -4639,7 +4642,7 @@ msgstr ""
 "horizontal, para luego operar sobre la selección. Esto será útil cuando se "
 "quieran borrar o evaluar varias celdas a un tiempo."
 
-#: ../src/wxMaxima.cpp:5856
+#: ../src/wxMaxima.cpp:5871
 #, c-format
 msgid ""
 "You have version %s. Current version is %s.\n"
@@ -4650,39 +4653,39 @@ msgstr ""
 "\n"
 "Selecciónese OK para acceder a la página de wxMaxima."
 
-#: ../src/wxMaxima.cpp:5921
+#: ../src/wxMaxima.cpp:5936
 msgid "Your changes will be lost if you don't save them."
 msgstr "Se perderán los cambios si no se guardan."
 
-#: ../src/wxMaxima.cpp:5866
+#: ../src/wxMaxima.cpp:5881
 msgid "Your version of wxMaxima is up to date."
 msgstr "La versión de wxMaxima está actualizada"
 
-#: ../src/wxMaximaFrame.cpp:1369
+#: ../src/wxMaximaFrame.cpp:1368
 msgid "Zeta"
 msgstr "Zeta"
 
-#: ../src/wxMaximaFrame.cpp:562
+#: ../src/wxMaximaFrame.cpp:561
 msgid "Zoom &In\tCtrl-+"
 msgstr "Ampliar\tCtrl-+"
 
-#: ../src/wxMaximaFrame.cpp:564
+#: ../src/wxMaximaFrame.cpp:563
 msgid "Zoom Ou&t\tCtrl--"
 msgstr "Disminuir\tCtrl--"
 
-#: ../src/wxMaximaFrame.cpp:563
+#: ../src/wxMaximaFrame.cpp:562
 msgid "Zoom in 10%"
 msgstr "Disminuir 10%"
 
-#: ../src/wxMaximaFrame.cpp:565
+#: ../src/wxMaximaFrame.cpp:564
 msgid "Zoom out 10%"
 msgstr "Ampliar 10%"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaximaFrame.cpp:287
 msgid "[ unsaved ]"
 msgstr "[no guardado]"
 
-#: ../src/wxMaxima.cpp:5700
+#: ../src/wxMaxima.cpp:5715
 msgid "[ unsaved* ]"
 msgstr "[no guardado*]"
 
@@ -4691,17 +4694,17 @@ msgstr "[no guardado*]"
 msgid "[%i digits]"
 msgstr "[%i dígitos]"
 
-#: ../src/MathCtrl.cpp:4392
+#: ../src/MathCtrl.cpp:4447
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" style=\"max-width:90%%;\" >\n"
 msgstr "_%d.gif\"  alt=\"Diagrama animado\" style=\"max-width:90%%;\" >\n"
 
-#: ../src/MathCtrl.cpp:4517
+#: ../src/MathCtrl.cpp:4572
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" >"
 msgstr "_%d.gif\" alt=\"Diagrama animado\" style=\"max-width:90%%;\" >"
 
-#: ../src/wxMaximaFrame.cpp:1333
+#: ../src/wxMaximaFrame.cpp:1332
 msgid "alpha"
 msgstr "alfa"
 
@@ -4713,7 +4716,7 @@ msgstr "and"
 msgid "antisymmetric"
 msgstr "antisimétrica"
 
-#: ../src/wxMaximaFrame.cpp:1334
+#: ../src/wxMaximaFrame.cpp:1333
 msgid "beta"
 msgstr "beta"
 
@@ -4757,7 +4760,7 @@ msgstr ""
 msgid "bug:Invalid sup tag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1354
+#: ../src/wxMaximaFrame.cpp:1353
 msgid "chi"
 msgstr "ji"
 
@@ -4770,7 +4773,7 @@ msgstr "elija el entorno Lisp con el se compiló Maxima"
 msgid "default"
 msgstr "predeterminado"
 
-#: ../src/wxMaximaFrame.cpp:1336
+#: ../src/wxMaximaFrame.cpp:1335
 msgid "delta"
 msgstr "delta"
 
@@ -4782,7 +4785,7 @@ msgstr "diagonal"
 msgid "empty"
 msgstr "vacío"
 
-#: ../src/wxMaximaFrame.cpp:1337
+#: ../src/wxMaximaFrame.cpp:1336
 msgid "epsilon"
 msgstr "épsilon"
 
@@ -4790,7 +4793,7 @@ msgstr "épsilon"
 msgid "equivalent"
 msgstr "equivalente"
 
-#: ../src/wxMaximaFrame.cpp:1339
+#: ../src/wxMaximaFrame.cpp:1338
 msgid "eta"
 msgstr "eta"
 
@@ -4810,7 +4813,7 @@ msgstr ""
 "números o letras sencillas\n"
 "all=_ marca subíndices."
 
-#: ../src/wxMaximaFrame.cpp:1335
+#: ../src/wxMaximaFrame.cpp:1334
 msgid "gamma"
 msgstr "gamma"
 
@@ -4836,15 +4839,15 @@ msgstr "en línea"
 msgid "intersection"
 msgstr "intersección"
 
-#: ../src/wxMaximaFrame.cpp:1341
+#: ../src/wxMaximaFrame.cpp:1340
 msgid "iota"
 msgstr "iota"
 
-#: ../src/wxMaximaFrame.cpp:1342
+#: ../src/wxMaximaFrame.cpp:1341
 msgid "kappa"
 msgstr "kappa"
 
-#: ../src/wxMaximaFrame.cpp:1343
+#: ../src/wxMaximaFrame.cpp:1342
 msgid "lambda"
 msgstr "lambda"
 
@@ -4860,7 +4863,7 @@ msgstr "menor o igual"
 msgid "logscale"
 msgstr "escala logarítmica"
 
-#: ../src/wxMaxima.cpp:3783
+#: ../src/wxMaxima.cpp:3795
 msgid "matrix[i,j]:"
 msgstr "matriz[i,j]:"
 
@@ -4868,7 +4871,7 @@ msgstr "matriz[i,j]:"
 msgid "maxima's pwd is path to document"
 msgstr "El pwd de Maxima es la ruta al documento"
 
-#: ../src/wxMaximaFrame.cpp:1344
+#: ../src/wxMaximaFrame.cpp:1343
 msgid "mu"
 msgstr ""
 
@@ -4884,7 +4887,7 @@ msgstr "mucho menor que"
 msgid "nand"
 msgstr "nand"
 
-#: ../src/wxMaxima.cpp:4524
+#: ../src/wxMaxima.cpp:4536
 msgid "no"
 msgstr "no"
 
@@ -4908,15 +4911,15 @@ msgstr "no subconjunto"
 msgid "not subset or equal"
 msgstr "no subconjunto o igual"
 
-#: ../src/wxMaximaFrame.cpp:1345
+#: ../src/wxMaximaFrame.cpp:1344
 msgid "nu"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1356
+#: ../src/wxMaximaFrame.cpp:1355
 msgid "omega"
 msgstr "omega"
 
-#: ../src/wxMaximaFrame.cpp:1347
+#: ../src/wxMaximaFrame.cpp:1346
 msgid "omicron"
 msgstr ""
 
@@ -4928,11 +4931,11 @@ msgstr "or"
 msgid "partial sign"
 msgstr "símbolo parcial"
 
-#: ../src/wxMaximaFrame.cpp:1353
+#: ../src/wxMaximaFrame.cpp:1352
 msgid "phi"
 msgstr "fi"
 
-#: ../src/wxMaximaFrame.cpp:1348
+#: ../src/wxMaximaFrame.cpp:1347
 msgid "pi"
 msgstr "pi"
 
@@ -4944,11 +4947,11 @@ msgstr ""
 msgid "proportional to"
 msgstr "proporcional a"
 
-#: ../src/wxMaximaFrame.cpp:1355
+#: ../src/wxMaximaFrame.cpp:1354
 msgid "psi"
 msgstr "psi"
 
-#: ../src/wxMaximaFrame.cpp:1349
+#: ../src/wxMaximaFrame.cpp:1348
 msgid "rho"
 msgstr "ro"
 
@@ -4956,7 +4959,7 @@ msgstr "ro"
 msgid "right"
 msgstr "derecha"
 
-#: ../src/wxMaximaFrame.cpp:1350
+#: ../src/wxMaximaFrame.cpp:1349
 msgid "sigma"
 msgstr "sigma"
 
@@ -4976,7 +4979,7 @@ msgstr "subconjunto o igual"
 msgid "symmetric"
 msgstr "simétrica"
 
-#: ../src/wxMaximaFrame.cpp:1351
+#: ../src/wxMaximaFrame.cpp:1350
 msgid "tau"
 msgstr "tau"
 
@@ -4989,7 +4992,7 @@ msgstr "Indicar a sbcl que utilice <n>Megabytes de pila "
 msgid "there is no"
 msgstr "no hay"
 
-#: ../src/wxMaximaFrame.cpp:1340
+#: ../src/wxMaximaFrame.cpp:1339
 msgid "theta"
 msgstr "theta"
 
@@ -5005,12 +5008,12 @@ msgstr "a la tercera potencia"
 msgid "union"
 msgstr "unión"
 
-#: ../src/wxMaxima.cpp:5903
+#: ../src/wxMaxima.cpp:5918
 msgid "unsaved"
 msgstr "no guardado"
 
-#: ../src/wxMaximaFrame.cpp:290 ../src/wxMaxima.cpp:2559
-#: ../src/wxMaxima.cpp:2826
+#: ../src/wxMaxima.cpp:2566 ../src/wxMaxima.cpp:2834
+#: ../src/wxMaximaFrame.cpp:289
 msgid "untitled"
 msgstr "sin nombre"
 
@@ -5019,26 +5022,26 @@ msgstr "sin nombre"
 msgid "untitled %d"
 msgstr "sin título %d"
 
-#: ../src/wxMaximaFrame.cpp:1352
+#: ../src/wxMaximaFrame.cpp:1351
 #, fuzzy
 msgid "upsilon"
 msgstr "Épsilon"
 
-#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4538
+#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4550
 msgid "wxMaxima"
 msgstr "wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
-#: ../src/wxMaxima.cpp:5700 ../src/wxMaxima.cpp:5709 ../src/wxMaxima.cpp:5712
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaxima.cpp:5715 ../src/wxMaxima.cpp:5724
+#: ../src/wxMaxima.cpp:5727 ../src/wxMaximaFrame.cpp:287
 #, c-format
 msgid "wxMaxima %s "
 msgstr "wxMaxima %s "
 
-#: ../src/wxMaximaFrame.cpp:952
+#: ../src/wxMaximaFrame.cpp:951
 msgid "wxMaxima &Help\tCtrl+?"
 msgstr "Ayuda de wxMaxima\tCtrl+?"
 
-#: ../src/wxMaximaFrame.cpp:955
+#: ../src/wxMaximaFrame.cpp:954
 msgid "wxMaxima &Help\tF1"
 msgstr "A&yuda de Maxima\tF1"
 
@@ -5053,11 +5056,11 @@ msgstr ""
 "wxmaxima.rc del directorio cuya ruta se almacena en la variable global "
 "maxima_userdir"
 
-#: ../src/wxMaxima.cpp:1619
+#: ../src/wxMaxima.cpp:1624
 msgid "wxMaxima cannot open content.xml in the .wxmx zip archive "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1633
+#: ../src/wxMaxima.cpp:1638
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
@@ -5065,7 +5068,7 @@ msgstr ""
 msgid "wxMaxima configuration"
 msgstr "Configuración de wxMaxima"
 
-#: ../src/wxMaxima.cpp:1947
+#: ../src/wxMaxima.cpp:1952
 msgid ""
 "wxMaxima could not find Maxima!\n"
 "\n"
@@ -5077,7 +5080,7 @@ msgstr ""
 "Configure wxMaxima con 'Editar->Configurar.\n"
 "A continuación inicie Maxima con 'Maxima->Reiniciar maxima'."
 
-#: ../src/wxMaxima.cpp:2204
+#: ../src/wxMaxima.cpp:2209
 msgid ""
 "wxMaxima could not find help files.\n"
 "\n"
@@ -5086,7 +5089,7 @@ msgstr ""
 "wxMaxima no pudo encontrar los archivos de ayuda.\n"
 "Compruebe su instalación."
 
-#: ../src/wxMaxima.cpp:2032
+#: ../src/wxMaxima.cpp:2037
 msgid ""
 "wxMaxima could not find tip files.\n"
 "\n"
@@ -5096,7 +5099,7 @@ msgstr ""
 "\n"
 "Compruebe su instalación."
 
-#: ../src/wxMaxima.cpp:282
+#: ../src/wxMaxima.cpp:283
 msgid ""
 "wxMaxima could not start the server.\n"
 "\n"
@@ -5118,23 +5121,23 @@ msgstr ""
 "de las cuales es '%'. Si ha hecho una selección en el documento, ésta será "
 "utilizada en lugar de '%'."
 
-#: ../src/wxMaxima.cpp:2330
+#: ../src/wxMaxima.cpp:2336
 msgid "wxMaxima document"
 msgstr "Documento wxMaxima"
 
-#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2799
+#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2807
 msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 msgstr "Documento wxMaxima (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 
-#: ../src/wxMaxima.cpp:1455 ../src/wxMaxima.cpp:1469
+#: ../src/wxMaxima.cpp:1460 ../src/wxMaxima.cpp:1474
 msgid "wxMaxima encountered an error loading "
 msgstr "wxMaxima encontró un error durante la carga "
 
-#: ../src/wxMaxima.cpp:4463
+#: ../src/wxMaxima.cpp:4475
 msgid "wxMaxima icon"
 msgstr "Icono de wxMaxima"
 
-#: ../src/wxMaxima.cpp:4455
+#: ../src/wxMaxima.cpp:4467
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "MAXIMA based on wxWidgets."
@@ -5142,7 +5145,7 @@ msgstr ""
 "wxMaxima es una interface gráfica de usuario para el Sistema de Álgebra "
 "Simbólica (CAS) Maxima, basado en wxWidgets."
 
-#: ../src/wxMaxima.cpp:4516
+#: ../src/wxMaxima.cpp:4528
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "Maxima based on wxWidgets."
@@ -5162,11 +5165,11 @@ msgstr ""
 msgid "x"
 msgstr "x"
 
-#: ../src/wxMaximaFrame.cpp:1346
+#: ../src/wxMaximaFrame.cpp:1345
 msgid "xi"
 msgstr "xi"
 
-#: ../src/wxMaxima.cpp:1643
+#: ../src/wxMaxima.cpp:1648
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
@@ -5174,11 +5177,11 @@ msgstr ""
 msgid "xor"
 msgstr "o exclusivo"
 
-#: ../src/wxMaxima.cpp:4522
+#: ../src/wxMaxima.cpp:4534
 msgid "yes"
 msgstr "sí"
 
-#: ../src/wxMaximaFrame.cpp:1338
+#: ../src/wxMaximaFrame.cpp:1337
 msgid "zeta"
 msgstr "zeta"
 

--- a/locales/fi.po
+++ b/locales/fi.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxmaxima\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-07 21:42+0200\n"
+"POT-Creation-Date: 2016-10-16 17:47+0900\n"
 "PO-Revision-Date: 2016-02-22 16:12-0500\n"
 "Last-Translator: kahkonen <mika.m.kahkonen@gmail.com>\n"
 "Language-Team: Finnish\n"
@@ -16,7 +16,7 @@ msgstr ""
 "X-Crowdin-Language: fi\n"
 "X-Crowdin-File: fi.po\n"
 
-#: ../src/wxMaxima.cpp:4519
+#: ../src/wxMaxima.cpp:4531
 #, c-format
 msgid ""
 "\n"
@@ -29,7 +29,7 @@ msgstr ""
 "wxWidgetit: %d.%d.%d\n"
 "Unicode-tuki: %s"
 
-#: ../src/wxMaxima.cpp:4532
+#: ../src/wxMaxima.cpp:4544
 msgid ""
 "\n"
 "Lisp: "
@@ -37,7 +37,7 @@ msgstr ""
 "\n"
 "Lisp: "
 
-#: ../src/wxMaxima.cpp:4528
+#: ../src/wxMaxima.cpp:4540
 msgid ""
 "\n"
 "Maxima version: "
@@ -45,7 +45,7 @@ msgstr ""
 "\n"
 "Maximan versio: "
 
-#: ../src/wxMaxima.cpp:5381
+#: ../src/wxMaxima.cpp:5397
 msgid ""
 "\n"
 "Not connected to Maxima!\n"
@@ -53,7 +53,7 @@ msgstr ""
 "\n"
 "Ei yhdistettynä Maximaan!\n"
 
-#: ../src/wxMaxima.cpp:4530
+#: ../src/wxMaxima.cpp:4542
 msgid ""
 "\n"
 "Not connected."
@@ -74,7 +74,7 @@ msgstr "      -l <nimi>"
 msgid " (Graphics) "
 msgstr " (Grafiikat) "
 
-#: ../src/EditorCell.cpp:3045 ../src/EditorCell.cpp:3227
+#: ../src/EditorCell.cpp:3088 ../src/EditorCell.cpp:3270
 #, c-format
 msgid " ... + %i hidden lines"
 msgstr ""
@@ -86,7 +86,7 @@ msgstr ""
 "...[piilotettu lisärivejä sillä tuloste on pidempi kuin asetuksissa "
 "sallitaan] "
 
-#: ../src/wxMaxima.cpp:1673
+#: ../src/wxMaxima.cpp:1678
 msgid ""
 " was saved using a newer version of wxMaxima so it may not load correctly. "
 "Please update your wxMaxima."
@@ -94,7 +94,7 @@ msgstr ""
 " tallennettiin uudemmalla wxMaximan versiolla, joten se ei avautunut "
 "kunnolla. Päivitä wxMaximasi."
 
-#: ../src/wxMaxima.cpp:1665
+#: ../src/wxMaxima.cpp:1670
 msgid ""
 " was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr " tallennettiin uudemmalla wxMaximan versiolla. Päivitä wxMaximasi."
@@ -107,64 +107,64 @@ msgstr "\"Kopioi LaTeX\" lisää kaavamerkinnät"
 msgid "\"implies\" symbol"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:101
+#: ../src/wxMaximaFrame.cpp:100
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr "%i solua arviointijonossa"
 
-#: ../src/wxMaximaFrame.cpp:773
+#: ../src/wxMaximaFrame.cpp:772
 msgid "&Algebra"
 msgstr "&Algebra "
 
-#: ../src/wxMaximaFrame.cpp:767
+#: ../src/wxMaximaFrame.cpp:766
 msgid "&Apply to List..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:964
+#: ../src/wxMaximaFrame.cpp:963
 msgid "&Apropos..."
 msgstr "&Etsi merkkijono..."
 
-#: ../src/wxMaximaFrame.cpp:478
+#: ../src/wxMaximaFrame.cpp:477
 msgid "&Batch File...\tCtrl-B"
 msgstr "&Komentojonotiedosto...\tCtrl-B"
 
-#: ../src/wxMaximaFrame.cpp:724
+#: ../src/wxMaximaFrame.cpp:723
 msgid "&Boundary Value Problem..."
 msgstr "&Raja-arvotehtävä"
 
-#: ../src/wxMaximaFrame.cpp:975
+#: ../src/wxMaximaFrame.cpp:974
 msgid "&Bug Report"
 msgstr "&Virheraportti"
 
-#: ../src/wxMaximaFrame.cpp:825
+#: ../src/wxMaximaFrame.cpp:824
 msgid "&Calculus"
 msgstr "&Analyysi"
 
-#: ../src/wxMaximaFrame.cpp:876
+#: ../src/wxMaximaFrame.cpp:875
 msgid "&Canonical Form"
 msgstr "&Kanoninen muoto"
 
-#: ../src/wxMaximaFrame.cpp:749
+#: ../src/wxMaximaFrame.cpp:748
 msgid "&Characteristic Polynomial..."
 msgstr "&Karakteristinen polynomi..."
 
-#: ../src/wxMaximaFrame.cpp:654
+#: ../src/wxMaximaFrame.cpp:653
 msgid "&Clear Memory"
 msgstr "&Tyhjennä muisti"
 
-#: ../src/wxMaximaFrame.cpp:859
+#: ../src/wxMaximaFrame.cpp:858
 msgid "&Combine Factorials"
 msgstr "&Yhdistä kertomat"
 
-#: ../src/wxMaximaFrame.cpp:902
+#: ../src/wxMaximaFrame.cpp:901
 msgid "&Complex Simplification"
 msgstr "&Kompleksi Sieventäminen"
 
-#: ../src/wxMaximaFrame.cpp:822
+#: ../src/wxMaximaFrame.cpp:821
 msgid "&Continued Fraction"
 msgstr "&Ketjumurtoluku"
 
-#: ../src/wxMaximaFrame.cpp:502
+#: ../src/wxMaximaFrame.cpp:501
 msgid "&Copy\tCtrl-C"
 msgstr "&Kopioi\tCtrl+C"
 
@@ -172,107 +172,107 @@ msgstr "&Kopioi\tCtrl+C"
 msgid "&Definite integration"
 msgstr "&Määrätty integraali"
 
-#: ../src/wxMaximaFrame.cpp:896
+#: ../src/wxMaximaFrame.cpp:895
 msgid "&Demoivre"
 msgstr "&Demoivre"
 
-#: ../src/wxMaximaFrame.cpp:752
+#: ../src/wxMaximaFrame.cpp:751
 msgid "&Determinant"
 msgstr "&Determinantti"
 
-#: ../src/wxMaximaFrame.cpp:785
+#: ../src/wxMaximaFrame.cpp:784
 msgid "&Differentiate..."
 msgstr "Derivoi..."
 
-#: ../src/wxMaximaFrame.cpp:543
+#: ../src/wxMaximaFrame.cpp:542
 msgid "&Edit"
 msgstr "&Muokkaa"
 
-#: ../src/wxMaximaFrame.cpp:709
+#: ../src/wxMaximaFrame.cpp:708
 msgid "&Eliminate Variable..."
 msgstr "&Poista muuttuja..."
 
-#: ../src/wxMaximaFrame.cpp:744
+#: ../src/wxMaximaFrame.cpp:743
 msgid "&Enter Matrix..."
 msgstr "&Syötä Matriisi..."
 
-#: ../src/wxMaximaFrame.cpp:961
+#: ../src/wxMaximaFrame.cpp:960
 msgid "&Example..."
 msgstr "&Esimerkki..."
 
-#: ../src/wxMaximaFrame.cpp:839
+#: ../src/wxMaximaFrame.cpp:838
 msgid "&Expand Expression"
 msgstr "&Laajenna lauseke"
 
-#: ../src/wxMaximaFrame.cpp:873
+#: ../src/wxMaximaFrame.cpp:872
 msgid "&Expand Trigonometric"
 msgstr "&Laajenna trigonometrinen"
 
-#: ../src/wxMaximaFrame.cpp:899
+#: ../src/wxMaximaFrame.cpp:898
 msgid "&Exponentialize"
 msgstr "&Muunna eksponenttimuotoon"
 
-#: ../src/wxMaximaFrame.cpp:480
+#: ../src/wxMaximaFrame.cpp:479
 msgid "&Export..."
 msgstr "&Vie..."
 
-#: ../src/wxMaximaFrame.cpp:834
+#: ../src/wxMaximaFrame.cpp:833
 msgid "&Factor Expression"
 msgstr "&Jaa tekijöihin"
 
-#: ../src/wxMaximaFrame.cpp:489
+#: ../src/wxMaximaFrame.cpp:488
 msgid "&File"
 msgstr "&Tiedosto"
 
-#: ../src/wxMaximaFrame.cpp:692
+#: ../src/wxMaximaFrame.cpp:691
 msgid "&Find Root..."
 msgstr "&Etsi juuri..."
 
-#: ../src/wxMaximaFrame.cpp:738
+#: ../src/wxMaximaFrame.cpp:737
 msgid "&Generate Matrix..."
 msgstr "&Luo matriisi..."
 
-#: ../src/wxMaximaFrame.cpp:809
+#: ../src/wxMaximaFrame.cpp:808
 msgid "&Greatest Common Divisor..."
 msgstr "&Suurin yhteinen tekijä"
 
-#: ../src/wxMaximaFrame.cpp:994
+#: ../src/wxMaximaFrame.cpp:993
 msgid "&Help"
 msgstr "O&hje"
 
-#: ../src/wxMaximaFrame.cpp:777
+#: ../src/wxMaximaFrame.cpp:776
 msgid "&Integrate..."
 msgstr "&Integroi..."
 
-#: ../src/wxMaximaFrame.cpp:645
+#: ../src/wxMaximaFrame.cpp:644
 msgid "&Interrupt\tCtrl-."
 msgstr "&Keskeytä\tCtrl-."
 
-#: ../src/wxMaximaFrame.cpp:649
+#: ../src/wxMaximaFrame.cpp:648
 msgid "&Interrupt\tCtrl-G"
 msgstr "&Keskeytä\tCtrl-G"
 
-#: ../src/wxMaximaFrame.cpp:746
+#: ../src/wxMaximaFrame.cpp:745
 msgid "&Invert Matrix"
 msgstr "&Käännä Matriisi"
 
-#: ../src/wxMaximaFrame.cpp:476
+#: ../src/wxMaximaFrame.cpp:475
 msgid "&Load Package...\tCtrl-L"
 msgstr "&Lataa Pakettu...\tCtrl-L"
 
-#: ../src/wxMaximaFrame.cpp:769
+#: ../src/wxMaximaFrame.cpp:768
 msgid "&Map to List(s)..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:684
+#: ../src/wxMaximaFrame.cpp:683
 msgid "&Maxima"
 msgstr "&Maxima"
 
-#: ../src/wxMaximaFrame.cpp:958
+#: ../src/wxMaximaFrame.cpp:957
 msgid "&Maxima help"
 msgstr "&Maximan ohje"
 
-#: ../src/wxMaximaFrame.cpp:917
+#: ../src/wxMaximaFrame.cpp:916
 msgid "&Modulus Computation..."
 msgstr "&Modulo-laskenta..."
 
@@ -280,7 +280,7 @@ msgstr "&Modulo-laskenta..."
 msgid "&New\tCtrl-N"
 msgstr "&Uusi\tCtrl+N"
 
-#: ../src/wxMaximaFrame.cpp:947
+#: ../src/wxMaximaFrame.cpp:946
 msgid "&Numeric"
 msgstr "&Numeerinen"
 
@@ -296,11 +296,11 @@ msgstr ""
 msgid "&Open\tCtrl-O"
 msgstr "&Avaa\tCtrl+O"
 
-#: ../src/wxMaximaFrame.cpp:463
+#: ../src/wxMaximaFrame.cpp:462
 msgid "&Open...\tCtrl-O"
 msgstr "&Avaa...\tCtrl+0"
 
-#: ../src/wxMaximaFrame.cpp:929
+#: ../src/wxMaximaFrame.cpp:928
 msgid "&Plot"
 msgstr "&Kuvaaja"
 
@@ -308,7 +308,7 @@ msgstr "&Kuvaaja"
 msgid "&Power series"
 msgstr "&Potenssisarja"
 
-#: ../src/wxMaximaFrame.cpp:483
+#: ../src/wxMaximaFrame.cpp:482
 msgid "&Print...\tCtrl-P"
 msgstr "&Tulosta...\tCtrl+P"
 
@@ -316,39 +316,39 @@ msgstr "&Tulosta...\tCtrl+P"
 msgid "&Rational"
 msgstr "&Rationaali"
 
-#: ../src/wxMaximaFrame.cpp:870
+#: ../src/wxMaximaFrame.cpp:869
 msgid "&Reduce Trigonometric"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "&Restart Maxima"
 msgstr "&Käynnistä Maxima uudelleen"
 
-#: ../src/wxMaximaFrame.cpp:700
+#: ../src/wxMaximaFrame.cpp:699
 msgid "&Roots of Polynomial (Real)"
 msgstr "&Polynomien juuret (Reaali)"
 
-#: ../src/wxMaximaFrame.cpp:472
+#: ../src/wxMaximaFrame.cpp:471
 msgid "&Save\tCtrl-S"
 msgstr "&Tallenna\tCtrl+S"
 
-#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:919
+#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:918
 msgid "&Simplify"
 msgstr "&Sievennä"
 
-#: ../src/wxMaximaFrame.cpp:829
+#: ../src/wxMaximaFrame.cpp:828
 msgid "&Simplify Expression"
 msgstr "&Sievennä lauseke"
 
-#: ../src/wxMaximaFrame.cpp:856
+#: ../src/wxMaximaFrame.cpp:855
 msgid "&Simplify Factorials"
 msgstr "&Sievennä kertomat"
 
-#: ../src/wxMaximaFrame.cpp:867
+#: ../src/wxMaximaFrame.cpp:866
 msgid "&Simplify Trigonometric"
 msgstr "&Sievennä trigonometriset"
 
-#: ../src/wxMaximaFrame.cpp:688
+#: ../src/wxMaximaFrame.cpp:687
 msgid "&Solve..."
 msgstr "&Ratkaise..."
 
@@ -360,11 +360,11 @@ msgstr ""
 msgid "&Taylor series"
 msgstr "&Taylorin sarja"
 
-#: ../src/wxMaximaFrame.cpp:762
+#: ../src/wxMaximaFrame.cpp:761
 msgid "&Transpose Matrix"
 msgstr "&Transponoi matriisi"
 
-#: ../src/wxMaximaFrame.cpp:879
+#: ../src/wxMaximaFrame.cpp:878
 msgid "&Trigonometric Simplification"
 msgstr "&Trigonometrinen sieventäminen"
 
@@ -382,7 +382,7 @@ msgstr "(Käytä oletuskieltä)"
 msgid "- Infinity"
 msgstr "- Ääretön"
 
-#: ../src/wxMaxima.cpp:351
+#: ../src/wxMaxima.cpp:356
 msgid ""
 "... [suppressed additional lines since the output is longer than allowed in "
 "the configuration] "
@@ -394,16 +394,16 @@ msgstr ""
 msgid "1/2"
 msgstr "1/2"
 
-#: ../src/wxMaximaFrame.cpp:103
+#: ../src/wxMaximaFrame.cpp:102
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4601
+#: ../src/wxMaxima.cpp:4613
 msgid "<br>Lisp: "
 msgstr "<br>Lisp: "
 
-#: ../src/wxMaxima.cpp:5487
+#: ../src/wxMaxima.cpp:5503
 msgid ""
 "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
@@ -436,11 +436,11 @@ msgid ""
 "\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1472
+#: ../src/wxMaximaFrame.cpp:1495
 msgid "A symbol from the configuration dialogue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:731
+#: ../src/wxMaximaFrame.cpp:730
 msgid "A&t Value..."
 msgstr "&Kohdassa..."
 
@@ -448,12 +448,12 @@ msgstr "&Kohdassa..."
 msgid "Abort evaluation on error"
 msgstr "Virhe"
 
-#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaxima.cpp:4603
+#: ../src/wxMaxima.cpp:4615 ../src/wxMaximaFrame.cpp:985
 msgid "About"
 msgstr "Tietoja"
 
-#: ../src/wxMaximaFrame.cpp:987 ../src/wxMaximaFrame.cpp:990
-#: ../src/wxMaximaFrame.cpp:991
+#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaximaFrame.cpp:989
+#: ../src/wxMaximaFrame.cpp:990
 msgid "About wxMaxima"
 msgstr "Tietoja wxMaximasta"
 
@@ -461,23 +461,23 @@ msgstr "Tietoja wxMaximasta"
 msgid "Active cell bracket"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:760
+#: ../src/wxMaximaFrame.cpp:759
 msgid "Ad&joint Matrix"
 msgstr "&Adjungoi matriisi"
 
-#: ../src/wxMaximaFrame.cpp:914
+#: ../src/wxMaximaFrame.cpp:913
 msgid "Add Algebraic E&quality..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:657
+#: ../src/wxMaximaFrame.cpp:656
 msgid "Add a directory to search path"
 msgstr "Lisää hakemisto hakupolkuun"
 
-#: ../src/wxMaxima.cpp:3353
+#: ../src/wxMaxima.cpp:3365
 msgid "Add dir to path:"
 msgstr "Lisää hakemisto polkuu:"
 
-#: ../src/wxMaximaFrame.cpp:915
+#: ../src/wxMaximaFrame.cpp:914
 msgid "Add equality to the rational simplifier"
 msgstr ""
 
@@ -485,7 +485,7 @@ msgstr ""
 msgid "Add the .wxmx file to the HTML export"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:656
+#: ../src/wxMaximaFrame.cpp:655
 msgid "Add to &Path..."
 msgstr "Lisää &Polkuun..."
 
@@ -524,27 +524,27 @@ msgstr "Kaikki muuttujanimet"
 msgid "All|*"
 msgstr "Kaikki | *"
 
-#: ../src/wxMaximaFrame.cpp:1364
+#: ../src/wxMaximaFrame.cpp:1363
 msgid "Alpha"
 msgstr "Alfa"
 
-#: ../src/wxMaxima.cpp:3838
+#: ../src/wxMaxima.cpp:3850
 msgid "Apply"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:768
+#: ../src/wxMaximaFrame.cpp:767
 msgid "Apply function to a list"
 msgstr "Sovella funktiota listaan"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Apropos"
 msgstr "Etsi merkkijono"
 
-#: ../src/wxMaxima.cpp:3764
+#: ../src/wxMaxima.cpp:3776
 msgid "Array:"
 msgstr "Taulukko:"
 
-#: ../src/wxMaxima.cpp:4462
+#: ../src/wxMaxima.cpp:4474
 msgid "Artwork by"
 msgstr "Kuvamateriaalin tehnyt"
 
@@ -552,7 +552,7 @@ msgstr "Kuvamateriaalin tehnyt"
 msgid "Ask to save untitled documents"
 msgstr "Ehdota nimettömien asiakirjojen tallentamista"
 
-#: ../src/wxMaxima.cpp:3650
+#: ../src/wxMaxima.cpp:3662
 msgid "At value"
 msgstr ""
 
@@ -574,11 +574,11 @@ msgstr ""
 msgid "Autosave interval (minutes, 0 means: off):"
 msgstr "Automaattitallennuksen väli (minuutteina, 0 tarkoittaa: off)"
 
-#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3557
+#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3569
 msgid "BC2"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1272
+#: ../src/wxMaximaFrame.cpp:1271
 msgid "Barsplot..."
 msgstr "Palkkikaavio..."
 
@@ -586,7 +586,7 @@ msgstr "Palkkikaavio..."
 msgid "Bat files (*.bat)|*.bat|All|*"
 msgstr "Bat-tiedostot (*.bat) | *.bat | Kaikki | *"
 
-#: ../src/wxMaxima.cpp:2943
+#: ../src/wxMaxima.cpp:2951
 msgid "Batch File"
 msgstr "Komentojonotiedosto"
 
@@ -599,7 +599,7 @@ msgid ""
 "cells."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1365
+#: ../src/wxMaximaFrame.cpp:1364
 msgid "Beta"
 msgstr "Beta"
 
@@ -611,11 +611,11 @@ msgstr ""
 msgid "Bold"
 msgstr "Lihavoi"
 
-#: ../src/wxMaxima.cpp:2359
+#: ../src/wxMaxima.cpp:2366
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1274
+#: ../src/wxMaximaFrame.cpp:1273
 msgid "Boxplot..."
 msgstr "Laatikkokaavio..."
 
@@ -627,15 +627,15 @@ msgstr "Selaa"
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2080
+#: ../src/MathCtrl.cpp:2127
 msgid "Bug: Cell left but not entered."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1178
+#: ../src/wxMaxima.cpp:1183
 msgid "Bug: Found a math end marker without any start marker."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1222
+#: ../src/wxMaxima.cpp:1227
 msgid "Bug: Found the end of autocompletion symbols but no beginning"
 msgstr ""
 
@@ -647,22 +647,22 @@ msgstr ""
 msgid "Bug: Fraction without enumerator"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2312
+#: ../src/MathCtrl.cpp:2359
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr "Virhe: Kysymykselle ei ole vastaussolua"
 
-#: ../src/MathCtrl.cpp:5839
+#: ../src/MathCtrl.cpp:5891
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of "
 "the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5913
+#: ../src/MathCtrl.cpp:5965
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5882
+#: ../src/MathCtrl.cpp:5934
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
@@ -672,49 +672,49 @@ msgstr ""
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
 msgstr ""
 
-#: ../src/GroupCell.cpp:780 ../src/GroupCell.cpp:951
+#: ../src/GroupCell.cpp:781 ../src/GroupCell.cpp:952
 msgid "Bug: No image counter to write to!"
 msgstr ""
 
-#: ../src/AbsCell.cpp:193
+#: ../src/AbsCell.cpp:199
 msgid "Bug: No last cell in an absCell!"
 msgstr ""
 
-#: ../src/ConjugateCell.cpp:185
+#: ../src/ConjugateCell.cpp:194
 msgid "Bug: No last cell in an conjugateCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:471
+#: ../src/FracCell.cpp:472
 msgid "Bug: No last cell in an denominator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:267
+#: ../src/ExptCell.cpp:270
 msgid "Bug: No last cell in an exponent of an exptCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:459
+#: ../src/FracCell.cpp:460
 msgid "Bug: No last cell in an numerator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:257
+#: ../src/ExptCell.cpp:260
 msgid "Bug: No last cell in the base of an exptCell!"
 msgstr ""
 
-#: ../src/ParenCell.cpp:534
+#: ../src/ParenCell.cpp:535
 msgid "Bug: No last cell inside a parenthesis!"
 msgstr ""
 
-#: ../src/SqrtCell.cpp:312
+#: ../src/SqrtCell.cpp:317
 msgid "Bug: No last cell inside a square root!"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2123
+#: ../src/MathCtrl.cpp:2170
 msgid ""
 "Bug: Start or end of merging of subsequent editing actions was requested two "
 "times in a row."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2090
+#: ../src/MathCtrl.cpp:2137
 msgid "Bug: Text changed, but no active cell."
 msgstr ""
 
@@ -722,41 +722,41 @@ msgstr ""
 msgid "Bug: Trying to append NULL to a group cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:555
+#: ../src/MathCtrl.cpp:600
 msgid "Bug: Trying to append maxima's output to a cell outside the worksheet."
 msgstr ""
 "Virhe: Yrittää lisätä maximan tulosteen työkirjan ulkopuolella olevaan "
 "soluun."
 
-#: ../src/MathCtrl.cpp:2014
+#: ../src/MathCtrl.cpp:2061
 msgid ""
 "Bug: Trying to merge individual cell adds to a region in the undo buffer but "
 "there are other cells between them."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6522
+#: ../src/MathCtrl.cpp:6577
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2092
+#: ../src/MathCtrl.cpp:2139
 msgid "Bug: Trying to record a cell contents change without a cell."
 msgstr "Virhe: Yrittää tallentaa solun sisällön muutoksen ilman solua."
 
-#: ../src/MathCtrl.cpp:1495
+#: ../src/MathCtrl.cpp:1540
 msgid "Bug: Trying to select inside a cell without having a current cell"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5883
+#: ../src/MathCtrl.cpp:5935
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5844 ../src/MathCtrl.cpp:5918 ../src/MathCtrl.cpp:5952
+#: ../src/MathCtrl.cpp:5896 ../src/MathCtrl.cpp:5970 ../src/MathCtrl.cpp:6004
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:973
+#: ../src/wxMaximaFrame.cpp:972
 msgid "Build &Info"
 msgstr "Versio&tiedot"
 
@@ -773,51 +773,51 @@ msgstr ""
 "komennossa valitsemalla 'Enter laskee solut'. Valinta muuttaa näiden kahden "
 "keskeisen näppäinkomennon toiminnot ristiin. "
 
-#: ../src/wxMaximaFrame.cpp:782
+#: ../src/wxMaximaFrame.cpp:781
 msgid "C&hange Variable..."
 msgstr "&Vaihda muuttuja"
 
-#: ../src/wxMaximaFrame.cpp:540
+#: ../src/wxMaximaFrame.cpp:539
 msgid "C&onfigure"
 msgstr "&Määritä"
 
-#: ../src/wxMaximaFrame.cpp:801
+#: ../src/wxMaximaFrame.cpp:800
 msgid "Calculate &Product..."
 msgstr "Laske &tulo..."
 
-#: ../src/wxMaximaFrame.cpp:799
+#: ../src/wxMaximaFrame.cpp:798
 msgid "Calculate Su&m..."
 msgstr "Laske &summa..."
 
-#: ../src/wxMaximaFrame.cpp:939
+#: ../src/wxMaximaFrame.cpp:938
 msgid "Calculate bigfloat value of the last result"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:936
+#: ../src/wxMaximaFrame.cpp:935
 msgid "Calculate float value of the last result"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3971
+#: ../src/wxMaxima.cpp:3983
 msgid "Calculate modulus:"
 msgstr "Laske modulus:"
 
-#: ../src/wxMaximaFrame.cpp:942
+#: ../src/wxMaximaFrame.cpp:941
 msgid "Calculate numeric value of the last result"
 msgstr "Laske likiarvo edelliselle tulokselle"
 
-#: ../src/wxMaximaFrame.cpp:802
+#: ../src/wxMaximaFrame.cpp:801
 msgid "Calculate products"
 msgstr "Laske tulot"
 
-#: ../src/wxMaximaFrame.cpp:800
+#: ../src/wxMaximaFrame.cpp:799
 msgid "Calculate sums"
 msgstr "Laske summat"
 
-#: ../src/wxMaxima.cpp:5830
+#: ../src/wxMaxima.cpp:5845
 msgid "Can not connect to the web server."
 msgstr "Ei yhteyttä palvelimeen"
 
-#: ../src/wxMaxima.cpp:5881
+#: ../src/wxMaxima.cpp:5896
 msgid "Can not download version info."
 msgstr "Versiotiedon lataaminen ei onnistu"
 
@@ -833,15 +833,15 @@ msgstr "Versiotiedon lataaminen ei onnistu"
 #: ../src/PlotFormatWiz.cpp:48 ../src/SeriesWiz.cpp:49 ../src/SeriesWiz.cpp:51
 #: ../src/SubstituteWiz.cpp:41 ../src/SubstituteWiz.cpp:43 ../src/SumWiz.cpp:44
 #: ../src/SumWiz.cpp:46 ../src/SystemWiz.cpp:38 ../src/SystemWiz.cpp:40
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Cancel"
 msgstr "Peruuta"
 
-#: ../src/wxMaximaFrame.cpp:126 ../src/wxMaxima.cpp:932
+#: ../src/wxMaxima.cpp:937 ../src/wxMaximaFrame.cpp:125
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1217
+#: ../src/wxMaximaFrame.cpp:1216
 msgid "Canonical (tr)"
 msgstr "Kanoninen (tr)"
 
@@ -849,7 +849,7 @@ msgstr "Kanoninen (tr)"
 msgid "Catalan"
 msgstr "Katalaani"
 
-#: ../src/wxMaximaFrame.cpp:638
+#: ../src/wxMaximaFrame.cpp:637
 msgid "Ce&ll"
 msgstr "Solu"
 
@@ -857,39 +857,39 @@ msgstr "Solu"
 msgid "Cell bracket"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5261
+#: ../src/wxMaxima.cpp:5273
 msgid "Cell ends in a backslash"
 msgstr "Solu päättyy kenoviivaan"
 
-#: ../src/wxMaximaFrame.cpp:676
+#: ../src/wxMaximaFrame.cpp:675
 msgid "Change &2d Display"
 msgstr "Vaihda &2d Näyttö"
 
-#: ../src/wxMaximaFrame.cpp:677
+#: ../src/wxMaximaFrame.cpp:676
 msgid "Change the 2d display algorithm used to display math output"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3995
+#: ../src/wxMaxima.cpp:4007
 msgid "Change variable"
 msgstr "Vaihda muuttuja"
 
-#: ../src/wxMaximaFrame.cpp:783
+#: ../src/wxMaximaFrame.cpp:782
 msgid "Change variable in integral or sum"
 msgstr "Vaihda muuttujaa integroinnissa tai summaamisessa"
 
-#: ../src/wxMaxima.cpp:3751
+#: ../src/wxMaxima.cpp:3763
 msgid "Char poly"
 msgstr "Karakteristinen polynomi:"
 
-#: ../src/wxMaximaFrame.cpp:978
+#: ../src/wxMaximaFrame.cpp:977
 msgid "Check for Updates"
 msgstr "Tarkista päivitykset"
 
-#: ../src/wxMaximaFrame.cpp:979
+#: ../src/wxMaximaFrame.cpp:978
 msgid "Check if a newer version of wxMaxima/Maxima exist."
 msgstr "Tarkista, onko wxMaximasta/Maximasta uudempaa versiota."
 
-#: ../src/wxMaximaFrame.cpp:1385
+#: ../src/wxMaximaFrame.cpp:1384
 msgid "Chi"
 msgstr "Khii"
 
@@ -910,15 +910,15 @@ msgstr "Valitse fontti"
 msgid "Choose new plot format:"
 msgstr "Valitse uusi kuvaajalaji:"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710
 msgid "Classes:"
 msgstr "Luokat:"
 
-#: ../src/wxMaximaFrame.cpp:469
+#: ../src/wxMaximaFrame.cpp:468
 msgid "Close\tCtrl-W"
 msgstr "Sulje\tCtrl+W"
 
-#: ../src/wxMaximaFrame.cpp:470
+#: ../src/wxMaximaFrame.cpp:469
 msgid "Close window"
 msgstr "Sulkee ikkunan"
 
@@ -950,19 +950,19 @@ msgstr "Koodin korostus: Merkkijonot"
 msgid "Code highlighting: Variables"
 msgstr "Koodin korotus: Muuttujat"
 
-#: ../src/wxMaxima.cpp:4806
+#: ../src/wxMaxima.cpp:4818
 msgid "Col. names:"
 msgstr "Sarakkeiden nimet:"
 
-#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Columns:"
 msgstr "Sarakkeet:"
 
-#: ../src/wxMaximaFrame.cpp:860
+#: ../src/wxMaximaFrame.cpp:859
 msgid "Combine factorials in an expression"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5293
+#: ../src/wxMaxima.cpp:5305
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
@@ -974,23 +974,23 @@ msgstr "Pilkuilla erotetut x-koordinaatit"
 msgid "Comma separated y coordinates"
 msgstr "Pilkuilla erotetut y-koordinaatit"
 
-#: ../src/MathCtrl.cpp:1030
+#: ../src/MathCtrl.cpp:1072
 msgid "Comment Selection"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:533
+#: ../src/wxMaximaFrame.cpp:532
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:532
+#: ../src/wxMaximaFrame.cpp:531
 msgid "Comment selection\tCtrl-/"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:601
+#: ../src/wxMaximaFrame.cpp:600
 msgid "Complete Word\tCtrl-K"
 msgstr "Täydennä sana\tCtrl-K"
 
-#: ../src/wxMaximaFrame.cpp:602
+#: ../src/wxMaximaFrame.cpp:601
 msgid "Complete word"
 msgstr "Täydennä sana"
 
@@ -998,35 +998,35 @@ msgstr "Täydennä sana"
 msgid "Completely stop maxima and restart it"
 msgstr "Pysäytä maxima kokonaan ja käynnistä se uudelleen"
 
-#: ../src/wxMaximaFrame.cpp:823
+#: ../src/wxMaximaFrame.cpp:822
 msgid "Compute continued fraction of a value"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:761
+#: ../src/wxMaximaFrame.cpp:760
 msgid "Compute the adjoint matrix"
 msgstr "Laske adjungoitu matriisi"
 
-#: ../src/wxMaximaFrame.cpp:750
+#: ../src/wxMaximaFrame.cpp:749
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:753
+#: ../src/wxMaximaFrame.cpp:752
 msgid "Compute the determinant of a matrix"
 msgstr "Laske matriisin determinantti"
 
-#: ../src/wxMaximaFrame.cpp:810
+#: ../src/wxMaximaFrame.cpp:809
 msgid "Compute the greatest common divisor"
 msgstr "Laske suurin yhteinen tekijä"
 
-#: ../src/wxMaximaFrame.cpp:747
+#: ../src/wxMaximaFrame.cpp:746
 msgid "Compute the inverse of a matrix"
 msgstr "Laske käänteismatriisi"
 
-#: ../src/wxMaximaFrame.cpp:813
+#: ../src/wxMaximaFrame.cpp:812
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr "Laske pienin yhteinen jaettava (lataa (load) funktiot ennen käyttöä)"
 
-#: ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4868
 msgid "Condition:"
 msgstr "Ehto:"
 
@@ -1038,8 +1038,8 @@ msgstr "Asetustiedosto (*.ini)|*.ini"
 msgid "Configuration warning"
 msgstr ""
 
-#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:538
-#: ../src/wxMaximaFrame.cpp:541
+#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:540
 msgid "Configure wxMaxima"
 msgstr "Määrittele wxMaxima"
 
@@ -1048,129 +1048,131 @@ msgstr "Määrittele wxMaxima"
 msgid "Constant"
 msgstr "Vakio"
 
-#: ../src/wxMaximaFrame.cpp:844
+#: ../src/wxMaximaFrame.cpp:843
 msgid "Contract Logarithms"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:851
+#: ../src/wxMaximaFrame.cpp:850
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr "Muunna binomit, beta- ja gamma funktiot kertomiksi"
 
-#: ../src/wxMaximaFrame.cpp:854
+#: ../src/wxMaximaFrame.cpp:853
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr "Muunna binomit, kertoimet ja betafunktiot gammafunktioksi"
 
-#: ../src/wxMaximaFrame.cpp:888
+#: ../src/wxMaximaFrame.cpp:887
 msgid "Convert complex expression to polar form"
 msgstr "Muunna kompleksilauseke polaarimuotoon"
 
-#: ../src/wxMaximaFrame.cpp:885
+#: ../src/wxMaximaFrame.cpp:884
 msgid "Convert complex expression to rect form"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:897
+#: ../src/wxMaximaFrame.cpp:896
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:842
+#: ../src/wxMaximaFrame.cpp:841
 msgid "Convert logarithm of product to sum of logarithms"
 msgstr "Muunna logaritmin tulo logaritmien summaksi"
 
-#: ../src/wxMaximaFrame.cpp:845
+#: ../src/wxMaximaFrame.cpp:844
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "Muunna logaritmien summa tulon logaritmiksi"
 
-#: ../src/wxMaximaFrame.cpp:850
+#: ../src/wxMaximaFrame.cpp:849
 msgid "Convert to &Factorials"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:853
+#: ../src/wxMaximaFrame.cpp:852
 msgid "Convert to &Gamma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:887
+#: ../src/wxMaximaFrame.cpp:886
 msgid "Convert to &Polarform"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:884
+#: ../src/wxMaximaFrame.cpp:883
 msgid "Convert to &Rectform"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:877
+#: ../src/wxMaximaFrame.cpp:876
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:900
+#: ../src/wxMaximaFrame.cpp:899
 msgid "Convert trigonometric functions to exponential form"
 msgstr "Muunna trigonometrinen funktio eksponenttimuotoon"
 
-#: ../src/ToolBar.cpp:140 ../src/MathCtrl.cpp:918 ../src/MathCtrl.cpp:931
-#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1024
+#: ../src/MathCtrl.cpp:960 ../src/MathCtrl.cpp:973 ../src/MathCtrl.cpp:1019
+#: ../src/MathCtrl.cpp:1066 ../src/ToolBar.cpp:140
 msgid "Copy"
 msgstr "Kopioi"
 
-#: ../src/wxMaximaFrame.cpp:597
+#: ../src/wxMaximaFrame.cpp:596
 msgid "Copy Previous Input\tCtrl-I"
 msgstr "Kopioi aiempi syöte\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:599
+#: ../src/wxMaximaFrame.cpp:598
 msgid "Copy Previous Output\tCtrl-U"
 msgstr "Kopioi aiempi tuloste\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:514 ../src/MathCtrl.cpp:936 ../src/MathCtrl.cpp:982
+#: ../src/MathCtrl.cpp:978 ../src/MathCtrl.cpp:1024
+#: ../src/wxMaximaFrame.cpp:513
 msgid "Copy as Image"
 msgstr "Kopioi kuvana"
 
-#: ../src/wxMaximaFrame.cpp:507 ../src/MathCtrl.cpp:932 ../src/MathCtrl.cpp:978
+#: ../src/MathCtrl.cpp:974 ../src/MathCtrl.cpp:1020
+#: ../src/wxMaximaFrame.cpp:506
 msgid "Copy as LaTeX"
 msgstr "Kopioi LaTeXina"
 
-#: ../src/wxMaximaFrame.cpp:510
+#: ../src/wxMaximaFrame.cpp:509
 #, fuzzy
 msgid "Copy as MathML"
 msgstr "Kopioi kuvana"
 
-#: ../src/MathCtrl.cpp:935 ../src/MathCtrl.cpp:980
+#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1022
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:504
+#: ../src/wxMaximaFrame.cpp:503
 msgid "Copy as Text\tCtrl-Shift-C"
 msgstr "Kopioi tekstinä"
 
-#: ../src/MathCtrl.cpp:933 ../src/MathCtrl.cpp:979
+#: ../src/MathCtrl.cpp:975 ../src/MathCtrl.cpp:1021
 #, fuzzy
 msgid "Copy as plain text"
 msgstr "Kopioi kuvana"
 
-#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:503
+#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:502
 msgid "Copy selection"
 msgstr "Kopioi valitun"
 
-#: ../src/wxMaximaFrame.cpp:515
+#: ../src/wxMaximaFrame.cpp:514
 msgid "Copy selection from document as an image"
 msgstr "Kopioi valitun osan dokumenttia kuvaksi"
 
-#: ../src/wxMaximaFrame.cpp:505
+#: ../src/wxMaximaFrame.cpp:504
 msgid "Copy selection from document as text"
 msgstr "Kopioi valitun osan dokumenttia tekstiksi"
 
-#: ../src/wxMaximaFrame.cpp:508
+#: ../src/wxMaximaFrame.cpp:507
 msgid "Copy selection from document in LaTeX format"
 msgstr "Tallenna valinta asiakirjasta LaTeX-muotoon"
 
-#: ../src/wxMaximaFrame.cpp:511
+#: ../src/wxMaximaFrame.cpp:510
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:598
+#: ../src/wxMaximaFrame.cpp:597
 msgid "Create a new cell with previous input"
 msgstr "Luo uusi solu aiemmalla syötteellä"
 
-#: ../src/wxMaximaFrame.cpp:600
+#: ../src/wxMaximaFrame.cpp:599
 msgid "Create a new cell with previous output"
 msgstr "Luo uusi solu aiemmalla tulosteella"
 
@@ -1178,15 +1180,15 @@ msgstr "Luo uusi solu aiemmalla tulosteella"
 msgid "Cursor"
 msgstr "Kursori"
 
-#: ../src/ToolBar.cpp:137 ../src/MathCtrl.cpp:1023
+#: ../src/MathCtrl.cpp:1065 ../src/ToolBar.cpp:137
 msgid "Cut"
 msgstr "Leikkaa"
 
-#: ../src/wxMaximaFrame.cpp:499
+#: ../src/wxMaximaFrame.cpp:498
 msgid "Cut\tCtrl-X"
 msgstr "Cut\tCtrl+X"
 
-#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:500
+#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:499
 msgid "Cut selection"
 msgstr "Leikkaa valitun"
 
@@ -1198,18 +1200,18 @@ msgstr "Tsekki"
 msgid "Danish"
 msgstr "Tanska"
 
-#: ../src/wxMaxima.cpp:4799 ../src/wxMaxima.cpp:4806 ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4811 ../src/wxMaxima.cpp:4818 ../src/wxMaxima.cpp:4868
 msgid "Data Matrix:"
 msgstr "Datamatriisi:"
 
-#: ../src/wxMaxima.cpp:4826
+#: ../src/wxMaxima.cpp:4838
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr "Datatiedosto  (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698 ../src/wxMaxima.cpp:4712
-#: ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726 ../src/wxMaxima.cpp:4734
-#: ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748 ../src/wxMaxima.cpp:4755
-#: ../src/wxMaxima.cpp:4791
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710 ../src/wxMaxima.cpp:4724
+#: ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738 ../src/wxMaxima.cpp:4746
+#: ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760 ../src/wxMaxima.cpp:4767
+#: ../src/wxMaxima.cpp:4803
 msgid "Data:"
 msgstr "Data:"
 
@@ -1217,7 +1219,7 @@ msgstr "Data:"
 msgid "Debug: watch maxima's stdout stream"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:820
+#: ../src/wxMaximaFrame.cpp:819
 msgid "Decompose rational function to partial fractions"
 msgstr ""
 
@@ -1247,47 +1249,47 @@ msgid ""
 "with."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3403 ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3415 ../src/wxMaxima.cpp:3424
 msgid "Delete"
 msgstr "Poista"
 
-#: ../src/wxMaximaFrame.cpp:667
+#: ../src/wxMaximaFrame.cpp:666
 msgid "Delete F&unction..."
 msgstr "Poista f&unktio..."
 
-#: ../src/MathCtrl.cpp:939 ../src/MathCtrl.cpp:985
+#: ../src/MathCtrl.cpp:981 ../src/MathCtrl.cpp:1027
 msgid "Delete Selection"
 msgstr "Poista valittu"
 
-#: ../src/wxMaximaFrame.cpp:669
+#: ../src/wxMaximaFrame.cpp:668
 msgid "Delete V&ariable..."
 msgstr "Poista &muuttuja..."
 
-#: ../src/wxMaximaFrame.cpp:668
+#: ../src/wxMaximaFrame.cpp:667
 msgid "Delete a function"
 msgstr "Poistaa funktion"
 
-#: ../src/wxMaximaFrame.cpp:670
+#: ../src/wxMaximaFrame.cpp:669
 msgid "Delete a variable"
 msgstr "Poistaa muuttujan"
 
-#: ../src/wxMaximaFrame.cpp:655
+#: ../src/wxMaximaFrame.cpp:654
 msgid "Delete all values from memory"
 msgstr "Poista kaikki arvot muistista"
 
-#: ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3424
 msgid "Delete function(s):"
 msgstr "Poista funktio(t):"
 
-#: ../src/wxMaxima.cpp:3403
+#: ../src/wxMaxima.cpp:3415
 msgid "Delete variable(s):"
 msgstr "Poista muuttuja(t):"
 
-#: ../src/wxMaximaFrame.cpp:1367
+#: ../src/wxMaximaFrame.cpp:1366
 msgid "Delta"
 msgstr "delta"
 
-#: ../src/wxMaxima.cpp:4011
+#: ../src/wxMaxima.cpp:4023
 msgid "Denom. deg:"
 msgstr ""
 
@@ -1295,35 +1297,35 @@ msgstr ""
 msgid "Depth:"
 msgstr "Syvyys:"
 
-#: ../src/wxMaxima.cpp:3541
+#: ../src/wxMaxima.cpp:3553
 msgid "Derivative:"
 msgstr "Derivaatta:"
 
-#: ../src/wxMaximaFrame.cpp:1258
+#: ../src/wxMaximaFrame.cpp:1257
 msgid "Deviation..."
 msgstr "Derivointi..."
 
-#: ../src/wxMaximaFrame.cpp:816
+#: ../src/wxMaximaFrame.cpp:815
 msgid "Di&vide Polynomials..."
 msgstr "&Jaa polynomit..."
 
-#: ../src/wxMaximaFrame.cpp:1223
+#: ../src/wxMaximaFrame.cpp:1222
 msgid "Diff..."
 msgstr "Deri..."
 
-#: ../src/wxMaxima.cpp:4154 ../src/wxMaxima.cpp:5066
+#: ../src/wxMaxima.cpp:4166 ../src/wxMaxima.cpp:5078
 msgid "Differentiate"
 msgstr "Derivoi"
 
-#: ../src/wxMaximaFrame.cpp:786
+#: ../src/wxMaximaFrame.cpp:785
 msgid "Differentiate expression"
 msgstr "Derivoi lauseke"
 
-#: ../src/MathCtrl.cpp:1001
+#: ../src/MathCtrl.cpp:1043
 msgid "Differentiate..."
 msgstr "Derivoi..."
 
-#: ../src/LimitWiz.cpp:37 ../src/FindReplacePane.cpp:76
+#: ../src/FindReplacePane.cpp:76 ../src/LimitWiz.cpp:37
 msgid "Direction:"
 msgstr "Suunta:"
 
@@ -1331,48 +1333,49 @@ msgstr "Suunta:"
 msgid "Discrete plot"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:679
+#: ../src/wxMaximaFrame.cpp:678
 msgid "Display Te&X Form"
 msgstr "Näytä Te&X muoto"
 
-#: ../src/wxMaxima.cpp:3320
+#: ../src/wxMaxima.cpp:3332
 msgid "Display algorithm"
 msgstr "Näytä algoritmi"
 
-#: ../src/wxMaximaFrame.cpp:680
+#: ../src/wxMaximaFrame.cpp:679
 msgid "Display last result in TeX form"
 msgstr "Näytä viimeisin tulos TeX-muodossa"
 
-#: ../src/wxMaximaFrame.cpp:674
+#: ../src/wxMaximaFrame.cpp:673
 msgid "Display time used for evaluation"
 msgstr "Näytä evaluointiin käytetty aika"
 
-#: ../src/wxMaxima.cpp:4061
+#: ../src/wxMaxima.cpp:4073
 msgid "Divide"
 msgstr "Jaa"
 
-#: ../src/MathCtrl.cpp:1032
+#: ../src/MathCtrl.cpp:1074
 msgid "Divide Cell"
 msgstr "Jaa solu"
 
-#: ../src/wxMaximaFrame.cpp:635
+#: ../src/wxMaximaFrame.cpp:634
 #, fuzzy
 msgid "Divide Cell\tCtrl-D"
 msgstr "Jaa solu"
 
-#: ../src/wxMaximaFrame.cpp:817
+#: ../src/wxMaximaFrame.cpp:816
 msgid "Divide numbers or polynomials"
 msgstr "Jaa luvut tai polynomit"
 
-#: ../src/wxMaximaFrame.cpp:636
+#: ../src/wxMaximaFrame.cpp:635
 msgid "Divide this input cell into two cells"
 msgstr "Jaa tämä syötesolu kahdeksi soluksi"
 
-#: ../src/wxMaxima.cpp:5917
-msgid "Do you want to save the changes you made in the document \""
+#: ../src/wxMaxima.cpp:5932
+#, fuzzy, c-format
+msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr "Haluatko tallentaa asiakirjaan tekemäsi muutokset? \""
 
-#: ../src/wxMaxima.cpp:1664 ../src/wxMaxima.cpp:1672
+#: ../src/wxMaxima.cpp:1669 ../src/wxMaxima.cpp:1677
 msgid "Document "
 msgstr "Asiakirja"
 
@@ -1391,7 +1394,7 @@ msgid ""
 "differences."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Don't save"
 msgstr "Älä tallenna"
 
@@ -1399,27 +1402,27 @@ msgstr "Älä tallenna"
 msgid "Down"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:734
+#: ../src/wxMaximaFrame.cpp:733
 msgid "E&quations"
 msgstr "&Yhtälöt"
 
-#: ../src/wxMaximaFrame.cpp:487
+#: ../src/wxMaximaFrame.cpp:486
 msgid "E&xit\tCtrl-Q"
 msgstr "&Poistu\tCtrl-Q"
 
-#: ../src/wxMaximaFrame.cpp:757
+#: ../src/wxMaximaFrame.cpp:756
 msgid "Eige&nvectors"
 msgstr "Omi&naisvektrorit"
 
-#: ../src/wxMaximaFrame.cpp:755
+#: ../src/wxMaximaFrame.cpp:754
 msgid "Eigen&values"
 msgstr "Ominaisar&vot"
 
-#: ../src/wxMaxima.cpp:3572
+#: ../src/wxMaxima.cpp:3584
 msgid "Eliminate"
 msgstr "Eliminoi"
 
-#: ../src/wxMaximaFrame.cpp:710
+#: ../src/wxMaximaFrame.cpp:709
 msgid "Eliminate a variable from a system of equations"
 msgstr "Eliminoi muuttuja yhtälöryhmästä"
 
@@ -1431,21 +1434,21 @@ msgstr "Todistuksen loppu"
 msgid "English"
 msgstr "Englanti"
 
-#: ../src/wxMaxima.cpp:4712 ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726
-#: ../src/wxMaxima.cpp:4734 ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748
-#: ../src/wxMaxima.cpp:4755 ../src/wxMaxima.cpp:4791 ../src/wxMaxima.cpp:4799
+#: ../src/wxMaxima.cpp:4724 ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738
+#: ../src/wxMaxima.cpp:4746 ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760
+#: ../src/wxMaxima.cpp:4767 ../src/wxMaxima.cpp:4803 ../src/wxMaxima.cpp:4811
 msgid "Enter Data"
 msgstr "Syötä data"
 
-#: ../src/wxMaximaFrame.cpp:1279
+#: ../src/wxMaximaFrame.cpp:1278
 msgid "Enter Matrix..."
 msgstr "Syötä matriisi..."
 
-#: ../src/wxMaximaFrame.cpp:745
+#: ../src/wxMaximaFrame.cpp:744
 msgid "Enter a matrix"
 msgstr "Syötä matriisi"
 
-#: ../src/wxMaxima.cpp:3962
+#: ../src/wxMaxima.cpp:3974
 msgid "Enter an equation for rational simplification:"
 msgstr ""
 
@@ -1457,11 +1460,11 @@ msgstr ""
 msgid "Enter evaluates cells"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3734
+#: ../src/wxMaxima.cpp:3746
 msgid "Enter matrix"
 msgstr "Syötä matriisi"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Enter new precision for bigfloats:"
 msgstr ""
 
@@ -1469,11 +1472,11 @@ msgstr ""
 msgid "Enter the path to the Maxima executable."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1368
+#: ../src/wxMaximaFrame.cpp:1367
 msgid "Epsilon"
 msgstr "Epsilon:"
 
-#: ../src/wxMaxima.cpp:4208
+#: ../src/wxMaxima.cpp:4220
 msgid "Epsilon:"
 msgstr ""
 
@@ -1482,13 +1485,13 @@ msgstr ""
 msgid "Equation %d:"
 msgstr "Yhtälö %d:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:3633
-#: ../src/wxMaxima.cpp:5019
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:3645
+#: ../src/wxMaxima.cpp:5031
 msgid "Equation(s):"
 msgstr "Yhtälö(t):"
 
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3993
-#: ../src/wxMaxima.cpp:4807 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:4005
+#: ../src/wxMaxima.cpp:4819 ../src/wxMaxima.cpp:5045
 msgid "Equation:"
 msgstr "Yhtälö:"
 
@@ -1499,77 +1502,77 @@ msgid ""
 "be introduced one into another. Also they are always printed out as 2D maths."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3570
+#: ../src/wxMaxima.cpp:3582
 msgid "Equations:"
 msgstr "Yhtälöt:"
 
-#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1455
-#: ../src/wxMaxima.cpp:1469 ../src/wxMaxima.cpp:1620 ../src/wxMaxima.cpp:1633
-#: ../src/wxMaxima.cpp:1643 ../src/wxMaxima.cpp:1666 ../src/wxMaxima.cpp:2034
-#: ../src/wxMaxima.cpp:2206 ../src/wxMaxima.cpp:5381 ../src/wxMaxima.cpp:5830
-#: ../src/wxMaxima.cpp:5881
+#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1460
+#: ../src/wxMaxima.cpp:1474 ../src/wxMaxima.cpp:1625 ../src/wxMaxima.cpp:1638
+#: ../src/wxMaxima.cpp:1648 ../src/wxMaxima.cpp:1671 ../src/wxMaxima.cpp:2039
+#: ../src/wxMaxima.cpp:2211 ../src/wxMaxima.cpp:5397 ../src/wxMaxima.cpp:5845
+#: ../src/wxMaxima.cpp:5896
 msgid "Error"
 msgstr "Virhe"
 
-#: ../src/wxMaxima.cpp:2886 ../src/wxMaxima.cpp:2900 ../src/wxMaxima.cpp:2913
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617 ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:2894 ../src/wxMaxima.cpp:2908 ../src/wxMaxima.cpp:2921
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629 ../src/wxMaxima.cpp:3740
 msgid "Error!"
 msgstr "Virhe!"
 
-#: ../src/wxMaximaFrame.cpp:1370
+#: ../src/wxMaximaFrame.cpp:1369
 msgid "Eta"
 msgstr "Eeta"
 
-#: ../src/wxMaximaFrame.cpp:909
+#: ../src/wxMaximaFrame.cpp:908
 msgid "Evaluate &Noun Forms"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:589
+#: ../src/wxMaximaFrame.cpp:588
 msgid "Evaluate All Cells\tCtrl-Shift-R"
 msgstr "Evaluoi kaikki solut\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:587
+#: ../src/wxMaximaFrame.cpp:586
 msgid "Evaluate All Visible Cells\tCtrl-R"
 msgstr "Evaluoi kaikki näkyvät solut\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:585 ../src/MathCtrl.cpp:942
+#: ../src/MathCtrl.cpp:984 ../src/wxMaximaFrame.cpp:584
 msgid "Evaluate Cell(s)"
 msgstr "Laske Solu(t)"
 
-#: ../src/wxMaximaFrame.cpp:591
+#: ../src/wxMaximaFrame.cpp:590
 #, fuzzy
 msgid "Evaluate Cells Above\tCtrl-Shift-P"
 msgstr "Evaluoi kaikki solut\tCtrl-R"
 
-#: ../src/MathCtrl.cpp:956 ../src/MathCtrl.cpp:1051
+#: ../src/MathCtrl.cpp:998 ../src/MathCtrl.cpp:1093
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:961 ../src/MathCtrl.cpp:1053
+#: ../src/MathCtrl.cpp:1003 ../src/MathCtrl.cpp:1095
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:971 ../src/MathCtrl.cpp:1057
+#: ../src/MathCtrl.cpp:1013 ../src/MathCtrl.cpp:1099
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:966 ../src/MathCtrl.cpp:1055
+#: ../src/MathCtrl.cpp:1008 ../src/MathCtrl.cpp:1097
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:586
+#: ../src/wxMaximaFrame.cpp:585
 msgid "Evaluate active or selected cell(s)"
 msgstr "Laske aktiivinen tai valitut solu(t)"
 
-#: ../src/wxMaximaFrame.cpp:590
+#: ../src/wxMaximaFrame.cpp:589
 msgid "Evaluate all cells in the document"
 msgstr "Laske asiakirjan kaikki solut"
 
-#: ../src/wxMaximaFrame.cpp:910
+#: ../src/wxMaximaFrame.cpp:909
 msgid "Evaluate all noun forms in expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:588
+#: ../src/wxMaximaFrame.cpp:587
 msgid "Evaluate all visible cells in the document"
 msgstr "Laske kaikki näkyvät solut\tCtrl-R"
 
@@ -1581,7 +1584,7 @@ msgstr ""
 msgid "Evaluate to point"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Example"
 msgstr "Esimerkki"
 
@@ -1593,31 +1596,31 @@ msgstr "Esimerkkiteksti"
 msgid "Examples:"
 msgstr "Esimerkit:"
 
-#: ../src/wxMaximaFrame.cpp:488
+#: ../src/wxMaximaFrame.cpp:487
 msgid "Exit wxMaxima"
 msgstr "Poistu wxMaximasta"
 
-#: ../src/wxMaximaFrame.cpp:1214
+#: ../src/wxMaximaFrame.cpp:1213
 msgid "Expand"
 msgstr "Laajenna"
 
-#: ../src/wxMaximaFrame.cpp:1219
+#: ../src/wxMaximaFrame.cpp:1218
 msgid "Expand (tr)"
 msgstr "Laajenna (tr)"
 
-#: ../src/MathCtrl.cpp:997
+#: ../src/MathCtrl.cpp:1039
 msgid "Expand Expression"
 msgstr "Laajenna lauseke"
 
-#: ../src/wxMaximaFrame.cpp:841
+#: ../src/wxMaximaFrame.cpp:840
 msgid "Expand Logarithms"
 msgstr "Laajenna logaritmit"
 
-#: ../src/wxMaximaFrame.cpp:840
+#: ../src/wxMaximaFrame.cpp:839
 msgid "Expand an expression"
 msgstr "Laajenna lauseke"
 
-#: ../src/wxMaximaFrame.cpp:874
+#: ../src/wxMaximaFrame.cpp:873
 msgid "Expand trigonometric expression"
 msgstr "Laajenna trigonometrinen lauseke"
 
@@ -1625,7 +1628,7 @@ msgstr "Laajenna trigonometrinen lauseke"
 msgid "Expected the icon files to be found at"
 msgstr ""
 
-#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2834
+#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2842
 msgid "Export"
 msgstr "Vie"
 
@@ -1634,31 +1637,31 @@ msgid ""
 "Export animations to TeX (Images only move if the PDF viewer supports this)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:481
+#: ../src/wxMaximaFrame.cpp:480
 msgid "Export document to a HTML or pdfLaTeX file"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:253
+#: ../src/wxMaximaFrame.cpp:252
 msgid "Export failed."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:239
+#: ../src/wxMaximaFrame.cpp:238
 msgid "Export successful."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2913
+#: ../src/wxMaxima.cpp:2921
 msgid "Exporting to HTML failed!"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2886
+#: ../src/wxMaxima.cpp:2894
 msgid "Exporting to TeX failed!"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2900
+#: ../src/wxMaxima.cpp:2908
 msgid "Exporting to maxima batch file failed!"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:229
+#: ../src/wxMaximaFrame.cpp:228
 msgid "Exporting..."
 msgstr ""
 
@@ -1671,42 +1674,42 @@ msgid "Expression(s):"
 msgstr "Lauseke/lausekkeet:"
 
 #: ../src/IntegrateWiz.cpp:30 ../src/LimitWiz.cpp:27 ../src/SeriesWiz.cpp:33
-#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3648
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:4205 ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5064
+#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3660
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:4217 ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5076
 msgid "Expression:"
 msgstr "Lauseke:"
 
-#: ../src/wxMaximaFrame.cpp:1213
+#: ../src/wxMaximaFrame.cpp:1212
 msgid "Factor"
 msgstr "Tekijä"
 
-#: ../src/wxMaximaFrame.cpp:836
+#: ../src/wxMaximaFrame.cpp:835
 msgid "Factor Complex"
 msgstr "Kompleksitekijä"
 
-#: ../src/MathCtrl.cpp:996
+#: ../src/MathCtrl.cpp:1038
 msgid "Factor Expression"
 msgstr "Lauseketekijä"
 
-#: ../src/wxMaximaFrame.cpp:835
+#: ../src/wxMaximaFrame.cpp:834
 msgid "Factor an expression"
 msgstr "Lausekkeen tekijä"
 
-#: ../src/wxMaximaFrame.cpp:837
+#: ../src/wxMaximaFrame.cpp:836
 msgid "Factor an expression in Gaussian numbers"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:862
+#: ../src/wxMaximaFrame.cpp:861
 msgid "Factorials and &Gamma"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:285
+#: ../src/wxMaxima.cpp:286
 msgid "Fatal error"
 msgstr ""
 
-#: ../src/GroupCell.cpp:1571
+#: ../src/GroupCell.cpp:1572
 #, c-format
 msgid "Figure %d:"
 msgstr ""
@@ -1715,20 +1718,20 @@ msgstr ""
 msgid "File"
 msgstr "Tiedosto"
 
-#: ../src/wxMaxima.cpp:1457 ../src/wxMaxima.cpp:1623 ../src/wxMaxima.cpp:1636
-#: ../src/wxMaxima.cpp:1646 ../src/wxMaxima.cpp:1668
+#: ../src/wxMaxima.cpp:1462 ../src/wxMaxima.cpp:1628 ../src/wxMaxima.cpp:1641
+#: ../src/wxMaxima.cpp:1651 ../src/wxMaxima.cpp:1673
 msgid "File could not be opened"
 msgstr "Tiedostoa ei voi avata"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File not found"
 msgstr "Tiedosto ei löydy"
 
-#: ../src/wxMaxima.cpp:1511 ../src/wxMaxima.cpp:1729
+#: ../src/wxMaxima.cpp:1516 ../src/wxMaxima.cpp:1734
 msgid "File opened"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File you tried to open does not exist."
 msgstr ""
 
@@ -1740,67 +1743,67 @@ msgstr "Tiedosto:"
 msgid "Find"
 msgstr "Etsi"
 
-#: ../src/wxMaximaFrame.cpp:523
+#: ../src/wxMaximaFrame.cpp:522
 msgid "Find\tCtrl-F"
 msgstr "Etsi\tCtrl+F"
 
-#: ../src/wxMaximaFrame.cpp:787
+#: ../src/wxMaximaFrame.cpp:786
 msgid "Find &Limit..."
 msgstr "&Etsi raja-arvo..."
 
-#: ../src/wxMaximaFrame.cpp:790
+#: ../src/wxMaximaFrame.cpp:789
 msgid "Find Minimum..."
 msgstr "Etsi minimi..."
 
-#: ../src/MathCtrl.cpp:993
+#: ../src/MathCtrl.cpp:1035
 msgid "Find Root..."
 msgstr "Etsi juuri..."
 
-#: ../src/wxMaximaFrame.cpp:791
+#: ../src/wxMaximaFrame.cpp:790
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:788
+#: ../src/wxMaximaFrame.cpp:787
 msgid "Find a limit of an expression"
 msgstr "Etsi lausekkeen raja-arvo"
 
-#: ../src/wxMaximaFrame.cpp:693
+#: ../src/wxMaximaFrame.cpp:692
 msgid "Find a root of an equation on an interval"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:695
+#: ../src/wxMaximaFrame.cpp:694
 msgid "Find all roots of a polynomial"
 msgstr "Etsi kaikki polynomin juuret"
 
-#: ../src/wxMaximaFrame.cpp:698
+#: ../src/wxMaximaFrame.cpp:697
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr "Etsi kaikki polynomin juuret (bfloat)"
 
-#: ../src/wxMaxima.cpp:3220
+#: ../src/wxMaxima.cpp:3215
 msgid "Find and Replace"
 msgstr "Etsi ja korvaa"
 
-#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:523
+#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:522
 msgid "Find and replace"
 msgstr "Etsi ja korvaa"
 
-#: ../src/wxMaximaFrame.cpp:756
+#: ../src/wxMaximaFrame.cpp:755
 msgid "Find eigenvalues of a matrix"
 msgstr "Etsi matriisin ominaisarvot"
 
-#: ../src/wxMaximaFrame.cpp:758
+#: ../src/wxMaximaFrame.cpp:757
 msgid "Find eigenvectors of a matrix"
 msgstr "Etsi matriisin ominaisvektorit"
 
-#: ../src/wxMaxima.cpp:4210
+#: ../src/wxMaxima.cpp:4222
 msgid "Find minimum"
 msgstr "Etsi minimi"
 
-#: ../src/wxMaximaFrame.cpp:701
+#: ../src/wxMaximaFrame.cpp:700
 msgid "Find real roots of a polynomial"
 msgstr "Ratkaise polynomin reaalijuuret "
 
-#: ../src/wxMaxima.cpp:3493 ../src/wxMaxima.cpp:5036
+#: ../src/wxMaxima.cpp:3505 ../src/wxMaxima.cpp:5048
 msgid "Find root"
 msgstr "Etsi juuri"
 
@@ -1823,11 +1826,11 @@ msgstr ""
 msgid "Fixed font in text controls"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:623
+#: ../src/wxMaximaFrame.cpp:622
 msgid "Fold All\tCtrl-Alt-["
 msgstr "Piilota kaikki\tCtrl-Alt-["
 
-#: ../src/wxMaximaFrame.cpp:624
+#: ../src/wxMaximaFrame.cpp:623
 msgid "Fold all sections"
 msgstr "Piilota kaikki kappaleet"
 
@@ -1835,25 +1838,25 @@ msgstr "Piilota kaikki kappaleet"
 msgid "Follow"
 msgstr "Seuraa"
 
-#: ../src/ParenCell.cpp:319
+#: ../src/ParenCell.cpp:320
 msgid "Font issue: The Parenthesis sign is too small!"
 msgstr ""
 
-#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:381
+#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:382
 msgid ""
 "Font issue: The char height is too small! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:199
+#: ../src/SqrtCell.cpp:202
 msgid ""
 "Font issue: The sqrt() sign has the size 0! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:198
+#: ../src/SqrtCell.cpp:201
 msgid "Font issue? The contents of a sqrt() has the size 0."
 msgstr ""
 
@@ -1884,15 +1887,15 @@ msgstr "Ranska"
 
 #: ../src/IntegrateWiz.cpp:37 ../src/Plot2dWiz.cpp:37 ../src/Plot2dWiz.cpp:47
 #: ../src/Plot2dWiz.cpp:536 ../src/Plot3dWiz.cpp:36 ../src/Plot3dWiz.cpp:45
-#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4240
+#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4252
 msgid "From:"
 msgstr "Mistä:"
 
-#: ../src/wxMaximaFrame.cpp:576
+#: ../src/wxMaximaFrame.cpp:575
 msgid "Full Screen\tAlt-Enter"
 msgstr "Koko ruutu\tAlt-Enter"
 
-#: ../src/wxMaxima.cpp:3342
+#: ../src/wxMaxima.cpp:3354
 msgid "Function"
 msgstr "Funktio"
 
@@ -1900,32 +1903,32 @@ msgstr "Funktio"
 msgid "Function names"
 msgstr "Funktioiden nimet"
 
-#: ../src/wxMaxima.cpp:3633
+#: ../src/wxMaxima.cpp:3645
 msgid "Function(s):"
 msgstr "Funktio(t):"
 
-#: ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3803
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3815
+#: ../src/wxMaxima.cpp:3848
 msgid "Function:"
 msgstr "Funktio:"
 
-#: ../src/wxMaximaFrame.cpp:904
+#: ../src/wxMaximaFrame.cpp:903
 msgid "Functions for complex simplification"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:864
+#: ../src/wxMaximaFrame.cpp:863
 msgid "Functions for simplifying factorials and gamma function"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:881
+#: ../src/wxMaximaFrame.cpp:880
 msgid "Functions for simplifying trigonometric expressions"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4046
+#: ../src/wxMaxima.cpp:4058
 msgid "GCD"
 msgstr "SYT"
 
-#: ../src/wxMaxima.cpp:5152
+#: ../src/wxMaxima.cpp:5164
 msgid "GIF image (*.gif)|*.gif"
 msgstr "GIF kuva (*.gif)|*.gif"
 
@@ -1933,31 +1936,31 @@ msgstr "GIF kuva (*.gif)|*.gif"
 msgid "Galician"
 msgstr "Galicia"
 
-#: ../src/wxMaximaFrame.cpp:1366
+#: ../src/wxMaximaFrame.cpp:1365
 msgid "Gamma"
 msgstr "gamma"
 
-#: ../src/wxMaximaFrame.cpp:391
+#: ../src/wxMaximaFrame.cpp:390
 msgid "General Math"
 msgstr "Yleinen Matematiikka"
 
-#: ../src/wxMaximaFrame.cpp:549
+#: ../src/wxMaximaFrame.cpp:548
 msgid "General Math\tAlt-Shift-M"
 msgstr "Yleinen Matematiikka\tAlt-Shift-M"
 
-#: ../src/wxMaxima.cpp:3766 ../src/wxMaxima.cpp:3785
+#: ../src/wxMaxima.cpp:3778 ../src/wxMaxima.cpp:3797
 msgid "Generate Matrix"
 msgstr "Luo matriisi"
 
-#: ../src/wxMaximaFrame.cpp:741
+#: ../src/wxMaximaFrame.cpp:740
 msgid "Generate Matrix from Expression..."
 msgstr "Luo matriisi lausekkeesta..."
 
-#: ../src/wxMaximaFrame.cpp:739
+#: ../src/wxMaximaFrame.cpp:738
 msgid "Generate a matrix from a 2-dimensional array"
 msgstr "Muodosta matriisi 2-ulotteisesta taulukosta"
 
-#: ../src/wxMaximaFrame.cpp:742
+#: ../src/wxMaximaFrame.cpp:741
 msgid "Generate a matrix from a lambda expression"
 msgstr ""
 
@@ -1965,39 +1968,39 @@ msgstr ""
 msgid "German"
 msgstr "Saksa"
 
-#: ../src/wxMaximaFrame.cpp:893
+#: ../src/wxMaximaFrame.cpp:892
 msgid "Get &Imaginary Part"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:793
+#: ../src/wxMaximaFrame.cpp:792
 msgid "Get &Series..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:804
+#: ../src/wxMaximaFrame.cpp:803
 msgid "Get Laplace transformation of an expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:890
+#: ../src/wxMaximaFrame.cpp:889
 msgid "Get Real P&art"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:807
+#: ../src/wxMaximaFrame.cpp:806
 msgid "Get inverse Laplace transformation of an expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:794
+#: ../src/wxMaximaFrame.cpp:793
 msgid "Get the Taylor or power series of expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:894
+#: ../src/wxMaximaFrame.cpp:893
 msgid "Get the imaginary part of complex expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:891
+#: ../src/wxMaximaFrame.cpp:890
 msgid "Get the real part of complex expression"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5932
+#: ../src/MathCtrl.cpp:5984
 msgid ""
 "Got a request to undo an action that involves an delete which isn't possible "
 "at this moment."
@@ -2007,12 +2010,12 @@ msgstr ""
 msgid "Greek"
 msgstr "Kreikka"
 
-#: ../src/wxMaximaFrame.cpp:356
+#: ../src/wxMaximaFrame.cpp:355
 #, fuzzy
 msgid "Greek Letters"
 msgstr "Kreikkalaiset kirjaimet"
 
-#: ../src/wxMaximaFrame.cpp:552
+#: ../src/wxMaximaFrame.cpp:551
 #, fuzzy
 msgid "Greek Letters\tAlt-Shift-G"
 msgstr "Kreikkalaiset kirjaimet\tAlt-Shift-G"
@@ -2025,7 +2028,7 @@ msgstr "Kreikkalaiset vakiot"
 msgid "Grid:"
 msgstr "Ruudukko"
 
-#: ../src/wxMaxima.cpp:2836
+#: ../src/wxMaxima.cpp:2844
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|pdfLaTeX file (*."
 "tex)|*.tex"
@@ -2039,11 +2042,11 @@ msgstr ""
 msgid "Help"
 msgstr "Ohje"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide All Toolbars\tAlt-Shift--"
 msgstr "Piilota kaikki työkalupalkit\tAlt-Shift--"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide all panes"
 msgstr "Piilota kaikki paneelit"
 
@@ -2051,19 +2054,19 @@ msgstr "Piilota kaikki paneelit"
 msgid "Highlight (dpart)"
 msgstr "Korosta (dpart)"
 
-#: ../src/wxMaxima.cpp:4685
+#: ../src/wxMaxima.cpp:4697
 msgid "Histogram"
 msgstr "Histogrammi"
 
-#: ../src/wxMaximaFrame.cpp:1270
+#: ../src/wxMaximaFrame.cpp:1269
 msgid "Histogram..."
 msgstr "Histogrammi..."
 
-#: ../src/wxMaximaFrame.cpp:309
+#: ../src/wxMaximaFrame.cpp:308
 msgid "History"
 msgstr "Historia"
 
-#: ../src/wxMaximaFrame.cpp:555
+#: ../src/wxMaximaFrame.cpp:554
 msgid "History\tAlt-Shift-I"
 msgstr "Historia\tAlt-Shift-H"
 
@@ -2084,11 +2087,11 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Unkari"
 
-#: ../src/wxMaxima.cpp:3527
+#: ../src/wxMaxima.cpp:3539
 msgid "IC1"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3543
+#: ../src/wxMaxima.cpp:3555
 msgid "IC2"
 msgstr ""
 
@@ -2104,7 +2107,7 @@ msgid ""
 "same output cell."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:683
+#: ../src/wxMaximaFrame.cpp:682
 msgid ""
 "If maxima ever finishes evaluating without wxMaxima realizing this this menu "
 "item can force wxMaxima to try to send commands to maxima again."
@@ -2166,11 +2169,11 @@ msgstr ""
 "Jos laskutoimituksesi laskeminen kestää liian kauan, voit käyttää 'Maxima-"
 ">Keskeytä' tai 'Maxima->Uudelleenkäynnistä Maxima' valikkokomentoja."
 
-#: ../src/wxMaximaFrame.cpp:1499
+#: ../src/wxMaximaFrame.cpp:1518
 msgid "Image"
 msgstr "Kuva"
 
-#: ../src/wxMaxima.cpp:5644
+#: ../src/wxMaxima.cpp:5659
 msgid "Image files (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 msgstr "Kuvatiedostot"
 
@@ -2197,7 +2200,7 @@ msgid ""
 "above it. Might increase readability for some fonts and short subscripts."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Include columns:"
 msgstr ""
 
@@ -2216,19 +2219,19 @@ msgstr ""
 msgid "Infinity"
 msgstr "Ääretön"
 
-#: ../src/wxMaximaFrame.cpp:974
+#: ../src/wxMaximaFrame.cpp:973
 msgid "Info about Maxima build"
 msgstr "Tietoa Maximan versiosta"
 
-#: ../src/wxMaxima.cpp:4207
+#: ../src/wxMaxima.cpp:4219
 msgid "Initial Estimates:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:718
+#: ../src/wxMaximaFrame.cpp:717
 msgid "Initial Value Problem (&1)..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:721
+#: ../src/wxMaximaFrame.cpp:720
 msgid "Initial Value Problem (&2)..."
 msgstr ""
 
@@ -2236,7 +2239,7 @@ msgstr ""
 msgid "Input labels"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:403
+#: ../src/wxMaximaFrame.cpp:402
 msgid "Insert"
 msgstr "Lisää"
 
@@ -2244,95 +2247,95 @@ msgstr "Lisää"
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:612
+#: ../src/wxMaximaFrame.cpp:611
 msgid "Insert &Section Cell\tCtrl-3"
 msgstr "Lisää &kappalesolu\tCtrl-3"
 
-#: ../src/wxMaximaFrame.cpp:608
+#: ../src/wxMaximaFrame.cpp:607
 msgid "Insert &Text Cell\tCtrl-1"
 msgstr "Lisää tekstisolu\tCtrl-1"
 
-#: ../src/wxMaximaFrame.cpp:558
+#: ../src/wxMaximaFrame.cpp:557
 msgid "Insert Cell\tAlt-Shift-C"
 msgstr "Lisää solu\tAlt-Shift-C"
 
-#: ../src/wxMaxima.cpp:5642
+#: ../src/wxMaxima.cpp:5657
 msgid "Insert Image"
 msgstr "Lisää kuva"
 
-#: ../src/wxMaximaFrame.cpp:620
+#: ../src/wxMaximaFrame.cpp:619
 msgid "Insert Image..."
 msgstr "Lisää kuva..."
 
-#: ../src/wxMaximaFrame.cpp:606
+#: ../src/wxMaximaFrame.cpp:605
 msgid "Insert Input &Cell"
 msgstr "Lisää &syötesolu"
 
-#: ../src/wxMaximaFrame.cpp:618
+#: ../src/wxMaximaFrame.cpp:617
 msgid "Insert Page Break"
 msgstr "Lisää sivunvaihto"
 
-#: ../src/wxMaximaFrame.cpp:614
+#: ../src/wxMaximaFrame.cpp:613
 msgid "Insert S&ubsection Cell\tCtrl-4"
 msgstr "Lisää &alikappalesolu\tCtrl-4"
 
-#: ../src/wxMaximaFrame.cpp:616
+#: ../src/wxMaximaFrame.cpp:615
 msgid "Insert S&ubsubsection Cell\tCtrl-5"
 msgstr "Lisää &alialikappalesolu\tCtrl-4"
 
-#: ../src/MathCtrl.cpp:1015
+#: ../src/MathCtrl.cpp:1057
 msgid "Insert Section Cell"
 msgstr "Lisää kappalesolu"
 
-#: ../src/MathCtrl.cpp:1016
+#: ../src/MathCtrl.cpp:1058
 msgid "Insert Subsection Cell"
 msgstr "Lisää alikappalesolu"
 
-#: ../src/MathCtrl.cpp:1017
+#: ../src/MathCtrl.cpp:1059
 msgid "Insert Subsubsection Cell"
 msgstr "Lisää alialikapplesolu"
 
-#: ../src/wxMaximaFrame.cpp:610
+#: ../src/wxMaximaFrame.cpp:609
 msgid "Insert T&itle Cell\tCtrl-2"
 msgstr "Lisää O&tsikkosolu\tCtrl-2"
 
-#: ../src/MathCtrl.cpp:1013
+#: ../src/MathCtrl.cpp:1055
 msgid "Insert Text Cell"
 msgstr "Lisää tekstisolu"
 
-#: ../src/MathCtrl.cpp:1014
+#: ../src/MathCtrl.cpp:1056
 msgid "Insert Title Cell"
 msgstr "Lisää otsikkosolu"
 
-#: ../src/wxMaximaFrame.cpp:607
+#: ../src/wxMaximaFrame.cpp:606
 msgid "Insert a new input cell"
 msgstr "Lisää uusi syötesolu"
 
-#: ../src/wxMaximaFrame.cpp:613
+#: ../src/wxMaximaFrame.cpp:612
 msgid "Insert a new section cell"
 msgstr "Lisää uusi kappalesolu"
 
-#: ../src/wxMaximaFrame.cpp:615
+#: ../src/wxMaximaFrame.cpp:614
 msgid "Insert a new subsection cell"
 msgstr "Lisää uusi alikapplesolu"
 
-#: ../src/wxMaximaFrame.cpp:617
+#: ../src/wxMaximaFrame.cpp:616
 msgid "Insert a new subsubsection cell"
 msgstr "Lisää uusi alialikappalesolu"
 
-#: ../src/wxMaximaFrame.cpp:609
+#: ../src/wxMaximaFrame.cpp:608
 msgid "Insert a new text cell"
 msgstr "Lisää uusi tekstisolu"
 
-#: ../src/wxMaximaFrame.cpp:611
+#: ../src/wxMaximaFrame.cpp:610
 msgid "Insert a new title cell"
 msgstr "Lisää uusi otsikkosolu"
 
-#: ../src/wxMaximaFrame.cpp:619
+#: ../src/wxMaximaFrame.cpp:618
 msgid "Insert a page break"
 msgstr "Lisää sivunvaihto"
 
-#: ../src/wxMaximaFrame.cpp:621
+#: ../src/wxMaximaFrame.cpp:620
 msgid "Insert image"
 msgstr "Lisää kuva"
 
@@ -2344,27 +2347,27 @@ msgstr "Kokonaisluvut ja yksittäiset kirjaimet"
 msgid "Integral sign"
 msgstr "Integraali merkki"
 
-#: ../src/wxMaxima.cpp:3992
+#: ../src/wxMaxima.cpp:4004
 msgid "Integral/Sum:"
 msgstr "Integraali/Summa:"
 
-#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4105 ../src/wxMaxima.cpp:5051
+#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4117 ../src/wxMaxima.cpp:5063
 msgid "Integrate"
 msgstr "Integroi"
 
-#: ../src/wxMaxima.cpp:4091
+#: ../src/wxMaxima.cpp:4103
 msgid "Integrate (risch)"
 msgstr "Integroi (risch)"
 
-#: ../src/wxMaximaFrame.cpp:778
+#: ../src/wxMaximaFrame.cpp:777
 msgid "Integrate expression"
 msgstr "Integroi lauseke"
 
-#: ../src/wxMaximaFrame.cpp:780
+#: ../src/wxMaximaFrame.cpp:779
 msgid "Integrate expression with Risch algorithm"
 msgstr "Integroi lauseke Rischin algoritmilla"
 
-#: ../src/wxMaximaFrame.cpp:1224 ../src/MathCtrl.cpp:1000
+#: ../src/MathCtrl.cpp:1042 ../src/wxMaximaFrame.cpp:1223
 msgid "Integrate..."
 msgstr "Integroi..."
 
@@ -2372,7 +2375,7 @@ msgstr "Integroi..."
 msgid "Interrupt"
 msgstr "Keskeytä"
 
-#: ../src/wxMaximaFrame.cpp:646 ../src/wxMaximaFrame.cpp:650
+#: ../src/wxMaximaFrame.cpp:645 ../src/wxMaximaFrame.cpp:649
 msgid "Interrupt current computation"
 msgstr "Keskeytä laskutoimitus"
 
@@ -2389,15 +2392,15 @@ msgid ""
 "Please enter the path to Maxima program again."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4137
+#: ../src/wxMaxima.cpp:4149
 msgid "Inverse Laplace"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:806
+#: ../src/wxMaximaFrame.cpp:805
 msgid "Inverse Laplace T&ransform..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1372
+#: ../src/wxMaximaFrame.cpp:1371
 msgid "Iota"
 msgstr "Ioota"
 
@@ -2431,7 +2434,7 @@ msgstr "Japani"
 msgid "Kabyle"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1373
+#: ../src/wxMaximaFrame.cpp:1372
 msgid "Kappa"
 msgstr "kappa"
 
@@ -2440,7 +2443,7 @@ msgstr "kappa"
 msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4031
+#: ../src/wxMaxima.cpp:4043
 msgid "LCM"
 msgstr "pyj"
 
@@ -2456,7 +2459,7 @@ msgstr ""
 msgid "Label width:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1374
+#: ../src/wxMaximaFrame.cpp:1373
 msgid "Lambda"
 msgstr "lambda"
 
@@ -2468,11 +2471,11 @@ msgstr ""
 msgid "Language:"
 msgstr "Kieli:"
 
-#: ../src/wxMaxima.cpp:4120
+#: ../src/wxMaxima.cpp:4132
 msgid "Laplace"
 msgstr "Laplace"
 
-#: ../src/wxMaximaFrame.cpp:803
+#: ../src/wxMaximaFrame.cpp:802
 msgid "Laplace &Transform..."
 msgstr ""
 
@@ -2480,15 +2483,15 @@ msgstr ""
 msgid "Leads to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:812
+#: ../src/wxMaximaFrame.cpp:811
 msgid "Least Common Multiple..."
 msgstr "Pienin yhteinen jaettava..."
 
-#: ../src/wxMaxima.cpp:4809
+#: ../src/wxMaxima.cpp:4821
 msgid "Least Squares Fit"
 msgstr "Pienimmän neliösumman sovitus"
 
-#: ../src/wxMaximaFrame.cpp:1266
+#: ../src/wxMaximaFrame.cpp:1265
 msgid "Least Squares Fit..."
 msgstr "Pienimmän neliösumman sovitus..."
 
@@ -2504,23 +2507,23 @@ msgstr ""
 "tallennetaan hakemistoon user directory. Hakemiston saa selville komennolla "
 "maxima_userdir  "
 
-#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4192
+#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4204
 msgid "Limit"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1225
+#: ../src/wxMaximaFrame.cpp:1224
 msgid "Limit..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1265
+#: ../src/wxMaximaFrame.cpp:1264
 msgid "Linear Regression..."
 msgstr "Lineaarinen regressio..."
 
-#: ../src/wxMaxima.cpp:3803
+#: ../src/wxMaxima.cpp:3815
 msgid "List(s):"
 msgstr "Lista(t):"
 
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3848
 msgid "List:"
 msgstr "Lista:"
 
@@ -2528,15 +2531,15 @@ msgstr "Lista:"
 msgid "Load"
 msgstr "Lataa"
 
-#: ../src/wxMaxima.cpp:2932
+#: ../src/wxMaxima.cpp:2940
 msgid "Load Package"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:479
+#: ../src/wxMaximaFrame.cpp:478
 msgid "Load a Maxima file using the batch command"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:477
+#: ../src/wxMaximaFrame.cpp:476
 msgid "Load a Maxima package file"
 msgstr ""
 
@@ -2548,47 +2551,47 @@ msgstr "Lataa tyyli tiedostosta"
 msgid "Long Right arrow"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Lower bound:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:771
+#: ../src/wxMaximaFrame.cpp:770
 msgid "Ma&p to Matrix..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:547
+#: ../src/wxMaximaFrame.cpp:546
 msgid "Main Toolbar\tAlt-Shift-B"
 msgstr "Päätyökalupalkki\tAlt+Shift+B"
 
-#: ../src/wxMaximaFrame.cpp:765
+#: ../src/wxMaximaFrame.cpp:764
 msgid "Make &List..."
 msgstr "Tee &lista..."
 
-#: ../src/wxMaxima.cpp:3821
+#: ../src/wxMaxima.cpp:3833
 msgid "Make list"
 msgstr "Tee lista"
 
-#: ../src/wxMaximaFrame.cpp:766
+#: ../src/wxMaximaFrame.cpp:765
 msgid "Make list from expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:907
+#: ../src/wxMaximaFrame.cpp:906
 msgid "Make substitution in expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:682
+#: ../src/wxMaximaFrame.cpp:681
 msgid "Manually Trigger Evaluation"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3805
+#: ../src/wxMaxima.cpp:3817
 msgid "Map"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:770
+#: ../src/wxMaximaFrame.cpp:769
 msgid "Map function to a list"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:772
+#: ../src/wxMaximaFrame.cpp:771
 msgid "Map function to a matrix"
 msgstr ""
 
@@ -2605,23 +2608,23 @@ msgstr ""
 msgid "Math font:"
 msgstr "Matematiikka fontti:"
 
-#: ../src/wxMaximaFrame.cpp:374
+#: ../src/wxMaximaFrame.cpp:373
 msgid "Mathematical Symbols"
 msgstr "Matemaattiset merkit"
 
-#: ../src/wxMaxima.cpp:3716
+#: ../src/wxMaxima.cpp:3728
 msgid "Matrix"
 msgstr "Matriisi"
 
-#: ../src/wxMaxima.cpp:3702
+#: ../src/wxMaxima.cpp:3714
 msgid "Matrix map"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Matrix name:"
 msgstr "Matriisin nimi:"
 
-#: ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3749
+#: ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3761
 msgid "Matrix:"
 msgstr "Matriisi:"
 
@@ -2629,7 +2632,7 @@ msgstr "Matriisi:"
 msgid "Maxima"
 msgstr "Maxima"
 
-#: ../src/wxMaximaFrame.cpp:137
+#: ../src/wxMaximaFrame.cpp:136
 #, fuzzy
 msgid "Maxima has a question"
 msgstr "Maxima-kysymykset"
@@ -2638,23 +2641,23 @@ msgstr "Maxima-kysymykset"
 msgid "Maxima input"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:166
+#: ../src/wxMaximaFrame.cpp:165
 msgid "Maxima is calculating"
 msgstr "Maxima laskee"
 
-#: ../src/wxMaximaFrame.cpp:111
+#: ../src/wxMaximaFrame.cpp:110
 msgid "Maxima is ready for input."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2945
+#: ../src/wxMaxima.cpp:2953
 msgid "Maxima package (*.mac)|*.mac"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2934
+#: ../src/wxMaxima.cpp:2942
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1014
+#: ../src/wxMaxima.cpp:1019
 msgid "Maxima process terminated."
 msgstr ""
 
@@ -2666,7 +2669,7 @@ msgstr ""
 msgid "Maxima questions"
 msgstr "Maxima-kysymykset"
 
-#: ../src/wxMaxima.cpp:942
+#: ../src/wxMaxima.cpp:947
 msgid "Maxima started. Waiting for connection..."
 msgstr ""
 
@@ -2688,7 +2691,7 @@ msgid ""
 "('f(x) := x^2;')."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4597
+#: ../src/wxMaxima.cpp:4609
 msgid "Maxima version: "
 msgstr "Maximan versio:"
 
@@ -2725,40 +2728,40 @@ msgstr ""
 msgid "Maximum displayed number of digits:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1263
+#: ../src/wxMaximaFrame.cpp:1262
 msgid "Mean Difference Test..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1262
+#: ../src/wxMaximaFrame.cpp:1261
 msgid "Mean Test..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1255
+#: ../src/wxMaximaFrame.cpp:1254
 msgid "Mean..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Mean:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1256
+#: ../src/wxMaximaFrame.cpp:1255
 msgid "Median..."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:945
+#: ../src/MathCtrl.cpp:987
 msgid "Merge Cells"
 msgstr "Yhdistä solut"
 
-#: ../src/wxMaximaFrame.cpp:633
+#: ../src/wxMaximaFrame.cpp:632
 #, fuzzy
 msgid "Merge Cells\tCtrl-M"
 msgstr "Yhdistä solut"
 
-#: ../src/wxMaximaFrame.cpp:634
+#: ../src/wxMaximaFrame.cpp:633
 msgid "Merge the text from two input cells into one"
 msgstr "Yhdistä kahden syötetyn solun teksti yhteen soluun"
 
-#: ../src/wxMaxima.cpp:2668
+#: ../src/wxMaxima.cpp:2676
 msgid "Message from the stdout of Maxima: "
 msgstr ""
 
@@ -2766,19 +2769,19 @@ msgstr ""
 msgid "Method:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5289
+#: ../src/wxMaxima.cpp:5301
 msgid "Mismatched parenthesis"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3972
+#: ../src/wxMaxima.cpp:3984
 msgid "Modulus"
 msgstr "Modulus"
 
-#: ../src/wxMaximaFrame.cpp:1375
+#: ../src/wxMaximaFrame.cpp:1374
 msgid "Mu"
 msgstr ""
 
-#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Name:"
 msgstr "Nimi:"
 
@@ -2786,7 +2789,7 @@ msgstr "Nimi:"
 msgid "New"
 msgstr "Uusi"
 
-#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
+#: ../src/wxMaximaFrame.cpp:456 ../src/wxMaximaFrame.cpp:459
 msgid "New\tCtrl-N"
 msgstr "Uusi\tCtrl-N"
 
@@ -2802,11 +2805,11 @@ msgstr ""
 msgid "New value:"
 msgstr "Uusi arvo:"
 
-#: ../src/wxMaxima.cpp:3993 ../src/wxMaxima.cpp:4119 ../src/wxMaxima.cpp:4136
+#: ../src/wxMaxima.cpp:4005 ../src/wxMaxima.cpp:4131 ../src/wxMaxima.cpp:4148
 msgid "New variable:"
 msgstr "Uusi muuttuja:"
 
-#: ../src/wxMaximaFrame.cpp:630
+#: ../src/wxMaximaFrame.cpp:629
 msgid "Next Command\tAlt-Down"
 msgstr "Seuraava komento\tAlt-Down"
 
@@ -2814,15 +2817,15 @@ msgstr "Seuraava komento\tAlt-Down"
 msgid "No"
 msgstr "Ei"
 
-#: ../src/wxMaxima.cpp:5362
+#: ../src/wxMaxima.cpp:5378
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr "Ei dollarimerkkiä ($) tai puolipistettä (;) komennon loppuun"
 
-#: ../src/wxMaxima.cpp:3249 ../src/wxMaxima.cpp:3271
+#: ../src/wxMaxima.cpp:3260 ../src/wxMaxima.cpp:3283
 msgid "No matches found!"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1264
+#: ../src/wxMaximaFrame.cpp:1263
 msgid "Normality Test..."
 msgstr ""
 
@@ -2845,31 +2848,31 @@ msgstr ""
 msgid "Norwegian"
 msgstr "Norja"
 
-#: ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:3740
 msgid "Not a valid matrix dimension!"
 msgstr "Kelvoton matriisin dimensio!"
 
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629
 msgid "Not a valid number of equations!"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:197
+#: ../src/wxMaximaFrame.cpp:196
 msgid "Not connected to maxima"
 msgstr "Ei yhdistetty maximaan"
 
-#: ../src/wxMaxima.cpp:4599
+#: ../src/wxMaxima.cpp:4611
 msgid "Not connected."
 msgstr "Ei yhdistetty."
 
-#: ../src/wxMaximaFrame.cpp:1376
+#: ../src/wxMaximaFrame.cpp:1375
 msgid "Nu"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Num. deg:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3585 ../src/wxMaxima.cpp:3609
+#: ../src/wxMaxima.cpp:3597 ../src/wxMaxima.cpp:3621
 msgid "Number of equations:"
 msgstr "Yhtälöiden lukumäärä:"
 
@@ -2896,15 +2899,15 @@ msgstr "Ok"
 msgid "Old value:"
 msgstr "Vanha arvo:"
 
-#: ../src/wxMaxima.cpp:3992 ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135
+#: ../src/wxMaxima.cpp:4004 ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147
 msgid "Old variable:"
 msgstr "Vanha muuttuja:"
 
-#: ../src/wxMaximaFrame.cpp:1387
+#: ../src/wxMaximaFrame.cpp:1386
 msgid "Omega"
 msgstr "Oomega"
 
-#: ../src/wxMaximaFrame.cpp:1378
+#: ../src/wxMaximaFrame.cpp:1377
 msgid "Omicron"
 msgstr ""
 
@@ -2918,20 +2921,20 @@ msgid ""
 "stream for messages."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4763
+#: ../src/wxMaxima.cpp:4775
 msgid "One sample t-test"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:971
+#: ../src/wxMaximaFrame.cpp:970
 msgid "Online tutorials"
 msgstr ""
 
 #: ../src/ConfigDialogue.cpp:656 ../src/main.cpp:347 ../src/ToolBar.cpp:119
-#: ../src/wxMaxima.cpp:2797
+#: ../src/wxMaxima.cpp:2805
 msgid "Open"
 msgstr "Avaa"
 
-#: ../src/wxMaximaFrame.cpp:466
+#: ../src/wxMaximaFrame.cpp:465
 msgid "Open Recent"
 msgstr "Avaa viimeisin"
 
@@ -2939,11 +2942,11 @@ msgstr "Avaa viimeisin"
 msgid "Open a cell when Maxima expects input"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:464
+#: ../src/wxMaximaFrame.cpp:463
 msgid "Open a document"
 msgstr "Avaa asiakirja"
 
-#: ../src/wxMaximaFrame.cpp:458 ../src/wxMaximaFrame.cpp:461
+#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
 msgid "Open a new window"
 msgstr "Avaa uusi ikkuna"
 
@@ -2951,11 +2954,11 @@ msgstr "Avaa uusi ikkuna"
 msgid "Open document"
 msgstr "Avaa asiakirja"
 
-#: ../src/wxMaxima.cpp:4824
+#: ../src/wxMaxima.cpp:4836
 msgid "Open matrix"
 msgstr "Avaa matriisi"
 
-#: ../src/wxMaxima.cpp:1446 ../src/wxMaxima.cpp:1518
+#: ../src/wxMaxima.cpp:1451 ../src/wxMaxima.cpp:1523
 msgid "Opening file"
 msgstr ""
 
@@ -2979,26 +2982,26 @@ msgstr "Vanhentuneet solut"
 msgid "Output labels"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:796
+#: ../src/wxMaximaFrame.cpp:795
 msgid "P&ade Approximation..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3132 ../src/wxMaxima.cpp:5133
+#: ../src/wxMaxima.cpp:3141 ../src/wxMaxima.cpp:5145
 msgid ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
 "bmp|Portable animap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X "
 "pixmap (*.xpm)|*.xpm"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4012
+#: ../src/wxMaxima.cpp:4024
 msgid "Pade approximation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:797
+#: ../src/wxMaximaFrame.cpp:796
 msgid "Pade approximation of a Taylor series"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1500
+#: ../src/wxMaximaFrame.cpp:1519
 msgid "Pagebreak"
 msgstr "Sivunvaihto"
 
@@ -3010,19 +3013,19 @@ msgstr "Yhdensuuntaiset"
 msgid "Parametric plot"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:188
+#: ../src/wxMaximaFrame.cpp:187
 msgid "Parsing output"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:819
+#: ../src/wxMaximaFrame.cpp:818
 msgid "Partial &Fractions..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4076
+#: ../src/wxMaxima.cpp:4088
 msgid "Partial fractions"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1769
+#: ../src/wxMaxima.cpp:1774
 msgid "Parts of the document will not be loaded correctly!"
 msgstr ""
 
@@ -3032,11 +3035,11 @@ msgid ""
 "Found unknown XML Tag name "
 msgstr ""
 
-#: ../src/ToolBar.cpp:143 ../src/MathCtrl.cpp:1010 ../src/MathCtrl.cpp:1025
+#: ../src/MathCtrl.cpp:1052 ../src/MathCtrl.cpp:1067 ../src/ToolBar.cpp:143
 msgid "Paste"
 msgstr "Liitä"
 
-#: ../src/wxMaximaFrame.cpp:518
+#: ../src/wxMaximaFrame.cpp:517
 msgid "Paste\tCtrl-V"
 msgstr "Liitä\tCtrl-V"
 
@@ -3044,7 +3047,7 @@ msgstr "Liitä\tCtrl-V"
 msgid "Paste from clipboard"
 msgstr "Liitä leikepöydältä"
 
-#: ../src/wxMaximaFrame.cpp:519
+#: ../src/wxMaximaFrame.cpp:518
 msgid "Paste text from clipboard"
 msgstr "Liitä teksti leikepöydältä"
 
@@ -3052,19 +3055,19 @@ msgstr "Liitä teksti leikepöydältä"
 msgid "Perpendicular to"
 msgstr "Kohtisuorassa"
 
-#: ../src/wxMaximaFrame.cpp:1384
+#: ../src/wxMaximaFrame.cpp:1383
 msgid "Phi"
 msgstr "Fii"
 
-#: ../src/wxMaximaFrame.cpp:1379
+#: ../src/wxMaximaFrame.cpp:1378
 msgid "Pi"
 msgstr "Pii"
 
-#: ../src/wxMaximaFrame.cpp:1273
+#: ../src/wxMaximaFrame.cpp:1272
 msgid "Piechart..."
 msgstr "Sektoridiagrammi..."
 
-#: ../src/wxMaxima.cpp:1952
+#: ../src/wxMaxima.cpp:1957
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr ""
 
@@ -3072,52 +3075,52 @@ msgstr ""
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:923
+#: ../src/wxMaximaFrame.cpp:922
 msgid "Plot &2d..."
 msgstr "Kuvaaja &2d..."
 
-#: ../src/wxMaximaFrame.cpp:925
+#: ../src/wxMaximaFrame.cpp:924
 msgid "Plot &3d..."
 msgstr "Kuvaaja &3d..."
 
-#: ../src/wxMaximaFrame.cpp:927
+#: ../src/wxMaximaFrame.cpp:926
 msgid "Plot &Format..."
 msgstr "&Kuvaajamuoto"
 
 #: ../src/Plot2dWiz.cpp:104 ../src/Plot2dWiz.cpp:450 ../src/Plot2dWiz.cpp:464
-#: ../src/wxMaxima.cpp:4283 ../src/wxMaxima.cpp:5102
+#: ../src/wxMaxima.cpp:4295 ../src/wxMaxima.cpp:5114
 msgid "Plot 2D"
 msgstr "Kuvaaja 2D"
 
-#: ../src/wxMaximaFrame.cpp:1227
+#: ../src/wxMaximaFrame.cpp:1226
 msgid "Plot 2D..."
 msgstr "Kuvaaja 2D..."
 
-#: ../src/MathCtrl.cpp:1003
+#: ../src/MathCtrl.cpp:1045
 msgid "Plot 2d..."
 msgstr "Kuvaaja 2d..."
 
-#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4269 ../src/wxMaxima.cpp:5115
+#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4281 ../src/wxMaxima.cpp:5127
 msgid "Plot 3D"
 msgstr "Kuvaaja 3D"
 
-#: ../src/wxMaximaFrame.cpp:1228
+#: ../src/wxMaximaFrame.cpp:1227
 msgid "Plot 3D..."
 msgstr "Kuvaaja 3D..."
 
-#: ../src/MathCtrl.cpp:1004
+#: ../src/MathCtrl.cpp:1046
 msgid "Plot 3d..."
 msgstr "Kuvaaja 3d..."
 
-#: ../src/wxMaxima.cpp:4296
+#: ../src/wxMaxima.cpp:4308
 msgid "Plot format"
 msgstr "Kuvaajamuoto"
 
-#: ../src/wxMaximaFrame.cpp:924
+#: ../src/wxMaximaFrame.cpp:923
 msgid "Plot in 2 dimensions"
 msgstr "Kaksiulotteinen kuvaaja"
 
-#: ../src/wxMaximaFrame.cpp:926
+#: ../src/wxMaximaFrame.cpp:925
 msgid "Plot in 3 dimensions"
 msgstr "Kolmiulotteinen kuvaaja"
 
@@ -3126,8 +3129,8 @@ msgid "Plot to file:"
 msgstr "Kuvaaja tiedostoksi:"
 
 #: ../src/BC2Wiz.cpp:30 ../src/BC2Wiz.cpp:36 ../src/LimitWiz.cpp:33
-#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
-#: ../src/wxMaxima.cpp:3648
+#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
+#: ../src/wxMaxima.cpp:3660
 msgid "Point:"
 msgstr "Piste:"
 
@@ -3135,11 +3138,11 @@ msgstr "Piste:"
 msgid "Polish"
 msgstr "Puola"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 1:"
 msgstr "Polynomi 1:"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 2:"
 msgstr "Polynomi 2:"
 
@@ -3151,11 +3154,11 @@ msgstr "Portugali (Brasilian)"
 msgid "Postscript file (*.eps)|*.eps|All|*"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Precision"
 msgstr "Tarkkuus"
 
-#: ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:536
 msgid "Preferences...\tCtrl+,"
 msgstr ""
 
@@ -3167,7 +3170,7 @@ msgid ""
 "packages and from functions that are defined in the current file."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:628
+#: ../src/wxMaximaFrame.cpp:627
 msgid "Previous Command\tAlt-Up"
 msgstr ""
 
@@ -3175,11 +3178,11 @@ msgstr ""
 msgid "Print"
 msgstr "Tulosta"
 
-#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:484
+#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:483
 msgid "Print document"
 msgstr "Tulosta asiakirja"
 
-#: ../src/wxMaxima.cpp:4242
+#: ../src/wxMaxima.cpp:4254
 msgid "Product"
 msgstr ""
 
@@ -3187,35 +3190,35 @@ msgstr ""
 msgid "Product sign"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1386
+#: ../src/wxMaximaFrame.cpp:1385
 msgid "Psi"
 msgstr "Psii"
 
-#: ../src/wxMaximaFrame.cpp:331
+#: ../src/wxMaximaFrame.cpp:330
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:592
+#: ../src/wxMaximaFrame.cpp:591
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1278
+#: ../src/wxMaximaFrame.cpp:1277
 msgid "Read Matrix..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:177
+#: ../src/wxMaximaFrame.cpp:176
 msgid "Reading Maxima output"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:153
+#: ../src/wxMaximaFrame.cpp:152
 msgid "Ready for user input"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:631
+#: ../src/wxMaximaFrame.cpp:630
 msgid "Recall next command from history"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:629
+#: ../src/wxMaximaFrame.cpp:628
 msgid "Recall previous command from history"
 msgstr ""
 
@@ -3223,35 +3226,35 @@ msgstr ""
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1215
+#: ../src/wxMaximaFrame.cpp:1214
 msgid "Rectform"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:495
+#: ../src/wxMaximaFrame.cpp:494
 msgid "Redo\tCtrl-Y"
 msgstr "Tee uudelleen\tCtrl+Y"
 
-#: ../src/wxMaximaFrame.cpp:496
+#: ../src/wxMaximaFrame.cpp:495
 msgid "Redo last change"
 msgstr "Tekee edellisen muutoksen uudelleen"
 
-#: ../src/wxMaximaFrame.cpp:1220
+#: ../src/wxMaximaFrame.cpp:1219
 msgid "Reduce (tr)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:871
+#: ../src/wxMaximaFrame.cpp:870
 msgid "Reduce trigonometric expression"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:622 ../src/wxMaxima.cpp:5495
+#: ../src/wxMaxima.cpp:627 ../src/wxMaxima.cpp:5511
 msgid "Refusing to send cell to maxima: "
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:594
+#: ../src/wxMaximaFrame.cpp:593
 msgid "Remove All Output"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:595
+#: ../src/wxMaximaFrame.cpp:594
 msgid "Remove output from input cells"
 msgstr ""
 
@@ -3260,7 +3263,7 @@ msgstr ""
 msgid "Replace All"
 msgstr "Valitse kaikki"
 
-#: ../src/wxMaxima.cpp:3282
+#: ../src/wxMaxima.cpp:3294
 #, c-format
 msgid "Replaced %d occurrences."
 msgstr ""
@@ -3269,11 +3272,11 @@ msgstr ""
 msgid "Replacement:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:976
+#: ../src/wxMaximaFrame.cpp:975
 msgid "Report bug"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "Restart Maxima"
 msgstr "Uudelleenkäynnistä Maxima"
 
@@ -3281,7 +3284,7 @@ msgstr "Uudelleenkäynnistä Maxima"
 msgid "Restart maxima"
 msgstr "Uudelleenkäynnistä maxima"
 
-#: ../src/MathCtrl.cpp:4442
+#: ../src/MathCtrl.cpp:4497
 msgid "Result"
 msgstr "Tulos"
 
@@ -3289,7 +3292,7 @@ msgstr "Tulos"
 msgid "Return to the cell that is currently being evaluated"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1380
+#: ../src/wxMaximaFrame.cpp:1379
 msgid "Rho"
 msgstr "Rhoo"
 
@@ -3297,19 +3300,19 @@ msgstr "Rhoo"
 msgid "Right arrow"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:779
+#: ../src/wxMaximaFrame.cpp:778
 msgid "Risch Integration..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:694
+#: ../src/wxMaximaFrame.cpp:693
 msgid "Roots of &Polynomial"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:697
+#: ../src/wxMaximaFrame.cpp:696
 msgid "Roots of Polynomial (bfloat)"
 msgstr ""
 
-#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Rows:"
 msgstr "Rivit:"
 
@@ -3317,56 +3320,56 @@ msgstr "Rivit:"
 msgid "Russian"
 msgstr "Venäjä"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 1:"
 msgstr "Esimerkki 1:"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 2:"
 msgstr "Esimerkki 2:"
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Sample:"
 msgstr "Esimerkki:"
 
 #: ../src/ConfigDialogue.cpp:781 ../src/ToolBar.cpp:122
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Save"
 msgstr "Tallenna"
 
-#: ../src/MathCtrl.cpp:921
+#: ../src/MathCtrl.cpp:963
 msgid "Save Animation..."
 msgstr "Tallenna animaatio..."
 
-#: ../src/wxMaxima.cpp:2565
+#: ../src/wxMaxima.cpp:2572
 msgid "Save As"
 msgstr "Tallenna nimellä"
 
-#: ../src/wxMaximaFrame.cpp:474
+#: ../src/wxMaximaFrame.cpp:473
 msgid "Save As...\tShift-Ctrl-S"
 msgstr "Tallenna nimellä...\tShift-Ctrl-S"
 
-#: ../src/MathCtrl.cpp:919
+#: ../src/MathCtrl.cpp:961
 msgid "Save Image..."
 msgstr "Tallenna kuva..."
 
-#: ../src/wxMaxima.cpp:3130
+#: ../src/wxMaxima.cpp:3139
 msgid "Save Selection to Image"
 msgstr "Tallenna valinta kuvaksi"
 
-#: ../src/wxMaximaFrame.cpp:528
+#: ../src/wxMaximaFrame.cpp:527
 msgid "Save Selection to Image..."
 msgstr "Tallenna valinta kuvaksi..."
 
-#: ../src/wxMaxima.cpp:5150
+#: ../src/wxMaxima.cpp:5162
 msgid "Save animation to file"
 msgstr "Tallenna animaatio tiedostoksi"
 
-#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:473
+#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:472
 msgid "Save document"
 msgstr "Tallenna asiakirja"
 
-#: ../src/wxMaximaFrame.cpp:475
+#: ../src/wxMaximaFrame.cpp:474
 msgid "Save document as"
 msgstr "Tallenna asiakirja nimellä"
 
@@ -3388,11 +3391,11 @@ msgstr ""
 msgid "Save plot to file"
 msgstr "Tallenna kuvaaja tiedostoksi "
 
-#: ../src/wxMaximaFrame.cpp:529
+#: ../src/wxMaximaFrame.cpp:528
 msgid "Save selection from document to an image file"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5131
+#: ../src/wxMaxima.cpp:5143
 msgid "Save selection to file"
 msgstr "Tallenna valinta tiedostoksi"
 
@@ -3408,27 +3411,27 @@ msgstr "Tallenna wxMaximan ikkuna koko ja sijanti"
 msgid "Save wxMaxima window size/position between sessions."
 msgstr "Tallenna wxMaximan ikkuna koko ja sijainti istuntojen välillä."
 
-#: ../src/wxMaximaFrame.cpp:246
+#: ../src/wxMaximaFrame.cpp:245
 msgid "Saving failed."
 msgstr "Tallentaminen epäonnistui."
 
-#: ../src/wxMaximaFrame.cpp:222
+#: ../src/wxMaximaFrame.cpp:221
 msgid "Saving successful."
 msgstr "Tallentaminen onnistui."
 
-#: ../src/wxMaximaFrame.cpp:212
+#: ../src/wxMaximaFrame.cpp:211
 msgid "Saving..."
 msgstr "Tallentaa..."
 
-#: ../src/wxMaxima.cpp:4699
+#: ../src/wxMaxima.cpp:4711
 msgid "Scatterplot"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1271
+#: ../src/wxMaximaFrame.cpp:1270
 msgid "Scatterplot..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1498
+#: ../src/wxMaximaFrame.cpp:1517
 msgid "Section"
 msgstr ""
 
@@ -3436,26 +3439,26 @@ msgstr ""
 msgid "Section cell"
 msgstr ""
 
-#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:292 ../src/TextCell.cpp:306
-#: ../src/TextCell.cpp:322 ../src/TextCell.cpp:334
+#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:290 ../src/TextCell.cpp:304
+#: ../src/TextCell.cpp:320 ../src/TextCell.cpp:332
 msgid ""
 "Seems like something is broken with a font. Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/TextCell.cpp:139
+#: ../src/TextCell.cpp:137
 msgid ""
 "Seems like something is broken with the maths font. Installing http://www."
 "math.union.edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use "
 "JSmath fonts\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1011 ../src/MathCtrl.cpp:1027
+#: ../src/MathCtrl.cpp:1053 ../src/MathCtrl.cpp:1069
 msgid "Select All"
 msgstr "Valitse kaikki"
 
-#: ../src/wxMaximaFrame.cpp:525
+#: ../src/wxMaximaFrame.cpp:524
 msgid "Select All\tCtrl-A"
 msgstr "Valitse kaikki\tCtrl-A"
 
@@ -3463,7 +3466,7 @@ msgstr "Valitse kaikki\tCtrl-A"
 msgid "Select Maxima program"
 msgstr "Valitse Maxima ohjelma"
 
-#: ../src/wxMaxima.cpp:4860
+#: ../src/wxMaxima.cpp:4872
 msgid "Select Subsample"
 msgstr ""
 
@@ -3472,11 +3475,11 @@ msgstr ""
 msgid "Select a constant"
 msgstr "Valitse vakio"
 
-#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:526
+#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:525
 msgid "Select all"
 msgstr "Valitse kaikki"
 
-#: ../src/wxMaxima.cpp:3319
+#: ../src/wxMaxima.cpp:3331
 msgid "Select math display algorithm"
 msgstr ""
 
@@ -3490,23 +3493,23 @@ msgstr ""
 msgid "Selection"
 msgstr ""
 
-#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4178
+#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4190
 msgid "Series"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1226
+#: ../src/wxMaximaFrame.cpp:1225
 msgid "Series..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:863
+#: ../src/wxMaxima.cpp:868
 msgid "Server started"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:575
+#: ../src/wxMaximaFrame.cpp:574
 msgid "Set Zoom"
 msgstr "Suurennos"
 
-#: ../src/wxMaximaFrame.cpp:944
+#: ../src/wxMaximaFrame.cpp:943
 msgid "Set bigfloat &Precision..."
 msgstr ""
 
@@ -3514,61 +3517,61 @@ msgstr ""
 msgid "Set fixed font in text controls."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:928
+#: ../src/wxMaximaFrame.cpp:927
 msgid "Set plot format"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:945
+#: ../src/wxMaximaFrame.cpp:944
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can "
 "be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:569
+#: ../src/wxMaximaFrame.cpp:568
 msgid "Set zoom to 100%"
 msgstr "Suurennos 100%"
 
-#: ../src/wxMaximaFrame.cpp:570
+#: ../src/wxMaximaFrame.cpp:569
 msgid "Set zoom to 120%"
 msgstr "Suurennos 120%"
 
-#: ../src/wxMaximaFrame.cpp:571
+#: ../src/wxMaximaFrame.cpp:570
 msgid "Set zoom to 150%"
 msgstr "Suurennos 150%"
 
-#: ../src/wxMaximaFrame.cpp:572
+#: ../src/wxMaximaFrame.cpp:571
 msgid "Set zoom to 200%"
 msgstr "Suurennos 200%"
 
-#: ../src/wxMaximaFrame.cpp:573
+#: ../src/wxMaximaFrame.cpp:572
 msgid "Set zoom to 300%"
 msgstr "Suurennos 300%"
 
-#: ../src/wxMaximaFrame.cpp:568
+#: ../src/wxMaximaFrame.cpp:567
 msgid "Set zoom to 80%"
 msgstr "Suurennos 80%"
 
-#: ../src/wxMaximaFrame.cpp:732
+#: ../src/wxMaximaFrame.cpp:731
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:918
+#: ../src/wxMaximaFrame.cpp:917
 msgid "Setup modulus computation"
 msgstr "Aseta modulo-laskenta"
 
-#: ../src/wxMaximaFrame.cpp:662
+#: ../src/wxMaximaFrame.cpp:661
 msgid "Show &Definition..."
 msgstr "Näytä &Määritelmä..."
 
-#: ../src/wxMaximaFrame.cpp:660
+#: ../src/wxMaximaFrame.cpp:659
 msgid "Show &Functions"
 msgstr "Näytä &Funktiot"
 
-#: ../src/wxMaximaFrame.cpp:967
+#: ../src/wxMaximaFrame.cpp:966
 msgid "Show &Tips..."
 msgstr "Näytä &Vinkit..."
 
-#: ../src/wxMaximaFrame.cpp:665
+#: ../src/wxMaximaFrame.cpp:664
 msgid "Show &Variables"
 msgstr "Näytä &Muuttujat"
 
@@ -3576,43 +3579,43 @@ msgstr "Näytä &Muuttujat"
 msgid "Show Maxima help"
 msgstr "Näytä Maxima ohje"
 
-#: ../src/wxMaximaFrame.cpp:603
+#: ../src/wxMaximaFrame.cpp:602
 msgid "Show Template\tCtrl-Shift-K"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:968
+#: ../src/wxMaximaFrame.cpp:967
 msgid "Show a tip"
 msgstr "Näytä vihje"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Show all commands similar to:"
 msgstr "Näytä kaikki samanlaiset komennot:"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Show an example for the command:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:962
+#: ../src/wxMaximaFrame.cpp:961
 msgid "Show an example of usage"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:965
+#: ../src/wxMaximaFrame.cpp:964
 msgid "Show commands similar to"
 msgstr "Näytä kaikki samanlaiset komennot"
 
-#: ../src/wxMaximaFrame.cpp:661
+#: ../src/wxMaximaFrame.cpp:660
 msgid "Show defined functions"
 msgstr "Näytä määritellyt funktiot"
 
-#: ../src/wxMaximaFrame.cpp:666
+#: ../src/wxMaximaFrame.cpp:665
 msgid "Show defined variables"
 msgstr "Näytä määritellyt muuttujat"
 
-#: ../src/wxMaximaFrame.cpp:663
+#: ../src/wxMaximaFrame.cpp:662
 msgid "Show definition of a function"
 msgstr "Näytä funktion määrittely"
 
-#: ../src/wxMaximaFrame.cpp:604
+#: ../src/wxMaximaFrame.cpp:603
 msgid "Show function template"
 msgstr ""
 
@@ -3625,7 +3628,7 @@ msgstr ""
 msgid "Show long expressions:"
 msgstr "Lausekkeen tekijä"
 
-#: ../src/wxMaxima.cpp:3341
+#: ../src/wxMaxima.cpp:3353
 msgid "Show the definition of function:"
 msgstr ""
 
@@ -3634,43 +3637,43 @@ msgstr ""
 msgid "Show user-defined labels instead of (%oxx)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:953 ../src/wxMaximaFrame.cpp:956
+#: ../src/wxMaximaFrame.cpp:952 ../src/wxMaximaFrame.cpp:955
 msgid "Show wxMaxima help"
 msgstr "Näytä Maxima ohje"
 
-#: ../src/wxMaximaFrame.cpp:1381
+#: ../src/wxMaximaFrame.cpp:1380
 msgid "Sigma"
 msgstr "Sigma"
 
-#: ../src/wxMaximaFrame.cpp:1211
+#: ../src/wxMaximaFrame.cpp:1210
 msgid "Simplify"
 msgstr "Sievennä"
 
-#: ../src/wxMaximaFrame.cpp:831
+#: ../src/wxMaximaFrame.cpp:830
 msgid "Simplify &Radicals"
 msgstr "Sievennä &juuret"
 
-#: ../src/wxMaximaFrame.cpp:1212
+#: ../src/wxMaximaFrame.cpp:1211
 msgid "Simplify (r)"
 msgstr "Sievennä (r)"
 
-#: ../src/wxMaximaFrame.cpp:1218
+#: ../src/wxMaximaFrame.cpp:1217
 msgid "Simplify (tr)"
 msgstr "Sievennä (tr)"
 
-#: ../src/MathCtrl.cpp:995
+#: ../src/MathCtrl.cpp:1037
 msgid "Simplify Expression"
 msgstr "Sievennä lauseke"
 
-#: ../src/wxMaximaFrame.cpp:857
+#: ../src/wxMaximaFrame.cpp:856
 msgid "Simplify an expression containing factorials"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:832
+#: ../src/wxMaximaFrame.cpp:831
 msgid "Simplify expression containing radicals"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:830
+#: ../src/wxMaximaFrame.cpp:829
 msgid "Simplify rational expression"
 msgstr "Sievennä rationaalilauseke"
 
@@ -3678,7 +3681,7 @@ msgstr "Sievennä rationaalilauseke"
 msgid "Simplify the sum"
 msgstr "Sievennä summa"
 
-#: ../src/wxMaximaFrame.cpp:868
+#: ../src/wxMaximaFrame.cpp:867
 msgid "Simplify trigonometric expression"
 msgstr "Sievennä trigonometrinen lauseke"
 
@@ -3690,87 +3693,87 @@ msgid ""
 "along with your document."
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
+#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
 msgid "Solution:"
 msgstr "Ratkaisu:"
 
-#: ../src/wxMaxima.cpp:3461 ../src/wxMaxima.cpp:3475 ../src/wxMaxima.cpp:5020
+#: ../src/wxMaxima.cpp:3473 ../src/wxMaxima.cpp:3487 ../src/wxMaxima.cpp:5032
 msgid "Solve"
 msgstr "Ratkaise"
 
-#: ../src/wxMaximaFrame.cpp:706
+#: ../src/wxMaximaFrame.cpp:705
 msgid "Solve &Algebraic System..."
 msgstr "Ratkaise algebrallinen &yhtälöryhmä"
 
-#: ../src/wxMaximaFrame.cpp:703
+#: ../src/wxMaximaFrame.cpp:702
 msgid "Solve &Linear System..."
 msgstr "Ratkaise lineaarinen &yhtälöryhmä"
 
-#: ../src/wxMaximaFrame.cpp:714
+#: ../src/wxMaximaFrame.cpp:713
 msgid "Solve &ODE..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:690
+#: ../src/wxMaximaFrame.cpp:689
 msgid "Solve (to_poly)..."
 msgstr "Ratkaise (to_poly)..."
 
-#: ../src/wxMaxima.cpp:3511 ../src/wxMaxima.cpp:3635
+#: ../src/wxMaxima.cpp:3523 ../src/wxMaxima.cpp:3647
 msgid "Solve ODE"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:728
+#: ../src/wxMaximaFrame.cpp:727
 msgid "Solve ODE with Lapla&ce..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1222
+#: ../src/wxMaximaFrame.cpp:1221
 msgid "Solve ODE..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3586 ../src/wxMaxima.cpp:3597
+#: ../src/wxMaxima.cpp:3598 ../src/wxMaxima.cpp:3609
 msgid "Solve algebraic system"
 msgstr "Ratkaise algebrallinen &yhtälöryhmä"
 
-#: ../src/wxMaximaFrame.cpp:707
+#: ../src/wxMaximaFrame.cpp:706
 msgid "Solve algebraic system of equations"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:725
+#: ../src/wxMaximaFrame.cpp:724
 msgid "Solve boundary value problem for second degree ODE"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:689
+#: ../src/wxMaximaFrame.cpp:688
 msgid "Solve equation(s)"
 msgstr "Ratkaise yhtälö(t)"
 
-#: ../src/wxMaximaFrame.cpp:691
+#: ../src/wxMaximaFrame.cpp:690
 msgid "Solve equation(s) with to_poly_solve"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:719
+#: ../src/wxMaximaFrame.cpp:718
 msgid "Solve initial value problem for first degree ODE"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:722
+#: ../src/wxMaximaFrame.cpp:721
 msgid "Solve initial value problem for second degree ODE"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3610 ../src/wxMaxima.cpp:3621
+#: ../src/wxMaxima.cpp:3622 ../src/wxMaxima.cpp:3633
 msgid "Solve linear system"
 msgstr "Ratkaise lineaarinen &yhtälöryhmä"
 
-#: ../src/wxMaximaFrame.cpp:704
+#: ../src/wxMaximaFrame.cpp:703
 msgid "Solve linear system of equations"
 msgstr "Ratkaise lineaarinen yhtälöryhmä"
 
-#: ../src/wxMaximaFrame.cpp:715
+#: ../src/wxMaximaFrame.cpp:714
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:729
+#: ../src/wxMaximaFrame.cpp:728
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1221 ../src/MathCtrl.cpp:992
+#: ../src/MathCtrl.cpp:1034 ../src/wxMaximaFrame.cpp:1220
 msgid "Solve..."
 msgstr "Ratkaise..."
 
@@ -3794,7 +3797,7 @@ msgstr ""
 msgid "Special constants"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:922
+#: ../src/MathCtrl.cpp:964
 msgid "Start Animation"
 msgstr "Aloita animaatio"
 
@@ -3812,28 +3815,28 @@ msgstr ""
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:294
+#: ../src/wxMaxima.cpp:295
 msgid "Starting Maxima process failed"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:928
+#: ../src/wxMaxima.cpp:933
 msgid "Starting Maxima..."
 msgstr "Käynnistetään Maximaa..."
 
-#: ../src/wxMaxima.cpp:292 ../src/wxMaxima.cpp:860
+#: ../src/wxMaxima.cpp:293 ../src/wxMaxima.cpp:865
 msgid "Starting server failed"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:841
+#: ../src/wxMaxima.cpp:846
 #, c-format
 msgid "Starting server on port %d"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:342
+#: ../src/wxMaximaFrame.cpp:341
 msgid "Statistics"
 msgstr "Tilastot"
 
-#: ../src/wxMaximaFrame.cpp:550
+#: ../src/wxMaximaFrame.cpp:549
 msgid "Statistics\tAlt-Shift-S"
 msgstr "Tilastot\tAlt-Shift- S"
 
@@ -3849,11 +3852,11 @@ msgstr "Tyyli"
 msgid "Styles"
 msgstr "Tyylit"
 
-#: ../src/wxMaximaFrame.cpp:1283
+#: ../src/wxMaximaFrame.cpp:1282
 msgid "Subsample..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1496
+#: ../src/wxMaximaFrame.cpp:1515
 msgid "Subsection"
 msgstr ""
 
@@ -3861,20 +3864,20 @@ msgstr ""
 msgid "Subsection cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1216
+#: ../src/wxMaximaFrame.cpp:1215
 msgid "Subst..."
 msgstr ""
 
-#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3423
-#: ../src/wxMaxima.cpp:5089
+#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3435
+#: ../src/wxMaxima.cpp:5101
 msgid "Substitute"
 msgstr "Korvaa"
 
-#: ../src/wxMaximaFrame.cpp:906 ../src/MathCtrl.cpp:998
+#: ../src/MathCtrl.cpp:1040 ../src/wxMaximaFrame.cpp:905
 msgid "Substitute..."
 msgstr "Korvaa..."
 
-#: ../src/wxMaximaFrame.cpp:1497
+#: ../src/wxMaximaFrame.cpp:1516
 msgid "Subsubsection"
 msgstr ""
 
@@ -3882,7 +3885,7 @@ msgstr ""
 msgid "Subsubsection cell"
 msgstr ""
 
-#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4226
+#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4238
 msgid "Sum"
 msgstr "Summa"
 
@@ -3890,36 +3893,36 @@ msgstr "Summa"
 msgid "Sum sign"
 msgstr "Summa-merkki"
 
-#: ../src/wxMaximaFrame.cpp:553
+#: ../src/wxMaximaFrame.cpp:552
 msgid "Symbols\tAlt-Shift-Y"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4456
+#: ../src/wxMaxima.cpp:4468
 msgid "System info"
 msgstr "Järjestelmätiedot"
 
-#: ../src/wxMaximaFrame.cpp:320
+#: ../src/wxMaximaFrame.cpp:319
 msgid "Table of Contents"
 msgstr "Sisällysluettelo"
 
-#: ../src/wxMaximaFrame.cpp:556
+#: ../src/wxMaximaFrame.cpp:555
 #, fuzzy
 msgid "Table of Contents\tAlt-Shift-T"
 msgstr "Sisällysluettelo\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:1382
+#: ../src/wxMaximaFrame.cpp:1381
 msgid "Tau"
 msgstr "tau"
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Taylor series:"
 msgstr "Taylorin sarjat:"
 
-#: ../src/wxMaxima.cpp:3963
+#: ../src/wxMaxima.cpp:3975
 msgid "Tellrat"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1494
+#: ../src/wxMaximaFrame.cpp:1513
 msgid "Text"
 msgstr "Teksti"
 
@@ -3964,7 +3967,7 @@ msgstr ""
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr ""
 
-#: ../src/TextCell.cpp:136
+#: ../src/TextCell.cpp:134
 msgid ""
 "The letter \"X\" is of width zero. Installing http://www.math.union.edu/"
 "~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts\" in "
@@ -3981,7 +3984,7 @@ msgstr ""
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:959
+#: ../src/wxMaximaFrame.cpp:958
 msgid "The offline manual of maxima"
 msgstr "Maximan offline-käsikirja"
 
@@ -4018,21 +4021,21 @@ msgstr ""
 "andrejv.github.com/wxmaxima/help.html löytää lisätietoja sekä tutoriaaleja "
 "wxMaximan ja Maximan käytöstä."
 
-#: ../src/SlideShowCell.cpp:332
+#: ../src/SlideShowCell.cpp:336
 msgid ""
 "There was an error during GIF export!\n"
 "\n"
 "Make sure ImageMagick is installed and wxMaxima can find the convert program."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:442
+#: ../src/wxMaxima.cpp:447
 msgid ""
 "There was an error in generated XML!\n"
 "\n"
 "Please report this as a bug."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1371
+#: ../src/wxMaximaFrame.cpp:1370
 msgid "Theta"
 msgstr "Theeta"
 
@@ -4040,7 +4043,7 @@ msgstr "Theeta"
 msgid "Ticks:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4153 ../src/wxMaxima.cpp:5065
+#: ../src/wxMaxima.cpp:4165 ../src/wxMaxima.cpp:5077
 msgid "Times:"
 msgstr ""
 
@@ -4048,7 +4051,7 @@ msgstr ""
 msgid "Tips not available, sorry!"
 msgstr "Vinkkejä ei ole saatavilla!"
 
-#: ../src/wxMaximaFrame.cpp:1495
+#: ../src/wxMaximaFrame.cpp:1514
 msgid "Title"
 msgstr "Otsikko"
 
@@ -4063,19 +4066,19 @@ msgid ""
 "all sublevels of that cell will also fold/unfold."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:938
+#: ../src/wxMaximaFrame.cpp:937
 msgid "To &Bigfloat"
 msgstr "&Liukuluvuksi (Bigfloat)"
 
-#: ../src/wxMaximaFrame.cpp:935
+#: ../src/wxMaximaFrame.cpp:934
 msgid "To &Float"
 msgstr "&Liukuluvuksi (Float)"
 
-#: ../src/MathCtrl.cpp:990
+#: ../src/MathCtrl.cpp:1032
 msgid "To Float"
 msgstr "Liukuluvuksi (Float)"
 
-#: ../src/wxMaximaFrame.cpp:941
+#: ../src/wxMaximaFrame.cpp:940
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr "N&umeeriseksi\tCtrl+Shift+N"
 
@@ -4111,51 +4114,51 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:41 ../src/Plot2dWiz.cpp:40 ../src/Plot2dWiz.cpp:50
 #: ../src/Plot2dWiz.cpp:539 ../src/Plot3dWiz.cpp:39 ../src/Plot3dWiz.cpp:48
-#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4241
+#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4253
 msgid "To:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:912
+#: ../src/wxMaximaFrame.cpp:911
 msgid "Toggle &Algebraic Flag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:933
+#: ../src/wxMaximaFrame.cpp:932
 msgid "Toggle &Numeric Output"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:673
+#: ../src/wxMaximaFrame.cpp:672
 msgid "Toggle &Time Display"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:913
+#: ../src/wxMaximaFrame.cpp:912
 msgid "Toggle algebraic flag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:577
+#: ../src/wxMaximaFrame.cpp:576
 msgid "Toggle full screen editing"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:934
+#: ../src/wxMaximaFrame.cpp:933
 msgid "Toggle numeric output"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4464
+#: ../src/wxMaxima.cpp:4476
 msgid "Toolbar icons"
 msgstr "Työkalurivin kuvakkeet"
 
-#: ../src/wxMaxima.cpp:4465
+#: ../src/wxMaxima.cpp:4477
 msgid "Translated by"
 msgstr "Käännös"
 
-#: ../src/wxMaximaFrame.cpp:763
+#: ../src/wxMaximaFrame.cpp:762
 msgid "Transpose a matrix"
 msgstr "Transponoi matriisi"
 
-#: ../src/MathCtrl.cpp:5834
+#: ../src/MathCtrl.cpp:5886
 msgid "Trying to undo an action without starting cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5901
+#: ../src/MathCtrl.cpp:5953
 msgid "Trying to undo something but the undo action is empty."
 msgstr ""
 
@@ -4163,11 +4166,11 @@ msgstr ""
 msgid "Turkish"
 msgstr "Turkki"
 
-#: ../src/wxMaximaFrame.cpp:970
+#: ../src/wxMaximaFrame.cpp:969
 msgid "Tutorials"
 msgstr "Oppaat"
 
-#: ../src/wxMaxima.cpp:4778
+#: ../src/wxMaxima.cpp:4790
 msgid "Two sample t-test"
 msgstr ""
 
@@ -4179,15 +4182,15 @@ msgstr "Tyyppi:"
 msgid "Ukrainian"
 msgstr "Ukraina"
 
-#: ../src/wxMaxima.cpp:5356
+#: ../src/wxMaxima.cpp:5372
 msgid "Un-closed parenthesis"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5323
+#: ../src/wxMaxima.cpp:5335
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5889
 msgid ""
 "Unable to interpret the version info I got from http://andrejv.github.io//"
 "wxmaxima/version.txt: "
@@ -4201,11 +4204,11 @@ msgstr "Alleviivattu"
 msgid "Underscore converts to subscripts:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:492
+#: ../src/wxMaximaFrame.cpp:491
 msgid "Undo\tCtrl-Z"
 msgstr "Kumoa\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:493
+#: ../src/wxMaximaFrame.cpp:492
 msgid "Undo last change"
 msgstr "Kumoa viimeisin muutos"
 
@@ -4213,23 +4216,23 @@ msgstr "Kumoa viimeisin muutos"
 msgid "Undo limit (0 for none):"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:625
+#: ../src/wxMaximaFrame.cpp:624
 msgid "Unfold All\tCtrl-Alt-]"
 msgstr "Näytä kaikki\tCtrl-Alt-]"
 
-#: ../src/wxMaximaFrame.cpp:626
+#: ../src/wxMaximaFrame.cpp:625
 msgid "Unfold all folded sections"
 msgstr "Näytä piilotetut kappaleet\tCtrl-Alt-]"
 
-#: ../src/wxMaxima.cpp:4458
+#: ../src/wxMaxima.cpp:4470
 msgid "Unicode Support"
 msgstr "Unicode tuki"
 
-#: ../src/wxMaxima.cpp:5335
+#: ../src/wxMaxima.cpp:5347
 msgid "Unterminated comment."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5309
+#: ../src/wxMaxima.cpp:5321
 msgid "Unterminated string."
 msgstr "Päättymätön merkkijono."
 
@@ -4237,15 +4240,15 @@ msgstr "Päättymätön merkkijono."
 msgid "Up"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5859 ../src/wxMaxima.cpp:5866 ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5874 ../src/wxMaxima.cpp:5881 ../src/wxMaxima.cpp:5889
 msgid "Upgrade"
 msgstr "Päivitä"
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Upper bound:"
 msgstr "Yläraja:"
 
-#: ../src/wxMaximaFrame.cpp:1383
+#: ../src/wxMaximaFrame.cpp:1382
 #, fuzzy
 msgid "Upsilon"
 msgstr "Epsilon:"
@@ -4290,22 +4293,22 @@ msgstr ""
 msgid "User-defined labels"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3525
-#: ../src/wxMaxima.cpp:3541 ../src/wxMaxima.cpp:3649
+#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3537
+#: ../src/wxMaxima.cpp:3553 ../src/wxMaxima.cpp:3661
 msgid "Value:"
 msgstr "Arvo"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:5019 ../src/wxMaxima.cpp:5064
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:5031 ../src/wxMaxima.cpp:5076
 msgid "Variable(s):"
 msgstr "Muuttuja(t)"
 
 #: ../src/IntegrateWiz.cpp:33 ../src/LimitWiz.cpp:30 ../src/Plot2dWiz.cpp:34
 #: ../src/Plot2dWiz.cpp:44 ../src/Plot2dWiz.cpp:533 ../src/Plot3dWiz.cpp:33
 #: ../src/Plot3dWiz.cpp:42 ../src/SeriesWiz.cpp:36 ../src/SumWiz.cpp:30
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3749
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3761
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5045
 msgid "Variable:"
 msgstr "Muuttuja"
 
@@ -4313,25 +4316,25 @@ msgstr "Muuttuja"
 msgid "Variables"
 msgstr "Muuttujat"
 
-#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3571 ../src/wxMaxima.cpp:4206
-#: ../src/wxMaxima.cpp:4807
+#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3583 ../src/wxMaxima.cpp:4218
+#: ../src/wxMaxima.cpp:4819
 msgid "Variables:"
 msgstr "Muuttujat:"
 
-#: ../src/wxMaximaFrame.cpp:1257
+#: ../src/wxMaximaFrame.cpp:1256
 msgid "Variance..."
 msgstr "Varianssi..."
 
-#: ../src/wxMaximaFrame.cpp:580
+#: ../src/wxMaximaFrame.cpp:579
 msgid "View"
 msgstr "Näkymä"
 
-#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1674 ../src/wxMaxima.cpp:1769
-#: ../src/wxMaxima.cpp:1950
+#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1679 ../src/wxMaxima.cpp:1774
+#: ../src/wxMaxima.cpp:1955
 msgid "Warning"
 msgstr "Varoitus"
 
-#: ../src/wxMaximaFrame.cpp:109 ../src/wxMaximaFrame.cpp:295
+#: ../src/wxMaximaFrame.cpp:108 ../src/wxMaximaFrame.cpp:294
 msgid "Welcome to wxMaxima"
 msgstr "Tervetuloa wxMaximaan"
 
@@ -4351,7 +4354,7 @@ msgid ""
 "introducing an empty line."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2567
+#: ../src/wxMaxima.cpp:2574
 #, fuzzy
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) "
@@ -4368,7 +4371,7 @@ msgid ""
 "as equation markers"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6798
+#: ../src/MathCtrl.cpp:6856
 msgid "Wrapped search"
 msgstr ""
 
@@ -4376,15 +4379,15 @@ msgstr ""
 msgid "Write matching parenthesis in text controls."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4461
+#: ../src/wxMaxima.cpp:4473
 msgid "Written by"
 msgstr "Kirjoittanut"
 
-#: ../src/wxMaximaFrame.cpp:557
+#: ../src/wxMaximaFrame.cpp:556
 msgid "XML Inspector"
 msgstr "XML tarkastaja"
 
-#: ../src/wxMaximaFrame.cpp:1377
+#: ../src/wxMaximaFrame.cpp:1376
 msgid "Xi"
 msgstr "Ksii"
 
@@ -4454,7 +4457,7 @@ msgstr ""
 "liikuttaessasi horisontaalista kursoria - ja järjestele valintoja. Tällä "
 "tavoin on näppärää poistaa tai arvioida useita soluja kerralla."
 
-#: ../src/wxMaxima.cpp:5856
+#: ../src/wxMaxima.cpp:5871
 #, c-format
 msgid ""
 "You have version %s. Current version is %s.\n"
@@ -4465,39 +4468,39 @@ msgstr ""
 "\n"
 "Valitse OK käydäksesi wxMaximan sivustolla."
 
-#: ../src/wxMaxima.cpp:5921
+#: ../src/wxMaxima.cpp:5936
 msgid "Your changes will be lost if you don't save them."
 msgstr "Tekemäsi muutokset häviävät ellet tallenna niitä."
 
-#: ../src/wxMaxima.cpp:5866
+#: ../src/wxMaxima.cpp:5881
 msgid "Your version of wxMaxima is up to date."
 msgstr "wxMaximassasi on viimeisin päivitys."
 
-#: ../src/wxMaximaFrame.cpp:1369
+#: ../src/wxMaximaFrame.cpp:1368
 msgid "Zeta"
 msgstr "Zeeta"
 
-#: ../src/wxMaximaFrame.cpp:562
+#: ../src/wxMaximaFrame.cpp:561
 msgid "Zoom &In\tCtrl-+"
 msgstr "Suurenna \tCtrl-+"
 
-#: ../src/wxMaximaFrame.cpp:564
+#: ../src/wxMaximaFrame.cpp:563
 msgid "Zoom Ou&t\tCtrl--"
 msgstr "Pienennä\tCtrl--"
 
-#: ../src/wxMaximaFrame.cpp:563
+#: ../src/wxMaximaFrame.cpp:562
 msgid "Zoom in 10%"
 msgstr "Suurenna 10%"
 
-#: ../src/wxMaximaFrame.cpp:565
+#: ../src/wxMaximaFrame.cpp:564
 msgid "Zoom out 10%"
 msgstr "Pienennä 10%"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaximaFrame.cpp:287
 msgid "[ unsaved ]"
 msgstr "[ tallentamaton ]"
 
-#: ../src/wxMaxima.cpp:5700
+#: ../src/wxMaxima.cpp:5715
 msgid "[ unsaved* ]"
 msgstr "[ tallentamaton* ]"
 
@@ -4506,17 +4509,17 @@ msgstr "[ tallentamaton* ]"
 msgid "[%i digits]"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4392
+#: ../src/MathCtrl.cpp:4447
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" style=\"max-width:90%%;\" >\n"
 msgstr "_%d.gif\"  alt=\"Animoitu Diagrammi\" style=\"max-width:90%%;\" >\n"
 
-#: ../src/MathCtrl.cpp:4517
+#: ../src/MathCtrl.cpp:4572
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" >"
 msgstr "_%d.gif\" alt=\"Animoitu Diagrammi\" style=\"max-width:90%%;\" >"
 
-#: ../src/wxMaximaFrame.cpp:1333
+#: ../src/wxMaximaFrame.cpp:1332
 msgid "alpha"
 msgstr "alfa"
 
@@ -4528,7 +4531,7 @@ msgstr "ja"
 msgid "antisymmetric"
 msgstr "epäsymmetrinen"
 
-#: ../src/wxMaximaFrame.cpp:1334
+#: ../src/wxMaximaFrame.cpp:1333
 msgid "beta"
 msgstr "beeta"
 
@@ -4572,7 +4575,7 @@ msgstr ""
 msgid "bug:Invalid sup tag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1354
+#: ../src/wxMaximaFrame.cpp:1353
 msgid "chi"
 msgstr "khii"
 
@@ -4585,7 +4588,7 @@ msgstr ""
 msgid "default"
 msgstr "oletus"
 
-#: ../src/wxMaximaFrame.cpp:1336
+#: ../src/wxMaximaFrame.cpp:1335
 msgid "delta"
 msgstr "delta"
 
@@ -4597,7 +4600,7 @@ msgstr "diagonaalinen"
 msgid "empty"
 msgstr "tyhjä"
 
-#: ../src/wxMaximaFrame.cpp:1337
+#: ../src/wxMaximaFrame.cpp:1336
 msgid "epsilon"
 msgstr "epsilon"
 
@@ -4605,7 +4608,7 @@ msgstr "epsilon"
 msgid "equivalent"
 msgstr "ekvivalentti"
 
-#: ../src/wxMaximaFrame.cpp:1339
+#: ../src/wxMaximaFrame.cpp:1338
 msgid "eta"
 msgstr "eeta"
 
@@ -4621,7 +4624,7 @@ msgid ""
 "all=_ marks subscripts."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1335
+#: ../src/wxMaximaFrame.cpp:1334
 msgid "gamma"
 msgstr "gamma"
 
@@ -4647,15 +4650,15 @@ msgstr "avoin"
 msgid "intersection"
 msgstr "leikkaus"
 
-#: ../src/wxMaximaFrame.cpp:1341
+#: ../src/wxMaximaFrame.cpp:1340
 msgid "iota"
 msgstr "ioota"
 
-#: ../src/wxMaximaFrame.cpp:1342
+#: ../src/wxMaximaFrame.cpp:1341
 msgid "kappa"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1343
+#: ../src/wxMaximaFrame.cpp:1342
 msgid "lambda"
 msgstr "lambda"
 
@@ -4671,7 +4674,7 @@ msgstr "pienempi tai yhtä suuri kuin"
 msgid "logscale"
 msgstr "logaritminen asteikko"
 
-#: ../src/wxMaxima.cpp:3783
+#: ../src/wxMaxima.cpp:3795
 msgid "matrix[i,j]:"
 msgstr "matriisi[i,j]:"
 
@@ -4679,7 +4682,7 @@ msgstr "matriisi[i,j]:"
 msgid "maxima's pwd is path to document"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1344
+#: ../src/wxMaximaFrame.cpp:1343
 msgid "mu"
 msgstr ""
 
@@ -4695,7 +4698,7 @@ msgstr "paljon pienempi kuin"
 msgid "nand"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4524
+#: ../src/wxMaxima.cpp:4536
 msgid "no"
 msgstr "ei"
 
@@ -4719,15 +4722,15 @@ msgstr "ei osajoukko"
 msgid "not subset or equal"
 msgstr "ei osajoukko tai yhtäsuuri"
 
-#: ../src/wxMaximaFrame.cpp:1345
+#: ../src/wxMaximaFrame.cpp:1344
 msgid "nu"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1356
+#: ../src/wxMaximaFrame.cpp:1355
 msgid "omega"
 msgstr "oomega"
 
-#: ../src/wxMaximaFrame.cpp:1347
+#: ../src/wxMaximaFrame.cpp:1346
 msgid "omicron"
 msgstr ""
 
@@ -4739,11 +4742,11 @@ msgstr "tai"
 msgid "partial sign"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1353
+#: ../src/wxMaximaFrame.cpp:1352
 msgid "phi"
 msgstr "fii"
 
-#: ../src/wxMaximaFrame.cpp:1348
+#: ../src/wxMaximaFrame.cpp:1347
 msgid "pi"
 msgstr "pii"
 
@@ -4755,11 +4758,11 @@ msgstr ""
 msgid "proportional to"
 msgstr "verrannollinen"
 
-#: ../src/wxMaximaFrame.cpp:1355
+#: ../src/wxMaximaFrame.cpp:1354
 msgid "psi"
 msgstr "psii"
 
-#: ../src/wxMaximaFrame.cpp:1349
+#: ../src/wxMaximaFrame.cpp:1348
 msgid "rho"
 msgstr "rhoo"
 
@@ -4767,7 +4770,7 @@ msgstr "rhoo"
 msgid "right"
 msgstr "oikea"
 
-#: ../src/wxMaximaFrame.cpp:1350
+#: ../src/wxMaximaFrame.cpp:1349
 msgid "sigma"
 msgstr "sigma"
 
@@ -4787,7 +4790,7 @@ msgstr "osajoukko tai yhtäsuuri"
 msgid "symmetric"
 msgstr "symmetrinen"
 
-#: ../src/wxMaximaFrame.cpp:1351
+#: ../src/wxMaximaFrame.cpp:1350
 msgid "tau"
 msgstr "tau"
 
@@ -4799,7 +4802,7 @@ msgstr ""
 msgid "there is no"
 msgstr "Ei ole olemassa"
 
-#: ../src/wxMaximaFrame.cpp:1340
+#: ../src/wxMaximaFrame.cpp:1339
 msgid "theta"
 msgstr "theeta"
 
@@ -4815,12 +4818,12 @@ msgstr "potenssiin 3"
 msgid "union"
 msgstr "unioni"
 
-#: ../src/wxMaxima.cpp:5903
+#: ../src/wxMaxima.cpp:5918
 msgid "unsaved"
 msgstr "tallentamaton"
 
-#: ../src/wxMaximaFrame.cpp:290 ../src/wxMaxima.cpp:2559
-#: ../src/wxMaxima.cpp:2826
+#: ../src/wxMaxima.cpp:2566 ../src/wxMaxima.cpp:2834
+#: ../src/wxMaximaFrame.cpp:289
 msgid "untitled"
 msgstr "nimetön"
 
@@ -4829,26 +4832,26 @@ msgstr "nimetön"
 msgid "untitled %d"
 msgstr "nimetön %d"
 
-#: ../src/wxMaximaFrame.cpp:1352
+#: ../src/wxMaximaFrame.cpp:1351
 #, fuzzy
 msgid "upsilon"
 msgstr "Epsilon:"
 
-#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4538
+#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4550
 msgid "wxMaxima"
 msgstr "wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
-#: ../src/wxMaxima.cpp:5700 ../src/wxMaxima.cpp:5709 ../src/wxMaxima.cpp:5712
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaxima.cpp:5715 ../src/wxMaxima.cpp:5724
+#: ../src/wxMaxima.cpp:5727 ../src/wxMaximaFrame.cpp:287
 #, c-format
 msgid "wxMaxima %s "
 msgstr "wxMaxima %s"
 
-#: ../src/wxMaximaFrame.cpp:952
+#: ../src/wxMaximaFrame.cpp:951
 msgid "wxMaxima &Help\tCtrl+?"
 msgstr "wxMaxima &Ohje\tCtrl+?"
 
-#: ../src/wxMaximaFrame.cpp:955
+#: ../src/wxMaximaFrame.cpp:954
 msgid "wxMaxima &Help\tF1"
 msgstr "wxMaxima &Ohje\tF1"
 
@@ -4864,11 +4867,11 @@ msgstr ""
 "tallennetaan hakemistoon user directory. Hakemiston saa selville komennolla "
 "maxima_userdir  "
 
-#: ../src/wxMaxima.cpp:1619
+#: ../src/wxMaxima.cpp:1624
 msgid "wxMaxima cannot open content.xml in the .wxmx zip archive "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1633
+#: ../src/wxMaxima.cpp:1638
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
@@ -4876,7 +4879,7 @@ msgstr ""
 msgid "wxMaxima configuration"
 msgstr "wxMaxima asetukset"
 
-#: ../src/wxMaxima.cpp:1947
+#: ../src/wxMaxima.cpp:1952
 msgid ""
 "wxMaxima could not find Maxima!\n"
 "\n"
@@ -4888,7 +4891,7 @@ msgstr ""
 "Konfiguroi wxMaxima 'Edit->Konfiguroi'.\n"
 "Käynnistä Maxima 'Maxima->Uudelleenkäynnistä Maxima'."
 
-#: ../src/wxMaxima.cpp:2204
+#: ../src/wxMaxima.cpp:2209
 msgid ""
 "wxMaxima could not find help files.\n"
 "\n"
@@ -4898,7 +4901,7 @@ msgstr ""
 "\n"
 "Tarkista asennus."
 
-#: ../src/wxMaxima.cpp:2032
+#: ../src/wxMaxima.cpp:2037
 msgid ""
 "wxMaxima could not find tip files.\n"
 "\n"
@@ -4908,7 +4911,7 @@ msgstr ""
 "\n"
 "Tarkista asennus."
 
-#: ../src/wxMaxima.cpp:282
+#: ../src/wxMaxima.cpp:283
 msgid ""
 "wxMaxima could not start the server.\n"
 "\n"
@@ -4929,23 +4932,23 @@ msgstr ""
 "wxMaxima dialogeissa oletusarvona syötteen merkinnälle on \"%\". Jos olet "
 "tehnyt valinnan dokumenttiin, valintaa käytetään \"%\" sijasta ."
 
-#: ../src/wxMaxima.cpp:2330
+#: ../src/wxMaxima.cpp:2336
 msgid "wxMaxima document"
 msgstr "wxMaxima asiakirja"
 
-#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2799
+#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2807
 msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 msgstr "wxMaxima asiakirja (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 
-#: ../src/wxMaxima.cpp:1455 ../src/wxMaxima.cpp:1469
+#: ../src/wxMaxima.cpp:1460 ../src/wxMaxima.cpp:1474
 msgid "wxMaxima encountered an error loading "
 msgstr "wxMaximalle tapahtui latausvirhe"
 
-#: ../src/wxMaxima.cpp:4463
+#: ../src/wxMaxima.cpp:4475
 msgid "wxMaxima icon"
 msgstr "wxMaxima kuvake"
 
-#: ../src/wxMaxima.cpp:4455
+#: ../src/wxMaxima.cpp:4467
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "MAXIMA based on wxWidgets."
@@ -4953,7 +4956,7 @@ msgstr ""
 "wxMaxima on wxWidgetteihin pohjautuva graafinen käyttöliittymä CAS "
 "MAXIMALLE. "
 
-#: ../src/wxMaxima.cpp:4516
+#: ../src/wxMaxima.cpp:4528
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "Maxima based on wxWidgets."
@@ -4973,11 +4976,11 @@ msgstr ""
 msgid "x"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1346
+#: ../src/wxMaximaFrame.cpp:1345
 msgid "xi"
 msgstr "ksii"
 
-#: ../src/wxMaxima.cpp:1643
+#: ../src/wxMaxima.cpp:1648
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
@@ -4985,11 +4988,11 @@ msgstr ""
 msgid "xor"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4522
+#: ../src/wxMaxima.cpp:4534
 msgid "yes"
 msgstr "kyllä"
 
-#: ../src/wxMaximaFrame.cpp:1338
+#: ../src/wxMaximaFrame.cpp:1337
 msgid "zeta"
 msgstr "zeeta"
 

--- a/locales/fr.po
+++ b/locales/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fr\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-07 21:42+0200\n"
+"POT-Creation-Date: 2016-10-16 17:47+0900\n"
 "PO-Revision-Date: 2013-11-04 00:21+0100\n"
 "Last-Translator: Bernard Alfonsi <bernard.alfonsi@free.fr>\n"
 "Language-Team: francais <fr@li.org>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.5.7\n"
 
-#: ../src/wxMaxima.cpp:4519
+#: ../src/wxMaxima.cpp:4531
 #, c-format
 msgid ""
 "\n"
@@ -29,7 +29,7 @@ msgstr ""
 "wxWidgets: %d.%d.%d\n"
 "Support d'Unicode: %s"
 
-#: ../src/wxMaxima.cpp:4532
+#: ../src/wxMaxima.cpp:4544
 msgid ""
 "\n"
 "Lisp: "
@@ -37,7 +37,7 @@ msgstr ""
 "\n"
 "Lisp : "
 
-#: ../src/wxMaxima.cpp:4528
+#: ../src/wxMaxima.cpp:4540
 msgid ""
 "\n"
 "Maxima version: "
@@ -45,7 +45,7 @@ msgstr ""
 "\n"
 "Version de Maxima : "
 
-#: ../src/wxMaxima.cpp:5381
+#: ../src/wxMaxima.cpp:5397
 msgid ""
 "\n"
 "Not connected to Maxima!\n"
@@ -53,7 +53,7 @@ msgstr ""
 "\n"
 "Non connecté à Maxima!\n"
 
-#: ../src/wxMaxima.cpp:4530
+#: ../src/wxMaxima.cpp:4542
 msgid ""
 "\n"
 "Not connected."
@@ -73,7 +73,7 @@ msgstr ""
 msgid " (Graphics) "
 msgstr ""
 
-#: ../src/EditorCell.cpp:3045 ../src/EditorCell.cpp:3227
+#: ../src/EditorCell.cpp:3088 ../src/EditorCell.cpp:3270
 #, c-format
 msgid " ... + %i hidden lines"
 msgstr ""
@@ -82,7 +82,7 @@ msgstr ""
 msgid " << Expression longer than allowed by the configuration setting! >>"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1673
+#: ../src/wxMaxima.cpp:1678
 msgid ""
 " was saved using a newer version of wxMaxima so it may not load correctly. "
 "Please update your wxMaxima."
@@ -90,7 +90,7 @@ msgstr ""
 "a été sauvegardé avec une version plus récente de wxMaxima, et peut ne pas "
 "se charger correctement. Veuillez mettre wxMaxima à jour."
 
-#: ../src/wxMaxima.cpp:1665
+#: ../src/wxMaxima.cpp:1670
 msgid ""
 " was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr ""
@@ -105,64 +105,64 @@ msgstr ""
 msgid "\"implies\" symbol"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:101
+#: ../src/wxMaximaFrame.cpp:100
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:773
+#: ../src/wxMaximaFrame.cpp:772
 msgid "&Algebra"
 msgstr "&Algèbre"
 
-#: ../src/wxMaximaFrame.cpp:767
+#: ../src/wxMaximaFrame.cpp:766
 msgid "&Apply to List..."
 msgstr "&Appliquer à une liste…"
 
-#: ../src/wxMaximaFrame.cpp:964
+#: ../src/wxMaximaFrame.cpp:963
 msgid "&Apropos..."
 msgstr "&À propos…"
 
-#: ../src/wxMaximaFrame.cpp:478
+#: ../src/wxMaximaFrame.cpp:477
 msgid "&Batch File...\tCtrl-B"
 msgstr "Traiter un fichier\tCTRL-B"
 
-#: ../src/wxMaximaFrame.cpp:724
+#: ../src/wxMaximaFrame.cpp:723
 msgid "&Boundary Value Problem..."
 msgstr "Pro&blème aux limites…"
 
-#: ../src/wxMaximaFrame.cpp:975
+#: ../src/wxMaximaFrame.cpp:974
 msgid "&Bug Report"
 msgstr "Rapport de &bogue"
 
-#: ../src/wxMaximaFrame.cpp:825
+#: ../src/wxMaximaFrame.cpp:824
 msgid "&Calculus"
 msgstr "Analyse"
 
-#: ../src/wxMaximaFrame.cpp:876
+#: ../src/wxMaximaFrame.cpp:875
 msgid "&Canonical Form"
 msgstr "Forme &canonique"
 
-#: ../src/wxMaximaFrame.cpp:749
+#: ../src/wxMaximaFrame.cpp:748
 msgid "&Characteristic Polynomial..."
 msgstr "Polynôme &caractéristique…"
 
-#: ../src/wxMaximaFrame.cpp:654
+#: ../src/wxMaximaFrame.cpp:653
 msgid "&Clear Memory"
 msgstr "Effa&cer la mémoire"
 
-#: ../src/wxMaximaFrame.cpp:859
+#: ../src/wxMaximaFrame.cpp:858
 msgid "&Combine Factorials"
 msgstr "&Combiner les factorielles"
 
-#: ../src/wxMaximaFrame.cpp:902
+#: ../src/wxMaximaFrame.cpp:901
 msgid "&Complex Simplification"
 msgstr "Simplification &complexe"
 
-#: ../src/wxMaximaFrame.cpp:822
+#: ../src/wxMaximaFrame.cpp:821
 msgid "&Continued Fraction"
 msgstr "Fraction &continue"
 
-#: ../src/wxMaximaFrame.cpp:502
+#: ../src/wxMaximaFrame.cpp:501
 msgid "&Copy\tCtrl-C"
 msgstr "&Copier\tCtrl-C"
 
@@ -170,109 +170,109 @@ msgstr "&Copier\tCtrl-C"
 msgid "&Definite integration"
 msgstr "Intégrale &définie"
 
-#: ../src/wxMaximaFrame.cpp:896
+#: ../src/wxMaximaFrame.cpp:895
 msgid "&Demoivre"
 msgstr "&Demoivre"
 
-#: ../src/wxMaximaFrame.cpp:752
+#: ../src/wxMaximaFrame.cpp:751
 msgid "&Determinant"
 msgstr "&Déterminant"
 
-#: ../src/wxMaximaFrame.cpp:785
+#: ../src/wxMaximaFrame.cpp:784
 msgid "&Differentiate..."
 msgstr "&Dériver…"
 
-#: ../src/wxMaximaFrame.cpp:543
+#: ../src/wxMaximaFrame.cpp:542
 msgid "&Edit"
 msgstr "&Édition"
 
-#: ../src/wxMaximaFrame.cpp:709
+#: ../src/wxMaximaFrame.cpp:708
 msgid "&Eliminate Variable..."
 msgstr "&Éliminer une variable…"
 
-#: ../src/wxMaximaFrame.cpp:744
+#: ../src/wxMaximaFrame.cpp:743
 msgid "&Enter Matrix..."
 msgstr "&Entrer une matrice…"
 
-#: ../src/wxMaximaFrame.cpp:961
+#: ../src/wxMaximaFrame.cpp:960
 msgid "&Example..."
 msgstr "&Exemple"
 
-#: ../src/wxMaximaFrame.cpp:839
+#: ../src/wxMaximaFrame.cpp:838
 msgid "&Expand Expression"
 msgstr "Dév&elopper une expression"
 
-#: ../src/wxMaximaFrame.cpp:873
+#: ../src/wxMaximaFrame.cpp:872
 msgid "&Expand Trigonometric"
 msgstr "Dév&elopper une expression trigonométrique"
 
-#: ../src/wxMaximaFrame.cpp:899
+#: ../src/wxMaximaFrame.cpp:898
 msgid "&Exponentialize"
 msgstr "&Exposant"
 
-#: ../src/wxMaximaFrame.cpp:480
+#: ../src/wxMaximaFrame.cpp:479
 msgid "&Export..."
 msgstr "&Exporter"
 
-#: ../src/wxMaximaFrame.cpp:834
+#: ../src/wxMaximaFrame.cpp:833
 msgid "&Factor Expression"
 msgstr "&Factoriser une expression"
 
-#: ../src/wxMaximaFrame.cpp:489
+#: ../src/wxMaximaFrame.cpp:488
 msgid "&File"
 msgstr "&Fichier"
 
-#: ../src/wxMaximaFrame.cpp:692
+#: ../src/wxMaximaFrame.cpp:691
 msgid "&Find Root..."
 msgstr "Trouver une &solution…"
 
-#: ../src/wxMaximaFrame.cpp:738
+#: ../src/wxMaximaFrame.cpp:737
 msgid "&Generate Matrix..."
 msgstr "&Générer une matrice…"
 
-#: ../src/wxMaximaFrame.cpp:809
+#: ../src/wxMaximaFrame.cpp:808
 msgid "&Greatest Common Divisor..."
 msgstr "Plus &grand diviseur commun…"
 
-#: ../src/wxMaximaFrame.cpp:994
+#: ../src/wxMaximaFrame.cpp:993
 msgid "&Help"
 msgstr "Aide"
 
-#: ../src/wxMaximaFrame.cpp:777
+#: ../src/wxMaximaFrame.cpp:776
 msgid "&Integrate..."
 msgstr "&Intégrer…"
 
-#: ../src/wxMaximaFrame.cpp:645
+#: ../src/wxMaximaFrame.cpp:644
 msgid "&Interrupt\tCtrl-."
 msgstr "&Interrompre\tCtrl-."
 
-#: ../src/wxMaximaFrame.cpp:649
+#: ../src/wxMaximaFrame.cpp:648
 msgid "&Interrupt\tCtrl-G"
 msgstr "&Interrompre\tCtrl-G"
 
-#: ../src/wxMaximaFrame.cpp:746
+#: ../src/wxMaximaFrame.cpp:745
 msgid "&Invert Matrix"
 msgstr "&Inverser la matrice"
 
-#: ../src/wxMaximaFrame.cpp:476
+#: ../src/wxMaximaFrame.cpp:475
 msgid "&Load Package...\tCtrl-L"
 msgstr "Charger un paquetage\tCtrl-L"
 
-#: ../src/wxMaximaFrame.cpp:769
+#: ../src/wxMaximaFrame.cpp:768
 #, fuzzy
 msgid "&Map to List(s)..."
 msgstr "Appliquer à une liste…"
 
-#: ../src/wxMaximaFrame.cpp:684
+#: ../src/wxMaximaFrame.cpp:683
 msgid "&Maxima"
 msgstr "&Maxima"
 
-#: ../src/wxMaximaFrame.cpp:958
+#: ../src/wxMaximaFrame.cpp:957
 #, fuzzy
 msgid "&Maxima help"
 msgstr "Montrer l'aide de Maxima"
 
-#: ../src/wxMaximaFrame.cpp:917
+#: ../src/wxMaximaFrame.cpp:916
 msgid "&Modulus Computation..."
 msgstr "Calcul &modulaire…"
 
@@ -280,7 +280,7 @@ msgstr "Calcul &modulaire…"
 msgid "&New\tCtrl-N"
 msgstr "&Nouvelle session\tCtrl-N"
 
-#: ../src/wxMaximaFrame.cpp:947
+#: ../src/wxMaximaFrame.cpp:946
 msgid "&Numeric"
 msgstr "&Numérique"
 
@@ -296,11 +296,11 @@ msgstr "&Nusum"
 msgid "&Open\tCtrl-O"
 msgstr "&Ouvrir une session\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:463
+#: ../src/wxMaximaFrame.cpp:462
 msgid "&Open...\tCtrl-O"
 msgstr "&Ouvrir une session\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:929
+#: ../src/wxMaximaFrame.cpp:928
 msgid "&Plot"
 msgstr "Tracé de courbes"
 
@@ -308,7 +308,7 @@ msgstr "Tracé de courbes"
 msgid "&Power series"
 msgstr "Série entière"
 
-#: ../src/wxMaximaFrame.cpp:483
+#: ../src/wxMaximaFrame.cpp:482
 msgid "&Print...\tCtrl-P"
 msgstr "Im&primer\tCtrl-P"
 
@@ -316,39 +316,39 @@ msgstr "Im&primer\tCtrl-P"
 msgid "&Rational"
 msgstr "&Rationnel"
 
-#: ../src/wxMaximaFrame.cpp:870
+#: ../src/wxMaximaFrame.cpp:869
 msgid "&Reduce Trigonometric"
 msgstr "&Réduire une expression trigonométrique"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "&Restart Maxima"
 msgstr "&Redémarrer Maxima"
 
-#: ../src/wxMaximaFrame.cpp:700
+#: ../src/wxMaximaFrame.cpp:699
 msgid "&Roots of Polynomial (Real)"
 msgstr "&Racines d'un polynôme (réelles)"
 
-#: ../src/wxMaximaFrame.cpp:472
+#: ../src/wxMaximaFrame.cpp:471
 msgid "&Save\tCtrl-S"
 msgstr "&Sauvegarder la session\tCtrl-S"
 
-#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:919
+#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:918
 msgid "&Simplify"
 msgstr "&Simplifier"
 
-#: ../src/wxMaximaFrame.cpp:829
+#: ../src/wxMaximaFrame.cpp:828
 msgid "&Simplify Expression"
 msgstr "&Simplifier une expression"
 
-#: ../src/wxMaximaFrame.cpp:856
+#: ../src/wxMaximaFrame.cpp:855
 msgid "&Simplify Factorials"
 msgstr "&Simplifier des factorielles"
 
-#: ../src/wxMaximaFrame.cpp:867
+#: ../src/wxMaximaFrame.cpp:866
 msgid "&Simplify Trigonometric"
 msgstr "&Simplifier une expression trigonométrique"
 
-#: ../src/wxMaximaFrame.cpp:688
+#: ../src/wxMaximaFrame.cpp:687
 msgid "&Solve..."
 msgstr "&Résoudre…"
 
@@ -360,11 +360,11 @@ msgstr "&Spécial"
 msgid "&Taylor series"
 msgstr "Série de Taylor :"
 
-#: ../src/wxMaximaFrame.cpp:762
+#: ../src/wxMaximaFrame.cpp:761
 msgid "&Transpose Matrix"
 msgstr "&Transposer une matrice"
 
-#: ../src/wxMaximaFrame.cpp:879
+#: ../src/wxMaximaFrame.cpp:878
 msgid "&Trigonometric Simplification"
 msgstr "Simplification &trigonométrique"
 
@@ -382,7 +382,7 @@ msgstr "(Utiliser la langue par défaut)"
 msgid "- Infinity"
 msgstr "- Infini"
 
-#: ../src/wxMaxima.cpp:351
+#: ../src/wxMaxima.cpp:356
 msgid ""
 "... [suppressed additional lines since the output is longer than allowed in "
 "the configuration] "
@@ -392,16 +392,16 @@ msgstr ""
 msgid "1/2"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:103
+#: ../src/wxMaximaFrame.cpp:102
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4601
+#: ../src/wxMaxima.cpp:4613
 msgid "<br>Lisp: "
 msgstr "<br>Lisp : "
 
-#: ../src/wxMaxima.cpp:5487
+#: ../src/wxMaxima.cpp:5503
 msgid ""
 "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
@@ -435,11 +435,11 @@ msgid ""
 "\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1472
+#: ../src/wxMaximaFrame.cpp:1495
 msgid "A symbol from the configuration dialogue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:731
+#: ../src/wxMaximaFrame.cpp:730
 msgid "A&t Value..."
 msgstr "À la valeur…"
 
@@ -447,12 +447,12 @@ msgstr "À la valeur…"
 msgid "Abort evaluation on error"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaxima.cpp:4603
+#: ../src/wxMaxima.cpp:4615 ../src/wxMaximaFrame.cpp:985
 msgid "About"
 msgstr "À propos"
 
-#: ../src/wxMaximaFrame.cpp:987 ../src/wxMaximaFrame.cpp:990
-#: ../src/wxMaximaFrame.cpp:991
+#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaximaFrame.cpp:989
+#: ../src/wxMaximaFrame.cpp:990
 msgid "About wxMaxima"
 msgstr "À propos de wxMaxima"
 
@@ -460,23 +460,23 @@ msgstr "À propos de wxMaxima"
 msgid "Active cell bracket"
 msgstr "Crochet de la cellule active"
 
-#: ../src/wxMaximaFrame.cpp:760
+#: ../src/wxMaximaFrame.cpp:759
 msgid "Ad&joint Matrix"
 msgstr "Matrice associée"
 
-#: ../src/wxMaximaFrame.cpp:914
+#: ../src/wxMaximaFrame.cpp:913
 msgid "Add Algebraic E&quality..."
 msgstr "Ajouter une égalité algébri&que"
 
-#: ../src/wxMaximaFrame.cpp:657
+#: ../src/wxMaximaFrame.cpp:656
 msgid "Add a directory to search path"
 msgstr "Ajouter un répertoire au chemin de recherche"
 
-#: ../src/wxMaxima.cpp:3353
+#: ../src/wxMaxima.cpp:3365
 msgid "Add dir to path:"
 msgstr "Ajouter le répertoire au chemin:"
 
-#: ../src/wxMaximaFrame.cpp:915
+#: ../src/wxMaximaFrame.cpp:914
 msgid "Add equality to the rational simplifier"
 msgstr "Ajouter une égalité au simplificateur rationnel"
 
@@ -484,7 +484,7 @@ msgstr "Ajouter une égalité au simplificateur rationnel"
 msgid "Add the .wxmx file to the HTML export"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:656
+#: ../src/wxMaximaFrame.cpp:655
 msgid "Add to &Path..."
 msgstr "Ajouter au &chemin"
 
@@ -525,27 +525,27 @@ msgstr "Ancienne variable :"
 msgid "All|*"
 msgstr "Tous|*"
 
-#: ../src/wxMaximaFrame.cpp:1364
+#: ../src/wxMaximaFrame.cpp:1363
 msgid "Alpha"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3838
+#: ../src/wxMaxima.cpp:3850
 msgid "Apply"
 msgstr "Appliquer"
 
-#: ../src/wxMaximaFrame.cpp:768
+#: ../src/wxMaximaFrame.cpp:767
 msgid "Apply function to a list"
 msgstr "Appliquer une fonction à une liste"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Apropos"
 msgstr "À propos"
 
-#: ../src/wxMaxima.cpp:3764
+#: ../src/wxMaxima.cpp:3776
 msgid "Array:"
 msgstr "Tableau :"
 
-#: ../src/wxMaxima.cpp:4462
+#: ../src/wxMaxima.cpp:4474
 msgid "Artwork by"
 msgstr "Graphisme de "
 
@@ -553,7 +553,7 @@ msgstr "Graphisme de "
 msgid "Ask to save untitled documents"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3650
+#: ../src/wxMaxima.cpp:3662
 msgid "At value"
 msgstr "À la valeur :"
 
@@ -574,11 +574,11 @@ msgstr ""
 msgid "Autosave interval (minutes, 0 means: off):"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3557
+#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3569
 msgid "BC2"
 msgstr "BC2"
 
-#: ../src/wxMaximaFrame.cpp:1272
+#: ../src/wxMaximaFrame.cpp:1271
 msgid "Barsplot..."
 msgstr "Diagramme en barres…"
 
@@ -586,7 +586,7 @@ msgstr "Diagramme en barres…"
 msgid "Bat files (*.bat)|*.bat|All|*"
 msgstr "Fichiers bat  (*.bat)|*.bat|Tous|*"
 
-#: ../src/wxMaxima.cpp:2943
+#: ../src/wxMaxima.cpp:2951
 msgid "Batch File"
 msgstr "Fichier de commandes"
 
@@ -599,7 +599,7 @@ msgid ""
 "cells."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1365
+#: ../src/wxMaximaFrame.cpp:1364
 msgid "Beta"
 msgstr ""
 
@@ -611,11 +611,11 @@ msgstr ""
 msgid "Bold"
 msgstr "Gras"
 
-#: ../src/wxMaxima.cpp:2359
+#: ../src/wxMaxima.cpp:2366
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1274
+#: ../src/wxMaximaFrame.cpp:1273
 msgid "Boxplot..."
 msgstr "Diagramme en boîte…"
 
@@ -627,15 +627,15 @@ msgstr "Parcourir"
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2080
+#: ../src/MathCtrl.cpp:2127
 msgid "Bug: Cell left but not entered."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1178
+#: ../src/wxMaxima.cpp:1183
 msgid "Bug: Found a math end marker without any start marker."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1222
+#: ../src/wxMaxima.cpp:1227
 msgid "Bug: Found the end of autocompletion symbols but no beginning"
 msgstr ""
 
@@ -647,22 +647,22 @@ msgstr ""
 msgid "Bug: Fraction without enumerator"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2312
+#: ../src/MathCtrl.cpp:2359
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5839
+#: ../src/MathCtrl.cpp:5891
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of "
 "the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5913
+#: ../src/MathCtrl.cpp:5965
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5882
+#: ../src/MathCtrl.cpp:5934
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
@@ -672,49 +672,49 @@ msgstr ""
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
 msgstr ""
 
-#: ../src/GroupCell.cpp:780 ../src/GroupCell.cpp:951
+#: ../src/GroupCell.cpp:781 ../src/GroupCell.cpp:952
 msgid "Bug: No image counter to write to!"
 msgstr ""
 
-#: ../src/AbsCell.cpp:193
+#: ../src/AbsCell.cpp:199
 msgid "Bug: No last cell in an absCell!"
 msgstr ""
 
-#: ../src/ConjugateCell.cpp:185
+#: ../src/ConjugateCell.cpp:194
 msgid "Bug: No last cell in an conjugateCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:471
+#: ../src/FracCell.cpp:472
 msgid "Bug: No last cell in an denominator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:267
+#: ../src/ExptCell.cpp:270
 msgid "Bug: No last cell in an exponent of an exptCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:459
+#: ../src/FracCell.cpp:460
 msgid "Bug: No last cell in an numerator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:257
+#: ../src/ExptCell.cpp:260
 msgid "Bug: No last cell in the base of an exptCell!"
 msgstr ""
 
-#: ../src/ParenCell.cpp:534
+#: ../src/ParenCell.cpp:535
 msgid "Bug: No last cell inside a parenthesis!"
 msgstr ""
 
-#: ../src/SqrtCell.cpp:312
+#: ../src/SqrtCell.cpp:317
 msgid "Bug: No last cell inside a square root!"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2123
+#: ../src/MathCtrl.cpp:2170
 msgid ""
 "Bug: Start or end of merging of subsequent editing actions was requested two "
 "times in a row."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2090
+#: ../src/MathCtrl.cpp:2137
 msgid "Bug: Text changed, but no active cell."
 msgstr ""
 
@@ -722,39 +722,39 @@ msgstr ""
 msgid "Bug: Trying to append NULL to a group cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:555
+#: ../src/MathCtrl.cpp:600
 msgid "Bug: Trying to append maxima's output to a cell outside the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2014
+#: ../src/MathCtrl.cpp:2061
 msgid ""
 "Bug: Trying to merge individual cell adds to a region in the undo buffer but "
 "there are other cells between them."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6522
+#: ../src/MathCtrl.cpp:6577
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2092
+#: ../src/MathCtrl.cpp:2139
 msgid "Bug: Trying to record a cell contents change without a cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1495
+#: ../src/MathCtrl.cpp:1540
 msgid "Bug: Trying to select inside a cell without having a current cell"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5883
+#: ../src/MathCtrl.cpp:5935
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5844 ../src/MathCtrl.cpp:5918 ../src/MathCtrl.cpp:5952
+#: ../src/MathCtrl.cpp:5896 ../src/MathCtrl.cpp:5970 ../src/MathCtrl.cpp:6004
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:973
+#: ../src/wxMaximaFrame.cpp:972
 msgid "Build &Info"
 msgstr "Information &de compilation"
 
@@ -772,52 +772,52 @@ msgstr ""
 "avec la touche Entrée\". Cette option permute le rôle de ces deux "
 "combinaisons de touches."
 
-#: ../src/wxMaximaFrame.cpp:782
+#: ../src/wxMaximaFrame.cpp:781
 msgid "C&hange Variable..."
 msgstr "C&hanger de variable…"
 
-#: ../src/wxMaximaFrame.cpp:540
+#: ../src/wxMaximaFrame.cpp:539
 msgid "C&onfigure"
 msgstr "C&onfigurer"
 
-#: ../src/wxMaximaFrame.cpp:801
+#: ../src/wxMaximaFrame.cpp:800
 msgid "Calculate &Product..."
 msgstr "Calculer le &produit…"
 
-#: ../src/wxMaximaFrame.cpp:799
+#: ../src/wxMaximaFrame.cpp:798
 msgid "Calculate Su&m..."
 msgstr "Calculer la som&me…"
 
-#: ../src/wxMaximaFrame.cpp:939
+#: ../src/wxMaximaFrame.cpp:938
 msgid "Calculate bigfloat value of the last result"
 msgstr "Valeur approchée (bigfloat) d'une expression"
 
-#: ../src/wxMaximaFrame.cpp:936
+#: ../src/wxMaximaFrame.cpp:935
 msgid "Calculate float value of the last result"
 msgstr "Calculer une valeur approchée du dernier résultat"
 
-#: ../src/wxMaxima.cpp:3971
+#: ../src/wxMaxima.cpp:3983
 msgid "Calculate modulus:"
 msgstr "Calculer le module :"
 
-#: ../src/wxMaximaFrame.cpp:942
+#: ../src/wxMaximaFrame.cpp:941
 #, fuzzy
 msgid "Calculate numeric value of the last result"
 msgstr "Calculer une valeur approchée du dernier résultat"
 
-#: ../src/wxMaximaFrame.cpp:802
+#: ../src/wxMaximaFrame.cpp:801
 msgid "Calculate products"
 msgstr "Calculer les produits"
 
-#: ../src/wxMaximaFrame.cpp:800
+#: ../src/wxMaximaFrame.cpp:799
 msgid "Calculate sums"
 msgstr "Calculer les sommes"
 
-#: ../src/wxMaxima.cpp:5830
+#: ../src/wxMaxima.cpp:5845
 msgid "Can not connect to the web server."
 msgstr "Impossible de se connecter au serveur web"
 
-#: ../src/wxMaxima.cpp:5881
+#: ../src/wxMaxima.cpp:5896
 msgid "Can not download version info."
 msgstr ""
 
@@ -833,15 +833,15 @@ msgstr ""
 #: ../src/PlotFormatWiz.cpp:48 ../src/SeriesWiz.cpp:49 ../src/SeriesWiz.cpp:51
 #: ../src/SubstituteWiz.cpp:41 ../src/SubstituteWiz.cpp:43 ../src/SumWiz.cpp:44
 #: ../src/SumWiz.cpp:46 ../src/SystemWiz.cpp:38 ../src/SystemWiz.cpp:40
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Cancel"
 msgstr "Annuler"
 
-#: ../src/wxMaximaFrame.cpp:126 ../src/wxMaxima.cpp:932
+#: ../src/wxMaxima.cpp:937 ../src/wxMaximaFrame.cpp:125
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1217
+#: ../src/wxMaximaFrame.cpp:1216
 msgid "Canonical (tr)"
 msgstr "Canonique (expr. trig.)"
 
@@ -849,7 +849,7 @@ msgstr "Canonique (expr. trig.)"
 msgid "Catalan"
 msgstr "Catalan"
 
-#: ../src/wxMaximaFrame.cpp:638
+#: ../src/wxMaximaFrame.cpp:637
 msgid "Ce&ll"
 msgstr ""
 
@@ -857,39 +857,39 @@ msgstr ""
 msgid "Cell bracket"
 msgstr "Crochet de la cellule"
 
-#: ../src/wxMaxima.cpp:5261
+#: ../src/wxMaxima.cpp:5273
 msgid "Cell ends in a backslash"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:676
+#: ../src/wxMaximaFrame.cpp:675
 msgid "Change &2d Display"
 msgstr "Basculer en affichage &2d"
 
-#: ../src/wxMaximaFrame.cpp:677
+#: ../src/wxMaximaFrame.cpp:676
 msgid "Change the 2d display algorithm used to display math output"
 msgstr "Modifier l'algorithme d'affichage 2d utilisé pour les mathématiques"
 
-#: ../src/wxMaxima.cpp:3995
+#: ../src/wxMaxima.cpp:4007
 msgid "Change variable"
 msgstr "Changer la variable"
 
-#: ../src/wxMaximaFrame.cpp:783
+#: ../src/wxMaximaFrame.cpp:782
 msgid "Change variable in integral or sum"
 msgstr "Change la variable dans l'intégrale ou la somme"
 
-#: ../src/wxMaxima.cpp:3751
+#: ../src/wxMaxima.cpp:3763
 msgid "Char poly"
 msgstr "Polynôme caractéristique"
 
-#: ../src/wxMaximaFrame.cpp:978
+#: ../src/wxMaximaFrame.cpp:977
 msgid "Check for Updates"
 msgstr "Rechercher des mises à jour"
 
-#: ../src/wxMaximaFrame.cpp:979
+#: ../src/wxMaximaFrame.cpp:978
 msgid "Check if a newer version of wxMaxima/Maxima exist."
 msgstr "Vérifier si une nouvelle version de wxMaxima éxiste"
 
-#: ../src/wxMaximaFrame.cpp:1385
+#: ../src/wxMaximaFrame.cpp:1384
 msgid "Chi"
 msgstr ""
 
@@ -911,15 +911,15 @@ msgstr "Choisir la police"
 msgid "Choose new plot format:"
 msgstr "Entrer un nouveau format de tracé :"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710
 msgid "Classes:"
 msgstr "Classes :"
 
-#: ../src/wxMaximaFrame.cpp:469
+#: ../src/wxMaximaFrame.cpp:468
 msgid "Close\tCtrl-W"
 msgstr "Fermer\tCtrl-W"
 
-#: ../src/wxMaximaFrame.cpp:470
+#: ../src/wxMaximaFrame.cpp:469
 msgid "Close window"
 msgstr "Fermer la fenêtre"
 
@@ -951,19 +951,19 @@ msgstr ""
 msgid "Code highlighting: Variables"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4806
+#: ../src/wxMaxima.cpp:4818
 msgid "Col. names:"
 msgstr "Noms des colonnes :"
 
-#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Columns:"
 msgstr "Colonnes :"
 
-#: ../src/wxMaximaFrame.cpp:860
+#: ../src/wxMaximaFrame.cpp:859
 msgid "Combine factorials in an expression"
 msgstr "Combiner les factorielles dans une expression"
 
-#: ../src/wxMaxima.cpp:5293
+#: ../src/wxMaxima.cpp:5305
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
@@ -975,24 +975,24 @@ msgstr "Liste x séparée par des virgules"
 msgid "Comma separated y coordinates"
 msgstr "Liste y séparée par des virgules"
 
-#: ../src/MathCtrl.cpp:1030
+#: ../src/MathCtrl.cpp:1072
 msgid "Comment Selection"
 msgstr "Commenter la sélection"
 
-#: ../src/wxMaximaFrame.cpp:533
+#: ../src/wxMaximaFrame.cpp:532
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:532
+#: ../src/wxMaximaFrame.cpp:531
 #, fuzzy
 msgid "Comment selection\tCtrl-/"
 msgstr "Commenter la sélection"
 
-#: ../src/wxMaximaFrame.cpp:601
+#: ../src/wxMaximaFrame.cpp:600
 msgid "Complete Word\tCtrl-K"
 msgstr "Compléter l'expression\tCtrl-K"
 
-#: ../src/wxMaximaFrame.cpp:602
+#: ../src/wxMaximaFrame.cpp:601
 msgid "Complete word"
 msgstr "Compléter le mot"
 
@@ -1000,36 +1000,36 @@ msgstr "Compléter le mot"
 msgid "Completely stop maxima and restart it"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:823
+#: ../src/wxMaximaFrame.cpp:822
 msgid "Compute continued fraction of a value"
 msgstr "Calculer la fraction continue d'une valeur"
 
-#: ../src/wxMaximaFrame.cpp:761
+#: ../src/wxMaximaFrame.cpp:760
 msgid "Compute the adjoint matrix"
 msgstr "Calculer la matrice adjointe"
 
-#: ../src/wxMaximaFrame.cpp:750
+#: ../src/wxMaximaFrame.cpp:749
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr "Calculer le polynôme caractéristique d'une matrice"
 
-#: ../src/wxMaximaFrame.cpp:753
+#: ../src/wxMaximaFrame.cpp:752
 msgid "Compute the determinant of a matrix"
 msgstr "Calculer le déterminant d'une matrice"
 
-#: ../src/wxMaximaFrame.cpp:810
+#: ../src/wxMaximaFrame.cpp:809
 msgid "Compute the greatest common divisor"
 msgstr "Calculer le plus grand diviseur commun"
 
-#: ../src/wxMaximaFrame.cpp:747
+#: ../src/wxMaximaFrame.cpp:746
 msgid "Compute the inverse of a matrix"
 msgstr "Calculer l'inverse d'une matrice"
 
-#: ../src/wxMaximaFrame.cpp:813
+#: ../src/wxMaximaFrame.cpp:812
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
 "Calculer le plus petit multiple commun (faire load(functs) avant utilisation)"
 
-#: ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4868
 msgid "Condition:"
 msgstr "Condition :"
 
@@ -1041,8 +1041,8 @@ msgstr "Fichier de configuration (*.ini)|*.ini"
 msgid "Configuration warning"
 msgstr "Alerte de configuration"
 
-#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:538
-#: ../src/wxMaximaFrame.cpp:541
+#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:540
 msgid "Configure wxMaxima"
 msgstr "Configurer wxMaxima"
 
@@ -1051,134 +1051,136 @@ msgstr "Configurer wxMaxima"
 msgid "Constant"
 msgstr "Constante"
 
-#: ../src/wxMaximaFrame.cpp:844
+#: ../src/wxMaximaFrame.cpp:843
 msgid "Contract Logarithms"
 msgstr "Regrouper les logarithmes"
 
-#: ../src/wxMaximaFrame.cpp:851
+#: ../src/wxMaximaFrame.cpp:850
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr "Convertir combinaisons, fonctions beta et gamma en factorielles"
 
-#: ../src/wxMaximaFrame.cpp:854
+#: ../src/wxMaximaFrame.cpp:853
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr ""
 "Convertir combinaisons, factorielles et fonctions beta en fonction gamma"
 
-#: ../src/wxMaximaFrame.cpp:888
+#: ../src/wxMaximaFrame.cpp:887
 msgid "Convert complex expression to polar form"
 msgstr "Mettre une expression complexe sous forme polaire"
 
-#: ../src/wxMaximaFrame.cpp:885
+#: ../src/wxMaximaFrame.cpp:884
 msgid "Convert complex expression to rect form"
 msgstr "Mettre une expression complexe sous forme cartésienne"
 
-#: ../src/wxMaximaFrame.cpp:897
+#: ../src/wxMaximaFrame.cpp:896
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
 "Convertir une fonction exponentielle d'argument imaginaire sous forme "
 "trigonométrique"
 
-#: ../src/wxMaximaFrame.cpp:842
+#: ../src/wxMaximaFrame.cpp:841
 msgid "Convert logarithm of product to sum of logarithms"
 msgstr "Convertir le logarithme d'un produit en une somme de logarithmes"
 
-#: ../src/wxMaximaFrame.cpp:845
+#: ../src/wxMaximaFrame.cpp:844
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "Convertir une somme de logarithmes en un logarithme d'un produit"
 
-#: ../src/wxMaximaFrame.cpp:850
+#: ../src/wxMaximaFrame.cpp:849
 msgid "Convert to &Factorials"
 msgstr "Convertir en &factorielles"
 
-#: ../src/wxMaximaFrame.cpp:853
+#: ../src/wxMaximaFrame.cpp:852
 msgid "Convert to &Gamma"
 msgstr "Convertir en &Gamma"
 
-#: ../src/wxMaximaFrame.cpp:887
+#: ../src/wxMaximaFrame.cpp:886
 msgid "Convert to &Polarform"
 msgstr "Mettre sous forme &polaire"
 
-#: ../src/wxMaximaFrame.cpp:884
+#: ../src/wxMaximaFrame.cpp:883
 msgid "Convert to &Rectform"
 msgstr "Mettre sous forme ca&rtésienne"
 
-#: ../src/wxMaximaFrame.cpp:877
+#: ../src/wxMaximaFrame.cpp:876
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr ""
 "Convertir une expression trigonométrique en forme quasi-linéaire canonique"
 
-#: ../src/wxMaximaFrame.cpp:900
+#: ../src/wxMaximaFrame.cpp:899
 msgid "Convert trigonometric functions to exponential form"
 msgstr "Convertir les fonctions trigonométriques en forme exponentielle"
 
-#: ../src/ToolBar.cpp:140 ../src/MathCtrl.cpp:918 ../src/MathCtrl.cpp:931
-#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1024
+#: ../src/MathCtrl.cpp:960 ../src/MathCtrl.cpp:973 ../src/MathCtrl.cpp:1019
+#: ../src/MathCtrl.cpp:1066 ../src/ToolBar.cpp:140
 msgid "Copy"
 msgstr "Copier"
 
-#: ../src/wxMaximaFrame.cpp:597
+#: ../src/wxMaximaFrame.cpp:596
 msgid "Copy Previous Input\tCtrl-I"
 msgstr "Copier l'entrée précédente\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:599
+#: ../src/wxMaximaFrame.cpp:598
 #, fuzzy
 msgid "Copy Previous Output\tCtrl-U"
 msgstr "Copier l'entrée précédente\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:514 ../src/MathCtrl.cpp:936 ../src/MathCtrl.cpp:982
+#: ../src/MathCtrl.cpp:978 ../src/MathCtrl.cpp:1024
+#: ../src/wxMaximaFrame.cpp:513
 msgid "Copy as Image"
 msgstr "Copier comme image"
 
-#: ../src/wxMaximaFrame.cpp:507 ../src/MathCtrl.cpp:932 ../src/MathCtrl.cpp:978
+#: ../src/MathCtrl.cpp:974 ../src/MathCtrl.cpp:1020
+#: ../src/wxMaximaFrame.cpp:506
 msgid "Copy as LaTeX"
 msgstr "Copier comme code LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:510
+#: ../src/wxMaximaFrame.cpp:509
 #, fuzzy
 msgid "Copy as MathML"
 msgstr "Copier comme image"
 
-#: ../src/MathCtrl.cpp:935 ../src/MathCtrl.cpp:980
+#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1022
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:504
+#: ../src/wxMaximaFrame.cpp:503
 msgid "Copy as Text\tCtrl-Shift-C"
 msgstr "&Copier comme texte\tCtrl-Maj-C"
 
-#: ../src/MathCtrl.cpp:933 ../src/MathCtrl.cpp:979
+#: ../src/MathCtrl.cpp:975 ../src/MathCtrl.cpp:1021
 #, fuzzy
 msgid "Copy as plain text"
 msgstr "Copier comme image"
 
-#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:503
+#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:502
 msgid "Copy selection"
 msgstr "Copier la sélection"
 
-#: ../src/wxMaximaFrame.cpp:515
+#: ../src/wxMaximaFrame.cpp:514
 msgid "Copy selection from document as an image"
 msgstr "Copier la sélection du document au format image"
 
-#: ../src/wxMaximaFrame.cpp:505
+#: ../src/wxMaximaFrame.cpp:504
 msgid "Copy selection from document as text"
 msgstr "Copier la sélection du document au format texte"
 
-#: ../src/wxMaximaFrame.cpp:508
+#: ../src/wxMaximaFrame.cpp:507
 msgid "Copy selection from document in LaTeX format"
 msgstr "Copier la sélection du document au format LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:511
+#: ../src/wxMaximaFrame.cpp:510
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:598
+#: ../src/wxMaximaFrame.cpp:597
 msgid "Create a new cell with previous input"
 msgstr "Créer une nouvelle cellule avec l'entrée précédente"
 
-#: ../src/wxMaximaFrame.cpp:600
+#: ../src/wxMaximaFrame.cpp:599
 #, fuzzy
 msgid "Create a new cell with previous output"
 msgstr "Créer une nouvelle cellule avec l'entrée précédente"
@@ -1187,15 +1189,15 @@ msgstr "Créer une nouvelle cellule avec l'entrée précédente"
 msgid "Cursor"
 msgstr "Curseur"
 
-#: ../src/ToolBar.cpp:137 ../src/MathCtrl.cpp:1023
+#: ../src/MathCtrl.cpp:1065 ../src/ToolBar.cpp:137
 msgid "Cut"
 msgstr "Couper"
 
-#: ../src/wxMaximaFrame.cpp:499
+#: ../src/wxMaximaFrame.cpp:498
 msgid "Cut\tCtrl-X"
 msgstr "&Couper\tCtrl-X"
 
-#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:500
+#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:499
 msgid "Cut selection"
 msgstr "Couper la sélection"
 
@@ -1207,18 +1209,18 @@ msgstr "Tchèque"
 msgid "Danish"
 msgstr "Danois"
 
-#: ../src/wxMaxima.cpp:4799 ../src/wxMaxima.cpp:4806 ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4811 ../src/wxMaxima.cpp:4818 ../src/wxMaxima.cpp:4868
 msgid "Data Matrix:"
 msgstr "Matrice des données :"
 
-#: ../src/wxMaxima.cpp:4826
+#: ../src/wxMaxima.cpp:4838
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr "Fichier de données (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698 ../src/wxMaxima.cpp:4712
-#: ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726 ../src/wxMaxima.cpp:4734
-#: ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748 ../src/wxMaxima.cpp:4755
-#: ../src/wxMaxima.cpp:4791
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710 ../src/wxMaxima.cpp:4724
+#: ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738 ../src/wxMaxima.cpp:4746
+#: ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760 ../src/wxMaxima.cpp:4767
+#: ../src/wxMaxima.cpp:4803
 msgid "Data:"
 msgstr "Données :"
 
@@ -1226,7 +1228,7 @@ msgstr "Données :"
 msgid "Debug: watch maxima's stdout stream"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:820
+#: ../src/wxMaximaFrame.cpp:819
 msgid "Decompose rational function to partial fractions"
 msgstr "Décomposer une fonction rationnelle en éléments simples"
 
@@ -1258,47 +1260,47 @@ msgid ""
 "with."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3403 ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3415 ../src/wxMaxima.cpp:3424
 msgid "Delete"
 msgstr "Effacer"
 
-#: ../src/wxMaximaFrame.cpp:667
+#: ../src/wxMaximaFrame.cpp:666
 msgid "Delete F&unction..."
 msgstr "Effacer la fonction"
 
-#: ../src/MathCtrl.cpp:939 ../src/MathCtrl.cpp:985
+#: ../src/MathCtrl.cpp:981 ../src/MathCtrl.cpp:1027
 msgid "Delete Selection"
 msgstr "Effacer la sélection"
 
-#: ../src/wxMaximaFrame.cpp:669
+#: ../src/wxMaximaFrame.cpp:668
 msgid "Delete V&ariable..."
 msgstr "Effacer la v&ariable"
 
-#: ../src/wxMaximaFrame.cpp:668
+#: ../src/wxMaximaFrame.cpp:667
 msgid "Delete a function"
 msgstr "Effacer une fonction"
 
-#: ../src/wxMaximaFrame.cpp:670
+#: ../src/wxMaximaFrame.cpp:669
 msgid "Delete a variable"
 msgstr "Effacer une variable"
 
-#: ../src/wxMaximaFrame.cpp:655
+#: ../src/wxMaximaFrame.cpp:654
 msgid "Delete all values from memory"
 msgstr "Effacer toutes les valeurs de la mémoire"
 
-#: ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3424
 msgid "Delete function(s):"
 msgstr "Effacer la (les) fonction(s):"
 
-#: ../src/wxMaxima.cpp:3403
+#: ../src/wxMaxima.cpp:3415
 msgid "Delete variable(s):"
 msgstr "Effacer la (les) variables(s):"
 
-#: ../src/wxMaximaFrame.cpp:1367
+#: ../src/wxMaximaFrame.cpp:1366
 msgid "Delta"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4011
+#: ../src/wxMaxima.cpp:4023
 msgid "Denom. deg:"
 msgstr "denom deg :"
 
@@ -1306,35 +1308,35 @@ msgstr "denom deg :"
 msgid "Depth:"
 msgstr "profondeur :"
 
-#: ../src/wxMaxima.cpp:3541
+#: ../src/wxMaxima.cpp:3553
 msgid "Derivative:"
 msgstr "la dérivée est :"
 
-#: ../src/wxMaximaFrame.cpp:1258
+#: ../src/wxMaximaFrame.cpp:1257
 msgid "Deviation..."
 msgstr "Écart-type"
 
-#: ../src/wxMaximaFrame.cpp:816
+#: ../src/wxMaximaFrame.cpp:815
 msgid "Di&vide Polynomials..."
 msgstr "Di&vision de polynômes…"
 
-#: ../src/wxMaximaFrame.cpp:1223
+#: ../src/wxMaximaFrame.cpp:1222
 msgid "Diff..."
 msgstr "Dériver"
 
-#: ../src/wxMaxima.cpp:4154 ../src/wxMaxima.cpp:5066
+#: ../src/wxMaxima.cpp:4166 ../src/wxMaxima.cpp:5078
 msgid "Differentiate"
 msgstr "Dériver"
 
-#: ../src/wxMaximaFrame.cpp:786
+#: ../src/wxMaximaFrame.cpp:785
 msgid "Differentiate expression"
 msgstr "Dériver l'expression"
 
-#: ../src/MathCtrl.cpp:1001
+#: ../src/MathCtrl.cpp:1043
 msgid "Differentiate..."
 msgstr "Dériver…"
 
-#: ../src/LimitWiz.cpp:37 ../src/FindReplacePane.cpp:76
+#: ../src/FindReplacePane.cpp:76 ../src/LimitWiz.cpp:37
 msgid "Direction:"
 msgstr "selon la direction"
 
@@ -1342,48 +1344,49 @@ msgstr "selon la direction"
 msgid "Discrete plot"
 msgstr "Graphe discret"
 
-#: ../src/wxMaximaFrame.cpp:679
+#: ../src/wxMaximaFrame.cpp:678
 msgid "Display Te&X Form"
 msgstr "Afficher en Te&X"
 
-#: ../src/wxMaxima.cpp:3320
+#: ../src/wxMaxima.cpp:3332
 msgid "Display algorithm"
 msgstr "Afficher l'algorithme"
 
-#: ../src/wxMaximaFrame.cpp:680
+#: ../src/wxMaximaFrame.cpp:679
 msgid "Display last result in TeX form"
 msgstr "Afficher la dernière expression en TeX"
 
-#: ../src/wxMaximaFrame.cpp:674
+#: ../src/wxMaximaFrame.cpp:673
 msgid "Display time used for evaluation"
 msgstr "Afficher le temps d'exécution"
 
-#: ../src/wxMaxima.cpp:4061
+#: ../src/wxMaxima.cpp:4073
 msgid "Divide"
 msgstr "Division"
 
-#: ../src/MathCtrl.cpp:1032
+#: ../src/MathCtrl.cpp:1074
 msgid "Divide Cell"
 msgstr "Partager la cellule"
 
-#: ../src/wxMaximaFrame.cpp:635
+#: ../src/wxMaximaFrame.cpp:634
 #, fuzzy
 msgid "Divide Cell\tCtrl-D"
 msgstr "Partager la cellule"
 
-#: ../src/wxMaximaFrame.cpp:817
+#: ../src/wxMaximaFrame.cpp:816
 msgid "Divide numbers or polynomials"
 msgstr "Division de nombres ou de polynômes"
 
-#: ../src/wxMaximaFrame.cpp:636
+#: ../src/wxMaximaFrame.cpp:635
 msgid "Divide this input cell into two cells"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5917
-msgid "Do you want to save the changes you made in the document \""
+#: ../src/wxMaxima.cpp:5932
+#, fuzzy, c-format
+msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr "Sauvegarder les modifications apportées au document ?\""
 
-#: ../src/wxMaxima.cpp:1664 ../src/wxMaxima.cpp:1672
+#: ../src/wxMaxima.cpp:1669 ../src/wxMaxima.cpp:1677
 msgid "Document "
 msgstr "Document"
 
@@ -1402,7 +1405,7 @@ msgid ""
 "differences."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Don't save"
 msgstr "Ne pas sauvegarder"
 
@@ -1410,27 +1413,27 @@ msgstr "Ne pas sauvegarder"
 msgid "Down"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:734
+#: ../src/wxMaximaFrame.cpp:733
 msgid "E&quations"
 msgstr "É&quations"
 
-#: ../src/wxMaximaFrame.cpp:487
+#: ../src/wxMaximaFrame.cpp:486
 msgid "E&xit\tCtrl-Q"
 msgstr "&Quitter\tCtrl-Q"
 
-#: ../src/wxMaximaFrame.cpp:757
+#: ../src/wxMaximaFrame.cpp:756
 msgid "Eige&nvectors"
 msgstr "Vecteurs propres"
 
-#: ../src/wxMaximaFrame.cpp:755
+#: ../src/wxMaximaFrame.cpp:754
 msgid "Eigen&values"
 msgstr "&Valeurs propres"
 
-#: ../src/wxMaxima.cpp:3572
+#: ../src/wxMaxima.cpp:3584
 msgid "Eliminate"
 msgstr "Éliminer"
 
-#: ../src/wxMaximaFrame.cpp:710
+#: ../src/wxMaximaFrame.cpp:709
 msgid "Eliminate a variable from a system of equations"
 msgstr "Éliminer une variable dans un système d'équations"
 
@@ -1442,21 +1445,21 @@ msgstr ""
 msgid "English"
 msgstr "Anglais"
 
-#: ../src/wxMaxima.cpp:4712 ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726
-#: ../src/wxMaxima.cpp:4734 ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748
-#: ../src/wxMaxima.cpp:4755 ../src/wxMaxima.cpp:4791 ../src/wxMaxima.cpp:4799
+#: ../src/wxMaxima.cpp:4724 ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738
+#: ../src/wxMaxima.cpp:4746 ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760
+#: ../src/wxMaxima.cpp:4767 ../src/wxMaxima.cpp:4803 ../src/wxMaxima.cpp:4811
 msgid "Enter Data"
 msgstr "Entrer les données"
 
-#: ../src/wxMaximaFrame.cpp:1279
+#: ../src/wxMaximaFrame.cpp:1278
 msgid "Enter Matrix..."
 msgstr "Entrer une matrice…"
 
-#: ../src/wxMaximaFrame.cpp:745
+#: ../src/wxMaximaFrame.cpp:744
 msgid "Enter a matrix"
 msgstr "Entrer une matrice"
 
-#: ../src/wxMaxima.cpp:3962
+#: ../src/wxMaxima.cpp:3974
 msgid "Enter an equation for rational simplification:"
 msgstr "Entrer une équation pour la simplification rationnelle :"
 
@@ -1468,11 +1471,11 @@ msgstr "Entrer une liste de variables séparées par des virgules"
 msgid "Enter evaluates cells"
 msgstr "Évaluation des cellules avec la touche Entrée"
 
-#: ../src/wxMaxima.cpp:3734
+#: ../src/wxMaxima.cpp:3746
 msgid "Enter matrix"
 msgstr "Entrer une matrice"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 #, fuzzy
 msgid "Enter new precision for bigfloats:"
 msgstr "Entrer la nouvelle précision :"
@@ -1481,12 +1484,12 @@ msgstr "Entrer la nouvelle précision :"
 msgid "Enter the path to the Maxima executable."
 msgstr "Entrez le chemin vers l'exécutable de Maxima:"
 
-#: ../src/wxMaximaFrame.cpp:1368
+#: ../src/wxMaximaFrame.cpp:1367
 #, fuzzy
 msgid "Epsilon"
 msgstr "Epsilon :"
 
-#: ../src/wxMaxima.cpp:4208
+#: ../src/wxMaxima.cpp:4220
 msgid "Epsilon:"
 msgstr "Epsilon :"
 
@@ -1495,13 +1498,13 @@ msgstr "Epsilon :"
 msgid "Equation %d:"
 msgstr "Équation %d :"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:3633
-#: ../src/wxMaxima.cpp:5019
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:3645
+#: ../src/wxMaxima.cpp:5031
 msgid "Equation(s):"
 msgstr "Équation(s):"
 
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3993
-#: ../src/wxMaxima.cpp:4807 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:4005
+#: ../src/wxMaxima.cpp:4819 ../src/wxMaxima.cpp:5045
 msgid "Equation:"
 msgstr "Équation :"
 
@@ -1512,83 +1515,83 @@ msgid ""
 "be introduced one into another. Also they are always printed out as 2D maths."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3570
+#: ../src/wxMaxima.cpp:3582
 msgid "Equations:"
 msgstr "Équation(s) :"
 
-#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1455
-#: ../src/wxMaxima.cpp:1469 ../src/wxMaxima.cpp:1620 ../src/wxMaxima.cpp:1633
-#: ../src/wxMaxima.cpp:1643 ../src/wxMaxima.cpp:1666 ../src/wxMaxima.cpp:2034
-#: ../src/wxMaxima.cpp:2206 ../src/wxMaxima.cpp:5381 ../src/wxMaxima.cpp:5830
-#: ../src/wxMaxima.cpp:5881
+#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1460
+#: ../src/wxMaxima.cpp:1474 ../src/wxMaxima.cpp:1625 ../src/wxMaxima.cpp:1638
+#: ../src/wxMaxima.cpp:1648 ../src/wxMaxima.cpp:1671 ../src/wxMaxima.cpp:2039
+#: ../src/wxMaxima.cpp:2211 ../src/wxMaxima.cpp:5397 ../src/wxMaxima.cpp:5845
+#: ../src/wxMaxima.cpp:5896
 msgid "Error"
 msgstr "Erreur"
 
-#: ../src/wxMaxima.cpp:2886 ../src/wxMaxima.cpp:2900 ../src/wxMaxima.cpp:2913
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617 ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:2894 ../src/wxMaxima.cpp:2908 ../src/wxMaxima.cpp:2921
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629 ../src/wxMaxima.cpp:3740
 msgid "Error!"
 msgstr "Erreur !"
 
-#: ../src/wxMaximaFrame.cpp:1370
+#: ../src/wxMaximaFrame.cpp:1369
 msgid "Eta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:909
+#: ../src/wxMaximaFrame.cpp:908
 msgid "Evaluate &Noun Forms"
 msgstr "Évaluer les formes &nommées"
 
-#: ../src/wxMaximaFrame.cpp:589
+#: ../src/wxMaximaFrame.cpp:588
 #, fuzzy
 msgid "Evaluate All Cells\tCtrl-Shift-R"
 msgstr "Évaluer toutes les cellules\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:587
+#: ../src/wxMaximaFrame.cpp:586
 #, fuzzy
 msgid "Evaluate All Visible Cells\tCtrl-R"
 msgstr "Évaluer toutes les cellules\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:585 ../src/MathCtrl.cpp:942
+#: ../src/MathCtrl.cpp:984 ../src/wxMaximaFrame.cpp:584
 msgid "Evaluate Cell(s)"
 msgstr "Évaluer la (les) cellule(s)"
 
-#: ../src/wxMaximaFrame.cpp:591
+#: ../src/wxMaximaFrame.cpp:590
 #, fuzzy
 msgid "Evaluate Cells Above\tCtrl-Shift-P"
 msgstr "Évaluer toutes les cellules\tCtrl-R"
 
-#: ../src/MathCtrl.cpp:956 ../src/MathCtrl.cpp:1051
+#: ../src/MathCtrl.cpp:998 ../src/MathCtrl.cpp:1093
 #, fuzzy
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr "&Évaluer la cellule\tMaj-Entrée"
 
-#: ../src/MathCtrl.cpp:961 ../src/MathCtrl.cpp:1053
+#: ../src/MathCtrl.cpp:1003 ../src/MathCtrl.cpp:1095
 #, fuzzy
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr "&Évaluer la cellule\tMaj-Entrée"
 
-#: ../src/MathCtrl.cpp:971 ../src/MathCtrl.cpp:1057
+#: ../src/MathCtrl.cpp:1013 ../src/MathCtrl.cpp:1099
 #, fuzzy
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr "&Évaluer la cellule\tMaj-Entrée"
 
-#: ../src/MathCtrl.cpp:966 ../src/MathCtrl.cpp:1055
+#: ../src/MathCtrl.cpp:1008 ../src/MathCtrl.cpp:1097
 #, fuzzy
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr "&Évaluer la cellule\tMaj-Entrée"
 
-#: ../src/wxMaximaFrame.cpp:586
+#: ../src/wxMaximaFrame.cpp:585
 msgid "Evaluate active or selected cell(s)"
 msgstr "Réévaluer la cellule sélectionnée"
 
-#: ../src/wxMaximaFrame.cpp:590
+#: ../src/wxMaximaFrame.cpp:589
 msgid "Evaluate all cells in the document"
 msgstr "Réévaluer toutes les cellules du document"
 
-#: ../src/wxMaximaFrame.cpp:910
+#: ../src/wxMaximaFrame.cpp:909
 msgid "Evaluate all noun forms in expression"
 msgstr "Evaluer toutes les formes nommées"
 
-#: ../src/wxMaximaFrame.cpp:588
+#: ../src/wxMaximaFrame.cpp:587
 #, fuzzy
 msgid "Evaluate all visible cells in the document"
 msgstr "Réévaluer toutes les cellules du document"
@@ -1602,7 +1605,7 @@ msgstr ""
 msgid "Evaluate to point"
 msgstr "Évaluer les formes &nommées"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Example"
 msgstr "Exemple"
 
@@ -1615,31 +1618,31 @@ msgstr "Texte exemple…"
 msgid "Examples:"
 msgstr "Exemple"
 
-#: ../src/wxMaximaFrame.cpp:488
+#: ../src/wxMaximaFrame.cpp:487
 msgid "Exit wxMaxima"
 msgstr "Quitter wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:1214
+#: ../src/wxMaximaFrame.cpp:1213
 msgid "Expand"
 msgstr "Développer"
 
-#: ../src/wxMaximaFrame.cpp:1219
+#: ../src/wxMaximaFrame.cpp:1218
 msgid "Expand (tr)"
 msgstr "Développer (expr. trig.)"
 
-#: ../src/MathCtrl.cpp:997
+#: ../src/MathCtrl.cpp:1039
 msgid "Expand Expression"
 msgstr "Développer une expression"
 
-#: ../src/wxMaximaFrame.cpp:841
+#: ../src/wxMaximaFrame.cpp:840
 msgid "Expand Logarithms"
 msgstr "Développer des logarithmes"
 
-#: ../src/wxMaximaFrame.cpp:840
+#: ../src/wxMaximaFrame.cpp:839
 msgid "Expand an expression"
 msgstr "Développer une expression"
 
-#: ../src/wxMaximaFrame.cpp:874
+#: ../src/wxMaximaFrame.cpp:873
 msgid "Expand trigonometric expression"
 msgstr "Développer une expression trigonométrique"
 
@@ -1647,7 +1650,7 @@ msgstr "Développer une expression trigonométrique"
 msgid "Expected the icon files to be found at"
 msgstr ""
 
-#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2834
+#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2842
 msgid "Export"
 msgstr "&Exporter"
 
@@ -1656,33 +1659,33 @@ msgid ""
 "Export animations to TeX (Images only move if the PDF viewer supports this)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:481
+#: ../src/wxMaximaFrame.cpp:480
 msgid "Export document to a HTML or pdfLaTeX file"
 msgstr "Exporter le document en HTML ou en pdfLateX"
 
-#: ../src/wxMaximaFrame.cpp:253
+#: ../src/wxMaximaFrame.cpp:252
 #, fuzzy
 msgid "Export failed."
 msgstr "Échec de l'export en TeX !"
 
-#: ../src/wxMaximaFrame.cpp:239
+#: ../src/wxMaximaFrame.cpp:238
 msgid "Export successful."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2913
+#: ../src/wxMaxima.cpp:2921
 msgid "Exporting to HTML failed!"
 msgstr "Échec de l'export en HTML"
 
-#: ../src/wxMaxima.cpp:2886
+#: ../src/wxMaxima.cpp:2894
 msgid "Exporting to TeX failed!"
 msgstr "Échec de l'export en TeX !"
 
-#: ../src/wxMaxima.cpp:2900
+#: ../src/wxMaxima.cpp:2908
 #, fuzzy
 msgid "Exporting to maxima batch file failed!"
 msgstr "Échec de l'export en TeX !"
 
-#: ../src/wxMaximaFrame.cpp:229
+#: ../src/wxMaximaFrame.cpp:228
 #, fuzzy
 msgid "Exporting..."
 msgstr "&Exporter"
@@ -1696,42 +1699,42 @@ msgid "Expression(s):"
 msgstr "Expression(s) :"
 
 #: ../src/IntegrateWiz.cpp:30 ../src/LimitWiz.cpp:27 ../src/SeriesWiz.cpp:33
-#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3648
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:4205 ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5064
+#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3660
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:4217 ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5076
 msgid "Expression:"
 msgstr "Expression :"
 
-#: ../src/wxMaximaFrame.cpp:1213
+#: ../src/wxMaximaFrame.cpp:1212
 msgid "Factor"
 msgstr "Factoriser"
 
-#: ../src/wxMaximaFrame.cpp:836
+#: ../src/wxMaximaFrame.cpp:835
 msgid "Factor Complex"
 msgstr "Factorisation &complexe"
 
-#: ../src/MathCtrl.cpp:996
+#: ../src/MathCtrl.cpp:1038
 msgid "Factor Expression"
 msgstr "Factoriser une expression"
 
-#: ../src/wxMaximaFrame.cpp:835
+#: ../src/wxMaximaFrame.cpp:834
 msgid "Factor an expression"
 msgstr "Factoriser une expression"
 
-#: ../src/wxMaximaFrame.cpp:837
+#: ../src/wxMaximaFrame.cpp:836
 msgid "Factor an expression in Gaussian numbers"
 msgstr "Factoriser une expression en nombre gaussiens"
 
-#: ../src/wxMaximaFrame.cpp:862
+#: ../src/wxMaximaFrame.cpp:861
 msgid "Factorials and &Gamma"
 msgstr "Factorielles et &gamma"
 
-#: ../src/wxMaxima.cpp:285
+#: ../src/wxMaxima.cpp:286
 msgid "Fatal error"
 msgstr "Erreur fatale"
 
-#: ../src/GroupCell.cpp:1571
+#: ../src/GroupCell.cpp:1572
 #, c-format
 msgid "Figure %d:"
 msgstr "Figure %d:"
@@ -1740,22 +1743,22 @@ msgstr "Figure %d:"
 msgid "File"
 msgstr "&Fichier"
 
-#: ../src/wxMaxima.cpp:1457 ../src/wxMaxima.cpp:1623 ../src/wxMaxima.cpp:1636
-#: ../src/wxMaxima.cpp:1646 ../src/wxMaxima.cpp:1668
+#: ../src/wxMaxima.cpp:1462 ../src/wxMaxima.cpp:1628 ../src/wxMaxima.cpp:1641
+#: ../src/wxMaxima.cpp:1651 ../src/wxMaxima.cpp:1673
 #, fuzzy
 msgid "File could not be opened"
 msgstr "Fichier non trouvé"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File not found"
 msgstr "Fichier non trouvé"
 
-#: ../src/wxMaxima.cpp:1511 ../src/wxMaxima.cpp:1729
+#: ../src/wxMaxima.cpp:1516 ../src/wxMaxima.cpp:1734
 #, fuzzy
 msgid "File opened"
 msgstr "Fichier non trouvé"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File you tried to open does not exist."
 msgstr "Le fichier que vous tentez d'ouvrir n'existe pas."
 
@@ -1767,67 +1770,67 @@ msgstr "&Fichier:"
 msgid "Find"
 msgstr "Chercher"
 
-#: ../src/wxMaximaFrame.cpp:523
+#: ../src/wxMaximaFrame.cpp:522
 msgid "Find\tCtrl-F"
 msgstr "Chercher\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:787
+#: ../src/wxMaximaFrame.cpp:786
 msgid "Find &Limit..."
 msgstr "Trouver la &limite…"
 
-#: ../src/wxMaximaFrame.cpp:790
+#: ../src/wxMaximaFrame.cpp:789
 msgid "Find Minimum..."
 msgstr "Trouver le minimum…"
 
-#: ../src/MathCtrl.cpp:993
+#: ../src/MathCtrl.cpp:1035
 msgid "Find Root..."
 msgstr "Trouver une racine…"
 
-#: ../src/wxMaximaFrame.cpp:791
+#: ../src/wxMaximaFrame.cpp:790
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr "Trouver un minimum (sans contrainte) d'une expression"
 
-#: ../src/wxMaximaFrame.cpp:788
+#: ../src/wxMaximaFrame.cpp:787
 msgid "Find a limit of an expression"
 msgstr "Trouver la limite d'une expression"
 
-#: ../src/wxMaximaFrame.cpp:693
+#: ../src/wxMaximaFrame.cpp:692
 msgid "Find a root of an equation on an interval"
 msgstr "Trouver une racine d'un polynôme dans un intervalle"
 
-#: ../src/wxMaximaFrame.cpp:695
+#: ../src/wxMaximaFrame.cpp:694
 msgid "Find all roots of a polynomial"
 msgstr "Trouver toutes les racines d'un polynôme"
 
-#: ../src/wxMaximaFrame.cpp:698
+#: ../src/wxMaximaFrame.cpp:697
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr "Trouver toutes les racines d'un polynôme (bfloat)"
 
-#: ../src/wxMaxima.cpp:3220
+#: ../src/wxMaxima.cpp:3215
 msgid "Find and Replace"
 msgstr "Chercher et remplacer"
 
-#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:523
+#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:522
 msgid "Find and replace"
 msgstr "Chercher et remplacer"
 
-#: ../src/wxMaximaFrame.cpp:756
+#: ../src/wxMaximaFrame.cpp:755
 msgid "Find eigenvalues of a matrix"
 msgstr "Trouver les valeurs propres d'une matrice"
 
-#: ../src/wxMaximaFrame.cpp:758
+#: ../src/wxMaximaFrame.cpp:757
 msgid "Find eigenvectors of a matrix"
 msgstr "Trouver les vecteurs propres d'une matrice"
 
-#: ../src/wxMaxima.cpp:4210
+#: ../src/wxMaxima.cpp:4222
 msgid "Find minimum"
 msgstr "Trouver le minimum"
 
-#: ../src/wxMaximaFrame.cpp:701
+#: ../src/wxMaximaFrame.cpp:700
 msgid "Find real roots of a polynomial"
 msgstr "Trouver les racines réelles d'un polynôme"
 
-#: ../src/wxMaxima.cpp:3493 ../src/wxMaxima.cpp:5036
+#: ../src/wxMaxima.cpp:3505 ../src/wxMaxima.cpp:5048
 msgid "Find root"
 msgstr "Trouver une solution"
 
@@ -1850,12 +1853,12 @@ msgstr ""
 msgid "Fixed font in text controls"
 msgstr "Police à chasse fixe dans les contrôles de texte"
 
-#: ../src/wxMaximaFrame.cpp:623
+#: ../src/wxMaximaFrame.cpp:622
 #, fuzzy
 msgid "Fold All\tCtrl-Alt-["
 msgstr "Tout sélectionner"
 
-#: ../src/wxMaximaFrame.cpp:624
+#: ../src/wxMaximaFrame.cpp:623
 msgid "Fold all sections"
 msgstr ""
 
@@ -1864,25 +1867,25 @@ msgstr ""
 msgid "Follow"
 msgstr "jaune"
 
-#: ../src/ParenCell.cpp:319
+#: ../src/ParenCell.cpp:320
 msgid "Font issue: The Parenthesis sign is too small!"
 msgstr ""
 
-#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:381
+#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:382
 msgid ""
 "Font issue: The char height is too small! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:199
+#: ../src/SqrtCell.cpp:202
 msgid ""
 "Font issue: The sqrt() sign has the size 0! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:198
+#: ../src/SqrtCell.cpp:201
 msgid "Font issue? The contents of a sqrt() has the size 0."
 msgstr ""
 
@@ -1913,15 +1916,15 @@ msgstr "Français"
 
 #: ../src/IntegrateWiz.cpp:37 ../src/Plot2dWiz.cpp:37 ../src/Plot2dWiz.cpp:47
 #: ../src/Plot2dWiz.cpp:536 ../src/Plot3dWiz.cpp:36 ../src/Plot3dWiz.cpp:45
-#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4240
+#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4252
 msgid "From:"
 msgstr "à partir de :"
 
-#: ../src/wxMaximaFrame.cpp:576
+#: ../src/wxMaximaFrame.cpp:575
 msgid "Full Screen\tAlt-Enter"
 msgstr "Plein écran\tAlt-Entrée"
 
-#: ../src/wxMaxima.cpp:3342
+#: ../src/wxMaxima.cpp:3354
 msgid "Function"
 msgstr "Fonction"
 
@@ -1929,32 +1932,32 @@ msgstr "Fonction"
 msgid "Function names"
 msgstr "Noms des fonctions"
 
-#: ../src/wxMaxima.cpp:3633
+#: ../src/wxMaxima.cpp:3645
 msgid "Function(s):"
 msgstr "Fonction(s) :"
 
-#: ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3803
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3815
+#: ../src/wxMaxima.cpp:3848
 msgid "Function:"
 msgstr "Fonction"
 
-#: ../src/wxMaximaFrame.cpp:904
+#: ../src/wxMaximaFrame.cpp:903
 msgid "Functions for complex simplification"
 msgstr "Fonctions pour simplification complexe"
 
-#: ../src/wxMaximaFrame.cpp:864
+#: ../src/wxMaximaFrame.cpp:863
 msgid "Functions for simplifying factorials and gamma function"
 msgstr "Fonctions pour simplifier les factorielles et fonction gamma"
 
-#: ../src/wxMaximaFrame.cpp:881
+#: ../src/wxMaximaFrame.cpp:880
 msgid "Functions for simplifying trigonometric expressions"
 msgstr "Fonctions pour simplifier les expressions trigonométriques"
 
-#: ../src/wxMaxima.cpp:4046
+#: ../src/wxMaxima.cpp:4058
 msgid "GCD"
 msgstr "PGCD"
 
-#: ../src/wxMaxima.cpp:5152
+#: ../src/wxMaxima.cpp:5164
 msgid "GIF image (*.gif)|*.gif"
 msgstr "image GIF (*.gif)|*.gif"
 
@@ -1962,31 +1965,31 @@ msgstr "image GIF (*.gif)|*.gif"
 msgid "Galician"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1366
+#: ../src/wxMaximaFrame.cpp:1365
 msgid "Gamma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:391
+#: ../src/wxMaximaFrame.cpp:390
 msgid "General Math"
 msgstr "Mathématiques générales"
 
-#: ../src/wxMaximaFrame.cpp:549
+#: ../src/wxMaximaFrame.cpp:548
 msgid "General Math\tAlt-Shift-M"
 msgstr "Mathématiques générales\tAlt-Maj-M"
 
-#: ../src/wxMaxima.cpp:3766 ../src/wxMaxima.cpp:3785
+#: ../src/wxMaxima.cpp:3778 ../src/wxMaxima.cpp:3797
 msgid "Generate Matrix"
 msgstr "Générer une matrice"
 
-#: ../src/wxMaximaFrame.cpp:741
+#: ../src/wxMaximaFrame.cpp:740
 msgid "Generate Matrix from Expression..."
 msgstr "&Générer une matrice à partir d'une expression…"
 
-#: ../src/wxMaximaFrame.cpp:739
+#: ../src/wxMaximaFrame.cpp:738
 msgid "Generate a matrix from a 2-dimensional array"
 msgstr "Générer une matrice à partir d'un tableau à 2 dimensions"
 
-#: ../src/wxMaximaFrame.cpp:742
+#: ../src/wxMaximaFrame.cpp:741
 msgid "Generate a matrix from a lambda expression"
 msgstr "Générer une matrice à partir d'une lambda-expression"
 
@@ -1994,39 +1997,39 @@ msgstr "Générer une matrice à partir d'une lambda-expression"
 msgid "German"
 msgstr "Allemand"
 
-#: ../src/wxMaximaFrame.cpp:893
+#: ../src/wxMaximaFrame.cpp:892
 msgid "Get &Imaginary Part"
 msgstr "Partie imaginaire"
 
-#: ../src/wxMaximaFrame.cpp:793
+#: ../src/wxMaximaFrame.cpp:792
 msgid "Get &Series..."
 msgstr "Obtenir une &série…"
 
-#: ../src/wxMaximaFrame.cpp:804
+#: ../src/wxMaximaFrame.cpp:803
 msgid "Get Laplace transformation of an expression"
 msgstr "Transformée de Laplace d'une expression"
 
-#: ../src/wxMaximaFrame.cpp:890
+#: ../src/wxMaximaFrame.cpp:889
 msgid "Get Real P&art"
 msgstr "P&artie réelle"
 
-#: ../src/wxMaximaFrame.cpp:807
+#: ../src/wxMaximaFrame.cpp:806
 msgid "Get inverse Laplace transformation of an expression"
 msgstr "Obtenir la transformée de Laplace inverse  d'une expression"
 
-#: ../src/wxMaximaFrame.cpp:794
+#: ../src/wxMaximaFrame.cpp:793
 msgid "Get the Taylor or power series of expression"
 msgstr "Obtenir le développement en série entière ou en série limité (Taylor)"
 
-#: ../src/wxMaximaFrame.cpp:894
+#: ../src/wxMaximaFrame.cpp:893
 msgid "Get the imaginary part of complex expression"
 msgstr "Partie imaginaire d'une expression complexe"
 
-#: ../src/wxMaximaFrame.cpp:891
+#: ../src/wxMaximaFrame.cpp:890
 msgid "Get the real part of complex expression"
 msgstr "Partie réelle d'une expression complexe"
 
-#: ../src/MathCtrl.cpp:5932
+#: ../src/MathCtrl.cpp:5984
 msgid ""
 "Got a request to undo an action that involves an delete which isn't possible "
 "at this moment."
@@ -2036,12 +2039,12 @@ msgstr ""
 msgid "Greek"
 msgstr "Grec"
 
-#: ../src/wxMaximaFrame.cpp:356
+#: ../src/wxMaximaFrame.cpp:355
 #, fuzzy
 msgid "Greek Letters"
 msgstr "Constantes grecques"
 
-#: ../src/wxMaximaFrame.cpp:552
+#: ../src/wxMaximaFrame.cpp:551
 #, fuzzy
 msgid "Greek Letters\tAlt-Shift-G"
 msgstr "Mathématiques générales\tAlt-Maj-M"
@@ -2054,7 +2057,7 @@ msgstr "Constantes grecques"
 msgid "Grid:"
 msgstr "Grille :"
 
-#: ../src/wxMaxima.cpp:2836
+#: ../src/wxMaxima.cpp:2844
 #, fuzzy
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|pdfLaTeX file (*."
@@ -2069,12 +2072,12 @@ msgstr ""
 msgid "Help"
 msgstr "Aide"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 #, fuzzy
 msgid "Hide All Toolbars\tAlt-Shift--"
 msgstr "Cacher tout\tAlt-Maj--"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide all panes"
 msgstr "Cacher tous les panneaux"
 
@@ -2082,19 +2085,19 @@ msgstr "Cacher tous les panneaux"
 msgid "Highlight (dpart)"
 msgstr "Surbrillance"
 
-#: ../src/wxMaxima.cpp:4685
+#: ../src/wxMaxima.cpp:4697
 msgid "Histogram"
 msgstr "Histogramme"
 
-#: ../src/wxMaximaFrame.cpp:1270
+#: ../src/wxMaximaFrame.cpp:1269
 msgid "Histogram..."
 msgstr "Histogramme…"
 
-#: ../src/wxMaximaFrame.cpp:309
+#: ../src/wxMaximaFrame.cpp:308
 msgid "History"
 msgstr "Historique"
 
-#: ../src/wxMaximaFrame.cpp:555
+#: ../src/wxMaximaFrame.cpp:554
 #, fuzzy
 msgid "History\tAlt-Shift-I"
 msgstr "Historique\tAlt-Maj-H"
@@ -2116,11 +2119,11 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Hongrois"
 
-#: ../src/wxMaxima.cpp:3527
+#: ../src/wxMaxima.cpp:3539
 msgid "IC1"
 msgstr "IC1"
 
-#: ../src/wxMaxima.cpp:3543
+#: ../src/wxMaxima.cpp:3555
 msgid "IC2"
 msgstr "IC2"
 
@@ -2136,7 +2139,7 @@ msgid ""
 "same output cell."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:683
+#: ../src/wxMaximaFrame.cpp:682
 msgid ""
 "If maxima ever finishes evaluating without wxMaxima realizing this this menu "
 "item can force wxMaxima to try to send commands to maxima again."
@@ -2198,11 +2201,11 @@ msgstr ""
 "Si votre calcul met trop de temps à être évalué, vous pouvez essayer "
 "\"Maxima->Interrompre\" puis \"Maxima->Redémarrer Maxima"
 
-#: ../src/wxMaximaFrame.cpp:1499
+#: ../src/wxMaximaFrame.cpp:1518
 msgid "Image"
 msgstr "Image"
 
-#: ../src/wxMaxima.cpp:5644
+#: ../src/wxMaxima.cpp:5659
 msgid "Image files (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 msgstr "Fichiers images (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 
@@ -2229,7 +2232,7 @@ msgid ""
 "above it. Might increase readability for some fonts and short subscripts."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Include columns:"
 msgstr "Inclure les colonnes :"
 
@@ -2248,19 +2251,19 @@ msgstr ""
 msgid "Infinity"
 msgstr "Infini"
 
-#: ../src/wxMaximaFrame.cpp:974
+#: ../src/wxMaximaFrame.cpp:973
 msgid "Info about Maxima build"
 msgstr "Infos sur la compilation de Maxima"
 
-#: ../src/wxMaxima.cpp:4207
+#: ../src/wxMaxima.cpp:4219
 msgid "Initial Estimates:"
 msgstr "Estimations initiales :"
 
-#: ../src/wxMaximaFrame.cpp:718
+#: ../src/wxMaximaFrame.cpp:717
 msgid "Initial Value Problem (&1)..."
 msgstr "Condition initiale (&1)…"
 
-#: ../src/wxMaximaFrame.cpp:721
+#: ../src/wxMaximaFrame.cpp:720
 msgid "Initial Value Problem (&2)..."
 msgstr "Condition initiale (&2)…"
 
@@ -2268,7 +2271,7 @@ msgstr "Condition initiale (&2)…"
 msgid "Input labels"
 msgstr "Étiquettes d'entrée"
 
-#: ../src/wxMaximaFrame.cpp:403
+#: ../src/wxMaximaFrame.cpp:402
 msgid "Insert"
 msgstr "Insérer"
 
@@ -2276,108 +2279,108 @@ msgstr "Insérer"
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:612
+#: ../src/wxMaximaFrame.cpp:611
 #, fuzzy
 msgid "Insert &Section Cell\tCtrl-3"
 msgstr "Insérer une cellule de section\tF8"
 
-#: ../src/wxMaximaFrame.cpp:608
+#: ../src/wxMaximaFrame.cpp:607
 #, fuzzy
 msgid "Insert &Text Cell\tCtrl-1"
 msgstr "Insérer une cellule de texte \tF6"
 
-#: ../src/wxMaximaFrame.cpp:558
+#: ../src/wxMaximaFrame.cpp:557
 msgid "Insert Cell\tAlt-Shift-C"
 msgstr "Insérer la cellule\tAlt-Maj-C"
 
-#: ../src/wxMaxima.cpp:5642
+#: ../src/wxMaxima.cpp:5657
 msgid "Insert Image"
 msgstr "Insérer une image"
 
-#: ../src/wxMaximaFrame.cpp:620
+#: ../src/wxMaximaFrame.cpp:619
 msgid "Insert Image..."
 msgstr "Insérer une image…"
 
-#: ../src/wxMaximaFrame.cpp:606
+#: ../src/wxMaximaFrame.cpp:605
 #, fuzzy
 msgid "Insert Input &Cell"
 msgstr "Insérer une cellule d'entrée\tF5"
 
-#: ../src/wxMaximaFrame.cpp:618
+#: ../src/wxMaximaFrame.cpp:617
 #, fuzzy
 msgid "Insert Page Break"
 msgstr "Insérer un saut de page\tF10"
 
-#: ../src/wxMaximaFrame.cpp:614
+#: ../src/wxMaximaFrame.cpp:613
 #, fuzzy
 msgid "Insert S&ubsection Cell\tCtrl-4"
 msgstr "Insérer une cellule de sous-section\tF7"
 
-#: ../src/wxMaximaFrame.cpp:616
+#: ../src/wxMaximaFrame.cpp:615
 #, fuzzy
 msgid "Insert S&ubsubsection Cell\tCtrl-5"
 msgstr "Insérer une cellule de sous-section\tF7"
 
-#: ../src/MathCtrl.cpp:1015
+#: ../src/MathCtrl.cpp:1057
 #, fuzzy
 msgid "Insert Section Cell"
 msgstr "Insérer une cellule de section\tF8"
 
-#: ../src/MathCtrl.cpp:1016
+#: ../src/MathCtrl.cpp:1058
 #, fuzzy
 msgid "Insert Subsection Cell"
 msgstr "Insérer une cellule de sous-section\tF7"
 
-#: ../src/MathCtrl.cpp:1017
+#: ../src/MathCtrl.cpp:1059
 #, fuzzy
 msgid "Insert Subsubsection Cell"
 msgstr "Insérer une cellule de sous-section\tF7"
 
-#: ../src/wxMaximaFrame.cpp:610
+#: ../src/wxMaximaFrame.cpp:609
 #, fuzzy
 msgid "Insert T&itle Cell\tCtrl-2"
 msgstr "Insérer une cellule de titre\tF9"
 
-#: ../src/MathCtrl.cpp:1013
+#: ../src/MathCtrl.cpp:1055
 #, fuzzy
 msgid "Insert Text Cell"
 msgstr "Insérer une cellule de texte \tF6"
 
-#: ../src/MathCtrl.cpp:1014
+#: ../src/MathCtrl.cpp:1056
 #, fuzzy
 msgid "Insert Title Cell"
 msgstr "Insérer une cellule de titre\tF9"
 
-#: ../src/wxMaximaFrame.cpp:607
+#: ../src/wxMaximaFrame.cpp:606
 msgid "Insert a new input cell"
 msgstr "Insérer une nouvelle cellule d'entrée"
 
-#: ../src/wxMaximaFrame.cpp:613
+#: ../src/wxMaximaFrame.cpp:612
 msgid "Insert a new section cell"
 msgstr "Insérer une nouvelle cellule de section"
 
-#: ../src/wxMaximaFrame.cpp:615
+#: ../src/wxMaximaFrame.cpp:614
 msgid "Insert a new subsection cell"
 msgstr "Insérer une nouvelle cellule de sous-section"
 
-#: ../src/wxMaximaFrame.cpp:617
+#: ../src/wxMaximaFrame.cpp:616
 #, fuzzy
 msgid "Insert a new subsubsection cell"
 msgstr "Insérer une nouvelle cellule de sous-section"
 
-#: ../src/wxMaximaFrame.cpp:609
+#: ../src/wxMaximaFrame.cpp:608
 msgid "Insert a new text cell"
 msgstr "Insérer une nouvelle cellule de texte"
 
-#: ../src/wxMaximaFrame.cpp:611
+#: ../src/wxMaximaFrame.cpp:610
 msgid "Insert a new title cell"
 msgstr "Insérer une nouvelle cellule de titre"
 
-#: ../src/wxMaximaFrame.cpp:619
+#: ../src/wxMaximaFrame.cpp:618
 msgid "Insert a page break"
 msgstr "Insérer un saut de page"
 
-#: ../src/wxMaximaFrame.cpp:621
+#: ../src/wxMaximaFrame.cpp:620
 msgid "Insert image"
 msgstr "Insérer une image"
 
@@ -2390,27 +2393,27 @@ msgstr ""
 msgid "Integral sign"
 msgstr "Intégrer une expression"
 
-#: ../src/wxMaxima.cpp:3992
+#: ../src/wxMaxima.cpp:4004
 msgid "Integral/Sum:"
 msgstr "Intégrale/somme"
 
-#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4105 ../src/wxMaxima.cpp:5051
+#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4117 ../src/wxMaxima.cpp:5063
 msgid "Integrate"
 msgstr "Intégrer"
 
-#: ../src/wxMaxima.cpp:4091
+#: ../src/wxMaxima.cpp:4103
 msgid "Integrate (risch)"
 msgstr "Intégrer (Risch)"
 
-#: ../src/wxMaximaFrame.cpp:778
+#: ../src/wxMaximaFrame.cpp:777
 msgid "Integrate expression"
 msgstr "Intégrer une expression"
 
-#: ../src/wxMaximaFrame.cpp:780
+#: ../src/wxMaximaFrame.cpp:779
 msgid "Integrate expression with Risch algorithm"
 msgstr "Intégrer une expression avec l'algorithme de Risch"
 
-#: ../src/wxMaximaFrame.cpp:1224 ../src/MathCtrl.cpp:1000
+#: ../src/MathCtrl.cpp:1042 ../src/wxMaximaFrame.cpp:1223
 msgid "Integrate..."
 msgstr "Intégrer…"
 
@@ -2418,7 +2421,7 @@ msgstr "Intégrer…"
 msgid "Interrupt"
 msgstr "Interrompre"
 
-#: ../src/wxMaximaFrame.cpp:646 ../src/wxMaximaFrame.cpp:650
+#: ../src/wxMaximaFrame.cpp:645 ../src/wxMaximaFrame.cpp:649
 msgid "Interrupt current computation"
 msgstr "Interrompre le calcul en cours"
 
@@ -2438,15 +2441,15 @@ msgstr ""
 "\n"
 "Entrer à nouveau le chemin vers l'exécutable Maxima."
 
-#: ../src/wxMaxima.cpp:4137
+#: ../src/wxMaxima.cpp:4149
 msgid "Inverse Laplace"
 msgstr "Inverse Laplace"
 
-#: ../src/wxMaximaFrame.cpp:806
+#: ../src/wxMaximaFrame.cpp:805
 msgid "Inverse Laplace T&ransform..."
 msgstr "&Transformée de Laplace  inverse…"
 
-#: ../src/wxMaximaFrame.cpp:1372
+#: ../src/wxMaximaFrame.cpp:1371
 msgid "Iota"
 msgstr ""
 
@@ -2480,7 +2483,7 @@ msgstr "Japonais"
 msgid "Kabyle"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1373
+#: ../src/wxMaximaFrame.cpp:1372
 msgid "Kappa"
 msgstr ""
 
@@ -2490,7 +2493,7 @@ msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr ""
 "Conserver le signe pourcentage avec les symboles spéciaux: %e, %i, etc."
 
-#: ../src/wxMaxima.cpp:4031
+#: ../src/wxMaxima.cpp:4043
 msgid "LCM"
 msgstr "PPCM"
 
@@ -2506,7 +2509,7 @@ msgstr ""
 msgid "Label width:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1374
+#: ../src/wxMaximaFrame.cpp:1373
 msgid "Lambda"
 msgstr ""
 
@@ -2518,11 +2521,11 @@ msgstr "Langue utilisée pour l'interface de wxMaxima"
 msgid "Language:"
 msgstr "Langue :"
 
-#: ../src/wxMaxima.cpp:4120
+#: ../src/wxMaxima.cpp:4132
 msgid "Laplace"
 msgstr "Laplace"
 
-#: ../src/wxMaximaFrame.cpp:803
+#: ../src/wxMaximaFrame.cpp:802
 msgid "Laplace &Transform..."
 msgstr "&Transformée de Laplace…"
 
@@ -2531,15 +2534,15 @@ msgstr "&Transformée de Laplace…"
 msgid "Leads to"
 msgstr "va jusqu'à :"
 
-#: ../src/wxMaximaFrame.cpp:812
+#: ../src/wxMaximaFrame.cpp:811
 msgid "Least Common Multiple..."
 msgstr "Plus petit commun multiple…"
 
-#: ../src/wxMaxima.cpp:4809
+#: ../src/wxMaxima.cpp:4821
 msgid "Least Squares Fit"
 msgstr "Ajustement par la méthode des moindres carrés"
 
-#: ../src/wxMaximaFrame.cpp:1266
+#: ../src/wxMaximaFrame.cpp:1265
 msgid "Least Squares Fit..."
 msgstr "Ajustement par la méthode des moindres carrés…"
 
@@ -2550,24 +2553,24 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4192
+#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4204
 msgid "Limit"
 msgstr "Limite"
 
-#: ../src/wxMaximaFrame.cpp:1225
+#: ../src/wxMaximaFrame.cpp:1224
 msgid "Limit..."
 msgstr "Limite…"
 
-#: ../src/wxMaximaFrame.cpp:1265
+#: ../src/wxMaximaFrame.cpp:1264
 msgid "Linear Regression..."
 msgstr "Régression linéaire…"
 
-#: ../src/wxMaxima.cpp:3803
+#: ../src/wxMaxima.cpp:3815
 #, fuzzy
 msgid "List(s):"
 msgstr "à la liste :"
 
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3848
 msgid "List:"
 msgstr "à la liste :"
 
@@ -2575,15 +2578,15 @@ msgstr "à la liste :"
 msgid "Load"
 msgstr "Charger"
 
-#: ../src/wxMaxima.cpp:2932
+#: ../src/wxMaxima.cpp:2940
 msgid "Load Package"
 msgstr "Charger un paquetage\tCtrl-L"
 
-#: ../src/wxMaximaFrame.cpp:479
+#: ../src/wxMaximaFrame.cpp:478
 msgid "Load a Maxima file using the batch command"
 msgstr "Ouvrir un fichier Maxima en utilisant une commande batch"
 
-#: ../src/wxMaximaFrame.cpp:477
+#: ../src/wxMaximaFrame.cpp:476
 msgid "Load a Maxima package file"
 msgstr "Charger un paquetage Maxima"
 
@@ -2595,49 +2598,49 @@ msgstr "Charger un style à partir d'un fichier"
 msgid "Long Right arrow"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Lower bound:"
 msgstr "borne inférieure :"
 
-#: ../src/wxMaximaFrame.cpp:771
+#: ../src/wxMaximaFrame.cpp:770
 msgid "Ma&p to Matrix..."
 msgstr "A&ppliquer à une matrice…"
 
-#: ../src/wxMaximaFrame.cpp:547
+#: ../src/wxMaximaFrame.cpp:546
 #, fuzzy
 msgid "Main Toolbar\tAlt-Shift-B"
 msgstr "Barre d'outils\tAlt-Maj-T"
 
-#: ../src/wxMaximaFrame.cpp:765
+#: ../src/wxMaximaFrame.cpp:764
 msgid "Make &List..."
 msgstr "Générer une &liste…"
 
-#: ../src/wxMaxima.cpp:3821
+#: ../src/wxMaxima.cpp:3833
 msgid "Make list"
 msgstr "Générer une liste"
 
-#: ../src/wxMaximaFrame.cpp:766
+#: ../src/wxMaximaFrame.cpp:765
 msgid "Make list from expression"
 msgstr "Générer une liste à partir d'une expression"
 
-#: ../src/wxMaximaFrame.cpp:907
+#: ../src/wxMaximaFrame.cpp:906
 msgid "Make substitution in expression"
 msgstr "Substituer dans une expression"
 
-#: ../src/wxMaximaFrame.cpp:682
+#: ../src/wxMaximaFrame.cpp:681
 #, fuzzy
 msgid "Manually Trigger Evaluation"
 msgstr "Afficher le temps d'exécution"
 
-#: ../src/wxMaxima.cpp:3805
+#: ../src/wxMaxima.cpp:3817
 msgid "Map"
 msgstr "Appliquer"
 
-#: ../src/wxMaximaFrame.cpp:770
+#: ../src/wxMaximaFrame.cpp:769
 msgid "Map function to a list"
 msgstr "Appliquer une fonction à une liste"
 
-#: ../src/wxMaximaFrame.cpp:772
+#: ../src/wxMaximaFrame.cpp:771
 msgid "Map function to a matrix"
 msgstr "Appliquer une fonction à une matrice"
 
@@ -2654,23 +2657,23 @@ msgstr "Faire correspondre les parenthèses dans les entrées de texte."
 msgid "Math font:"
 msgstr "Police mathématique :"
 
-#: ../src/wxMaximaFrame.cpp:374
+#: ../src/wxMaximaFrame.cpp:373
 msgid "Mathematical Symbols"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3716
+#: ../src/wxMaxima.cpp:3728
 msgid "Matrix"
 msgstr "Matrice"
 
-#: ../src/wxMaxima.cpp:3702
+#: ../src/wxMaxima.cpp:3714
 msgid "Matrix map"
 msgstr "Appliquer une matrice"
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Matrix name:"
 msgstr "Nom de la matrice :"
 
-#: ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3749
+#: ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3761
 msgid "Matrix:"
 msgstr "Matrice :"
 
@@ -2678,7 +2681,7 @@ msgstr "Matrice :"
 msgid "Maxima"
 msgstr "&Maxima"
 
-#: ../src/wxMaximaFrame.cpp:137
+#: ../src/wxMaximaFrame.cpp:136
 #, fuzzy
 msgid "Maxima has a question"
 msgstr "Questions sur Maxima"
@@ -2687,24 +2690,24 @@ msgstr "Questions sur Maxima"
 msgid "Maxima input"
 msgstr "Entrée Maxima"
 
-#: ../src/wxMaximaFrame.cpp:166
+#: ../src/wxMaximaFrame.cpp:165
 msgid "Maxima is calculating"
 msgstr "Maxima est en train de calculer"
 
-#: ../src/wxMaximaFrame.cpp:111
+#: ../src/wxMaximaFrame.cpp:110
 #, fuzzy
 msgid "Maxima is ready for input."
 msgstr "Entrée Maxima"
 
-#: ../src/wxMaxima.cpp:2945
+#: ../src/wxMaxima.cpp:2953
 msgid "Maxima package (*.mac)|*.mac"
 msgstr "paquetage Maxima (*.mac)|*.mac|"
 
-#: ../src/wxMaxima.cpp:2934
+#: ../src/wxMaxima.cpp:2942
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr "Paquetage Maxima (*.mac)|*.mac|Paquetage Lisp (*.lisp)|*.lisp|Tous|*"
 
-#: ../src/wxMaxima.cpp:1014
+#: ../src/wxMaxima.cpp:1019
 msgid "Maxima process terminated."
 msgstr "Maxima s'est arrêté."
 
@@ -2716,7 +2719,7 @@ msgstr "Programme Maxima :"
 msgid "Maxima questions"
 msgstr "Questions sur Maxima"
 
-#: ../src/wxMaxima.cpp:942
+#: ../src/wxMaxima.cpp:947
 msgid "Maxima started. Waiting for connection..."
 msgstr "Maxima  a démarré. Attente de la connection…"
 
@@ -2740,7 +2743,7 @@ msgstr ""
 "Maxima utilise ':' pour affecter une valeur à une variable ('a : 3;') et ':"
 "=' pour définir une fonction ('f(x) := x^2;')."
 
-#: ../src/wxMaxima.cpp:4597
+#: ../src/wxMaxima.cpp:4609
 msgid "Maxima version: "
 msgstr "Version de Maxima :"
 
@@ -2777,40 +2780,40 @@ msgstr ""
 msgid "Maximum displayed number of digits:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1263
+#: ../src/wxMaximaFrame.cpp:1262
 msgid "Mean Difference Test..."
 msgstr "Test de la différence des moyennes…"
 
-#: ../src/wxMaximaFrame.cpp:1262
+#: ../src/wxMaximaFrame.cpp:1261
 msgid "Mean Test..."
 msgstr "Test sur la moyenne…"
 
-#: ../src/wxMaximaFrame.cpp:1255
+#: ../src/wxMaximaFrame.cpp:1254
 msgid "Mean..."
 msgstr "Moyenne…"
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Mean:"
 msgstr "Moyenne :"
 
-#: ../src/wxMaximaFrame.cpp:1256
+#: ../src/wxMaximaFrame.cpp:1255
 msgid "Median..."
 msgstr "Médiane…"
 
-#: ../src/MathCtrl.cpp:945
+#: ../src/MathCtrl.cpp:987
 msgid "Merge Cells"
 msgstr "Fusionner les  cellules"
 
-#: ../src/wxMaximaFrame.cpp:633
+#: ../src/wxMaximaFrame.cpp:632
 #, fuzzy
 msgid "Merge Cells\tCtrl-M"
 msgstr "Fusionner les  cellules"
 
-#: ../src/wxMaximaFrame.cpp:634
+#: ../src/wxMaximaFrame.cpp:633
 msgid "Merge the text from two input cells into one"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2668
+#: ../src/wxMaxima.cpp:2676
 msgid "Message from the stdout of Maxima: "
 msgstr ""
 
@@ -2818,20 +2821,20 @@ msgstr ""
 msgid "Method:"
 msgstr "Méthode :"
 
-#: ../src/wxMaxima.cpp:5289
+#: ../src/wxMaxima.cpp:5301
 #, fuzzy
 msgid "Mismatched parenthesis"
 msgstr "Faire correspondre les parenthèses dans les entrées de texte."
 
-#: ../src/wxMaxima.cpp:3972
+#: ../src/wxMaxima.cpp:3984
 msgid "Modulus"
 msgstr "Module"
 
-#: ../src/wxMaximaFrame.cpp:1375
+#: ../src/wxMaximaFrame.cpp:1374
 msgid "Mu"
 msgstr ""
 
-#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Name:"
 msgstr "Nom :"
 
@@ -2839,7 +2842,7 @@ msgstr "Nom :"
 msgid "New"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
+#: ../src/wxMaximaFrame.cpp:456 ../src/wxMaximaFrame.cpp:459
 msgid "New\tCtrl-N"
 msgstr "&Nouvelle session\tCtrl-N"
 
@@ -2856,11 +2859,11 @@ msgstr ""
 msgid "New value:"
 msgstr "Nouvelle valeur"
 
-#: ../src/wxMaxima.cpp:3993 ../src/wxMaxima.cpp:4119 ../src/wxMaxima.cpp:4136
+#: ../src/wxMaxima.cpp:4005 ../src/wxMaxima.cpp:4131 ../src/wxMaxima.cpp:4148
 msgid "New variable:"
 msgstr "Nouvelle variable :"
 
-#: ../src/wxMaximaFrame.cpp:630
+#: ../src/wxMaximaFrame.cpp:629
 msgid "Next Command\tAlt-Down"
 msgstr "Commande suivante\tAlt-Down"
 
@@ -2868,15 +2871,15 @@ msgstr "Commande suivante\tAlt-Down"
 msgid "No"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5362
+#: ../src/wxMaxima.cpp:5378
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3249 ../src/wxMaxima.cpp:3271
+#: ../src/wxMaxima.cpp:3260 ../src/wxMaxima.cpp:3283
 msgid "No matches found!"
 msgstr "Recherche infructueuse !"
 
-#: ../src/wxMaximaFrame.cpp:1264
+#: ../src/wxMaximaFrame.cpp:1263
 msgid "Normality Test..."
 msgstr "Test de normalité…"
 
@@ -2899,34 +2902,34 @@ msgstr ""
 msgid "Norwegian"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:3740
 msgid "Not a valid matrix dimension!"
 msgstr "Dimension de matrice incorrecte !"
 
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629
 msgid "Not a valid number of equations!"
 msgstr "Nombre d'équations incorrect !"
 
-#: ../src/wxMaximaFrame.cpp:197
+#: ../src/wxMaximaFrame.cpp:196
 #, fuzzy
 msgid "Not connected to maxima"
 msgstr ""
 "\n"
 "Non connecté à Maxima!\n"
 
-#: ../src/wxMaxima.cpp:4599
+#: ../src/wxMaxima.cpp:4611
 msgid "Not connected."
 msgstr "Non connecté"
 
-#: ../src/wxMaximaFrame.cpp:1376
+#: ../src/wxMaximaFrame.cpp:1375
 msgid "Nu"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Num. deg:"
 msgstr "num deg :"
 
-#: ../src/wxMaxima.cpp:3585 ../src/wxMaxima.cpp:3609
+#: ../src/wxMaxima.cpp:3597 ../src/wxMaxima.cpp:3621
 msgid "Number of equations:"
 msgstr "Nombre d'équations :"
 
@@ -2953,15 +2956,15 @@ msgstr "OK"
 msgid "Old value:"
 msgstr "Ancienne valeur :"
 
-#: ../src/wxMaxima.cpp:3992 ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135
+#: ../src/wxMaxima.cpp:4004 ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147
 msgid "Old variable:"
 msgstr "Ancienne variable :"
 
-#: ../src/wxMaximaFrame.cpp:1387
+#: ../src/wxMaximaFrame.cpp:1386
 msgid "Omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1378
+#: ../src/wxMaximaFrame.cpp:1377
 msgid "Omicron"
 msgstr ""
 
@@ -2975,20 +2978,20 @@ msgid ""
 "stream for messages."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4763
+#: ../src/wxMaxima.cpp:4775
 msgid "One sample t-test"
 msgstr "Test de Student (t-test) à 1 échantillon…"
 
-#: ../src/wxMaximaFrame.cpp:971
+#: ../src/wxMaximaFrame.cpp:970
 msgid "Online tutorials"
 msgstr "Tutoriels en ligne"
 
 #: ../src/ConfigDialogue.cpp:656 ../src/main.cpp:347 ../src/ToolBar.cpp:119
-#: ../src/wxMaxima.cpp:2797
+#: ../src/wxMaxima.cpp:2805
 msgid "Open"
 msgstr "Ouvrir"
 
-#: ../src/wxMaximaFrame.cpp:466
+#: ../src/wxMaximaFrame.cpp:465
 msgid "Open Recent"
 msgstr "Ouvrir un fichier récent"
 
@@ -2996,11 +2999,11 @@ msgstr "Ouvrir un fichier récent"
 msgid "Open a cell when Maxima expects input"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:464
+#: ../src/wxMaximaFrame.cpp:463
 msgid "Open a document"
 msgstr "Ouvrir un document"
 
-#: ../src/wxMaximaFrame.cpp:458 ../src/wxMaximaFrame.cpp:461
+#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
 msgid "Open a new window"
 msgstr "Ouvrir une nouvelle fenêtre"
 
@@ -3008,11 +3011,11 @@ msgstr "Ouvrir une nouvelle fenêtre"
 msgid "Open document"
 msgstr "Ouvrir un document"
 
-#: ../src/wxMaxima.cpp:4824
+#: ../src/wxMaxima.cpp:4836
 msgid "Open matrix"
 msgstr "Entrer une matrice"
 
-#: ../src/wxMaxima.cpp:1446 ../src/wxMaxima.cpp:1518
+#: ../src/wxMaxima.cpp:1451 ../src/wxMaxima.cpp:1523
 msgid "Opening file"
 msgstr "Ouverture du fichier"
 
@@ -3036,11 +3039,11 @@ msgstr "Cellules inactualisées"
 msgid "Output labels"
 msgstr "Étiquettes de sorties"
 
-#: ../src/wxMaximaFrame.cpp:796
+#: ../src/wxMaximaFrame.cpp:795
 msgid "P&ade Approximation..."
 msgstr "Approximant de &Padé…"
 
-#: ../src/wxMaxima.cpp:3132 ../src/wxMaxima.cpp:5133
+#: ../src/wxMaxima.cpp:3141 ../src/wxMaxima.cpp:5145
 #, fuzzy
 msgid ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
@@ -3050,15 +3053,15 @@ msgstr ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
 "bmp|X pixmap (*.xpm)|*.xpm"
 
-#: ../src/wxMaxima.cpp:4012
+#: ../src/wxMaxima.cpp:4024
 msgid "Pade approximation"
 msgstr "Approximant de Padé"
 
-#: ../src/wxMaximaFrame.cpp:797
+#: ../src/wxMaximaFrame.cpp:796
 msgid "Pade approximation of a Taylor series"
 msgstr "Approximant de Padé d'un développement en série de Taylor"
 
-#: ../src/wxMaximaFrame.cpp:1500
+#: ../src/wxMaximaFrame.cpp:1519
 msgid "Pagebreak"
 msgstr "Saut de page"
 
@@ -3070,19 +3073,19 @@ msgstr ""
 msgid "Parametric plot"
 msgstr "Courbe paramétrée"
 
-#: ../src/wxMaximaFrame.cpp:188
+#: ../src/wxMaximaFrame.cpp:187
 msgid "Parsing output"
 msgstr "Analyse du résultat"
 
-#: ../src/wxMaximaFrame.cpp:819
+#: ../src/wxMaximaFrame.cpp:818
 msgid "Partial &Fractions..."
 msgstr "Éléments simples…"
 
-#: ../src/wxMaxima.cpp:4076
+#: ../src/wxMaxima.cpp:4088
 msgid "Partial fractions"
 msgstr "Éléments simples"
 
-#: ../src/wxMaxima.cpp:1769
+#: ../src/wxMaxima.cpp:1774
 msgid "Parts of the document will not be loaded correctly!"
 msgstr "Des parties du document ne seront pas chargées correctement !"
 
@@ -3093,11 +3096,11 @@ msgid ""
 "Found unknown XML Tag name "
 msgstr "Des parties du document ne seront pas chargées correctement !"
 
-#: ../src/ToolBar.cpp:143 ../src/MathCtrl.cpp:1010 ../src/MathCtrl.cpp:1025
+#: ../src/MathCtrl.cpp:1052 ../src/MathCtrl.cpp:1067 ../src/ToolBar.cpp:143
 msgid "Paste"
 msgstr "Coller"
 
-#: ../src/wxMaximaFrame.cpp:518
+#: ../src/wxMaximaFrame.cpp:517
 msgid "Paste\tCtrl-V"
 msgstr "&Coller\tCtrl-V"
 
@@ -3105,7 +3108,7 @@ msgstr "&Coller\tCtrl-V"
 msgid "Paste from clipboard"
 msgstr "Coller le texte du presse-papier"
 
-#: ../src/wxMaximaFrame.cpp:519
+#: ../src/wxMaximaFrame.cpp:518
 msgid "Paste text from clipboard"
 msgstr "Coller le texte du presse-papier"
 
@@ -3113,19 +3116,19 @@ msgstr "Coller le texte du presse-papier"
 msgid "Perpendicular to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1384
+#: ../src/wxMaximaFrame.cpp:1383
 msgid "Phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1379
+#: ../src/wxMaximaFrame.cpp:1378
 msgid "Pi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1273
+#: ../src/wxMaximaFrame.cpp:1272
 msgid "Piechart..."
 msgstr "Diagramme circulaire…"
 
-#: ../src/wxMaxima.cpp:1952
+#: ../src/wxMaxima.cpp:1957
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr "Configurer wxMaxima avec 'Édition->Configurer'."
 
@@ -3133,52 +3136,52 @@ msgstr "Configurer wxMaxima avec 'Édition->Configurer'."
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr "Redémarrer wxMaxima pour que les changements prennent effet."
 
-#: ../src/wxMaximaFrame.cpp:923
+#: ../src/wxMaximaFrame.cpp:922
 msgid "Plot &2d..."
 msgstr "Courbe &2d…"
 
-#: ../src/wxMaximaFrame.cpp:925
+#: ../src/wxMaximaFrame.cpp:924
 msgid "Plot &3d..."
 msgstr "Courbe &3d…"
 
-#: ../src/wxMaximaFrame.cpp:927
+#: ../src/wxMaximaFrame.cpp:926
 msgid "Plot &Format..."
 msgstr "&Format de la courbe…"
 
 #: ../src/Plot2dWiz.cpp:104 ../src/Plot2dWiz.cpp:450 ../src/Plot2dWiz.cpp:464
-#: ../src/wxMaxima.cpp:4283 ../src/wxMaxima.cpp:5102
+#: ../src/wxMaxima.cpp:4295 ../src/wxMaxima.cpp:5114
 msgid "Plot 2D"
 msgstr "Courbe 2D"
 
-#: ../src/wxMaximaFrame.cpp:1227
+#: ../src/wxMaximaFrame.cpp:1226
 msgid "Plot 2D..."
 msgstr "Courbe 2D"
 
-#: ../src/MathCtrl.cpp:1003
+#: ../src/MathCtrl.cpp:1045
 msgid "Plot 2d..."
 msgstr "Courbe 2d…"
 
-#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4269 ../src/wxMaxima.cpp:5115
+#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4281 ../src/wxMaxima.cpp:5127
 msgid "Plot 3D"
 msgstr "Courbe 3D"
 
-#: ../src/wxMaximaFrame.cpp:1228
+#: ../src/wxMaximaFrame.cpp:1227
 msgid "Plot 3D..."
 msgstr "Courbe 3D"
 
-#: ../src/MathCtrl.cpp:1004
+#: ../src/MathCtrl.cpp:1046
 msgid "Plot 3d..."
 msgstr "Courbe 3d…"
 
-#: ../src/wxMaxima.cpp:4296
+#: ../src/wxMaxima.cpp:4308
 msgid "Plot format"
 msgstr "Format de la courbe"
 
-#: ../src/wxMaximaFrame.cpp:924
+#: ../src/wxMaximaFrame.cpp:923
 msgid "Plot in 2 dimensions"
 msgstr "Courbe en 2 dimensions"
 
-#: ../src/wxMaximaFrame.cpp:926
+#: ../src/wxMaximaFrame.cpp:925
 msgid "Plot in 3 dimensions"
 msgstr "Courbe en 3 dimensions"
 
@@ -3187,8 +3190,8 @@ msgid "Plot to file:"
 msgstr "Tracer dans un fichier :"
 
 #: ../src/BC2Wiz.cpp:30 ../src/BC2Wiz.cpp:36 ../src/LimitWiz.cpp:33
-#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
-#: ../src/wxMaxima.cpp:3648
+#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
+#: ../src/wxMaxima.cpp:3660
 msgid "Point:"
 msgstr "Point :"
 
@@ -3196,11 +3199,11 @@ msgstr "Point :"
 msgid "Polish"
 msgstr "Polonais"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 1:"
 msgstr "Polynôme 1 :"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 2:"
 msgstr "Polynôme 2 :"
 
@@ -3212,11 +3215,11 @@ msgstr "Portugais (Brésil)"
 msgid "Postscript file (*.eps)|*.eps|All|*"
 msgstr "Fichier postscript (*.eps)|*.eps|Tous|*"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Precision"
 msgstr "Précision"
 
-#: ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:536
 msgid "Preferences...\tCtrl+,"
 msgstr ""
 
@@ -3228,7 +3231,7 @@ msgid ""
 "packages and from functions that are defined in the current file."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:628
+#: ../src/wxMaximaFrame.cpp:627
 msgid "Previous Command\tAlt-Up"
 msgstr "Commande précédente\tAlt-Up"
 
@@ -3236,11 +3239,11 @@ msgstr "Commande précédente\tAlt-Up"
 msgid "Print"
 msgstr "Imprimer"
 
-#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:484
+#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:483
 msgid "Print document"
 msgstr "Imprimer le document"
 
-#: ../src/wxMaxima.cpp:4242
+#: ../src/wxMaxima.cpp:4254
 msgid "Product"
 msgstr "Produit"
 
@@ -3249,36 +3252,36 @@ msgstr "Produit"
 msgid "Product sign"
 msgstr "Produit"
 
-#: ../src/wxMaximaFrame.cpp:1386
+#: ../src/wxMaximaFrame.cpp:1385
 msgid "Psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:331
+#: ../src/wxMaximaFrame.cpp:330
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:592
+#: ../src/wxMaximaFrame.cpp:591
 #, fuzzy
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr "Réévaluer toutes les cellules du document"
 
-#: ../src/wxMaximaFrame.cpp:1278
+#: ../src/wxMaximaFrame.cpp:1277
 msgid "Read Matrix..."
 msgstr "&Lire la matrice…"
 
-#: ../src/wxMaximaFrame.cpp:177
+#: ../src/wxMaximaFrame.cpp:176
 msgid "Reading Maxima output"
 msgstr "Lecture des résultats de Maxima"
 
-#: ../src/wxMaximaFrame.cpp:153
+#: ../src/wxMaximaFrame.cpp:152
 msgid "Ready for user input"
 msgstr "Prêt pour une entrée utilisateur"
 
-#: ../src/wxMaximaFrame.cpp:631
+#: ../src/wxMaximaFrame.cpp:630
 msgid "Recall next command from history"
 msgstr "Rappeler la commande suivante dans l'historique"
 
-#: ../src/wxMaximaFrame.cpp:629
+#: ../src/wxMaximaFrame.cpp:628
 msgid "Recall previous command from history"
 msgstr "Rappeler la commande précédent dans l'historique"
 
@@ -3286,37 +3289,37 @@ msgstr "Rappeler la commande précédent dans l'historique"
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1215
+#: ../src/wxMaximaFrame.cpp:1214
 msgid "Rectform"
 msgstr "Forme cartésienne"
 
-#: ../src/wxMaximaFrame.cpp:495
+#: ../src/wxMaximaFrame.cpp:494
 #, fuzzy
 msgid "Redo\tCtrl-Y"
 msgstr "&Annuler\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:496
+#: ../src/wxMaximaFrame.cpp:495
 #, fuzzy
 msgid "Redo last change"
 msgstr "Annuler la dernière modification"
 
-#: ../src/wxMaximaFrame.cpp:1220
+#: ../src/wxMaximaFrame.cpp:1219
 msgid "Reduce (tr)"
 msgstr "Réduire (expr. trig.)"
 
-#: ../src/wxMaximaFrame.cpp:871
+#: ../src/wxMaximaFrame.cpp:870
 msgid "Reduce trigonometric expression"
 msgstr "Réduire une expression trigonométrique"
 
-#: ../src/wxMaxima.cpp:622 ../src/wxMaxima.cpp:5495
+#: ../src/wxMaxima.cpp:627 ../src/wxMaxima.cpp:5511
 msgid "Refusing to send cell to maxima: "
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:594
+#: ../src/wxMaximaFrame.cpp:593
 msgid "Remove All Output"
 msgstr "Supprimer tous les résultats"
 
-#: ../src/wxMaximaFrame.cpp:595
+#: ../src/wxMaximaFrame.cpp:594
 msgid "Remove output from input cells"
 msgstr "Supprimer les résultats des cellules"
 
@@ -3325,7 +3328,7 @@ msgstr "Supprimer les résultats des cellules"
 msgid "Replace All"
 msgstr "Tout sélectionner"
 
-#: ../src/wxMaxima.cpp:3282
+#: ../src/wxMaxima.cpp:3294
 #, fuzzy, c-format
 msgid "Replaced %d occurrences."
 msgstr "%d occurrences remplacées"
@@ -3334,11 +3337,11 @@ msgstr "%d occurrences remplacées"
 msgid "Replacement:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:976
+#: ../src/wxMaximaFrame.cpp:975
 msgid "Report bug"
 msgstr "Rapport de bogue"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "Restart Maxima"
 msgstr "Redémarrer Maxima"
 
@@ -3347,7 +3350,7 @@ msgstr "Redémarrer Maxima"
 msgid "Restart maxima"
 msgstr "Redémarrer Maxima"
 
-#: ../src/MathCtrl.cpp:4442
+#: ../src/MathCtrl.cpp:4497
 msgid "Result"
 msgstr ""
 
@@ -3355,7 +3358,7 @@ msgstr ""
 msgid "Return to the cell that is currently being evaluated"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1380
+#: ../src/wxMaximaFrame.cpp:1379
 msgid "Rho"
 msgstr ""
 
@@ -3363,19 +3366,19 @@ msgstr ""
 msgid "Right arrow"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:779
+#: ../src/wxMaximaFrame.cpp:778
 msgid "Risch Integration..."
 msgstr "Intégration de Risch…"
 
-#: ../src/wxMaximaFrame.cpp:694
+#: ../src/wxMaximaFrame.cpp:693
 msgid "Roots of &Polynomial"
 msgstr "Racines d'un &polynôme"
 
-#: ../src/wxMaximaFrame.cpp:697
+#: ../src/wxMaximaFrame.cpp:696
 msgid "Roots of Polynomial (bfloat)"
 msgstr "&Racines d'un polynôme (bigfloat)"
 
-#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Rows:"
 msgstr "Lignes :"
 
@@ -3383,56 +3386,56 @@ msgstr "Lignes :"
 msgid "Russian"
 msgstr "Russe"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 1:"
 msgstr "Échantillon 1 :"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 2:"
 msgstr "Échantillon 2 :"
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Sample:"
 msgstr "Échantillon"
 
 #: ../src/ConfigDialogue.cpp:781 ../src/ToolBar.cpp:122
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Save"
 msgstr "Enregistrer"
 
-#: ../src/MathCtrl.cpp:921
+#: ../src/MathCtrl.cpp:963
 msgid "Save Animation..."
 msgstr "Sauvegarder l'animation…"
 
-#: ../src/wxMaxima.cpp:2565
+#: ../src/wxMaxima.cpp:2572
 msgid "Save As"
 msgstr "Enregistrer sous"
 
-#: ../src/wxMaximaFrame.cpp:474
+#: ../src/wxMaximaFrame.cpp:473
 msgid "Save As...\tShift-Ctrl-S"
 msgstr "&Sauvegarder la session sous…\tMaj-Ctrl-S"
 
-#: ../src/MathCtrl.cpp:919
+#: ../src/MathCtrl.cpp:961
 msgid "Save Image..."
 msgstr "Enregistrer l'image…"
 
-#: ../src/wxMaxima.cpp:3130
+#: ../src/wxMaxima.cpp:3139
 msgid "Save Selection to Image"
 msgstr "Sauvegarder la sélection comme image"
 
-#: ../src/wxMaximaFrame.cpp:528
+#: ../src/wxMaximaFrame.cpp:527
 msgid "Save Selection to Image..."
 msgstr "Sauvegarder la sélection comme image…"
 
-#: ../src/wxMaxima.cpp:5150
+#: ../src/wxMaxima.cpp:5162
 msgid "Save animation to file"
 msgstr "Enregistrer l'animation dans un fichier"
 
-#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:473
+#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:472
 msgid "Save document"
 msgstr "Sauvegarder le document"
 
-#: ../src/wxMaximaFrame.cpp:475
+#: ../src/wxMaximaFrame.cpp:474
 msgid "Save document as"
 msgstr "Sauvegarder le document sous"
 
@@ -3456,11 +3459,11 @@ msgstr ""
 msgid "Save plot to file"
 msgstr "Enregistrer le tracé dans un fichier "
 
-#: ../src/wxMaximaFrame.cpp:529
+#: ../src/wxMaximaFrame.cpp:528
 msgid "Save selection from document to an image file"
 msgstr "Sauvegarder la sélection du document dans un fichier image "
 
-#: ../src/wxMaxima.cpp:5131
+#: ../src/wxMaxima.cpp:5143
 msgid "Save selection to file"
 msgstr "Enregistrer la sélection dans un fichier"
 
@@ -3478,28 +3481,28 @@ msgstr ""
 "Enregistrer la taille/position de la fenêtre de wxMaxima d'une session à "
 "l'autre"
 
-#: ../src/wxMaximaFrame.cpp:246
+#: ../src/wxMaximaFrame.cpp:245
 #, fuzzy
 msgid "Saving failed."
 msgstr "Échec du démarrage du serveur"
 
-#: ../src/wxMaximaFrame.cpp:222
+#: ../src/wxMaximaFrame.cpp:221
 msgid "Saving successful."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:212
+#: ../src/wxMaximaFrame.cpp:211
 msgid "Saving..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4699
+#: ../src/wxMaxima.cpp:4711
 msgid "Scatterplot"
 msgstr "Nuage de points"
 
-#: ../src/wxMaximaFrame.cpp:1271
+#: ../src/wxMaximaFrame.cpp:1270
 msgid "Scatterplot..."
 msgstr "Nuage de points…"
 
-#: ../src/wxMaximaFrame.cpp:1498
+#: ../src/wxMaximaFrame.cpp:1517
 msgid "Section"
 msgstr "Section"
 
@@ -3507,26 +3510,26 @@ msgstr "Section"
 msgid "Section cell"
 msgstr "Celllule de section"
 
-#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:292 ../src/TextCell.cpp:306
-#: ../src/TextCell.cpp:322 ../src/TextCell.cpp:334
+#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:290 ../src/TextCell.cpp:304
+#: ../src/TextCell.cpp:320 ../src/TextCell.cpp:332
 msgid ""
 "Seems like something is broken with a font. Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/TextCell.cpp:139
+#: ../src/TextCell.cpp:137
 msgid ""
 "Seems like something is broken with the maths font. Installing http://www."
 "math.union.edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use "
 "JSmath fonts\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1011 ../src/MathCtrl.cpp:1027
+#: ../src/MathCtrl.cpp:1053 ../src/MathCtrl.cpp:1069
 msgid "Select All"
 msgstr "Tout sélectionner"
 
-#: ../src/wxMaximaFrame.cpp:525
+#: ../src/wxMaximaFrame.cpp:524
 msgid "Select All\tCtrl-A"
 msgstr "Tout sélectionner"
 
@@ -3534,7 +3537,7 @@ msgstr "Tout sélectionner"
 msgid "Select Maxima program"
 msgstr "Choisir le programme Maxima"
 
-#: ../src/wxMaxima.cpp:4860
+#: ../src/wxMaxima.cpp:4872
 msgid "Select Subsample"
 msgstr "Choisir un sous-échantillon"
 
@@ -3543,11 +3546,11 @@ msgstr "Choisir un sous-échantillon"
 msgid "Select a constant"
 msgstr "Choisir une constante"
 
-#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:526
+#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:525
 msgid "Select all"
 msgstr "Tout sélectionner"
 
-#: ../src/wxMaxima.cpp:3319
+#: ../src/wxMaxima.cpp:3331
 msgid "Select math display algorithm"
 msgstr "Choisir l'algorithme d'affichage mathématique"
 
@@ -3564,23 +3567,23 @@ msgstr ""
 msgid "Selection"
 msgstr "Sélection"
 
-#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4178
+#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4190
 msgid "Series"
 msgstr "Série"
 
-#: ../src/wxMaximaFrame.cpp:1226
+#: ../src/wxMaximaFrame.cpp:1225
 msgid "Series..."
 msgstr "Série…"
 
-#: ../src/wxMaxima.cpp:863
+#: ../src/wxMaxima.cpp:868
 msgid "Server started"
 msgstr "Serveur démarré"
 
-#: ../src/wxMaximaFrame.cpp:575
+#: ../src/wxMaximaFrame.cpp:574
 msgid "Set Zoom"
 msgstr "Régler le zoom"
 
-#: ../src/wxMaximaFrame.cpp:944
+#: ../src/wxMaximaFrame.cpp:943
 #, fuzzy
 msgid "Set bigfloat &Precision..."
 msgstr "Régler la précision de la virgule flottante"
@@ -3589,63 +3592,63 @@ msgstr "Régler la précision de la virgule flottante"
 msgid "Set fixed font in text controls."
 msgstr "Sélectionner une police à chasse fixe dans les entrées de texte."
 
-#: ../src/wxMaximaFrame.cpp:928
+#: ../src/wxMaximaFrame.cpp:927
 msgid "Set plot format"
 msgstr "Régler le format de courbe"
 
-#: ../src/wxMaximaFrame.cpp:945
+#: ../src/wxMaximaFrame.cpp:944
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can "
 "be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:569
+#: ../src/wxMaximaFrame.cpp:568
 msgid "Set zoom to 100%"
 msgstr "Régler le zoom à 100%"
 
-#: ../src/wxMaximaFrame.cpp:570
+#: ../src/wxMaximaFrame.cpp:569
 msgid "Set zoom to 120%"
 msgstr "Régler le zoom à 120%"
 
-#: ../src/wxMaximaFrame.cpp:571
+#: ../src/wxMaximaFrame.cpp:570
 msgid "Set zoom to 150%"
 msgstr "Régler le zoom à 150%"
 
-#: ../src/wxMaximaFrame.cpp:572
+#: ../src/wxMaximaFrame.cpp:571
 msgid "Set zoom to 200%"
 msgstr "Régler le zoom à 200%"
 
-#: ../src/wxMaximaFrame.cpp:573
+#: ../src/wxMaximaFrame.cpp:572
 msgid "Set zoom to 300%"
 msgstr "Régler le zoom à 300%"
 
-#: ../src/wxMaximaFrame.cpp:568
+#: ../src/wxMaximaFrame.cpp:567
 msgid "Set zoom to 80%"
 msgstr "Régler le zoom à 80%"
 
-#: ../src/wxMaximaFrame.cpp:732
+#: ../src/wxMaximaFrame.cpp:731
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
 "Choisir 'à la valeur' pour la résolution d'une é.d.o. avec la transformée de "
 "Laplace"
 
-#: ../src/wxMaximaFrame.cpp:918
+#: ../src/wxMaximaFrame.cpp:917
 msgid "Setup modulus computation"
 msgstr "Calculer le module"
 
-#: ../src/wxMaximaFrame.cpp:662
+#: ../src/wxMaximaFrame.cpp:661
 msgid "Show &Definition..."
 msgstr "Montrer les &définitions"
 
-#: ../src/wxMaximaFrame.cpp:660
+#: ../src/wxMaximaFrame.cpp:659
 msgid "Show &Functions"
 msgstr "Montrer les &fonctions"
 
-#: ../src/wxMaximaFrame.cpp:967
+#: ../src/wxMaximaFrame.cpp:966
 msgid "Show &Tips..."
 msgstr "Montrer les as&tuces"
 
-#: ../src/wxMaximaFrame.cpp:665
+#: ../src/wxMaximaFrame.cpp:664
 msgid "Show &Variables"
 msgstr "Montrer les &variables"
 
@@ -3653,43 +3656,43 @@ msgstr "Montrer les &variables"
 msgid "Show Maxima help"
 msgstr "Montrer l'aide de Maxima"
 
-#: ../src/wxMaximaFrame.cpp:603
+#: ../src/wxMaximaFrame.cpp:602
 msgid "Show Template\tCtrl-Shift-K"
 msgstr "Montrer le modèle\tCtrl-Maj-K"
 
-#: ../src/wxMaximaFrame.cpp:968
+#: ../src/wxMaximaFrame.cpp:967
 msgid "Show a tip"
 msgstr "Montrer une astuce"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Show all commands similar to:"
 msgstr "Montrer toutes les commandes analogues à :"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Show an example for the command:"
 msgstr "Montrer un exemple pour la commande :"
 
-#: ../src/wxMaximaFrame.cpp:962
+#: ../src/wxMaximaFrame.cpp:961
 msgid "Show an example of usage"
 msgstr "Montrer un exemple d'utilisation"
 
-#: ../src/wxMaximaFrame.cpp:965
+#: ../src/wxMaximaFrame.cpp:964
 msgid "Show commands similar to"
 msgstr "Montrer les commandes analogues à"
 
-#: ../src/wxMaximaFrame.cpp:661
+#: ../src/wxMaximaFrame.cpp:660
 msgid "Show defined functions"
 msgstr "Montrer les fonctions définies"
 
-#: ../src/wxMaximaFrame.cpp:666
+#: ../src/wxMaximaFrame.cpp:665
 msgid "Show defined variables"
 msgstr "Montrer les variables déclarées"
 
-#: ../src/wxMaximaFrame.cpp:663
+#: ../src/wxMaximaFrame.cpp:662
 msgid "Show definition of a function"
 msgstr "Montrer la définition d'une fonction"
 
-#: ../src/wxMaximaFrame.cpp:604
+#: ../src/wxMaximaFrame.cpp:603
 msgid "Show function template"
 msgstr "Montrer le modèle de la fonction"
 
@@ -3702,7 +3705,7 @@ msgstr "Montrer les expressions longues dans la console de wxMaxima"
 msgid "Show long expressions:"
 msgstr "Montrer les expressions longues"
 
-#: ../src/wxMaxima.cpp:3341
+#: ../src/wxMaxima.cpp:3353
 msgid "Show the definition of function:"
 msgstr "Montrer la définition de la fonction :"
 
@@ -3711,44 +3714,44 @@ msgstr "Montrer la définition de la fonction :"
 msgid "Show user-defined labels instead of (%oxx)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:953 ../src/wxMaximaFrame.cpp:956
+#: ../src/wxMaximaFrame.cpp:952 ../src/wxMaximaFrame.cpp:955
 #, fuzzy
 msgid "Show wxMaxima help"
 msgstr "Montrer l'aide de Maxima"
 
-#: ../src/wxMaximaFrame.cpp:1381
+#: ../src/wxMaximaFrame.cpp:1380
 msgid "Sigma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1211
+#: ../src/wxMaximaFrame.cpp:1210
 msgid "Simplify"
 msgstr "Simplifier"
 
-#: ../src/wxMaximaFrame.cpp:831
+#: ../src/wxMaximaFrame.cpp:830
 msgid "Simplify &Radicals"
 msgstr "Simplifier des &radicaux"
 
-#: ../src/wxMaximaFrame.cpp:1212
+#: ../src/wxMaximaFrame.cpp:1211
 msgid "Simplify (r)"
 msgstr "Simplifier (r)"
 
-#: ../src/wxMaximaFrame.cpp:1218
+#: ../src/wxMaximaFrame.cpp:1217
 msgid "Simplify (tr)"
 msgstr "Simplifier (expr. trig.)"
 
-#: ../src/MathCtrl.cpp:995
+#: ../src/MathCtrl.cpp:1037
 msgid "Simplify Expression"
 msgstr "Simplifier une expression"
 
-#: ../src/wxMaximaFrame.cpp:857
+#: ../src/wxMaximaFrame.cpp:856
 msgid "Simplify an expression containing factorials"
 msgstr "Simplifier une expression contenant des factorielles"
 
-#: ../src/wxMaximaFrame.cpp:832
+#: ../src/wxMaximaFrame.cpp:831
 msgid "Simplify expression containing radicals"
 msgstr "Simplifier une expression contenant des radicaux"
 
-#: ../src/wxMaximaFrame.cpp:830
+#: ../src/wxMaximaFrame.cpp:829
 msgid "Simplify rational expression"
 msgstr "Simplifier une expression rationnelle"
 
@@ -3756,7 +3759,7 @@ msgstr "Simplifier une expression rationnelle"
 msgid "Simplify the sum"
 msgstr "Simplifier la somme"
 
-#: ../src/wxMaximaFrame.cpp:868
+#: ../src/wxMaximaFrame.cpp:867
 msgid "Simplify trigonometric expression"
 msgstr "Simplifier une expression trigonométrique"
 
@@ -3772,88 +3775,88 @@ msgstr ""
 "vous voulez que les images soient sauvegardées dans vos documents, vous "
 "devez utiliser le format \"Document xml wxMaxima\"."
 
-#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
+#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
 msgid "Solution:"
 msgstr "Solution :"
 
-#: ../src/wxMaxima.cpp:3461 ../src/wxMaxima.cpp:3475 ../src/wxMaxima.cpp:5020
+#: ../src/wxMaxima.cpp:3473 ../src/wxMaxima.cpp:3487 ../src/wxMaxima.cpp:5032
 msgid "Solve"
 msgstr "Résoudre"
 
-#: ../src/wxMaximaFrame.cpp:706
+#: ../src/wxMaximaFrame.cpp:705
 msgid "Solve &Algebraic System..."
 msgstr "Résoudre un système &algébrique…"
 
-#: ../src/wxMaximaFrame.cpp:703
+#: ../src/wxMaximaFrame.cpp:702
 msgid "Solve &Linear System..."
 msgstr "Résoudre un système &linéaire…"
 
-#: ../src/wxMaximaFrame.cpp:714
+#: ../src/wxMaximaFrame.cpp:713
 msgid "Solve &ODE..."
 msgstr "Résoudre &une équation différentielle…"
 
-#: ../src/wxMaximaFrame.cpp:690
+#: ../src/wxMaximaFrame.cpp:689
 msgid "Solve (to_poly)..."
 msgstr "Résoudre (to_poly)…"
 
-#: ../src/wxMaxima.cpp:3511 ../src/wxMaxima.cpp:3635
+#: ../src/wxMaxima.cpp:3523 ../src/wxMaxima.cpp:3647
 msgid "Solve ODE"
 msgstr "Résoudre une équation différentielle…"
 
-#: ../src/wxMaximaFrame.cpp:728
+#: ../src/wxMaximaFrame.cpp:727
 msgid "Solve ODE with Lapla&ce..."
 msgstr "Résoudre une équation différentielle avec Lapla&ce…"
 
-#: ../src/wxMaximaFrame.cpp:1222
+#: ../src/wxMaximaFrame.cpp:1221
 msgid "Solve ODE..."
 msgstr "Résoudre une équation différentielle…"
 
-#: ../src/wxMaxima.cpp:3586 ../src/wxMaxima.cpp:3597
+#: ../src/wxMaxima.cpp:3598 ../src/wxMaxima.cpp:3609
 msgid "Solve algebraic system"
 msgstr "Résoudre un système algébrique"
 
-#: ../src/wxMaximaFrame.cpp:707
+#: ../src/wxMaximaFrame.cpp:706
 msgid "Solve algebraic system of equations"
 msgstr "Résoudre un système d'équations algébriques"
 
-#: ../src/wxMaximaFrame.cpp:725
+#: ../src/wxMaximaFrame.cpp:724
 msgid "Solve boundary value problem for second degree ODE"
 msgstr "Résoudre un problème aux limites pour une é.d.o. du second ordre"
 
-#: ../src/wxMaximaFrame.cpp:689
+#: ../src/wxMaximaFrame.cpp:688
 msgid "Solve equation(s)"
 msgstr "Résoudre une (des) équation(s)"
 
-#: ../src/wxMaximaFrame.cpp:691
+#: ../src/wxMaximaFrame.cpp:690
 msgid "Solve equation(s) with to_poly_solve"
 msgstr "Résoudre une (des) équation(s) avec to_poly_solve"
 
-#: ../src/wxMaximaFrame.cpp:719
+#: ../src/wxMaximaFrame.cpp:718
 msgid "Solve initial value problem for first degree ODE"
 msgstr "Résoudre une é.d.o. du premier ordre avec condition initiale"
 
-#: ../src/wxMaximaFrame.cpp:722
+#: ../src/wxMaximaFrame.cpp:721
 msgid "Solve initial value problem for second degree ODE"
 msgstr "Résoudre une é.d.o. du second ordre avec conditions initiales"
 
-#: ../src/wxMaxima.cpp:3610 ../src/wxMaxima.cpp:3621
+#: ../src/wxMaxima.cpp:3622 ../src/wxMaxima.cpp:3633
 msgid "Solve linear system"
 msgstr "Résoudre un système &linéaire"
 
-#: ../src/wxMaximaFrame.cpp:704
+#: ../src/wxMaximaFrame.cpp:703
 msgid "Solve linear system of equations"
 msgstr "Résoudre un système d'équations linéaires"
 
-#: ../src/wxMaximaFrame.cpp:715
+#: ../src/wxMaximaFrame.cpp:714
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr "Résoudre une équation différentielle ordinaire de degré au plus 2"
 
-#: ../src/wxMaximaFrame.cpp:729
+#: ../src/wxMaximaFrame.cpp:728
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
 "Résoudre une équation différentielle ordinaire avec la transformée de Laplace"
 
-#: ../src/wxMaximaFrame.cpp:1221 ../src/MathCtrl.cpp:992
+#: ../src/MathCtrl.cpp:1034 ../src/wxMaximaFrame.cpp:1220
 msgid "Solve..."
 msgstr "Résoudre…"
 
@@ -3877,7 +3880,7 @@ msgstr "Spécial"
 msgid "Special constants"
 msgstr "Constantes spéciales"
 
-#: ../src/MathCtrl.cpp:922
+#: ../src/MathCtrl.cpp:964
 msgid "Start Animation"
 msgstr "Démarrer l'animation"
 
@@ -3896,28 +3899,28 @@ msgstr ""
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:294
+#: ../src/wxMaxima.cpp:295
 msgid "Starting Maxima process failed"
 msgstr "Le démarrage de Maxima a échoué"
 
-#: ../src/wxMaxima.cpp:928
+#: ../src/wxMaxima.cpp:933
 msgid "Starting Maxima..."
 msgstr "Démarrage de Maxima…"
 
-#: ../src/wxMaxima.cpp:292 ../src/wxMaxima.cpp:860
+#: ../src/wxMaxima.cpp:293 ../src/wxMaxima.cpp:865
 msgid "Starting server failed"
 msgstr "Échec du démarrage du serveur"
 
-#: ../src/wxMaxima.cpp:841
+#: ../src/wxMaxima.cpp:846
 #, c-format
 msgid "Starting server on port %d"
 msgstr "Démarrage du serveur sur le port %d"
 
-#: ../src/wxMaximaFrame.cpp:342
+#: ../src/wxMaximaFrame.cpp:341
 msgid "Statistics"
 msgstr "Statistiques"
 
-#: ../src/wxMaximaFrame.cpp:550
+#: ../src/wxMaximaFrame.cpp:549
 msgid "Statistics\tAlt-Shift-S"
 msgstr "Statistiques\tAlt-Maj-S"
 
@@ -3933,11 +3936,11 @@ msgstr "Style"
 msgid "Styles"
 msgstr "Styles"
 
-#: ../src/wxMaximaFrame.cpp:1283
+#: ../src/wxMaximaFrame.cpp:1282
 msgid "Subsample..."
 msgstr "Sous-échantillon"
 
-#: ../src/wxMaximaFrame.cpp:1496
+#: ../src/wxMaximaFrame.cpp:1515
 msgid "Subsection"
 msgstr "Sous-section"
 
@@ -3945,20 +3948,20 @@ msgstr "Sous-section"
 msgid "Subsection cell"
 msgstr "Cellule de sous-section"
 
-#: ../src/wxMaximaFrame.cpp:1216
+#: ../src/wxMaximaFrame.cpp:1215
 msgid "Subst..."
 msgstr "Substituer…"
 
-#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3423
-#: ../src/wxMaxima.cpp:5089
+#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3435
+#: ../src/wxMaxima.cpp:5101
 msgid "Substitute"
 msgstr "Substituer"
 
-#: ../src/wxMaximaFrame.cpp:906 ../src/MathCtrl.cpp:998
+#: ../src/MathCtrl.cpp:1040 ../src/wxMaximaFrame.cpp:905
 msgid "Substitute..."
 msgstr "Substituer…"
 
-#: ../src/wxMaximaFrame.cpp:1497
+#: ../src/wxMaximaFrame.cpp:1516
 #, fuzzy
 msgid "Subsubsection"
 msgstr "Sous-section"
@@ -3968,7 +3971,7 @@ msgstr "Sous-section"
 msgid "Subsubsection cell"
 msgstr "Cellule de sous-section"
 
-#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4226
+#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4238
 msgid "Sum"
 msgstr "Somme"
 
@@ -3976,37 +3979,37 @@ msgstr "Somme"
 msgid "Sum sign"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:553
+#: ../src/wxMaximaFrame.cpp:552
 #, fuzzy
 msgid "Symbols\tAlt-Shift-Y"
 msgstr "Statistiques\tAlt-Maj-S"
 
-#: ../src/wxMaxima.cpp:4456
+#: ../src/wxMaxima.cpp:4468
 msgid "System info"
 msgstr "Info système"
 
-#: ../src/wxMaximaFrame.cpp:320
+#: ../src/wxMaximaFrame.cpp:319
 msgid "Table of Contents"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:556
+#: ../src/wxMaximaFrame.cpp:555
 #, fuzzy
 msgid "Table of Contents\tAlt-Shift-T"
 msgstr "Barre d'outils\tAlt-Maj-T"
 
-#: ../src/wxMaximaFrame.cpp:1382
+#: ../src/wxMaximaFrame.cpp:1381
 msgid "Tau"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Taylor series:"
 msgstr "Séries de Taylor :"
 
-#: ../src/wxMaxima.cpp:3963
+#: ../src/wxMaxima.cpp:3975
 msgid "Tellrat"
 msgstr "Tellrat"
 
-#: ../src/wxMaximaFrame.cpp:1494
+#: ../src/wxMaximaFrame.cpp:1513
 msgid "Text"
 msgstr "Texte"
 
@@ -4053,7 +4056,7 @@ msgstr ""
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr ""
 
-#: ../src/TextCell.cpp:136
+#: ../src/TextCell.cpp:134
 msgid ""
 "The letter \"X\" is of width zero. Installing http://www.math.union.edu/"
 "~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts\" in "
@@ -4070,7 +4073,7 @@ msgstr ""
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:959
+#: ../src/wxMaximaFrame.cpp:958
 msgid "The offline manual of maxima"
 msgstr ""
 
@@ -4108,7 +4111,7 @@ msgstr ""
 "http://wxmaxima.sourceforge.net/wiki/index.php/Tutorials pour obtenir plus "
 "d'information sur l'utilisation de wxMaxima et Maxima."
 
-#: ../src/SlideShowCell.cpp:332
+#: ../src/SlideShowCell.cpp:336
 #, fuzzy
 msgid ""
 "There was an error during GIF export!\n"
@@ -4120,7 +4123,7 @@ msgstr ""
 " Vérifiez que ImageMagick est installé et que wxMaxima trouve le programme "
 "de conversion."
 
-#: ../src/wxMaxima.cpp:442
+#: ../src/wxMaxima.cpp:447
 msgid ""
 "There was an error in generated XML!\n"
 "\n"
@@ -4130,7 +4133,7 @@ msgstr ""
 "\n"
 "Merci de faire un rapport de bogue."
 
-#: ../src/wxMaximaFrame.cpp:1371
+#: ../src/wxMaximaFrame.cpp:1370
 msgid "Theta"
 msgstr ""
 
@@ -4138,7 +4141,7 @@ msgstr ""
 msgid "Ticks:"
 msgstr "Graduations :"
 
-#: ../src/wxMaxima.cpp:4153 ../src/wxMaxima.cpp:5065
+#: ../src/wxMaxima.cpp:4165 ../src/wxMaxima.cpp:5077
 msgid "Times:"
 msgstr "fois :"
 
@@ -4146,7 +4149,7 @@ msgstr "fois :"
 msgid "Tips not available, sorry!"
 msgstr "Les astuces ne sont pas disponibles !"
 
-#: ../src/wxMaximaFrame.cpp:1495
+#: ../src/wxMaximaFrame.cpp:1514
 msgid "Title"
 msgstr "Titre"
 
@@ -4165,19 +4168,19 @@ msgstr ""
 "triangle à côté de la cellule. Si vous cliquez en enfonçant  la touche Maj, "
 "tous les sous-niveaux de cette cellule seront aussi repliés ou dépliés."
 
-#: ../src/wxMaximaFrame.cpp:938
+#: ../src/wxMaximaFrame.cpp:937
 msgid "To &Bigfloat"
 msgstr "Valeur approchée (bfloat)"
 
-#: ../src/wxMaximaFrame.cpp:935
+#: ../src/wxMaximaFrame.cpp:934
 msgid "To &Float"
 msgstr "En virgule flottante"
 
-#: ../src/MathCtrl.cpp:990
+#: ../src/MathCtrl.cpp:1032
 msgid "To Float"
 msgstr "En virgule &flottante"
 
-#: ../src/wxMaximaFrame.cpp:941
+#: ../src/wxMaximaFrame.cpp:940
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr ""
 
@@ -4220,51 +4223,51 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:41 ../src/Plot2dWiz.cpp:40 ../src/Plot2dWiz.cpp:50
 #: ../src/Plot2dWiz.cpp:539 ../src/Plot3dWiz.cpp:39 ../src/Plot3dWiz.cpp:48
-#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4241
+#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4253
 msgid "To:"
 msgstr "à :"
 
-#: ../src/wxMaximaFrame.cpp:912
+#: ../src/wxMaximaFrame.cpp:911
 msgid "Toggle &Algebraic Flag"
 msgstr "Basculer le mode &algébrique"
 
-#: ../src/wxMaximaFrame.cpp:933
+#: ../src/wxMaximaFrame.cpp:932
 msgid "Toggle &Numeric Output"
 msgstr "Basculer l'affichage numérique"
 
-#: ../src/wxMaximaFrame.cpp:673
+#: ../src/wxMaximaFrame.cpp:672
 msgid "Toggle &Time Display"
 msgstr "Affichage du &temps"
 
-#: ../src/wxMaximaFrame.cpp:913
+#: ../src/wxMaximaFrame.cpp:912
 msgid "Toggle algebraic flag"
 msgstr "Basculer le mode algébrique"
 
-#: ../src/wxMaximaFrame.cpp:577
+#: ../src/wxMaximaFrame.cpp:576
 msgid "Toggle full screen editing"
 msgstr "Basculer en plein écran d'édition"
 
-#: ../src/wxMaximaFrame.cpp:934
+#: ../src/wxMaximaFrame.cpp:933
 msgid "Toggle numeric output"
 msgstr "Basculer l'affichage numérique entre valeur exacte et valeur approchée"
 
-#: ../src/wxMaxima.cpp:4464
+#: ../src/wxMaxima.cpp:4476
 msgid "Toolbar icons"
 msgstr "Icônes de la barre d'outils"
 
-#: ../src/wxMaxima.cpp:4465
+#: ../src/wxMaxima.cpp:4477
 msgid "Translated by"
 msgstr "Traduit par "
 
-#: ../src/wxMaximaFrame.cpp:763
+#: ../src/wxMaximaFrame.cpp:762
 msgid "Transpose a matrix"
 msgstr "Transposer une matrice"
 
-#: ../src/MathCtrl.cpp:5834
+#: ../src/MathCtrl.cpp:5886
 msgid "Trying to undo an action without starting cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5901
+#: ../src/MathCtrl.cpp:5953
 msgid "Trying to undo something but the undo action is empty."
 msgstr ""
 
@@ -4272,11 +4275,11 @@ msgstr ""
 msgid "Turkish"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:970
+#: ../src/wxMaximaFrame.cpp:969
 msgid "Tutorials"
 msgstr "Tutoriels"
 
-#: ../src/wxMaxima.cpp:4778
+#: ../src/wxMaxima.cpp:4790
 msgid "Two sample t-test"
 msgstr "Test de Student (t-test) à 2 échantillons…"
 
@@ -4288,15 +4291,15 @@ msgstr "Type :"
 msgid "Ukrainian"
 msgstr "Ukrainien"
 
-#: ../src/wxMaxima.cpp:5356
+#: ../src/wxMaxima.cpp:5372
 msgid "Un-closed parenthesis"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5323
+#: ../src/wxMaxima.cpp:5335
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5889
 msgid ""
 "Unable to interpret the version info I got from http://andrejv.github.io//"
 "wxmaxima/version.txt: "
@@ -4310,11 +4313,11 @@ msgstr "Souligné"
 msgid "Underscore converts to subscripts:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:492
+#: ../src/wxMaximaFrame.cpp:491
 msgid "Undo\tCtrl-Z"
 msgstr "&Annuler\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:493
+#: ../src/wxMaximaFrame.cpp:492
 msgid "Undo last change"
 msgstr "Annuler la dernière modification"
 
@@ -4322,26 +4325,26 @@ msgstr "Annuler la dernière modification"
 msgid "Undo limit (0 for none):"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:625
+#: ../src/wxMaximaFrame.cpp:624
 #, fuzzy
 msgid "Unfold All\tCtrl-Alt-]"
 msgstr "Tout sélectionner"
 
-#: ../src/wxMaximaFrame.cpp:626
+#: ../src/wxMaximaFrame.cpp:625
 #, fuzzy
 msgid "Unfold all folded sections"
 msgstr "Déplier tous les groupes"
 
-#: ../src/wxMaxima.cpp:4458
+#: ../src/wxMaxima.cpp:4470
 msgid "Unicode Support"
 msgstr "Support Unicode"
 
-#: ../src/wxMaxima.cpp:5335
+#: ../src/wxMaxima.cpp:5347
 #, fuzzy
 msgid "Unterminated comment."
 msgstr "Décommenter"
 
-#: ../src/wxMaxima.cpp:5309
+#: ../src/wxMaxima.cpp:5321
 msgid "Unterminated string."
 msgstr ""
 
@@ -4349,15 +4352,15 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5859 ../src/wxMaxima.cpp:5866 ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5874 ../src/wxMaxima.cpp:5881 ../src/wxMaxima.cpp:5889
 msgid "Upgrade"
 msgstr "Mettre à jour"
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Upper bound:"
 msgstr "borne supérieure :"
 
-#: ../src/wxMaximaFrame.cpp:1383
+#: ../src/wxMaximaFrame.cpp:1382
 #, fuzzy
 msgid "Upsilon"
 msgstr "Epsilon :"
@@ -4402,22 +4405,22 @@ msgstr ""
 msgid "User-defined labels"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3525
-#: ../src/wxMaxima.cpp:3541 ../src/wxMaxima.cpp:3649
+#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3537
+#: ../src/wxMaxima.cpp:3553 ../src/wxMaxima.cpp:3661
 msgid "Value:"
 msgstr "Valeur :"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:5019 ../src/wxMaxima.cpp:5064
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:5031 ../src/wxMaxima.cpp:5076
 msgid "Variable(s):"
 msgstr "Variables :"
 
 #: ../src/IntegrateWiz.cpp:33 ../src/LimitWiz.cpp:30 ../src/Plot2dWiz.cpp:34
 #: ../src/Plot2dWiz.cpp:44 ../src/Plot2dWiz.cpp:533 ../src/Plot3dWiz.cpp:33
 #: ../src/Plot3dWiz.cpp:42 ../src/SeriesWiz.cpp:36 ../src/SumWiz.cpp:30
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3749
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3761
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5045
 msgid "Variable:"
 msgstr "Variable :"
 
@@ -4425,25 +4428,25 @@ msgstr "Variable :"
 msgid "Variables"
 msgstr "Variables"
 
-#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3571 ../src/wxMaxima.cpp:4206
-#: ../src/wxMaxima.cpp:4807
+#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3583 ../src/wxMaxima.cpp:4218
+#: ../src/wxMaxima.cpp:4819
 msgid "Variables:"
 msgstr "Variables :"
 
-#: ../src/wxMaximaFrame.cpp:1257
+#: ../src/wxMaximaFrame.cpp:1256
 msgid "Variance..."
 msgstr "Variance…"
 
-#: ../src/wxMaximaFrame.cpp:580
+#: ../src/wxMaximaFrame.cpp:579
 msgid "View"
 msgstr ""
 
-#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1674 ../src/wxMaxima.cpp:1769
-#: ../src/wxMaxima.cpp:1950
+#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1679 ../src/wxMaxima.cpp:1774
+#: ../src/wxMaxima.cpp:1955
 msgid "Warning"
 msgstr "Alerte"
 
-#: ../src/wxMaximaFrame.cpp:109 ../src/wxMaximaFrame.cpp:295
+#: ../src/wxMaximaFrame.cpp:108 ../src/wxMaximaFrame.cpp:294
 msgid "Welcome to wxMaxima"
 msgstr "Bienvenue dans wxMaxima"
 
@@ -4467,7 +4470,7 @@ msgid ""
 "introducing an empty line."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2567
+#: ../src/wxMaxima.cpp:2574
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) "
 "(*.wxm)|*.wxm"
@@ -4483,7 +4486,7 @@ msgid ""
 "as equation markers"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6798
+#: ../src/MathCtrl.cpp:6856
 msgid "Wrapped search"
 msgstr ""
 
@@ -4491,16 +4494,16 @@ msgstr ""
 msgid "Write matching parenthesis in text controls."
 msgstr "Faire correspondre les parenthèses dans les entrées de texte."
 
-#: ../src/wxMaxima.cpp:4461
+#: ../src/wxMaxima.cpp:4473
 msgid "Written by"
 msgstr "Écrit par"
 
-#: ../src/wxMaximaFrame.cpp:557
+#: ../src/wxMaximaFrame.cpp:556
 #, fuzzy
 msgid "XML Inspector"
 msgstr "Inspecteur"
 
-#: ../src/wxMaximaFrame.cpp:1377
+#: ../src/wxMaximaFrame.cpp:1376
 msgid "Xi"
 msgstr ""
 
@@ -4575,7 +4578,7 @@ msgstr ""
 "horizontal. Ensuite, opérez sur la sélection. Utile pour supprimer ou "
 "évaluer plusieurs cellules."
 
-#: ../src/wxMaxima.cpp:5856
+#: ../src/wxMaxima.cpp:5871
 #, c-format
 msgid ""
 "You have version %s. Current version is %s.\n"
@@ -4586,41 +4589,41 @@ msgstr ""
 "\n"
 "Appuyez sur OK pour visiter le site de wxMaxima."
 
-#: ../src/wxMaxima.cpp:5921
+#: ../src/wxMaxima.cpp:5936
 msgid "Your changes will be lost if you don't save them."
 msgstr "Les changements seront perdus si vous ne les enregistrez pas"
 
-#: ../src/wxMaxima.cpp:5866
+#: ../src/wxMaxima.cpp:5881
 msgid "Your version of wxMaxima is up to date."
 msgstr "Votre version de wxMaxima est à jour."
 
-#: ../src/wxMaximaFrame.cpp:1369
+#: ../src/wxMaximaFrame.cpp:1368
 msgid "Zeta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:562
+#: ../src/wxMaximaFrame.cpp:561
 #, fuzzy
 msgid "Zoom &In\tCtrl-+"
 msgstr "Zoom avant\tAlt-I"
 
-#: ../src/wxMaximaFrame.cpp:564
+#: ../src/wxMaximaFrame.cpp:563
 #, fuzzy
 msgid "Zoom Ou&t\tCtrl--"
 msgstr "Zoom arrière\tAlt-O"
 
-#: ../src/wxMaximaFrame.cpp:563
+#: ../src/wxMaximaFrame.cpp:562
 msgid "Zoom in 10%"
 msgstr "Zoom avant de 10%"
 
-#: ../src/wxMaximaFrame.cpp:565
+#: ../src/wxMaximaFrame.cpp:564
 msgid "Zoom out 10%"
 msgstr "Zoom arrière de 10%"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaximaFrame.cpp:287
 msgid "[ unsaved ]"
 msgstr "[ non sauvegardé ]"
 
-#: ../src/wxMaxima.cpp:5700
+#: ../src/wxMaxima.cpp:5715
 msgid "[ unsaved* ]"
 msgstr "[ non sauvegardé* ]"
 
@@ -4629,17 +4632,17 @@ msgstr "[ non sauvegardé* ]"
 msgid "[%i digits]"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4392
+#: ../src/MathCtrl.cpp:4447
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" style=\"max-width:90%%;\" >\n"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4517
+#: ../src/MathCtrl.cpp:4572
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" >"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1333
+#: ../src/wxMaximaFrame.cpp:1332
 msgid "alpha"
 msgstr ""
 
@@ -4652,7 +4655,7 @@ msgstr "brun roux"
 msgid "antisymmetric"
 msgstr "antisymétrique"
 
-#: ../src/wxMaximaFrame.cpp:1334
+#: ../src/wxMaximaFrame.cpp:1333
 msgid "beta"
 msgstr ""
 
@@ -4696,7 +4699,7 @@ msgstr ""
 msgid "bug:Invalid sup tag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1354
+#: ../src/wxMaximaFrame.cpp:1353
 #, fuzzy
 msgid "chi"
 msgstr "orchidée"
@@ -4710,7 +4713,7 @@ msgstr ""
 msgid "default"
 msgstr "par défaut"
 
-#: ../src/wxMaximaFrame.cpp:1336
+#: ../src/wxMaximaFrame.cpp:1335
 msgid "delta"
 msgstr ""
 
@@ -4722,7 +4725,7 @@ msgstr "diagonale"
 msgid "empty"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1337
+#: ../src/wxMaximaFrame.cpp:1336
 #, fuzzy
 msgid "epsilon"
 msgstr "Epsilon :"
@@ -4731,7 +4734,7 @@ msgstr "Epsilon :"
 msgid "equivalent"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1339
+#: ../src/wxMaximaFrame.cpp:1338
 msgid "eta"
 msgstr ""
 
@@ -4747,7 +4750,7 @@ msgid ""
 "all=_ marks subscripts."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1335
+#: ../src/wxMaximaFrame.cpp:1334
 msgid "gamma"
 msgstr ""
 
@@ -4776,15 +4779,15 @@ msgstr "en ligne"
 msgid "intersection"
 msgstr "selon la direction"
 
-#: ../src/wxMaximaFrame.cpp:1341
+#: ../src/wxMaximaFrame.cpp:1340
 msgid "iota"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1342
+#: ../src/wxMaximaFrame.cpp:1341
 msgid "kappa"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1343
+#: ../src/wxMaximaFrame.cpp:1342
 msgid "lambda"
 msgstr ""
 
@@ -4801,7 +4804,7 @@ msgstr "Cellule de sous-section"
 msgid "logscale"
 msgstr "échelle logarithmique"
 
-#: ../src/wxMaxima.cpp:3783
+#: ../src/wxMaxima.cpp:3795
 msgid "matrix[i,j]:"
 msgstr "coefficient[i,j] : "
 
@@ -4809,7 +4812,7 @@ msgstr "coefficient[i,j] : "
 msgid "maxima's pwd is path to document"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1344
+#: ../src/wxMaximaFrame.cpp:1343
 msgid "mu"
 msgstr ""
 
@@ -4826,7 +4829,7 @@ msgstr ""
 msgid "nand"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4524
+#: ../src/wxMaxima.cpp:4536
 msgid "no"
 msgstr "Non"
 
@@ -4852,15 +4855,15 @@ msgstr ""
 msgid "not subset or equal"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1345
+#: ../src/wxMaximaFrame.cpp:1344
 msgid "nu"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1356
+#: ../src/wxMaximaFrame.cpp:1355
 msgid "omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1347
+#: ../src/wxMaximaFrame.cpp:1346
 msgid "omicron"
 msgstr ""
 
@@ -4873,11 +4876,11 @@ msgstr ""
 msgid "partial sign"
 msgstr "Éléments simples"
 
-#: ../src/wxMaximaFrame.cpp:1353
+#: ../src/wxMaximaFrame.cpp:1352
 msgid "phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1348
+#: ../src/wxMaximaFrame.cpp:1347
 #, fuzzy
 msgid "pi"
 msgstr "rose"
@@ -4890,11 +4893,11 @@ msgstr ""
 msgid "proportional to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1355
+#: ../src/wxMaximaFrame.cpp:1354
 msgid "psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1349
+#: ../src/wxMaximaFrame.cpp:1348
 msgid "rho"
 msgstr ""
 
@@ -4902,7 +4905,7 @@ msgstr ""
 msgid "right"
 msgstr "à droite"
 
-#: ../src/wxMaximaFrame.cpp:1350
+#: ../src/wxMaximaFrame.cpp:1349
 msgid "sigma"
 msgstr ""
 
@@ -4924,7 +4927,7 @@ msgstr "Cellule de sous-section"
 msgid "symmetric"
 msgstr "symétrique"
 
-#: ../src/wxMaximaFrame.cpp:1351
+#: ../src/wxMaximaFrame.cpp:1350
 msgid "tau"
 msgstr ""
 
@@ -4936,7 +4939,7 @@ msgstr ""
 msgid "there is no"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1340
+#: ../src/wxMaximaFrame.cpp:1339
 msgid "theta"
 msgstr ""
 
@@ -4952,12 +4955,12 @@ msgstr ""
 msgid "union"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5903
+#: ../src/wxMaxima.cpp:5918
 msgid "unsaved"
 msgstr "non sauvegardé"
 
-#: ../src/wxMaximaFrame.cpp:290 ../src/wxMaxima.cpp:2559
-#: ../src/wxMaxima.cpp:2826
+#: ../src/wxMaxima.cpp:2566 ../src/wxMaxima.cpp:2834
+#: ../src/wxMaximaFrame.cpp:289
 msgid "untitled"
 msgstr "sans nom"
 
@@ -4966,27 +4969,27 @@ msgstr "sans nom"
 msgid "untitled %d"
 msgstr "sans nom %d"
 
-#: ../src/wxMaximaFrame.cpp:1352
+#: ../src/wxMaximaFrame.cpp:1351
 #, fuzzy
 msgid "upsilon"
 msgstr "Epsilon :"
 
-#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4538
+#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4550
 msgid "wxMaxima"
 msgstr "wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
-#: ../src/wxMaxima.cpp:5700 ../src/wxMaxima.cpp:5709 ../src/wxMaxima.cpp:5712
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaxima.cpp:5715 ../src/wxMaxima.cpp:5724
+#: ../src/wxMaxima.cpp:5727 ../src/wxMaximaFrame.cpp:287
 #, c-format
 msgid "wxMaxima %s "
 msgstr "wxMaxima %s"
 
-#: ../src/wxMaximaFrame.cpp:952
+#: ../src/wxMaximaFrame.cpp:951
 #, fuzzy
 msgid "wxMaxima &Help\tCtrl+?"
 msgstr "Aide de Maxima\tF1"
 
-#: ../src/wxMaximaFrame.cpp:955
+#: ../src/wxMaximaFrame.cpp:954
 #, fuzzy
 msgid "wxMaxima &Help\tF1"
 msgstr "Aide de Maxima\tF1"
@@ -4998,11 +5001,11 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1619
+#: ../src/wxMaxima.cpp:1624
 msgid "wxMaxima cannot open content.xml in the .wxmx zip archive "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1633
+#: ../src/wxMaxima.cpp:1638
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
@@ -5010,7 +5013,7 @@ msgstr ""
 msgid "wxMaxima configuration"
 msgstr "Configuration de wxMaxima "
 
-#: ../src/wxMaxima.cpp:1947
+#: ../src/wxMaxima.cpp:1952
 msgid ""
 "wxMaxima could not find Maxima!\n"
 "\n"
@@ -5022,7 +5025,7 @@ msgstr ""
 "Configurez wxMaxima avec 'Édition->Configurer'.\n"
 "Puis redémarrez Maxima avec 'Maxima->Redémarrer Maxima'."
 
-#: ../src/wxMaxima.cpp:2204
+#: ../src/wxMaxima.cpp:2209
 msgid ""
 "wxMaxima could not find help files.\n"
 "\n"
@@ -5032,7 +5035,7 @@ msgstr ""
 "\n"
 "Vérifiez votre installation."
 
-#: ../src/wxMaxima.cpp:2032
+#: ../src/wxMaxima.cpp:2037
 msgid ""
 "wxMaxima could not find tip files.\n"
 "\n"
@@ -5042,7 +5045,7 @@ msgstr ""
 "\n"
 "Vérifiez votre installation."
 
-#: ../src/wxMaxima.cpp:282
+#: ../src/wxMaxima.cpp:283
 msgid ""
 "wxMaxima could not start the server.\n"
 "\n"
@@ -5064,23 +5067,23 @@ msgstr ""
 "dialogue, l'une d'entre elles étant '%'. Si vous avez opéré une sélection "
 "dans votre document, cette sélection sera utilisée au lieu de '%'."
 
-#: ../src/wxMaxima.cpp:2330
+#: ../src/wxMaxima.cpp:2336
 msgid "wxMaxima document"
 msgstr "Document wxMaxima "
 
-#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2799
+#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2807
 msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 msgstr "document wxMaxima (*.wxm)|*.wxm"
 
-#: ../src/wxMaxima.cpp:1455 ../src/wxMaxima.cpp:1469
+#: ../src/wxMaxima.cpp:1460 ../src/wxMaxima.cpp:1474
 msgid "wxMaxima encountered an error loading "
 msgstr "Erreur de wxMaxima au chargement"
 
-#: ../src/wxMaxima.cpp:4463
+#: ../src/wxMaxima.cpp:4475
 msgid "wxMaxima icon"
 msgstr "Icône wxMaxima"
 
-#: ../src/wxMaxima.cpp:4455
+#: ../src/wxMaxima.cpp:4467
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "MAXIMA based on wxWidgets."
@@ -5088,7 +5091,7 @@ msgstr ""
 "wxMaxima est une interface graphique pour le logiciel de calcul formel "
 "MAXIMA basée sur wxWidgets."
 
-#: ../src/wxMaxima.cpp:4516
+#: ../src/wxMaxima.cpp:4528
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "Maxima based on wxWidgets."
@@ -5108,11 +5111,11 @@ msgstr ""
 msgid "x"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1346
+#: ../src/wxMaximaFrame.cpp:1345
 msgid "xi"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1643
+#: ../src/wxMaxima.cpp:1648
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
@@ -5121,11 +5124,11 @@ msgstr ""
 msgid "xor"
 msgstr "&Exporter"
 
-#: ../src/wxMaxima.cpp:4522
+#: ../src/wxMaxima.cpp:4534
 msgid "yes"
 msgstr "oui"
 
-#: ../src/wxMaximaFrame.cpp:1338
+#: ../src/wxMaximaFrame.cpp:1337
 msgid "zeta"
 msgstr ""
 

--- a/locales/gl.po
+++ b/locales/gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: es\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-07 21:42+0200\n"
+"POT-Creation-Date: 2016-10-16 17:47+0900\n"
 "PO-Revision-Date: 2007-08-02 17:05+0200\n"
 "Last-Translator: Mario Rodriguez <mario@edu.xunta.es>\n"
 "Language-Team:  <gl@li.org>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../src/wxMaxima.cpp:4519
+#: ../src/wxMaxima.cpp:4531
 #, c-format
 msgid ""
 "\n"
@@ -29,7 +29,7 @@ msgstr ""
 "wxWidgets: %d.%d.%d\n"
 "Soporte unicode: %s"
 
-#: ../src/wxMaxima.cpp:4532
+#: ../src/wxMaxima.cpp:4544
 msgid ""
 "\n"
 "Lisp: "
@@ -37,7 +37,7 @@ msgstr ""
 "\n"
 "Lisp: "
 
-#: ../src/wxMaxima.cpp:4528
+#: ../src/wxMaxima.cpp:4540
 msgid ""
 "\n"
 "Maxima version: "
@@ -45,7 +45,7 @@ msgstr ""
 "\n"
 "Versión de Maxima: "
 
-#: ../src/wxMaxima.cpp:5381
+#: ../src/wxMaxima.cpp:5397
 msgid ""
 "\n"
 "Not connected to Maxima!\n"
@@ -53,7 +53,7 @@ msgstr ""
 "\n"
 "Non conectado a Maxima!\n"
 
-#: ../src/wxMaxima.cpp:4530
+#: ../src/wxMaxima.cpp:4542
 msgid ""
 "\n"
 "Not connected."
@@ -74,7 +74,7 @@ msgstr "      -l <nome>"
 msgid " (Graphics) "
 msgstr " (Gráficos) "
 
-#: ../src/EditorCell.cpp:3045 ../src/EditorCell.cpp:3227
+#: ../src/EditorCell.cpp:3088 ../src/EditorCell.cpp:3270
 #, c-format
 msgid " ... + %i hidden lines"
 msgstr ""
@@ -86,7 +86,7 @@ msgstr ""
 "...[suprimidas liñas adicionais; resultado maior do indicado en "
 "configuración]"
 
-#: ../src/wxMaxima.cpp:1673
+#: ../src/wxMaxima.cpp:1678
 msgid ""
 " was saved using a newer version of wxMaxima so it may not load correctly. "
 "Please update your wxMaxima."
@@ -94,7 +94,7 @@ msgstr ""
 " foi gardado cunha versión máis actualizada de wxMaxima, polo que é posible "
 "que non se cargue correctamente. Rógase a actualización de wxMaxima."
 
-#: ../src/wxMaxima.cpp:1665
+#: ../src/wxMaxima.cpp:1670
 msgid ""
 " was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr ""
@@ -109,64 +109,64 @@ msgstr "\"Copy LaTeX\" engade marcadores de ecuacións"
 msgid "\"implies\" symbol"
 msgstr "símbolo \"implica\""
 
-#: ../src/wxMaximaFrame.cpp:101
+#: ../src/wxMaximaFrame.cpp:100
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr "celas %i na cola de avaliación"
 
-#: ../src/wxMaximaFrame.cpp:773
+#: ../src/wxMaximaFrame.cpp:772
 msgid "&Algebra"
 msgstr "Álxe&bra"
 
-#: ../src/wxMaximaFrame.cpp:767
+#: ../src/wxMaximaFrame.cpp:766
 msgid "&Apply to List..."
 msgstr "&Aplicar a lista"
 
-#: ../src/wxMaximaFrame.cpp:964
+#: ../src/wxMaximaFrame.cpp:963
 msgid "&Apropos..."
 msgstr "&A propósito"
 
-#: ../src/wxMaximaFrame.cpp:478
+#: ../src/wxMaximaFrame.cpp:477
 msgid "&Batch File...\tCtrl-B"
 msgstr "Arquivo por &lotes\tCtrl-B"
 
-#: ../src/wxMaximaFrame.cpp:724
+#: ../src/wxMaximaFrame.cpp:723
 msgid "&Boundary Value Problem..."
 msgstr "Pro&blema de contorna"
 
-#: ../src/wxMaximaFrame.cpp:975
+#: ../src/wxMaximaFrame.cpp:974
 msgid "&Bug Report"
 msgstr "Informar de e&rro"
 
-#: ../src/wxMaximaFrame.cpp:825
+#: ../src/wxMaximaFrame.cpp:824
 msgid "&Calculus"
 msgstr "A&nálise"
 
-#: ../src/wxMaximaFrame.cpp:876
+#: ../src/wxMaximaFrame.cpp:875
 msgid "&Canonical Form"
 msgstr "Forma &canónica"
 
-#: ../src/wxMaximaFrame.cpp:749
+#: ../src/wxMaximaFrame.cpp:748
 msgid "&Characteristic Polynomial..."
 msgstr "Polinomio &característico"
 
-#: ../src/wxMaximaFrame.cpp:654
+#: ../src/wxMaximaFrame.cpp:653
 msgid "&Clear Memory"
 msgstr "&Limpar memoria"
 
-#: ../src/wxMaximaFrame.cpp:859
+#: ../src/wxMaximaFrame.cpp:858
 msgid "&Combine Factorials"
 msgstr "&Combinar factoriais"
 
-#: ../src/wxMaximaFrame.cpp:902
+#: ../src/wxMaximaFrame.cpp:901
 msgid "&Complex Simplification"
 msgstr "Simplificación &complexa"
 
-#: ../src/wxMaximaFrame.cpp:822
+#: ../src/wxMaximaFrame.cpp:821
 msgid "&Continued Fraction"
 msgstr "Fracción contin&ua"
 
-#: ../src/wxMaximaFrame.cpp:502
+#: ../src/wxMaximaFrame.cpp:501
 msgid "&Copy\tCtrl-C"
 msgstr "&Copiar\tCtrl-C"
 
@@ -174,107 +174,107 @@ msgstr "&Copiar\tCtrl-C"
 msgid "&Definite integration"
 msgstr "Integración &definida"
 
-#: ../src/wxMaximaFrame.cpp:896
+#: ../src/wxMaximaFrame.cpp:895
 msgid "&Demoivre"
 msgstr "&Demoivre"
 
-#: ../src/wxMaximaFrame.cpp:752
+#: ../src/wxMaximaFrame.cpp:751
 msgid "&Determinant"
 msgstr "&Determinante"
 
-#: ../src/wxMaximaFrame.cpp:785
+#: ../src/wxMaximaFrame.cpp:784
 msgid "&Differentiate..."
 msgstr "&Derivar"
 
-#: ../src/wxMaximaFrame.cpp:543
+#: ../src/wxMaximaFrame.cpp:542
 msgid "&Edit"
 msgstr "&Editar"
 
-#: ../src/wxMaximaFrame.cpp:709
+#: ../src/wxMaximaFrame.cpp:708
 msgid "&Eliminate Variable..."
 msgstr "Eliminar &variable"
 
-#: ../src/wxMaximaFrame.cpp:744
+#: ../src/wxMaximaFrame.cpp:743
 msgid "&Enter Matrix..."
 msgstr "&Introducir matriz"
 
-#: ../src/wxMaximaFrame.cpp:961
+#: ../src/wxMaximaFrame.cpp:960
 msgid "&Example..."
 msgstr "&Exemplo"
 
-#: ../src/wxMaximaFrame.cpp:839
+#: ../src/wxMaximaFrame.cpp:838
 msgid "&Expand Expression"
 msgstr "&Expandir expresión"
 
-#: ../src/wxMaximaFrame.cpp:873
+#: ../src/wxMaximaFrame.cpp:872
 msgid "&Expand Trigonometric"
 msgstr "Expandir &trigonometría"
 
-#: ../src/wxMaximaFrame.cpp:899
+#: ../src/wxMaximaFrame.cpp:898
 msgid "&Exponentialize"
 msgstr "Expo&nencializar"
 
-#: ../src/wxMaximaFrame.cpp:480
+#: ../src/wxMaximaFrame.cpp:479
 msgid "&Export..."
 msgstr "&Exportar"
 
-#: ../src/wxMaximaFrame.cpp:834
+#: ../src/wxMaximaFrame.cpp:833
 msgid "&Factor Expression"
 msgstr "&Factorizar expresión"
 
-#: ../src/wxMaximaFrame.cpp:489
+#: ../src/wxMaximaFrame.cpp:488
 msgid "&File"
 msgstr "&Arquivo"
 
-#: ../src/wxMaximaFrame.cpp:692
+#: ../src/wxMaximaFrame.cpp:691
 msgid "&Find Root..."
 msgstr "C&alcular raíz"
 
-#: ../src/wxMaximaFrame.cpp:738
+#: ../src/wxMaximaFrame.cpp:737
 msgid "&Generate Matrix..."
 msgstr "&Xerar matriz"
 
-#: ../src/wxMaximaFrame.cpp:809
+#: ../src/wxMaximaFrame.cpp:808
 msgid "&Greatest Common Divisor..."
 msgstr "Má&ximo común divisor"
 
-#: ../src/wxMaximaFrame.cpp:994
+#: ../src/wxMaximaFrame.cpp:993
 msgid "&Help"
 msgstr "A&xuda"
 
-#: ../src/wxMaximaFrame.cpp:777
+#: ../src/wxMaximaFrame.cpp:776
 msgid "&Integrate..."
 msgstr "&Integrar"
 
-#: ../src/wxMaximaFrame.cpp:645
+#: ../src/wxMaximaFrame.cpp:644
 msgid "&Interrupt\tCtrl-."
 msgstr "&Interrumpir\tCtrl-G"
 
-#: ../src/wxMaximaFrame.cpp:649
+#: ../src/wxMaximaFrame.cpp:648
 msgid "&Interrupt\tCtrl-G"
 msgstr "&Interrumpir\tCtrl-G"
 
-#: ../src/wxMaximaFrame.cpp:746
+#: ../src/wxMaximaFrame.cpp:745
 msgid "&Invert Matrix"
 msgstr "In&vertir matriz"
 
-#: ../src/wxMaximaFrame.cpp:476
+#: ../src/wxMaximaFrame.cpp:475
 msgid "&Load Package...\tCtrl-L"
 msgstr "Cargar &paquete\tCtrl-L"
 
-#: ../src/wxMaximaFrame.cpp:769
+#: ../src/wxMaximaFrame.cpp:768
 msgid "&Map to List(s)..."
 msgstr "Distribui&r sobre lista..."
 
-#: ../src/wxMaximaFrame.cpp:684
+#: ../src/wxMaximaFrame.cpp:683
 msgid "&Maxima"
 msgstr "&Maxima"
 
-#: ../src/wxMaximaFrame.cpp:958
+#: ../src/wxMaximaFrame.cpp:957
 msgid "&Maxima help"
 msgstr "Axuda de Maxima"
 
-#: ../src/wxMaximaFrame.cpp:917
+#: ../src/wxMaximaFrame.cpp:916
 msgid "&Modulus Computation..."
 msgstr "Cálculo do &módulo"
 
@@ -282,7 +282,7 @@ msgstr "Cálculo do &módulo"
 msgid "&New\tCtrl-N"
 msgstr "&Novo\tCtrl-N"
 
-#: ../src/wxMaximaFrame.cpp:947
+#: ../src/wxMaximaFrame.cpp:946
 msgid "&Numeric"
 msgstr "N&umérico"
 
@@ -298,11 +298,11 @@ msgstr "&Nusum"
 msgid "&Open\tCtrl-O"
 msgstr "&Abrir\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:463
+#: ../src/wxMaximaFrame.cpp:462
 msgid "&Open...\tCtrl-O"
 msgstr "&Abrir...\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:929
+#: ../src/wxMaximaFrame.cpp:928
 msgid "&Plot"
 msgstr "&Gráficos"
 
@@ -310,7 +310,7 @@ msgstr "&Gráficos"
 msgid "&Power series"
 msgstr "Serie de &potencias"
 
-#: ../src/wxMaximaFrame.cpp:483
+#: ../src/wxMaximaFrame.cpp:482
 msgid "&Print...\tCtrl-P"
 msgstr "&Imprimir...\tCtrl-P"
 
@@ -318,39 +318,39 @@ msgstr "&Imprimir...\tCtrl-P"
 msgid "&Rational"
 msgstr "&Racional"
 
-#: ../src/wxMaximaFrame.cpp:870
+#: ../src/wxMaximaFrame.cpp:869
 msgid "&Reduce Trigonometric"
 msgstr "R&educir trigonometría"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "&Restart Maxima"
 msgstr "&Reiniciar Maxima"
 
-#: ../src/wxMaximaFrame.cpp:700
+#: ../src/wxMaximaFrame.cpp:699
 msgid "&Roots of Polynomial (Real)"
 msgstr "Raíces reais dun polino&mio"
 
-#: ../src/wxMaximaFrame.cpp:472
+#: ../src/wxMaximaFrame.cpp:471
 msgid "&Save\tCtrl-S"
 msgstr "&Gardar\tCtrl-S"
 
-#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:919
+#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:918
 msgid "&Simplify"
 msgstr "&Simplificar"
 
-#: ../src/wxMaximaFrame.cpp:829
+#: ../src/wxMaximaFrame.cpp:828
 msgid "&Simplify Expression"
 msgstr "&Simplificar expresión"
 
-#: ../src/wxMaximaFrame.cpp:856
+#: ../src/wxMaximaFrame.cpp:855
 msgid "&Simplify Factorials"
 msgstr "&Simplificar factoriais"
 
-#: ../src/wxMaximaFrame.cpp:867
+#: ../src/wxMaximaFrame.cpp:866
 msgid "&Simplify Trigonometric"
 msgstr "&Simplificar trigonometría"
 
-#: ../src/wxMaximaFrame.cpp:688
+#: ../src/wxMaximaFrame.cpp:687
 msgid "&Solve..."
 msgstr "&Resolver"
 
@@ -362,11 +362,11 @@ msgstr "Especial"
 msgid "&Taylor series"
 msgstr "Serie de Taylor"
 
-#: ../src/wxMaximaFrame.cpp:762
+#: ../src/wxMaximaFrame.cpp:761
 msgid "&Transpose Matrix"
 msgstr "&Traspoñer matriz"
 
-#: ../src/wxMaximaFrame.cpp:879
+#: ../src/wxMaximaFrame.cpp:878
 msgid "&Trigonometric Simplification"
 msgstr "Simplificación &trigonométrica"
 
@@ -384,7 +384,7 @@ msgstr "(Usar idioma predeterminado)"
 msgid "- Infinity"
 msgstr "- Infinito"
 
-#: ../src/wxMaxima.cpp:351
+#: ../src/wxMaxima.cpp:356
 msgid ""
 "... [suppressed additional lines since the output is longer than allowed in "
 "the configuration] "
@@ -396,16 +396,16 @@ msgstr ""
 msgid "1/2"
 msgstr "1/2"
 
-#: ../src/wxMaximaFrame.cpp:103
+#: ../src/wxMaximaFrame.cpp:102
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4601
+#: ../src/wxMaxima.cpp:4613
 msgid "<br>Lisp: "
 msgstr "<br>Lisp: "
 
-#: ../src/wxMaxima.cpp:5487
+#: ../src/wxMaxima.cpp:5503
 msgid ""
 "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
@@ -437,12 +437,12 @@ msgid ""
 "\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1472
+#: ../src/wxMaximaFrame.cpp:1495
 #, fuzzy
 msgid "A symbol from the configuration dialogue"
 msgstr "Un símbolo do diálogo de configuración"
 
-#: ../src/wxMaximaFrame.cpp:731
+#: ../src/wxMaximaFrame.cpp:730
 msgid "A&t Value..."
 msgstr "&Condición inicial"
 
@@ -450,12 +450,12 @@ msgstr "&Condición inicial"
 msgid "Abort evaluation on error"
 msgstr "Interrupción do cálculo debido a erro"
 
-#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaxima.cpp:4603
+#: ../src/wxMaxima.cpp:4615 ../src/wxMaximaFrame.cpp:985
 msgid "About"
 msgstr "A&cerca de..."
 
-#: ../src/wxMaximaFrame.cpp:987 ../src/wxMaximaFrame.cpp:990
-#: ../src/wxMaximaFrame.cpp:991
+#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaximaFrame.cpp:989
+#: ../src/wxMaximaFrame.cpp:990
 msgid "About wxMaxima"
 msgstr "Acerca de wxMaxima"
 
@@ -463,23 +463,23 @@ msgstr "Acerca de wxMaxima"
 msgid "Active cell bracket"
 msgstr "Corchete de cela activa"
 
-#: ../src/wxMaximaFrame.cpp:760
+#: ../src/wxMaximaFrame.cpp:759
 msgid "Ad&joint Matrix"
 msgstr "Matriz ad&xunta"
 
-#: ../src/wxMaximaFrame.cpp:914
+#: ../src/wxMaximaFrame.cpp:913
 msgid "Add Algebraic E&quality..."
 msgstr "Engadir &igualdade alxébrica"
 
-#: ../src/wxMaximaFrame.cpp:657
+#: ../src/wxMaximaFrame.cpp:656
 msgid "Add a directory to search path"
 msgstr "Engadir directorio á ruta de busca"
 
-#: ../src/wxMaxima.cpp:3353
+#: ../src/wxMaxima.cpp:3365
 msgid "Add dir to path:"
 msgstr "Engadir dir á ruta:"
 
-#: ../src/wxMaximaFrame.cpp:915
+#: ../src/wxMaximaFrame.cpp:914
 msgid "Add equality to the rational simplifier"
 msgstr "Egadir igualdade ó simplificador racional"
 
@@ -487,7 +487,7 @@ msgstr "Egadir igualdade ó simplificador racional"
 msgid "Add the .wxmx file to the HTML export"
 msgstr "Engadir arquivo .wxmx á exportación HTML"
 
-#: ../src/wxMaximaFrame.cpp:656
+#: ../src/wxMaximaFrame.cpp:655
 msgid "Add to &Path..."
 msgstr "Enga&dir á ruta"
 
@@ -529,27 +529,27 @@ msgstr "Todos os nomes de variables"
 msgid "All|*"
 msgstr "Todos|*"
 
-#: ../src/wxMaximaFrame.cpp:1364
+#: ../src/wxMaximaFrame.cpp:1363
 msgid "Alpha"
 msgstr "Alfa"
 
-#: ../src/wxMaxima.cpp:3838
+#: ../src/wxMaxima.cpp:3850
 msgid "Apply"
 msgstr "Aplicar"
 
-#: ../src/wxMaximaFrame.cpp:768
+#: ../src/wxMaximaFrame.cpp:767
 msgid "Apply function to a list"
 msgstr "Aplicar función a lista"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Apropos"
 msgstr "A propósito"
 
-#: ../src/wxMaxima.cpp:3764
+#: ../src/wxMaxima.cpp:3776
 msgid "Array:"
 msgstr "Array:"
 
-#: ../src/wxMaxima.cpp:4462
+#: ../src/wxMaxima.cpp:4474
 msgid "Artwork by"
 msgstr "Arte por"
 
@@ -557,7 +557,7 @@ msgstr "Arte por"
 msgid "Ask to save untitled documents"
 msgstr "Preguntar para gardar documentos non titulados"
 
-#: ../src/wxMaxima.cpp:3650
+#: ../src/wxMaxima.cpp:3662
 msgid "At value"
 msgstr "Condición inicial"
 
@@ -585,11 +585,11 @@ msgstr ""
 msgid "Autosave interval (minutes, 0 means: off):"
 msgstr "Intervalo de autogardado (minutos, 0 significa desactivado)"
 
-#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3557
+#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3569
 msgid "BC2"
 msgstr "BC2"
 
-#: ../src/wxMaximaFrame.cpp:1272
+#: ../src/wxMaximaFrame.cpp:1271
 msgid "Barsplot..."
 msgstr "Diagrama de barras"
 
@@ -597,7 +597,7 @@ msgstr "Diagrama de barras"
 msgid "Bat files (*.bat)|*.bat|All|*"
 msgstr "Arquivos bat (*.bat)|*.bat|Todos|*"
 
-#: ../src/wxMaxima.cpp:2943
+#: ../src/wxMaxima.cpp:2951
 msgid "Batch File"
 msgstr "Arquivo por lotes"
 
@@ -615,7 +615,7 @@ msgstr ""
 "a celas. Premendo Ctrl+Z dentro dunha cela permite facer cambios que só "
 "afectan a ela mesma."
 
-#: ../src/wxMaximaFrame.cpp:1365
+#: ../src/wxMaximaFrame.cpp:1364
 msgid "Beta"
 msgstr "Beta"
 
@@ -628,11 +628,11 @@ msgstr "Escala bitmap para exportar"
 msgid "Bold"
 msgstr "Negrita"
 
-#: ../src/wxMaxima.cpp:2359
+#: ../src/wxMaxima.cpp:2366
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr "Cursores horizontal e vertical activos ó mesmo tempo"
 
-#: ../src/wxMaximaFrame.cpp:1274
+#: ../src/wxMaximaFrame.cpp:1273
 msgid "Boxplot..."
 msgstr "Diagrama de caixas"
 
@@ -644,15 +644,15 @@ msgstr "Navegar"
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr "Fallo: autocompleción solicitada para elemento descoñecido."
 
-#: ../src/MathCtrl.cpp:2080
+#: ../src/MathCtrl.cpp:2127
 msgid "Bug: Cell left but not entered."
 msgstr "Fallo: cela abandoada sen ter entrado."
 
-#: ../src/wxMaxima.cpp:1178
+#: ../src/wxMaxima.cpp:1183
 msgid "Bug: Found a math end marker without any start marker."
 msgstr "Fallo: encontrado marcador final sen marcador de inicio."
 
-#: ../src/wxMaxima.cpp:1222
+#: ../src/wxMaxima.cpp:1227
 msgid "Bug: Found the end of autocompletion symbols but no beginning"
 msgstr "Fallo: encontrado fin de autocompleción sen inicio"
 
@@ -664,11 +664,11 @@ msgstr ""
 msgid "Bug: Fraction without enumerator"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2312
+#: ../src/MathCtrl.cpp:2359
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr "Fallo: pregunta sen cela asociada"
 
-#: ../src/MathCtrl.cpp:5839
+#: ../src/MathCtrl.cpp:5891
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of "
 "the worksheet."
@@ -676,14 +676,14 @@ msgstr ""
 "Fallo: Solicitouse cambiar o contido dunha cela por riba do comezo da folla "
 "de traballo."
 
-#: ../src/MathCtrl.cpp:5913
+#: ../src/MathCtrl.cpp:5965
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 "Fallo: Solicitouse eliminar o contido dunha cela por riba do comezo da folla "
 "de traballo."
 
-#: ../src/MathCtrl.cpp:5882
+#: ../src/MathCtrl.cpp:5934
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
@@ -694,43 +694,43 @@ msgstr ""
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
 msgstr "Fallo: cela sen grupo ó que pertencer"
 
-#: ../src/GroupCell.cpp:780 ../src/GroupCell.cpp:951
+#: ../src/GroupCell.cpp:781 ../src/GroupCell.cpp:952
 msgid "Bug: No image counter to write to!"
 msgstr ""
 
-#: ../src/AbsCell.cpp:193
+#: ../src/AbsCell.cpp:199
 msgid "Bug: No last cell in an absCell!"
 msgstr ""
 
-#: ../src/ConjugateCell.cpp:185
+#: ../src/ConjugateCell.cpp:194
 msgid "Bug: No last cell in an conjugateCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:471
+#: ../src/FracCell.cpp:472
 msgid "Bug: No last cell in an denominator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:267
+#: ../src/ExptCell.cpp:270
 msgid "Bug: No last cell in an exponent of an exptCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:459
+#: ../src/FracCell.cpp:460
 msgid "Bug: No last cell in an numerator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:257
+#: ../src/ExptCell.cpp:260
 msgid "Bug: No last cell in the base of an exptCell!"
 msgstr ""
 
-#: ../src/ParenCell.cpp:534
+#: ../src/ParenCell.cpp:535
 msgid "Bug: No last cell inside a parenthesis!"
 msgstr ""
 
-#: ../src/SqrtCell.cpp:312
+#: ../src/SqrtCell.cpp:317
 msgid "Bug: No last cell inside a square root!"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2123
+#: ../src/MathCtrl.cpp:2170
 msgid ""
 "Bug: Start or end of merging of subsequent editing actions was requested two "
 "times in a row."
@@ -738,7 +738,7 @@ msgstr ""
 "Fallo: Solicitouse dúas veces nunha fila o inicio e final de pegado de "
 "accións de edición."
 
-#: ../src/MathCtrl.cpp:2090
+#: ../src/MathCtrl.cpp:2137
 msgid "Bug: Text changed, but no active cell."
 msgstr "Fallo: Texto cambiado sen cela activa."
 
@@ -746,13 +746,13 @@ msgstr "Fallo: Texto cambiado sen cela activa."
 msgid "Bug: Trying to append NULL to a group cell."
 msgstr "Fallo: Intento de engadir NULL a un grupo de celas."
 
-#: ../src/MathCtrl.cpp:555
+#: ../src/MathCtrl.cpp:600
 msgid "Bug: Trying to append maxima's output to a cell outside the worksheet."
 msgstr ""
 "Fallo: Intento de engadir o resultado de Maxima a unha cela fóra da folla de "
 "traballo."
 
-#: ../src/MathCtrl.cpp:2014
+#: ../src/MathCtrl.cpp:2061
 msgid ""
 "Bug: Trying to merge individual cell adds to a region in the undo buffer but "
 "there are other cells between them."
@@ -760,30 +760,30 @@ msgstr ""
 "Fallo: Intento de xuntar celas individuais nunha rexión do búffer de "
 "desfacer, pero no hai outras celas entre elas."
 
-#: ../src/MathCtrl.cpp:6522
+#: ../src/MathCtrl.cpp:6577
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr "Fallo: intento de mover cursor horizontal dentro dun grupo de celas."
 
-#: ../src/MathCtrl.cpp:2092
+#: ../src/MathCtrl.cpp:2139
 msgid "Bug: Trying to record a cell contents change without a cell."
 msgstr "Fallo: Intento de gardar o cambio do contido dunha cela sen cela."
 
-#: ../src/MathCtrl.cpp:1495
+#: ../src/MathCtrl.cpp:1540
 msgid "Bug: Trying to select inside a cell without having a current cell"
 msgstr "Fallo: Intento de selección non válida do contido dunha cela."
 
-#: ../src/MathCtrl.cpp:5883
+#: ../src/MathCtrl.cpp:5935
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr "Fallo: Acción de desfacer."
 
-#: ../src/MathCtrl.cpp:5844 ../src/MathCtrl.cpp:5918 ../src/MathCtrl.cpp:5952
+#: ../src/MathCtrl.cpp:5896 ../src/MathCtrl.cpp:5970 ../src/MathCtrl.cpp:6004
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
 "Fallo: Solicitude de desfacer para unha cela fóra da folla de traballo."
 
-#: ../src/wxMaximaFrame.cpp:973
+#: ../src/wxMaximaFrame.cpp:972
 msgid "Build &Info"
 msgstr "&Información de compilación"
 
@@ -800,51 +800,51 @@ msgstr ""
 "'Editar->Preferencias' seleccionando 'Tecla retorno avalía celas', co que se "
 "intercambiarán os roles destas teclas."
 
-#: ../src/wxMaximaFrame.cpp:782
+#: ../src/wxMaximaFrame.cpp:781
 msgid "C&hange Variable..."
 msgstr "C&ambiar variable"
 
-#: ../src/wxMaximaFrame.cpp:540
+#: ../src/wxMaximaFrame.cpp:539
 msgid "C&onfigure"
 msgstr "&Preferencias"
 
-#: ../src/wxMaximaFrame.cpp:801
+#: ../src/wxMaximaFrame.cpp:800
 msgid "Calculate &Product..."
 msgstr "&Calcular produto"
 
-#: ../src/wxMaximaFrame.cpp:799
+#: ../src/wxMaximaFrame.cpp:798
 msgid "Calculate Su&m..."
 msgstr "Calcular su&ma"
 
-#: ../src/wxMaximaFrame.cpp:939
+#: ../src/wxMaximaFrame.cpp:938
 msgid "Calculate bigfloat value of the last result"
 msgstr "Formato real grande da última expresión"
 
-#: ../src/wxMaximaFrame.cpp:936
+#: ../src/wxMaximaFrame.cpp:935
 msgid "Calculate float value of the last result"
 msgstr "Formato real da última expresión"
 
-#: ../src/wxMaxima.cpp:3971
+#: ../src/wxMaxima.cpp:3983
 msgid "Calculate modulus:"
 msgstr "Calcular módulo:"
 
-#: ../src/wxMaximaFrame.cpp:942
+#: ../src/wxMaximaFrame.cpp:941
 msgid "Calculate numeric value of the last result"
 msgstr "Calcula o valor numérico do derradeiro resultado"
 
-#: ../src/wxMaximaFrame.cpp:802
+#: ../src/wxMaximaFrame.cpp:801
 msgid "Calculate products"
 msgstr "Calcular produtos"
 
-#: ../src/wxMaximaFrame.cpp:800
+#: ../src/wxMaximaFrame.cpp:799
 msgid "Calculate sums"
 msgstr "Calcular sumas"
 
-#: ../src/wxMaxima.cpp:5830
+#: ../src/wxMaxima.cpp:5845
 msgid "Can not connect to the web server."
 msgstr "Non se pode acceder ó servidor web."
 
-#: ../src/wxMaxima.cpp:5881
+#: ../src/wxMaxima.cpp:5896
 msgid "Can not download version info."
 msgstr "Non se pode descargar a versión."
 
@@ -860,15 +860,15 @@ msgstr "Non se pode descargar a versión."
 #: ../src/PlotFormatWiz.cpp:48 ../src/SeriesWiz.cpp:49 ../src/SeriesWiz.cpp:51
 #: ../src/SubstituteWiz.cpp:41 ../src/SubstituteWiz.cpp:43 ../src/SumWiz.cpp:44
 #: ../src/SumWiz.cpp:46 ../src/SystemWiz.cpp:38 ../src/SystemWiz.cpp:40
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../src/wxMaximaFrame.cpp:126 ../src/wxMaxima.cpp:932
+#: ../src/wxMaxima.cpp:937 ../src/wxMaximaFrame.cpp:125
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1217
+#: ../src/wxMaximaFrame.cpp:1216
 msgid "Canonical (tr)"
 msgstr "Canónico (tr)"
 
@@ -876,7 +876,7 @@ msgstr "Canónico (tr)"
 msgid "Catalan"
 msgstr "Catalán"
 
-#: ../src/wxMaximaFrame.cpp:638
+#: ../src/wxMaximaFrame.cpp:637
 msgid "Ce&ll"
 msgstr "Ce&la"
 
@@ -884,40 +884,40 @@ msgstr "Ce&la"
 msgid "Cell bracket"
 msgstr "Corchete de cela"
 
-#: ../src/wxMaxima.cpp:5261
+#: ../src/wxMaxima.cpp:5273
 msgid "Cell ends in a backslash"
 msgstr "Cela termina en barra invertida"
 
-#: ../src/wxMaximaFrame.cpp:676
+#: ../src/wxMaximaFrame.cpp:675
 msgid "Change &2d Display"
 msgstr "Cambiar pantalla &2D"
 
-#: ../src/wxMaximaFrame.cpp:677
+#: ../src/wxMaximaFrame.cpp:676
 msgid "Change the 2d display algorithm used to display math output"
 msgstr ""
 "Cambiar o algoritmo empregado para amosar a saída matemática na pantalla 2D."
 
-#: ../src/wxMaxima.cpp:3995
+#: ../src/wxMaxima.cpp:4007
 msgid "Change variable"
 msgstr "Cambiar variable"
 
-#: ../src/wxMaximaFrame.cpp:783
+#: ../src/wxMaximaFrame.cpp:782
 msgid "Change variable in integral or sum"
 msgstr "Cambiar variable en integral ou suma"
 
-#: ../src/wxMaxima.cpp:3751
+#: ../src/wxMaxima.cpp:3763
 msgid "Char poly"
 msgstr "Polinomio característico"
 
-#: ../src/wxMaximaFrame.cpp:978
+#: ../src/wxMaximaFrame.cpp:977
 msgid "Check for Updates"
 msgstr "Comproba actualizacións"
 
-#: ../src/wxMaximaFrame.cpp:979
+#: ../src/wxMaximaFrame.cpp:978
 msgid "Check if a newer version of wxMaxima/Maxima exist."
 msgstr "Comproba se existe nova versión de wxMaxima/Maxima."
 
-#: ../src/wxMaximaFrame.cpp:1385
+#: ../src/wxMaximaFrame.cpp:1384
 msgid "Chi"
 msgstr "Ji"
 
@@ -938,15 +938,15 @@ msgstr "Elixir tipografía"
 msgid "Choose new plot format:"
 msgstr "Elixir un novo formato de gráficos:"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710
 msgid "Classes:"
 msgstr "Clases:"
 
-#: ../src/wxMaximaFrame.cpp:469
+#: ../src/wxMaximaFrame.cpp:468
 msgid "Close\tCtrl-W"
 msgstr "&Pechar\tCtrl-W"
 
-#: ../src/wxMaximaFrame.cpp:470
+#: ../src/wxMaximaFrame.cpp:469
 msgid "Close window"
 msgstr "Pechar xanela"
 
@@ -978,19 +978,19 @@ msgstr "Resaltado de código: Cadeas de texto"
 msgid "Code highlighting: Variables"
 msgstr "Resaltado de código: Variables"
 
-#: ../src/wxMaxima.cpp:4806
+#: ../src/wxMaxima.cpp:4818
 msgid "Col. names:"
 msgstr "Nomes col.:"
 
-#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Columns:"
 msgstr "Columnas:"
 
-#: ../src/wxMaximaFrame.cpp:860
+#: ../src/wxMaximaFrame.cpp:859
 msgid "Combine factorials in an expression"
 msgstr "Combinar factoriais nunha expresión"
 
-#: ../src/wxMaxima.cpp:5293
+#: ../src/wxMaxima.cpp:5305
 msgid "Comma directly followed by a closing parenthesis"
 msgstr "Coma seguida inmediatamente dun paréntese pechado"
 
@@ -1002,23 +1002,23 @@ msgstr "Coordenadas x separadas por comas."
 msgid "Comma separated y coordinates"
 msgstr "Coordenadas y separadas por comas."
 
-#: ../src/MathCtrl.cpp:1030
+#: ../src/MathCtrl.cpp:1072
 msgid "Comment Selection"
 msgstr "Comentar selección"
 
-#: ../src/wxMaximaFrame.cpp:533
+#: ../src/wxMaximaFrame.cpp:532
 msgid "Comment out the currently selected text"
 msgstr "Descomentar o texto seleccionado"
 
-#: ../src/wxMaximaFrame.cpp:532
+#: ../src/wxMaximaFrame.cpp:531
 msgid "Comment selection\tCtrl-/"
 msgstr "Comentar selección\tCtrl-/"
 
-#: ../src/wxMaximaFrame.cpp:601
+#: ../src/wxMaximaFrame.cpp:600
 msgid "Complete Word\tCtrl-K"
 msgstr "&Autocompletar\tCtrl-K"
 
-#: ../src/wxMaximaFrame.cpp:602
+#: ../src/wxMaximaFrame.cpp:601
 msgid "Complete word"
 msgstr "Autocompletar"
 
@@ -1026,36 +1026,36 @@ msgstr "Autocompletar"
 msgid "Completely stop maxima and restart it"
 msgstr "Parar completamente Maxima e arrincar de novo"
 
-#: ../src/wxMaximaFrame.cpp:823
+#: ../src/wxMaximaFrame.cpp:822
 msgid "Compute continued fraction of a value"
 msgstr "Calcular fracción continua dun valor"
 
-#: ../src/wxMaximaFrame.cpp:761
+#: ../src/wxMaximaFrame.cpp:760
 msgid "Compute the adjoint matrix"
 msgstr "Calcula a matriz adxunta"
 
-#: ../src/wxMaximaFrame.cpp:750
+#: ../src/wxMaximaFrame.cpp:749
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr "Calcula o polinomio característico dunha matriz"
 
-#: ../src/wxMaximaFrame.cpp:753
+#: ../src/wxMaximaFrame.cpp:752
 msgid "Compute the determinant of a matrix"
 msgstr "Calcula o determinante dunha matriz"
 
-#: ../src/wxMaximaFrame.cpp:810
+#: ../src/wxMaximaFrame.cpp:809
 msgid "Compute the greatest common divisor"
 msgstr "Calcula o máximo común divisor"
 
-#: ../src/wxMaximaFrame.cpp:747
+#: ../src/wxMaximaFrame.cpp:746
 msgid "Compute the inverse of a matrix"
 msgstr "Calcula a inversa dunha matriz"
 
-#: ../src/wxMaximaFrame.cpp:813
+#: ../src/wxMaximaFrame.cpp:812
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
 "Calcula o mínimo común múltiplo (executar load(funcións) antes de usar)"
 
-#: ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4868
 msgid "Condition:"
 msgstr "Condición"
 
@@ -1067,8 +1067,8 @@ msgstr "Arquivo de configuración (*.ini)|*.ini"
 msgid "Configuration warning"
 msgstr "Advertencia sobre configuración"
 
-#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:538
-#: ../src/wxMaximaFrame.cpp:541
+#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:540
 msgid "Configure wxMaxima"
 msgstr "Configura wxMaxima"
 
@@ -1077,130 +1077,132 @@ msgstr "Configura wxMaxima"
 msgid "Constant"
 msgstr "Constante"
 
-#: ../src/wxMaximaFrame.cpp:844
+#: ../src/wxMaximaFrame.cpp:843
 msgid "Contract Logarithms"
 msgstr "C&ontrae logaritmos"
 
-#: ../src/wxMaximaFrame.cpp:851
+#: ../src/wxMaximaFrame.cpp:850
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr "Convirte binomiais, funcións beta e gamma a factoriais"
 
-#: ../src/wxMaximaFrame.cpp:854
+#: ../src/wxMaximaFrame.cpp:853
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr "Convirte binomiais, funcións factoriais e beta á función gamma"
 
-#: ../src/wxMaximaFrame.cpp:888
+#: ../src/wxMaximaFrame.cpp:887
 msgid "Convert complex expression to polar form"
 msgstr "Convirte expresión complexa á forma polar"
 
-#: ../src/wxMaximaFrame.cpp:885
+#: ../src/wxMaximaFrame.cpp:884
 msgid "Convert complex expression to rect form"
 msgstr "Convirte expresión complexa á forma cartesiá"
 
-#: ../src/wxMaximaFrame.cpp:897
+#: ../src/wxMaximaFrame.cpp:896
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
 "Convirte función exponencial de argumento imaxinario á forma trigonométrica"
 
-#: ../src/wxMaximaFrame.cpp:842
+#: ../src/wxMaximaFrame.cpp:841
 msgid "Convert logarithm of product to sum of logarithms"
 msgstr "Convirte logaritmo dun produto en suma de logaritmos"
 
-#: ../src/wxMaximaFrame.cpp:845
+#: ../src/wxMaximaFrame.cpp:844
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "Convirte suma de logaritmos en logaritmo dun produto"
 
-#: ../src/wxMaximaFrame.cpp:850
+#: ../src/wxMaximaFrame.cpp:849
 msgid "Convert to &Factorials"
 msgstr "Convirte a &factoriais"
 
-#: ../src/wxMaximaFrame.cpp:853
+#: ../src/wxMaximaFrame.cpp:852
 msgid "Convert to &Gamma"
 msgstr "Convirte a &gamma"
 
-#: ../src/wxMaximaFrame.cpp:887
+#: ../src/wxMaximaFrame.cpp:886
 msgid "Convert to &Polarform"
 msgstr "Convirte á forma &polar"
 
-#: ../src/wxMaximaFrame.cpp:884
+#: ../src/wxMaximaFrame.cpp:883
 msgid "Convert to &Rectform"
 msgstr "Convirte á forma &cartesiá"
 
-#: ../src/wxMaximaFrame.cpp:877
+#: ../src/wxMaximaFrame.cpp:876
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr "Convirte expresión trigonométrica á forma canónica casi linear"
 
-#: ../src/wxMaximaFrame.cpp:900
+#: ../src/wxMaximaFrame.cpp:899
 msgid "Convert trigonometric functions to exponential form"
 msgstr "Convirte funcións trigonométricas á forma exponencial"
 
-#: ../src/ToolBar.cpp:140 ../src/MathCtrl.cpp:918 ../src/MathCtrl.cpp:931
-#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1024
+#: ../src/MathCtrl.cpp:960 ../src/MathCtrl.cpp:973 ../src/MathCtrl.cpp:1019
+#: ../src/MathCtrl.cpp:1066 ../src/ToolBar.cpp:140
 msgid "Copy"
 msgstr "Copiar"
 
-#: ../src/wxMaximaFrame.cpp:597
+#: ../src/wxMaximaFrame.cpp:596
 msgid "Copy Previous Input\tCtrl-I"
 msgstr "&Copiar entrada anterior\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:599
+#: ../src/wxMaximaFrame.cpp:598
 msgid "Copy Previous Output\tCtrl-U"
 msgstr "Copia resultado anterior\tCtrl-U"
 
-#: ../src/wxMaximaFrame.cpp:514 ../src/MathCtrl.cpp:936 ../src/MathCtrl.cpp:982
+#: ../src/MathCtrl.cpp:978 ../src/MathCtrl.cpp:1024
+#: ../src/wxMaximaFrame.cpp:513
 msgid "Copy as Image"
 msgstr "Copiar como imaxen"
 
-#: ../src/wxMaximaFrame.cpp:507 ../src/MathCtrl.cpp:932 ../src/MathCtrl.cpp:978
+#: ../src/MathCtrl.cpp:974 ../src/MathCtrl.cpp:1020
+#: ../src/wxMaximaFrame.cpp:506
 msgid "Copy as LaTeX"
 msgstr "Copiar como &LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:510
+#: ../src/wxMaximaFrame.cpp:509
 #, fuzzy
 msgid "Copy as MathML"
 msgstr "Copiar como imaxen"
 
-#: ../src/MathCtrl.cpp:935 ../src/MathCtrl.cpp:980
+#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1022
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:504
+#: ../src/wxMaximaFrame.cpp:503
 msgid "Copy as Text\tCtrl-Shift-C"
 msgstr "Copiar como &texto\tCtrl-Shift-C"
 
-#: ../src/MathCtrl.cpp:933 ../src/MathCtrl.cpp:979
+#: ../src/MathCtrl.cpp:975 ../src/MathCtrl.cpp:1021
 #, fuzzy
 msgid "Copy as plain text"
 msgstr "Copiar como imaxen"
 
-#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:503
+#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:502
 msgid "Copy selection"
 msgstr "Copiar selección"
 
-#: ../src/wxMaximaFrame.cpp:515
+#: ../src/wxMaximaFrame.cpp:514
 msgid "Copy selection from document as an image"
 msgstr "Copiar selección do documento como imaxe"
 
-#: ../src/wxMaximaFrame.cpp:505
+#: ../src/wxMaximaFrame.cpp:504
 msgid "Copy selection from document as text"
 msgstr "Copiar selección do documento con formato texto"
 
-#: ../src/wxMaximaFrame.cpp:508
+#: ../src/wxMaximaFrame.cpp:507
 msgid "Copy selection from document in LaTeX format"
 msgstr "Copiar selección do documento con formato LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:511
+#: ../src/wxMaximaFrame.cpp:510
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:598
+#: ../src/wxMaximaFrame.cpp:597
 msgid "Create a new cell with previous input"
 msgstr "Crear unha nova cela coa entrada anterior"
 
-#: ../src/wxMaximaFrame.cpp:600
+#: ../src/wxMaximaFrame.cpp:599
 msgid "Create a new cell with previous output"
 msgstr "Crear unha nova cela coa saída anterior"
 
@@ -1208,15 +1210,15 @@ msgstr "Crear unha nova cela coa saída anterior"
 msgid "Cursor"
 msgstr "Cursor"
 
-#: ../src/ToolBar.cpp:137 ../src/MathCtrl.cpp:1023
+#: ../src/MathCtrl.cpp:1065 ../src/ToolBar.cpp:137
 msgid "Cut"
 msgstr "Cortar"
 
-#: ../src/wxMaximaFrame.cpp:499
+#: ../src/wxMaximaFrame.cpp:498
 msgid "Cut\tCtrl-X"
 msgstr "Co&rtar\tCtrl-X"
 
-#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:500
+#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:499
 msgid "Cut selection"
 msgstr "Cortar selección"
 
@@ -1228,18 +1230,18 @@ msgstr "Checo"
 msgid "Danish"
 msgstr "Danés"
 
-#: ../src/wxMaxima.cpp:4799 ../src/wxMaxima.cpp:4806 ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4811 ../src/wxMaxima.cpp:4818 ../src/wxMaxima.cpp:4868
 msgid "Data Matrix:"
 msgstr "Matriz de datos:"
 
-#: ../src/wxMaxima.cpp:4826
+#: ../src/wxMaxima.cpp:4838
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr "Arquivo de datos (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698 ../src/wxMaxima.cpp:4712
-#: ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726 ../src/wxMaxima.cpp:4734
-#: ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748 ../src/wxMaxima.cpp:4755
-#: ../src/wxMaxima.cpp:4791
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710 ../src/wxMaxima.cpp:4724
+#: ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738 ../src/wxMaxima.cpp:4746
+#: ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760 ../src/wxMaxima.cpp:4767
+#: ../src/wxMaxima.cpp:4803
 msgid "Data:"
 msgstr "Datos:"
 
@@ -1248,7 +1250,7 @@ msgstr "Datos:"
 msgid "Debug: watch maxima's stdout stream"
 msgstr "Depurado: mirar o fluxo de saída de Maxima"
 
-#: ../src/wxMaximaFrame.cpp:820
+#: ../src/wxMaximaFrame.cpp:819
 msgid "Decompose rational function to partial fractions"
 msgstr "Descompoñer función racional en fraccións simples"
 
@@ -1279,47 +1281,47 @@ msgid ""
 "with."
 msgstr "Definir a frecuencia de imaxes para a reproducción de animacións."
 
-#: ../src/wxMaxima.cpp:3403 ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3415 ../src/wxMaxima.cpp:3424
 msgid "Delete"
 msgstr "Borra"
 
-#: ../src/wxMaximaFrame.cpp:667
+#: ../src/wxMaximaFrame.cpp:666
 msgid "Delete F&unction..."
 msgstr "Borra f&unción"
 
-#: ../src/MathCtrl.cpp:939 ../src/MathCtrl.cpp:985
+#: ../src/MathCtrl.cpp:981 ../src/MathCtrl.cpp:1027
 msgid "Delete Selection"
 msgstr "Borra selección"
 
-#: ../src/wxMaximaFrame.cpp:669
+#: ../src/wxMaximaFrame.cpp:668
 msgid "Delete V&ariable..."
 msgstr "Borra v&ariable"
 
-#: ../src/wxMaximaFrame.cpp:668
+#: ../src/wxMaximaFrame.cpp:667
 msgid "Delete a function"
 msgstr "Borra unha función"
 
-#: ../src/wxMaximaFrame.cpp:670
+#: ../src/wxMaximaFrame.cpp:669
 msgid "Delete a variable"
 msgstr "Borra unha variable"
 
-#: ../src/wxMaximaFrame.cpp:655
+#: ../src/wxMaximaFrame.cpp:654
 msgid "Delete all values from memory"
 msgstr "Borra todas as variables da memoria"
 
-#: ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3424
 msgid "Delete function(s):"
 msgstr "Borra función(s):"
 
-#: ../src/wxMaxima.cpp:3403
+#: ../src/wxMaxima.cpp:3415
 msgid "Delete variable(s):"
 msgstr "Borra variable(s):"
 
-#: ../src/wxMaximaFrame.cpp:1367
+#: ../src/wxMaximaFrame.cpp:1366
 msgid "Delta"
 msgstr "Delta"
 
-#: ../src/wxMaxima.cpp:4011
+#: ../src/wxMaxima.cpp:4023
 msgid "Denom. deg:"
 msgstr "denom deg:"
 
@@ -1327,35 +1329,35 @@ msgstr "denom deg:"
 msgid "Depth:"
 msgstr "Profundidad:"
 
-#: ../src/wxMaxima.cpp:3541
+#: ../src/wxMaxima.cpp:3553
 msgid "Derivative:"
 msgstr "Derivada:"
 
-#: ../src/wxMaximaFrame.cpp:1258
+#: ../src/wxMaximaFrame.cpp:1257
 msgid "Deviation..."
 msgstr "Desviación"
 
-#: ../src/wxMaximaFrame.cpp:816
+#: ../src/wxMaximaFrame.cpp:815
 msgid "Di&vide Polynomials..."
 msgstr "Di&vide polinomios"
 
-#: ../src/wxMaximaFrame.cpp:1223
+#: ../src/wxMaximaFrame.cpp:1222
 msgid "Diff..."
 msgstr "Deriva"
 
-#: ../src/wxMaxima.cpp:4154 ../src/wxMaxima.cpp:5066
+#: ../src/wxMaxima.cpp:4166 ../src/wxMaxima.cpp:5078
 msgid "Differentiate"
 msgstr "Deriva"
 
-#: ../src/wxMaximaFrame.cpp:786
+#: ../src/wxMaximaFrame.cpp:785
 msgid "Differentiate expression"
 msgstr "Deriva expresión"
 
-#: ../src/MathCtrl.cpp:1001
+#: ../src/MathCtrl.cpp:1043
 msgid "Differentiate..."
 msgstr "Deriva"
 
-#: ../src/LimitWiz.cpp:37 ../src/FindReplacePane.cpp:76
+#: ../src/FindReplacePane.cpp:76 ../src/LimitWiz.cpp:37
 msgid "Direction:"
 msgstr "Dirección:"
 
@@ -1363,48 +1365,49 @@ msgstr "Dirección:"
 msgid "Discrete plot"
 msgstr "Gráfico de puntos"
 
-#: ../src/wxMaximaFrame.cpp:679
+#: ../src/wxMaximaFrame.cpp:678
 msgid "Display Te&X Form"
 msgstr "Amosa formato Te&X"
 
-#: ../src/wxMaxima.cpp:3320
+#: ../src/wxMaxima.cpp:3332
 msgid "Display algorithm"
 msgstr "Amosa algoritmo"
 
-#: ../src/wxMaximaFrame.cpp:680
+#: ../src/wxMaximaFrame.cpp:679
 msgid "Display last result in TeX form"
 msgstr "Amosa último resultado en formato TeX"
 
-#: ../src/wxMaximaFrame.cpp:674
+#: ../src/wxMaximaFrame.cpp:673
 msgid "Display time used for evaluation"
 msgstr "Amosa tempo de execución"
 
-#: ../src/wxMaxima.cpp:4061
+#: ../src/wxMaxima.cpp:4073
 msgid "Divide"
 msgstr "Divide"
 
-#: ../src/MathCtrl.cpp:1032
+#: ../src/MathCtrl.cpp:1074
 msgid "Divide Cell"
 msgstr "Divide cela"
 
-#: ../src/wxMaximaFrame.cpp:635
+#: ../src/wxMaximaFrame.cpp:634
 #, fuzzy
 msgid "Divide Cell\tCtrl-D"
 msgstr "Divide cela"
 
-#: ../src/wxMaximaFrame.cpp:817
+#: ../src/wxMaximaFrame.cpp:816
 msgid "Divide numbers or polynomials"
 msgstr "Divide números ou polinomios"
 
-#: ../src/wxMaximaFrame.cpp:636
+#: ../src/wxMaximaFrame.cpp:635
 msgid "Divide this input cell into two cells"
 msgstr "Dividir esta cela de entrada en dúas celas"
 
-#: ../src/wxMaxima.cpp:5917
-msgid "Do you want to save the changes you made in the document \""
+#: ../src/wxMaxima.cpp:5932
+#, fuzzy, c-format
+msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr "Gárdanse os cambios feitos no documento? \""
 
-#: ../src/wxMaxima.cpp:1664 ../src/wxMaxima.cpp:1672
+#: ../src/wxMaxima.cpp:1669 ../src/wxMaxima.cpp:1677
 msgid "Document "
 msgstr "Documento"
 
@@ -1426,7 +1429,7 @@ msgstr ""
 "dificulta ós sistemas de control de versións (git, svn) detectar diferenzas "
 "de forma efectiva."
 
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Don't save"
 msgstr "Non guardar"
 
@@ -1434,27 +1437,27 @@ msgstr "Non guardar"
 msgid "Down"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:734
+#: ../src/wxMaximaFrame.cpp:733
 msgid "E&quations"
 msgstr "E&cuacións"
 
-#: ../src/wxMaximaFrame.cpp:487
+#: ../src/wxMaximaFrame.cpp:486
 msgid "E&xit\tCtrl-Q"
 msgstr "&Sair\tCtrl-Q"
 
-#: ../src/wxMaximaFrame.cpp:757
+#: ../src/wxMaximaFrame.cpp:756
 msgid "Eige&nvectors"
 msgstr "Vectores &propios"
 
-#: ../src/wxMaximaFrame.cpp:755
+#: ../src/wxMaximaFrame.cpp:754
 msgid "Eigen&values"
 msgstr "Va&lores propios"
 
-#: ../src/wxMaxima.cpp:3572
+#: ../src/wxMaxima.cpp:3584
 msgid "Eliminate"
 msgstr "Elimina"
 
-#: ../src/wxMaximaFrame.cpp:710
+#: ../src/wxMaximaFrame.cpp:709
 msgid "Eliminate a variable from a system of equations"
 msgstr "Elimina unha variable dun sistema de ecuacións"
 
@@ -1466,21 +1469,21 @@ msgstr "Fin de proba"
 msgid "English"
 msgstr "Inglés"
 
-#: ../src/wxMaxima.cpp:4712 ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726
-#: ../src/wxMaxima.cpp:4734 ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748
-#: ../src/wxMaxima.cpp:4755 ../src/wxMaxima.cpp:4791 ../src/wxMaxima.cpp:4799
+#: ../src/wxMaxima.cpp:4724 ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738
+#: ../src/wxMaxima.cpp:4746 ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760
+#: ../src/wxMaxima.cpp:4767 ../src/wxMaxima.cpp:4803 ../src/wxMaxima.cpp:4811
 msgid "Enter Data"
 msgstr "Introduce datos"
 
-#: ../src/wxMaximaFrame.cpp:1279
+#: ../src/wxMaximaFrame.cpp:1278
 msgid "Enter Matrix..."
 msgstr "Introduce matriz"
 
-#: ../src/wxMaximaFrame.cpp:745
+#: ../src/wxMaximaFrame.cpp:744
 msgid "Enter a matrix"
 msgstr "Introduce unha matriz"
 
-#: ../src/wxMaxima.cpp:3962
+#: ../src/wxMaxima.cpp:3974
 msgid "Enter an equation for rational simplification:"
 msgstr "Introduce unha ecuación para a simplificación racional:"
 
@@ -1492,11 +1495,11 @@ msgstr "Introduce unha lista de variables separadas por comas."
 msgid "Enter evaluates cells"
 msgstr "Tecla retorno avalía celas"
 
-#: ../src/wxMaxima.cpp:3734
+#: ../src/wxMaxima.cpp:3746
 msgid "Enter matrix"
 msgstr "Introduce matriz"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Enter new precision for bigfloats:"
 msgstr "Precisión para bigfloats:"
 
@@ -1504,11 +1507,11 @@ msgstr "Precisión para bigfloats:"
 msgid "Enter the path to the Maxima executable."
 msgstr "Introduce a ruta ó ejecutable Maxima."
 
-#: ../src/wxMaximaFrame.cpp:1368
+#: ../src/wxMaximaFrame.cpp:1367
 msgid "Epsilon"
 msgstr "Épsilon"
 
-#: ../src/wxMaxima.cpp:4208
+#: ../src/wxMaxima.cpp:4220
 msgid "Epsilon:"
 msgstr "Épsilon:"
 
@@ -1517,13 +1520,13 @@ msgstr "Épsilon:"
 msgid "Equation %d:"
 msgstr "Ecuación %d:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:3633
-#: ../src/wxMaxima.cpp:5019
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:3645
+#: ../src/wxMaxima.cpp:5031
 msgid "Equation(s):"
 msgstr "Ecuación(s):"
 
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3993
-#: ../src/wxMaxima.cpp:4807 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:4005
+#: ../src/wxMaxima.cpp:4819 ../src/wxMaxima.cpp:5045
 msgid "Equation:"
 msgstr "Ecuación:"
 
@@ -1534,77 +1537,77 @@ msgid ""
 "be introduced one into another. Also they are always printed out as 2D maths."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3570
+#: ../src/wxMaxima.cpp:3582
 msgid "Equations:"
 msgstr "Ecuacións:"
 
-#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1455
-#: ../src/wxMaxima.cpp:1469 ../src/wxMaxima.cpp:1620 ../src/wxMaxima.cpp:1633
-#: ../src/wxMaxima.cpp:1643 ../src/wxMaxima.cpp:1666 ../src/wxMaxima.cpp:2034
-#: ../src/wxMaxima.cpp:2206 ../src/wxMaxima.cpp:5381 ../src/wxMaxima.cpp:5830
-#: ../src/wxMaxima.cpp:5881
+#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1460
+#: ../src/wxMaxima.cpp:1474 ../src/wxMaxima.cpp:1625 ../src/wxMaxima.cpp:1638
+#: ../src/wxMaxima.cpp:1648 ../src/wxMaxima.cpp:1671 ../src/wxMaxima.cpp:2039
+#: ../src/wxMaxima.cpp:2211 ../src/wxMaxima.cpp:5397 ../src/wxMaxima.cpp:5845
+#: ../src/wxMaxima.cpp:5896
 msgid "Error"
 msgstr "Erro"
 
-#: ../src/wxMaxima.cpp:2886 ../src/wxMaxima.cpp:2900 ../src/wxMaxima.cpp:2913
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617 ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:2894 ../src/wxMaxima.cpp:2908 ../src/wxMaxima.cpp:2921
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629 ../src/wxMaxima.cpp:3740
 msgid "Error!"
 msgstr "Erro!"
 
-#: ../src/wxMaximaFrame.cpp:1370
+#: ../src/wxMaximaFrame.cpp:1369
 msgid "Eta"
 msgstr "Eta"
 
-#: ../src/wxMaximaFrame.cpp:909
+#: ../src/wxMaximaFrame.cpp:908
 msgid "Evaluate &Noun Forms"
 msgstr "Avalía formas &nominais"
 
-#: ../src/wxMaximaFrame.cpp:589
+#: ../src/wxMaximaFrame.cpp:588
 msgid "Evaluate All Cells\tCtrl-Shift-R"
 msgstr "Avaliar todas as celas\tCtrl-Shift-R"
 
-#: ../src/wxMaximaFrame.cpp:587
+#: ../src/wxMaximaFrame.cpp:586
 msgid "Evaluate All Visible Cells\tCtrl-R"
 msgstr "Avaliar todas as celas visibles\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:585 ../src/MathCtrl.cpp:942
+#: ../src/MathCtrl.cpp:984 ../src/wxMaximaFrame.cpp:584
 msgid "Evaluate Cell(s)"
 msgstr "A&valía cela(s)"
 
-#: ../src/wxMaximaFrame.cpp:591
+#: ../src/wxMaximaFrame.cpp:590
 #, fuzzy
 msgid "Evaluate Cells Above\tCtrl-Shift-P"
 msgstr "Avaliar celas superiores\tCtrl-Shift-R"
 
-#: ../src/MathCtrl.cpp:956 ../src/MathCtrl.cpp:1051
+#: ../src/MathCtrl.cpp:998 ../src/MathCtrl.cpp:1093
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr "Avaliar parte\tShift+Ctrl+Enter"
 
-#: ../src/MathCtrl.cpp:961 ../src/MathCtrl.cpp:1053
+#: ../src/MathCtrl.cpp:1003 ../src/MathCtrl.cpp:1095
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr "Avaliar cela\tShift+Ctrl+Enter"
 
-#: ../src/MathCtrl.cpp:971 ../src/MathCtrl.cpp:1057
+#: ../src/MathCtrl.cpp:1013 ../src/MathCtrl.cpp:1099
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr "Avaliar sub-subsección\tShift+Ctrl+Enter"
 
-#: ../src/MathCtrl.cpp:966 ../src/MathCtrl.cpp:1055
+#: ../src/MathCtrl.cpp:1008 ../src/MathCtrl.cpp:1097
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr "Avaliar subsección\tShift+Ctrl+Enter"
 
-#: ../src/wxMaximaFrame.cpp:586
+#: ../src/wxMaximaFrame.cpp:585
 msgid "Evaluate active or selected cell(s)"
 msgstr "Avalía celas activas ou seleccionadas"
 
-#: ../src/wxMaximaFrame.cpp:590
+#: ../src/wxMaximaFrame.cpp:589
 msgid "Evaluate all cells in the document"
 msgstr "Avalía todas as celas do documento"
 
-#: ../src/wxMaximaFrame.cpp:910
+#: ../src/wxMaximaFrame.cpp:909
 msgid "Evaluate all noun forms in expression"
 msgstr "Avalía todas as formas nominais nunha expresión"
 
-#: ../src/wxMaximaFrame.cpp:588
+#: ../src/wxMaximaFrame.cpp:587
 msgid "Evaluate all visible cells in the document"
 msgstr "Avaliar todas as celas visibles do documento"
 
@@ -1616,7 +1619,7 @@ msgstr "Avalía o ficheiro dende o comezo ata a cela sobre o cursor"
 msgid "Evaluate to point"
 msgstr "Avaliar ata o punto"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Example"
 msgstr "Exemplo"
 
@@ -1628,31 +1631,31 @@ msgstr "Texto de exemplo"
 msgid "Examples:"
 msgstr "Exemplos:"
 
-#: ../src/wxMaximaFrame.cpp:488
+#: ../src/wxMaximaFrame.cpp:487
 msgid "Exit wxMaxima"
 msgstr "Sae de wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:1214
+#: ../src/wxMaximaFrame.cpp:1213
 msgid "Expand"
 msgstr "Expande"
 
-#: ../src/wxMaximaFrame.cpp:1219
+#: ../src/wxMaximaFrame.cpp:1218
 msgid "Expand (tr)"
 msgstr "Expande (tr)"
 
-#: ../src/MathCtrl.cpp:997
+#: ../src/MathCtrl.cpp:1039
 msgid "Expand Expression"
 msgstr "Expande expresión"
 
-#: ../src/wxMaximaFrame.cpp:841
+#: ../src/wxMaximaFrame.cpp:840
 msgid "Expand Logarithms"
 msgstr "Ex&pande logaritmos"
 
-#: ../src/wxMaximaFrame.cpp:840
+#: ../src/wxMaximaFrame.cpp:839
 msgid "Expand an expression"
 msgstr "Expande unha expresión"
 
-#: ../src/wxMaximaFrame.cpp:874
+#: ../src/wxMaximaFrame.cpp:873
 msgid "Expand trigonometric expression"
 msgstr "Expande expresión trigonométrica"
 
@@ -1660,7 +1663,7 @@ msgstr "Expande expresión trigonométrica"
 msgid "Expected the icon files to be found at"
 msgstr "Ubicación de iconos de arquivos en"
 
-#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2834
+#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2842
 msgid "Export"
 msgstr "&Exporta"
 
@@ -1671,31 +1674,31 @@ msgstr ""
 "Exportar animacións a TeX (as imaxes terán movemento só se o visor PDF o "
 "admite)"
 
-#: ../src/wxMaximaFrame.cpp:481
+#: ../src/wxMaximaFrame.cpp:480
 msgid "Export document to a HTML or pdfLaTeX file"
 msgstr "Exporta documento a arquivo HTML ou TeX"
 
-#: ../src/wxMaximaFrame.cpp:253
+#: ../src/wxMaximaFrame.cpp:252
 msgid "Export failed."
 msgstr "Fallou a exportación"
 
-#: ../src/wxMaximaFrame.cpp:239
+#: ../src/wxMaximaFrame.cpp:238
 msgid "Export successful."
 msgstr "Exportación realizada."
 
-#: ../src/wxMaxima.cpp:2913
+#: ../src/wxMaxima.cpp:2921
 msgid "Exporting to HTML failed!"
 msgstr "Fallou a exportación a HTML!"
 
-#: ../src/wxMaxima.cpp:2886
+#: ../src/wxMaxima.cpp:2894
 msgid "Exporting to TeX failed!"
 msgstr "Fallou a exportación a TeX!"
 
-#: ../src/wxMaxima.cpp:2900
+#: ../src/wxMaxima.cpp:2908
 msgid "Exporting to maxima batch file failed!"
 msgstr "Fallou la exportación a arquivo por lotes"
 
-#: ../src/wxMaximaFrame.cpp:229
+#: ../src/wxMaximaFrame.cpp:228
 msgid "Exporting..."
 msgstr "Exportando..."
 
@@ -1708,42 +1711,42 @@ msgid "Expression(s):"
 msgstr "Expresión(s):"
 
 #: ../src/IntegrateWiz.cpp:30 ../src/LimitWiz.cpp:27 ../src/SeriesWiz.cpp:33
-#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3648
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:4205 ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5064
+#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3660
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:4217 ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5076
 msgid "Expression:"
 msgstr "Expresión:"
 
-#: ../src/wxMaximaFrame.cpp:1213
+#: ../src/wxMaximaFrame.cpp:1212
 msgid "Factor"
 msgstr "Factoriza"
 
-#: ../src/wxMaximaFrame.cpp:836
+#: ../src/wxMaximaFrame.cpp:835
 msgid "Factor Complex"
 msgstr "Factoriza comple&xo"
 
-#: ../src/MathCtrl.cpp:996
+#: ../src/MathCtrl.cpp:1038
 msgid "Factor Expression"
 msgstr "Factoriza expresión"
 
-#: ../src/wxMaximaFrame.cpp:835
+#: ../src/wxMaximaFrame.cpp:834
 msgid "Factor an expression"
 msgstr "Factoriza unha expresión"
 
-#: ../src/wxMaximaFrame.cpp:837
+#: ../src/wxMaximaFrame.cpp:836
 msgid "Factor an expression in Gaussian numbers"
 msgstr "Factoriza unha expresión en números gaussianos"
 
-#: ../src/wxMaximaFrame.cpp:862
+#: ../src/wxMaximaFrame.cpp:861
 msgid "Factorials and &Gamma"
 msgstr "Factoriais e &gamma"
 
-#: ../src/wxMaxima.cpp:285
+#: ../src/wxMaxima.cpp:286
 msgid "Fatal error"
 msgstr "Erro fatal"
 
-#: ../src/GroupCell.cpp:1571
+#: ../src/GroupCell.cpp:1572
 #, c-format
 msgid "Figure %d:"
 msgstr "Figura %d:"
@@ -1752,20 +1755,20 @@ msgstr "Figura %d:"
 msgid "File"
 msgstr "Arquivo"
 
-#: ../src/wxMaxima.cpp:1457 ../src/wxMaxima.cpp:1623 ../src/wxMaxima.cpp:1636
-#: ../src/wxMaxima.cpp:1646 ../src/wxMaxima.cpp:1668
+#: ../src/wxMaxima.cpp:1462 ../src/wxMaxima.cpp:1628 ../src/wxMaxima.cpp:1641
+#: ../src/wxMaxima.cpp:1651 ../src/wxMaxima.cpp:1673
 msgid "File could not be opened"
 msgstr "Arquivo non se puido abrir"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File not found"
 msgstr "Arquivo non atopado"
 
-#: ../src/wxMaxima.cpp:1511 ../src/wxMaxima.cpp:1729
+#: ../src/wxMaxima.cpp:1516 ../src/wxMaxima.cpp:1734
 msgid "File opened"
 msgstr "Arquivo aberto"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File you tried to open does not exist."
 msgstr "O arquivo a abrir non existe."
 
@@ -1777,67 +1780,67 @@ msgstr "Arquivo"
 msgid "Find"
 msgstr "Busca"
 
-#: ../src/wxMaximaFrame.cpp:523
+#: ../src/wxMaximaFrame.cpp:522
 msgid "Find\tCtrl-F"
 msgstr "&Busca\tCtrl-F"
 
-#: ../src/wxMaximaFrame.cpp:787
+#: ../src/wxMaximaFrame.cpp:786
 msgid "Find &Limit..."
 msgstr "Calcula &límite"
 
-#: ../src/wxMaximaFrame.cpp:790
+#: ../src/wxMaximaFrame.cpp:789
 msgid "Find Minimum..."
 msgstr "Calcula mínim&o"
 
-#: ../src/MathCtrl.cpp:993
+#: ../src/MathCtrl.cpp:1035
 msgid "Find Root..."
 msgstr "Calcula raíz..."
 
-#: ../src/wxMaximaFrame.cpp:791
+#: ../src/wxMaximaFrame.cpp:790
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr "Calcula mínimo (sen restricións) dunha expresión"
 
-#: ../src/wxMaximaFrame.cpp:788
+#: ../src/wxMaximaFrame.cpp:787
 msgid "Find a limit of an expression"
 msgstr "Calcula o límite dunha expresión"
 
-#: ../src/wxMaximaFrame.cpp:693
+#: ../src/wxMaximaFrame.cpp:692
 msgid "Find a root of an equation on an interval"
 msgstr "Calcula unha raíz dunha ecuación nun intervalo"
 
-#: ../src/wxMaximaFrame.cpp:695
+#: ../src/wxMaximaFrame.cpp:694
 msgid "Find all roots of a polynomial"
 msgstr "Calcula todas as raíces dun polinomio"
 
-#: ../src/wxMaximaFrame.cpp:698
+#: ../src/wxMaximaFrame.cpp:697
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr "Calcula todas as raíces reais dun polinomio"
 
-#: ../src/wxMaxima.cpp:3220
+#: ../src/wxMaxima.cpp:3215
 msgid "Find and Replace"
 msgstr "Busca e substitue"
 
-#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:523
+#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:522
 msgid "Find and replace"
 msgstr "Busca e substitue"
 
-#: ../src/wxMaximaFrame.cpp:756
+#: ../src/wxMaximaFrame.cpp:755
 msgid "Find eigenvalues of a matrix"
 msgstr "Calcula os valores propios dunha matriz"
 
-#: ../src/wxMaximaFrame.cpp:758
+#: ../src/wxMaximaFrame.cpp:757
 msgid "Find eigenvectors of a matrix"
 msgstr "Calcula os vectores propios dunha matriz"
 
-#: ../src/wxMaxima.cpp:4210
+#: ../src/wxMaxima.cpp:4222
 msgid "Find minimum"
 msgstr "Calcula mínimo"
 
-#: ../src/wxMaximaFrame.cpp:701
+#: ../src/wxMaximaFrame.cpp:700
 msgid "Find real roots of a polynomial"
 msgstr "Calcula as raíces reais dun polinomio"
 
-#: ../src/wxMaxima.cpp:3493 ../src/wxMaxima.cpp:5036
+#: ../src/wxMaxima.cpp:3505 ../src/wxMaxima.cpp:5048
 msgid "Find root"
 msgstr "Calcula raíz"
 
@@ -1860,11 +1863,11 @@ msgstr "Axustar os índices de orde (%i e %o) antes de gardar"
 msgid "Fixed font in text controls"
 msgstr "Tipografía proporcional en controis de texto"
 
-#: ../src/wxMaximaFrame.cpp:623
+#: ../src/wxMaximaFrame.cpp:622
 msgid "Fold All\tCtrl-Alt-["
 msgstr "Ocultar todo\tCtrl-Alt-["
 
-#: ../src/wxMaximaFrame.cpp:624
+#: ../src/wxMaximaFrame.cpp:623
 msgid "Fold all sections"
 msgstr "Ocultar todas as seccións"
 
@@ -1872,11 +1875,11 @@ msgstr "Ocultar todas as seccións"
 msgid "Follow"
 msgstr "Seguir"
 
-#: ../src/ParenCell.cpp:319
+#: ../src/ParenCell.cpp:320
 msgid "Font issue: The Parenthesis sign is too small!"
 msgstr "Problema tipográfico: parénteses demasiado pequeno"
 
-#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:381
+#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:382
 msgid ""
 "Font issue: The char height is too small! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
@@ -1887,7 +1890,7 @@ msgstr ""
 "comprobando \"Use JSmath fonts\" no diálogo de configuración debería "
 "resolver o problema."
 
-#: ../src/SqrtCell.cpp:199
+#: ../src/SqrtCell.cpp:202
 msgid ""
 "Font issue: The sqrt() sign has the size 0! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
@@ -1897,7 +1900,7 @@ msgstr ""
 "math.union.edu/~dpvc/jsmath/download/jsMath-fonts.html e comprobando \"Use "
 "JSmath fonts\" no diálogo de configuración debería resolver o problema."
 
-#: ../src/SqrtCell.cpp:198
+#: ../src/SqrtCell.cpp:201
 msgid "Font issue? The contents of a sqrt() has the size 0."
 msgstr "Problema tipográfico: o contido de sqrt() ten tamaño 0."
 
@@ -1928,15 +1931,15 @@ msgstr "Francés"
 
 #: ../src/IntegrateWiz.cpp:37 ../src/Plot2dWiz.cpp:37 ../src/Plot2dWiz.cpp:47
 #: ../src/Plot2dWiz.cpp:536 ../src/Plot3dWiz.cpp:36 ../src/Plot3dWiz.cpp:45
-#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4240
+#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4252
 msgid "From:"
 msgstr "Dende:"
 
-#: ../src/wxMaximaFrame.cpp:576
+#: ../src/wxMaximaFrame.cpp:575
 msgid "Full Screen\tAlt-Enter"
 msgstr "P&antalla completa\tAlt-Retorno"
 
-#: ../src/wxMaxima.cpp:3342
+#: ../src/wxMaxima.cpp:3354
 msgid "Function"
 msgstr "Función"
 
@@ -1944,32 +1947,32 @@ msgstr "Función"
 msgid "Function names"
 msgstr "Nomes de funcións"
 
-#: ../src/wxMaxima.cpp:3633
+#: ../src/wxMaxima.cpp:3645
 msgid "Function(s):"
 msgstr "Función(s):"
 
-#: ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3803
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3815
+#: ../src/wxMaxima.cpp:3848
 msgid "Function:"
 msgstr "Función:"
 
-#: ../src/wxMaximaFrame.cpp:904
+#: ../src/wxMaximaFrame.cpp:903
 msgid "Functions for complex simplification"
 msgstr "Funcións para a simplificación complexa"
 
-#: ../src/wxMaximaFrame.cpp:864
+#: ../src/wxMaximaFrame.cpp:863
 msgid "Functions for simplifying factorials and gamma function"
 msgstr "Funcións para simplificar factoriais e función gamma"
 
-#: ../src/wxMaximaFrame.cpp:881
+#: ../src/wxMaximaFrame.cpp:880
 msgid "Functions for simplifying trigonometric expressions"
 msgstr "Funcións para simplificar expresións trigonométricas"
 
-#: ../src/wxMaxima.cpp:4046
+#: ../src/wxMaxima.cpp:4058
 msgid "GCD"
 msgstr "MCD"
 
-#: ../src/wxMaxima.cpp:5152
+#: ../src/wxMaxima.cpp:5164
 msgid "GIF image (*.gif)|*.gif"
 msgstr "Imaxe GIF (*.gif)|*.gif"
 
@@ -1977,31 +1980,31 @@ msgstr "Imaxe GIF (*.gif)|*.gif"
 msgid "Galician"
 msgstr "Galego"
 
-#: ../src/wxMaximaFrame.cpp:1366
+#: ../src/wxMaximaFrame.cpp:1365
 msgid "Gamma"
 msgstr "Gamma"
 
-#: ../src/wxMaximaFrame.cpp:391
+#: ../src/wxMaximaFrame.cpp:390
 msgid "General Math"
 msgstr "Matemáticas xerais"
 
-#: ../src/wxMaximaFrame.cpp:549
+#: ../src/wxMaximaFrame.cpp:548
 msgid "General Math\tAlt-Shift-M"
 msgstr "&Matemáticas xerais\tAlt-Shift-M"
 
-#: ../src/wxMaxima.cpp:3766 ../src/wxMaxima.cpp:3785
+#: ../src/wxMaxima.cpp:3778 ../src/wxMaxima.cpp:3797
 msgid "Generate Matrix"
 msgstr "Xera matriz"
 
-#: ../src/wxMaximaFrame.cpp:741
+#: ../src/wxMaximaFrame.cpp:740
 msgid "Generate Matrix from Expression..."
 msgstr "&Xera matriz a partir de expresión"
 
-#: ../src/wxMaximaFrame.cpp:739
+#: ../src/wxMaximaFrame.cpp:738
 msgid "Generate a matrix from a 2-dimensional array"
 msgstr "Xera unha matriz a partir dunha táboa de 2 dimensións"
 
-#: ../src/wxMaximaFrame.cpp:742
+#: ../src/wxMaximaFrame.cpp:741
 msgid "Generate a matrix from a lambda expression"
 msgstr "Xera unha matriz a partir dunha expresión lambda"
 
@@ -2009,39 +2012,39 @@ msgstr "Xera unha matriz a partir dunha expresión lambda"
 msgid "German"
 msgstr "Alemán"
 
-#: ../src/wxMaximaFrame.cpp:893
+#: ../src/wxMaximaFrame.cpp:892
 msgid "Get &Imaginary Part"
 msgstr "Calcula parte &imaxinaria"
 
-#: ../src/wxMaximaFrame.cpp:793
+#: ../src/wxMaximaFrame.cpp:792
 msgid "Get &Series..."
 msgstr "Calcula &serie"
 
-#: ../src/wxMaximaFrame.cpp:804
+#: ../src/wxMaximaFrame.cpp:803
 msgid "Get Laplace transformation of an expression"
 msgstr "Calcula a transformada de Laplace dunha expresión"
 
-#: ../src/wxMaximaFrame.cpp:890
+#: ../src/wxMaximaFrame.cpp:889
 msgid "Get Real P&art"
 msgstr "Calcula parte &real"
 
-#: ../src/wxMaximaFrame.cpp:807
+#: ../src/wxMaximaFrame.cpp:806
 msgid "Get inverse Laplace transformation of an expression"
 msgstr "Calcula a transformada inversa de Laplace dunha expresión"
 
-#: ../src/wxMaximaFrame.cpp:794
+#: ../src/wxMaximaFrame.cpp:793
 msgid "Get the Taylor or power series of expression"
 msgstr "Calcula o desenvolvemento de Taylor ou serie de potencias da expresión"
 
-#: ../src/wxMaximaFrame.cpp:894
+#: ../src/wxMaximaFrame.cpp:893
 msgid "Get the imaginary part of complex expression"
 msgstr "Calcula a parte imaxinaria dunha expresión complexa"
 
-#: ../src/wxMaximaFrame.cpp:891
+#: ../src/wxMaximaFrame.cpp:890
 msgid "Get the real part of complex expression"
 msgstr "Calcula a parte real dunha expresión complexa"
 
-#: ../src/MathCtrl.cpp:5932
+#: ../src/MathCtrl.cpp:5984
 msgid ""
 "Got a request to undo an action that involves an delete which isn't possible "
 "at this moment."
@@ -2053,12 +2056,12 @@ msgstr ""
 msgid "Greek"
 msgstr "Grego"
 
-#: ../src/wxMaximaFrame.cpp:356
+#: ../src/wxMaximaFrame.cpp:355
 #, fuzzy
 msgid "Greek Letters"
 msgstr "Letras gregas"
 
-#: ../src/wxMaximaFrame.cpp:552
+#: ../src/wxMaximaFrame.cpp:551
 #, fuzzy
 msgid "Greek Letters\tAlt-Shift-G"
 msgstr "Letras gregas\tAlt-Shift-G"
@@ -2071,7 +2074,7 @@ msgstr "Constantes gregas"
 msgid "Grid:"
 msgstr "Cuadrícula:"
 
-#: ../src/wxMaxima.cpp:2836
+#: ../src/wxMaxima.cpp:2844
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|pdfLaTeX file (*."
 "tex)|*.tex"
@@ -2087,11 +2090,11 @@ msgstr "Celas HTML/Texto: Exportar todos os saltos de liña"
 msgid "Help"
 msgstr "A&xuda"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide All Toolbars\tAlt-Shift--"
 msgstr "Oculta todas as barras de ferramentas\tAlt-Shift--"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide all panes"
 msgstr "Oculta todos os paneis"
 
@@ -2099,19 +2102,19 @@ msgstr "Oculta todos os paneis"
 msgid "Highlight (dpart)"
 msgstr "Resalta"
 
-#: ../src/wxMaxima.cpp:4685
+#: ../src/wxMaxima.cpp:4697
 msgid "Histogram"
 msgstr "Histograma"
 
-#: ../src/wxMaximaFrame.cpp:1270
+#: ../src/wxMaximaFrame.cpp:1269
 msgid "Histogram..."
 msgstr "Histograma"
 
-#: ../src/wxMaximaFrame.cpp:309
+#: ../src/wxMaximaFrame.cpp:308
 msgid "History"
 msgstr "Historia"
 
-#: ../src/wxMaximaFrame.cpp:555
+#: ../src/wxMaximaFrame.cpp:554
 msgid "History\tAlt-Shift-I"
 msgstr "&Historia\tAlt-Shift-I"
 
@@ -2131,11 +2134,11 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: ../src/wxMaxima.cpp:3527
+#: ../src/wxMaxima.cpp:3539
 msgid "IC1"
 msgstr "IC1"
 
-#: ../src/wxMaxima.cpp:3543
+#: ../src/wxMaxima.cpp:3555
 msgid "IC2"
 msgstr "IC2"
 
@@ -2153,7 +2156,7 @@ msgstr ""
 "Se unha instrucción comeza cunha etiqueta seguida de : wxMaxima amosará esta "
 "etiqueta en lugar da etiqueta %o por defecto de Maxima."
 
-#: ../src/wxMaximaFrame.cpp:683
+#: ../src/wxMaximaFrame.cpp:682
 msgid ""
 "If maxima ever finishes evaluating without wxMaxima realizing this this menu "
 "item can force wxMaxima to try to send commands to maxima again."
@@ -2231,11 +2234,11 @@ msgstr ""
 "Se un cálculo leva moito tempo, pódese parar seleccionando 'Maxima-"
 ">Interrumpir' ou 'Maxima->Reiniciar Maxima' no menú."
 
-#: ../src/wxMaximaFrame.cpp:1499
+#: ../src/wxMaximaFrame.cpp:1518
 msgid "Image"
 msgstr "Imaxe"
 
-#: ../src/wxMaxima.cpp:5644
+#: ../src/wxMaxima.cpp:5659
 msgid "Image files (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 msgstr "Arquivos gráficos (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 
@@ -2264,7 +2267,7 @@ msgstr ""
 "En exportación LaTeX: Poñer exponentes despois das expresións en lugar de "
 "colocalos enriba delas. Pode facilitar a lectura con algunhas fontes."
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Include columns:"
 msgstr "Inclúe columnas:"
 
@@ -2283,19 +2286,19 @@ msgstr ""
 msgid "Infinity"
 msgstr "Infinito"
 
-#: ../src/wxMaximaFrame.cpp:974
+#: ../src/wxMaximaFrame.cpp:973
 msgid "Info about Maxima build"
 msgstr "Información sobre a compilación de Maxima"
 
-#: ../src/wxMaxima.cpp:4207
+#: ../src/wxMaxima.cpp:4219
 msgid "Initial Estimates:"
 msgstr "Estimadores iniciais:"
 
-#: ../src/wxMaximaFrame.cpp:718
+#: ../src/wxMaximaFrame.cpp:717
 msgid "Initial Value Problem (&1)..."
 msgstr "Problema de valor inicial (&1)"
 
-#: ../src/wxMaximaFrame.cpp:721
+#: ../src/wxMaximaFrame.cpp:720
 msgid "Initial Value Problem (&2)..."
 msgstr "Problema de valor inicial (&2)"
 
@@ -2303,7 +2306,7 @@ msgstr "Problema de valor inicial (&2)"
 msgid "Input labels"
 msgstr "Introduce etiquetas"
 
-#: ../src/wxMaximaFrame.cpp:403
+#: ../src/wxMaximaFrame.cpp:402
 msgid "Insert"
 msgstr "Inserta"
 
@@ -2311,95 +2314,95 @@ msgstr "Inserta"
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr "Inserir % antes dun operador ó comezo dunha cela"
 
-#: ../src/wxMaximaFrame.cpp:612
+#: ../src/wxMaximaFrame.cpp:611
 msgid "Insert &Section Cell\tCtrl-3"
 msgstr "Nova cela de &sección\tCtrl-3"
 
-#: ../src/wxMaximaFrame.cpp:608
+#: ../src/wxMaximaFrame.cpp:607
 msgid "Insert &Text Cell\tCtrl-1"
 msgstr "Nova cela de te&xto\tCtrl-1"
 
-#: ../src/wxMaximaFrame.cpp:558
+#: ../src/wxMaximaFrame.cpp:557
 msgid "Insert Cell\tAlt-Shift-C"
 msgstr "In&serta cela\tAlt-Shift-C"
 
-#: ../src/wxMaxima.cpp:5642
+#: ../src/wxMaxima.cpp:5657
 msgid "Insert Image"
 msgstr "Inserta imaxe"
 
-#: ../src/wxMaximaFrame.cpp:620
+#: ../src/wxMaximaFrame.cpp:619
 msgid "Insert Image..."
 msgstr "I&nserta imaxe"
 
-#: ../src/wxMaximaFrame.cpp:606
+#: ../src/wxMaximaFrame.cpp:605
 msgid "Insert Input &Cell"
 msgstr "Nova cela de &entrada"
 
-#: ../src/wxMaximaFrame.cpp:618
+#: ../src/wxMaximaFrame.cpp:617
 msgid "Insert Page Break"
 msgstr "Salto de páxina"
 
-#: ../src/wxMaximaFrame.cpp:614
+#: ../src/wxMaximaFrame.cpp:613
 msgid "Insert S&ubsection Cell\tCtrl-4"
 msgstr "Nova cela de s&ubsección\tCtrl-4"
 
-#: ../src/wxMaximaFrame.cpp:616
+#: ../src/wxMaximaFrame.cpp:615
 msgid "Insert S&ubsubsection Cell\tCtrl-5"
 msgstr "Inserir cela de subsubsección\tCtrl-5"
 
-#: ../src/MathCtrl.cpp:1015
+#: ../src/MathCtrl.cpp:1057
 msgid "Insert Section Cell"
 msgstr "Nova cela de &sección\tF8"
 
-#: ../src/MathCtrl.cpp:1016
+#: ../src/MathCtrl.cpp:1058
 msgid "Insert Subsection Cell"
 msgstr "Nova cela de subsección"
 
-#: ../src/MathCtrl.cpp:1017
+#: ../src/MathCtrl.cpp:1059
 msgid "Insert Subsubsection Cell"
 msgstr "Inserir cela de subsubsección"
 
-#: ../src/wxMaximaFrame.cpp:610
+#: ../src/wxMaximaFrame.cpp:609
 msgid "Insert T&itle Cell\tCtrl-2"
 msgstr "Nova cela de &título\tCtrl-2"
 
-#: ../src/MathCtrl.cpp:1013
+#: ../src/MathCtrl.cpp:1055
 msgid "Insert Text Cell"
 msgstr "Nova cela de texto"
 
-#: ../src/MathCtrl.cpp:1014
+#: ../src/MathCtrl.cpp:1056
 msgid "Insert Title Cell"
 msgstr "Nova cela de título"
 
-#: ../src/wxMaximaFrame.cpp:607
+#: ../src/wxMaximaFrame.cpp:606
 msgid "Insert a new input cell"
 msgstr "Nova cela de entrada"
 
-#: ../src/wxMaximaFrame.cpp:613
+#: ../src/wxMaximaFrame.cpp:612
 msgid "Insert a new section cell"
 msgstr "Nova cela de sección"
 
-#: ../src/wxMaximaFrame.cpp:615
+#: ../src/wxMaximaFrame.cpp:614
 msgid "Insert a new subsection cell"
 msgstr "Nova cela de subsección"
 
-#: ../src/wxMaximaFrame.cpp:617
+#: ../src/wxMaximaFrame.cpp:616
 msgid "Insert a new subsubsection cell"
 msgstr "Inserir nova cela de subsubsección"
 
-#: ../src/wxMaximaFrame.cpp:609
+#: ../src/wxMaximaFrame.cpp:608
 msgid "Insert a new text cell"
 msgstr "Nova cela de texto"
 
-#: ../src/wxMaximaFrame.cpp:611
+#: ../src/wxMaximaFrame.cpp:610
 msgid "Insert a new title cell"
 msgstr "Nova cela de título"
 
-#: ../src/wxMaximaFrame.cpp:619
+#: ../src/wxMaximaFrame.cpp:618
 msgid "Insert a page break"
 msgstr "Salto de páxina"
 
-#: ../src/wxMaximaFrame.cpp:621
+#: ../src/wxMaximaFrame.cpp:620
 msgid "Insert image"
 msgstr "Inserta imaxe"
 
@@ -2411,27 +2414,27 @@ msgstr "Enteiros e letras simples"
 msgid "Integral sign"
 msgstr "Símbolo integral"
 
-#: ../src/wxMaxima.cpp:3992
+#: ../src/wxMaxima.cpp:4004
 msgid "Integral/Sum:"
 msgstr "Integral/suma:"
 
-#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4105 ../src/wxMaxima.cpp:5051
+#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4117 ../src/wxMaxima.cpp:5063
 msgid "Integrate"
 msgstr "Integra"
 
-#: ../src/wxMaxima.cpp:4091
+#: ../src/wxMaxima.cpp:4103
 msgid "Integrate (risch)"
 msgstr "Integra (risch)"
 
-#: ../src/wxMaximaFrame.cpp:778
+#: ../src/wxMaximaFrame.cpp:777
 msgid "Integrate expression"
 msgstr "Integra expresión"
 
-#: ../src/wxMaximaFrame.cpp:780
+#: ../src/wxMaximaFrame.cpp:779
 msgid "Integrate expression with Risch algorithm"
 msgstr "Integra expresión con algoritmo Risch"
 
-#: ../src/wxMaximaFrame.cpp:1224 ../src/MathCtrl.cpp:1000
+#: ../src/MathCtrl.cpp:1042 ../src/wxMaximaFrame.cpp:1223
 msgid "Integrate..."
 msgstr "Integra"
 
@@ -2439,7 +2442,7 @@ msgstr "Integra"
 msgid "Interrupt"
 msgstr "Interrumpe"
 
-#: ../src/wxMaximaFrame.cpp:646 ../src/wxMaximaFrame.cpp:650
+#: ../src/wxMaximaFrame.cpp:645 ../src/wxMaximaFrame.cpp:649
 msgid "Interrupt current computation"
 msgstr "Interrumpe o cálculo actual"
 
@@ -2461,15 +2464,15 @@ msgstr ""
 "\n"
 "Por favor, introduza de novo a ruta ó programa Maxima."
 
-#: ../src/wxMaxima.cpp:4137
+#: ../src/wxMaxima.cpp:4149
 msgid "Inverse Laplace"
 msgstr "Inversa de Laplace"
 
-#: ../src/wxMaximaFrame.cpp:806
+#: ../src/wxMaximaFrame.cpp:805
 msgid "Inverse Laplace T&ransform..."
 msgstr "Trans&formada inversa de Laplace"
 
-#: ../src/wxMaximaFrame.cpp:1372
+#: ../src/wxMaximaFrame.cpp:1371
 msgid "Iota"
 msgstr "Iota"
 
@@ -2507,7 +2510,7 @@ msgstr "Xaponés"
 msgid "Kabyle"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1373
+#: ../src/wxMaximaFrame.cpp:1372
 msgid "Kappa"
 msgstr "Kappa"
 
@@ -2516,7 +2519,7 @@ msgstr "Kappa"
 msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr "Manter o símbolo porcentual en constantes especiais: %e, %i, etc."
 
-#: ../src/wxMaxima.cpp:4031
+#: ../src/wxMaxima.cpp:4043
 msgid "LCM"
 msgstr "MCM"
 
@@ -2535,7 +2538,7 @@ msgstr ""
 msgid "Label width:"
 msgstr "Ancho de etiqueta"
 
-#: ../src/wxMaximaFrame.cpp:1374
+#: ../src/wxMaximaFrame.cpp:1373
 msgid "Lambda"
 msgstr "Lambda"
 
@@ -2547,11 +2550,11 @@ msgstr "Idioma usado na interface de usuario de wxMaxima."
 msgid "Language:"
 msgstr "Idioma:"
 
-#: ../src/wxMaxima.cpp:4120
+#: ../src/wxMaxima.cpp:4132
 msgid "Laplace"
 msgstr "Laplace"
 
-#: ../src/wxMaximaFrame.cpp:803
+#: ../src/wxMaximaFrame.cpp:802
 msgid "Laplace &Transform..."
 msgstr "&Transformada de Laplace"
 
@@ -2560,15 +2563,15 @@ msgstr "&Transformada de Laplace"
 msgid "Leads to"
 msgstr "tende a:"
 
-#: ../src/wxMaximaFrame.cpp:812
+#: ../src/wxMaximaFrame.cpp:811
 msgid "Least Common Multiple..."
 msgstr "Mí&nimo común múltiplo"
 
-#: ../src/wxMaxima.cpp:4809
+#: ../src/wxMaxima.cpp:4821
 msgid "Least Squares Fit"
 msgstr "Axuste por mínimos cadrados"
 
-#: ../src/wxMaximaFrame.cpp:1266
+#: ../src/wxMaximaFrame.cpp:1265
 msgid "Least Squares Fit..."
 msgstr "Axuste por mínimos cadrados"
 
@@ -2582,23 +2585,23 @@ msgstr ""
 "As librarías de Maxima son sempre accesibles, independientemente do "
 "directorio no que se atopen, se este se garda na variable maxima_userdir"
 
-#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4192
+#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4204
 msgid "Limit"
 msgstr "Límite"
 
-#: ../src/wxMaximaFrame.cpp:1225
+#: ../src/wxMaximaFrame.cpp:1224
 msgid "Limit..."
 msgstr "Límite"
 
-#: ../src/wxMaximaFrame.cpp:1265
+#: ../src/wxMaximaFrame.cpp:1264
 msgid "Linear Regression..."
 msgstr "Regresión linear"
 
-#: ../src/wxMaxima.cpp:3803
+#: ../src/wxMaxima.cpp:3815
 msgid "List(s):"
 msgstr "Lista(s):"
 
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3848
 msgid "List:"
 msgstr "Lista:"
 
@@ -2606,15 +2609,15 @@ msgstr "Lista:"
 msgid "Load"
 msgstr "Carga"
 
-#: ../src/wxMaxima.cpp:2932
+#: ../src/wxMaxima.cpp:2940
 msgid "Load Package"
 msgstr "Carga paquete"
 
-#: ../src/wxMaximaFrame.cpp:479
+#: ../src/wxMaximaFrame.cpp:478
 msgid "Load a Maxima file using the batch command"
 msgstr "Carga un arquivo de Maxima usando a instrucion 'batch'"
 
-#: ../src/wxMaximaFrame.cpp:477
+#: ../src/wxMaximaFrame.cpp:476
 msgid "Load a Maxima package file"
 msgstr "Carga un paquete de Maxima"
 
@@ -2626,48 +2629,48 @@ msgstr "Le estilo dende un arquivo"
 msgid "Long Right arrow"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Lower bound:"
 msgstr "Cota inferior:"
 
-#: ../src/wxMaximaFrame.cpp:771
+#: ../src/wxMaximaFrame.cpp:770
 msgid "Ma&p to Matrix..."
 msgstr "Distribúe sobre &matriz"
 
-#: ../src/wxMaximaFrame.cpp:547
+#: ../src/wxMaximaFrame.cpp:546
 msgid "Main Toolbar\tAlt-Shift-B"
 msgstr "Barra de ferramentas principal\tAlt-Shift-B"
 
-#: ../src/wxMaximaFrame.cpp:765
+#: ../src/wxMaximaFrame.cpp:764
 msgid "Make &List..."
 msgstr "Constrúe &lista"
 
-#: ../src/wxMaxima.cpp:3821
+#: ../src/wxMaxima.cpp:3833
 msgid "Make list"
 msgstr "Constrúe lista"
 
-#: ../src/wxMaximaFrame.cpp:766
+#: ../src/wxMaximaFrame.cpp:765
 msgid "Make list from expression"
 msgstr "Constrúe unha lista a partir dunha expresión"
 
-#: ../src/wxMaximaFrame.cpp:907
+#: ../src/wxMaximaFrame.cpp:906
 msgid "Make substitution in expression"
 msgstr "Fai unha substitución nunha expresión"
 
-#: ../src/wxMaximaFrame.cpp:682
+#: ../src/wxMaximaFrame.cpp:681
 #, fuzzy
 msgid "Manually Trigger Evaluation"
 msgstr "Inicio manual do cálculo"
 
-#: ../src/wxMaxima.cpp:3805
+#: ../src/wxMaxima.cpp:3817
 msgid "Map"
 msgstr "Aplica"
 
-#: ../src/wxMaximaFrame.cpp:770
+#: ../src/wxMaximaFrame.cpp:769
 msgid "Map function to a list"
 msgstr "Aplica función a unha lista"
 
-#: ../src/wxMaximaFrame.cpp:772
+#: ../src/wxMaximaFrame.cpp:771
 msgid "Map function to a matrix"
 msgstr "Aplica función a unha matriz"
 
@@ -2684,23 +2687,23 @@ msgstr "Fai coincidir parénteses nos controis de texto"
 msgid "Math font:"
 msgstr "Tipografía matemática:"
 
-#: ../src/wxMaximaFrame.cpp:374
+#: ../src/wxMaximaFrame.cpp:373
 msgid "Mathematical Symbols"
 msgstr "Símbolos matemáticos"
 
-#: ../src/wxMaxima.cpp:3716
+#: ../src/wxMaxima.cpp:3728
 msgid "Matrix"
 msgstr "Matriz"
 
-#: ../src/wxMaxima.cpp:3702
+#: ../src/wxMaxima.cpp:3714
 msgid "Matrix map"
 msgstr "Aplica a matriz"
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Matrix name:"
 msgstr "Nome de matriz:"
 
-#: ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3749
+#: ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3761
 msgid "Matrix:"
 msgstr "Matriz:"
 
@@ -2708,7 +2711,7 @@ msgstr "Matriz:"
 msgid "Maxima"
 msgstr "Maxima"
 
-#: ../src/wxMaximaFrame.cpp:137
+#: ../src/wxMaximaFrame.cpp:136
 #, fuzzy
 msgid "Maxima has a question"
 msgstr "Pregunta Maxima"
@@ -2717,24 +2720,24 @@ msgstr "Pregunta Maxima"
 msgid "Maxima input"
 msgstr "Entrada Maxima"
 
-#: ../src/wxMaximaFrame.cpp:166
+#: ../src/wxMaximaFrame.cpp:165
 msgid "Maxima is calculating"
 msgstr "Maxima está calculando"
 
-#: ../src/wxMaximaFrame.cpp:111
+#: ../src/wxMaximaFrame.cpp:110
 #, fuzzy
 msgid "Maxima is ready for input."
 msgstr "Entrada Maxima"
 
-#: ../src/wxMaxima.cpp:2945
+#: ../src/wxMaxima.cpp:2953
 msgid "Maxima package (*.mac)|*.mac"
 msgstr "Paquete de Maxima (*.mac)|*.mac"
 
-#: ../src/wxMaxima.cpp:2934
+#: ../src/wxMaxima.cpp:2942
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr "Paquete Maxima (*.mac)|*.mac|Paquete Lisp (*.lisp)|*.lisp|Todos|*"
 
-#: ../src/wxMaxima.cpp:1014
+#: ../src/wxMaxima.cpp:1019
 msgid "Maxima process terminated."
 msgstr "Proceso de Maxima terminado."
 
@@ -2746,7 +2749,7 @@ msgstr "Programa Maxima:"
 msgid "Maxima questions"
 msgstr "Opcións de Maxima"
 
-#: ../src/wxMaxima.cpp:942
+#: ../src/wxMaxima.cpp:947
 msgid "Maxima started. Waiting for connection..."
 msgstr "Maxima iniciado. Esperando a conexión..."
 
@@ -2778,7 +2781,7 @@ msgstr ""
 "Maxima utiliza ':' para asignar un valor a unha variable ('a : 3;') e ':=' "
 "para definir funcións ('f(x) := x^2;')."
 
-#: ../src/wxMaxima.cpp:4597
+#: ../src/wxMaxima.cpp:4609
 msgid "Maxima version: "
 msgstr "Versión de Maxima: "
 
@@ -2815,40 +2818,40 @@ msgstr ""
 msgid "Maximum displayed number of digits:"
 msgstr "Número máximo de díxitos a amosar:"
 
-#: ../src/wxMaximaFrame.cpp:1263
+#: ../src/wxMaximaFrame.cpp:1262
 msgid "Mean Difference Test..."
 msgstr "Contraste de diferenza de medias"
 
-#: ../src/wxMaximaFrame.cpp:1262
+#: ../src/wxMaximaFrame.cpp:1261
 msgid "Mean Test..."
 msgstr "Contraste de medias"
 
-#: ../src/wxMaximaFrame.cpp:1255
+#: ../src/wxMaximaFrame.cpp:1254
 msgid "Mean..."
 msgstr "Media"
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Mean:"
 msgstr "Media:"
 
-#: ../src/wxMaximaFrame.cpp:1256
+#: ../src/wxMaximaFrame.cpp:1255
 msgid "Median..."
 msgstr "Mediana"
 
-#: ../src/MathCtrl.cpp:945
+#: ../src/MathCtrl.cpp:987
 msgid "Merge Cells"
 msgstr "Une celas"
 
-#: ../src/wxMaximaFrame.cpp:633
+#: ../src/wxMaximaFrame.cpp:632
 #, fuzzy
 msgid "Merge Cells\tCtrl-M"
 msgstr "Une celas"
 
-#: ../src/wxMaximaFrame.cpp:634
+#: ../src/wxMaximaFrame.cpp:633
 msgid "Merge the text from two input cells into one"
 msgstr "Unir o texto de dúas celas de entrada nunha soa"
 
-#: ../src/wxMaxima.cpp:2668
+#: ../src/wxMaxima.cpp:2676
 msgid "Message from the stdout of Maxima: "
 msgstr "Mensaxe da saída estándar de Maxima: "
 
@@ -2856,19 +2859,19 @@ msgstr "Mensaxe da saída estándar de Maxima: "
 msgid "Method:"
 msgstr "Método:"
 
-#: ../src/wxMaxima.cpp:5289
+#: ../src/wxMaxima.cpp:5301
 msgid "Mismatched parenthesis"
 msgstr "Parénteses non emparellados"
 
-#: ../src/wxMaxima.cpp:3972
+#: ../src/wxMaxima.cpp:3984
 msgid "Modulus"
 msgstr "Módulo"
 
-#: ../src/wxMaximaFrame.cpp:1375
+#: ../src/wxMaximaFrame.cpp:1374
 msgid "Mu"
 msgstr ""
 
-#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Name:"
 msgstr "Nome"
 
@@ -2876,7 +2879,7 @@ msgstr "Nome"
 msgid "New"
 msgstr "Novo"
 
-#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
+#: ../src/wxMaximaFrame.cpp:456 ../src/wxMaximaFrame.cpp:459
 msgid "New\tCtrl-N"
 msgstr "&Novo\tCtrl-N"
 
@@ -2892,11 +2895,11 @@ msgstr ""
 msgid "New value:"
 msgstr "Novo valor:"
 
-#: ../src/wxMaxima.cpp:3993 ../src/wxMaxima.cpp:4119 ../src/wxMaxima.cpp:4136
+#: ../src/wxMaxima.cpp:4005 ../src/wxMaxima.cpp:4131 ../src/wxMaxima.cpp:4148
 msgid "New variable:"
 msgstr "Nova variable:"
 
-#: ../src/wxMaximaFrame.cpp:630
+#: ../src/wxMaximaFrame.cpp:629
 msgid "Next Command\tAlt-Down"
 msgstr "Seguinte instrución\tAlt-Abajo"
 
@@ -2904,16 +2907,16 @@ msgstr "Seguinte instrución\tAlt-Abajo"
 msgid "No"
 msgstr "No"
 
-#: ../src/wxMaxima.cpp:5362
+#: ../src/wxMaxima.cpp:5378
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 "Non hai símbolo de dólar ($) nin de punto e coma (;) ó final da instrucción"
 
-#: ../src/wxMaxima.cpp:3249 ../src/wxMaxima.cpp:3271
+#: ../src/wxMaxima.cpp:3260 ../src/wxMaxima.cpp:3283
 msgid "No matches found!"
 msgstr "Non se atoparon coincidencias!"
 
-#: ../src/wxMaximaFrame.cpp:1264
+#: ../src/wxMaximaFrame.cpp:1263
 msgid "Normality Test..."
 msgstr "Contraste de normalidad"
 
@@ -2943,31 +2946,31 @@ msgstr ""
 msgid "Norwegian"
 msgstr "Noruego"
 
-#: ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:3740
 msgid "Not a valid matrix dimension!"
 msgstr "A dimensión da matriz non é válida!"
 
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629
 msgid "Not a valid number of equations!"
 msgstr "O número de ecuacións é incorrecto!"
 
-#: ../src/wxMaximaFrame.cpp:197
+#: ../src/wxMaximaFrame.cpp:196
 msgid "Not connected to maxima"
 msgstr "Non conectado a Maxima"
 
-#: ../src/wxMaxima.cpp:4599
+#: ../src/wxMaxima.cpp:4611
 msgid "Not connected."
 msgstr "Non conectado."
 
-#: ../src/wxMaximaFrame.cpp:1376
+#: ../src/wxMaximaFrame.cpp:1375
 msgid "Nu"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Num. deg:"
 msgstr "num deg:"
 
-#: ../src/wxMaxima.cpp:3585 ../src/wxMaxima.cpp:3609
+#: ../src/wxMaxima.cpp:3597 ../src/wxMaxima.cpp:3621
 msgid "Number of equations:"
 msgstr "Número de ecuacións:"
 
@@ -2994,15 +2997,15 @@ msgstr "Aceptar"
 msgid "Old value:"
 msgstr "Valor antigo:"
 
-#: ../src/wxMaxima.cpp:3992 ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135
+#: ../src/wxMaxima.cpp:4004 ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147
 msgid "Old variable:"
 msgstr "Variable antiga:"
 
-#: ../src/wxMaximaFrame.cpp:1387
+#: ../src/wxMaximaFrame.cpp:1386
 msgid "Omega"
 msgstr "Omega"
 
-#: ../src/wxMaximaFrame.cpp:1378
+#: ../src/wxMaximaFrame.cpp:1377
 msgid "Omicron"
 msgstr ""
 
@@ -3019,20 +3022,20 @@ msgstr ""
 "necesita enviar mensaxes pola saída estándar, pero si o Lisp que funciona en "
 "segundo plano."
 
-#: ../src/wxMaxima.cpp:4763
+#: ../src/wxMaxima.cpp:4775
 msgid "One sample t-test"
 msgstr "Contraste t para unha mostra"
 
-#: ../src/wxMaximaFrame.cpp:971
+#: ../src/wxMaximaFrame.cpp:970
 msgid "Online tutorials"
 msgstr "Tutoriais en liña"
 
 #: ../src/ConfigDialogue.cpp:656 ../src/main.cpp:347 ../src/ToolBar.cpp:119
-#: ../src/wxMaxima.cpp:2797
+#: ../src/wxMaxima.cpp:2805
 msgid "Open"
 msgstr "Abri"
 
-#: ../src/wxMaximaFrame.cpp:466
+#: ../src/wxMaximaFrame.cpp:465
 msgid "Open Recent"
 msgstr "Abre sesión &recente"
 
@@ -3040,11 +3043,11 @@ msgstr "Abre sesión &recente"
 msgid "Open a cell when Maxima expects input"
 msgstr "Abre unha cela cando Maxima espera unha entrada"
 
-#: ../src/wxMaximaFrame.cpp:464
+#: ../src/wxMaximaFrame.cpp:463
 msgid "Open a document"
 msgstr "Abre documento"
 
-#: ../src/wxMaximaFrame.cpp:458 ../src/wxMaximaFrame.cpp:461
+#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
 msgid "Open a new window"
 msgstr "Abre nova xanela"
 
@@ -3052,11 +3055,11 @@ msgstr "Abre nova xanela"
 msgid "Open document"
 msgstr "Abre documento"
 
-#: ../src/wxMaxima.cpp:4824
+#: ../src/wxMaxima.cpp:4836
 msgid "Open matrix"
 msgstr "Abre matriz"
 
-#: ../src/wxMaxima.cpp:1446 ../src/wxMaxima.cpp:1518
+#: ../src/wxMaxima.cpp:1451 ../src/wxMaxima.cpp:1523
 msgid "Opening file"
 msgstr "Abrindo arquivo"
 
@@ -3080,11 +3083,11 @@ msgstr "Celas obsoletas"
 msgid "Output labels"
 msgstr "Etiquetas de saída"
 
-#: ../src/wxMaximaFrame.cpp:796
+#: ../src/wxMaximaFrame.cpp:795
 msgid "P&ade Approximation..."
 msgstr "Achegamento de &Padé"
 
-#: ../src/wxMaxima.cpp:3132 ../src/wxMaxima.cpp:5133
+#: ../src/wxMaxima.cpp:3141 ../src/wxMaxima.cpp:5145
 msgid ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
 "bmp|Portable animap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X "
@@ -3094,15 +3097,15 @@ msgstr ""
 "bmp|Portable any map (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X "
 "pixmap (*.xpm)|*.xpm"
 
-#: ../src/wxMaxima.cpp:4012
+#: ../src/wxMaxima.cpp:4024
 msgid "Pade approximation"
 msgstr "Achegamento de Padé"
 
-#: ../src/wxMaximaFrame.cpp:797
+#: ../src/wxMaximaFrame.cpp:796
 msgid "Pade approximation of a Taylor series"
 msgstr "Achegamento de Padé dunha serie de Taylor"
 
-#: ../src/wxMaximaFrame.cpp:1500
+#: ../src/wxMaximaFrame.cpp:1519
 msgid "Pagebreak"
 msgstr "Salto de páxina"
 
@@ -3114,19 +3117,19 @@ msgstr "Paralelo a"
 msgid "Parametric plot"
 msgstr "Gráfico paramétrico"
 
-#: ../src/wxMaximaFrame.cpp:188
+#: ../src/wxMaximaFrame.cpp:187
 msgid "Parsing output"
 msgstr "Analizando saída"
 
-#: ../src/wxMaximaFrame.cpp:819
+#: ../src/wxMaximaFrame.cpp:818
 msgid "Partial &Fractions..."
 msgstr "Fracción&s simples"
 
-#: ../src/wxMaxima.cpp:4076
+#: ../src/wxMaxima.cpp:4088
 msgid "Partial fractions"
 msgstr "Fraccións simples"
 
-#: ../src/wxMaxima.cpp:1769
+#: ../src/wxMaxima.cpp:1774
 msgid "Parts of the document will not be loaded correctly!"
 msgstr "Lectura do documento parcialmente correcta!"
 
@@ -3139,11 +3142,11 @@ msgstr ""
 "Partes do documento non se cargarán correctamente!\n"
 "Atopouse etiqueta XML descoñecida "
 
-#: ../src/ToolBar.cpp:143 ../src/MathCtrl.cpp:1010 ../src/MathCtrl.cpp:1025
+#: ../src/MathCtrl.cpp:1052 ../src/MathCtrl.cpp:1067 ../src/ToolBar.cpp:143
 msgid "Paste"
 msgstr "Pega"
 
-#: ../src/wxMaximaFrame.cpp:518
+#: ../src/wxMaximaFrame.cpp:517
 msgid "Paste\tCtrl-V"
 msgstr "Pe&ga\tCtrl-V"
 
@@ -3151,7 +3154,7 @@ msgstr "Pe&ga\tCtrl-V"
 msgid "Paste from clipboard"
 msgstr "Pega dende o portapapeis"
 
-#: ../src/wxMaximaFrame.cpp:519
+#: ../src/wxMaximaFrame.cpp:518
 msgid "Paste text from clipboard"
 msgstr "Pega texto dende o portapapeis"
 
@@ -3159,19 +3162,19 @@ msgstr "Pega texto dende o portapapeis"
 msgid "Perpendicular to"
 msgstr "Perpendicular a"
 
-#: ../src/wxMaximaFrame.cpp:1384
+#: ../src/wxMaximaFrame.cpp:1383
 msgid "Phi"
 msgstr "Fi"
 
-#: ../src/wxMaximaFrame.cpp:1379
+#: ../src/wxMaximaFrame.cpp:1378
 msgid "Pi"
 msgstr "Pi"
 
-#: ../src/wxMaximaFrame.cpp:1273
+#: ../src/wxMaximaFrame.cpp:1272
 msgid "Piechart..."
 msgstr "Diagrama de sectores"
 
-#: ../src/wxMaxima.cpp:1952
+#: ../src/wxMaxima.cpp:1957
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr "Configure wxMaxima con 'Edita->Configura'."
 
@@ -3179,52 +3182,52 @@ msgstr "Configure wxMaxima con 'Edita->Configura'."
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr "Reinicie wxMaxima para que os cambios teñan efecto"
 
-#: ../src/wxMaximaFrame.cpp:923
+#: ../src/wxMaximaFrame.cpp:922
 msgid "Plot &2d..."
 msgstr "Gráficos &2D"
 
-#: ../src/wxMaximaFrame.cpp:925
+#: ../src/wxMaximaFrame.cpp:924
 msgid "Plot &3d..."
 msgstr "Gráficos &3D"
 
-#: ../src/wxMaximaFrame.cpp:927
+#: ../src/wxMaximaFrame.cpp:926
 msgid "Plot &Format..."
 msgstr "&Formato de gráficos"
 
 #: ../src/Plot2dWiz.cpp:104 ../src/Plot2dWiz.cpp:450 ../src/Plot2dWiz.cpp:464
-#: ../src/wxMaxima.cpp:4283 ../src/wxMaxima.cpp:5102
+#: ../src/wxMaxima.cpp:4295 ../src/wxMaxima.cpp:5114
 msgid "Plot 2D"
 msgstr "Gráficos 2D"
 
-#: ../src/wxMaximaFrame.cpp:1227
+#: ../src/wxMaximaFrame.cpp:1226
 msgid "Plot 2D..."
 msgstr "Gráficos 2D"
 
-#: ../src/MathCtrl.cpp:1003
+#: ../src/MathCtrl.cpp:1045
 msgid "Plot 2d..."
 msgstr "Gráficos 2D"
 
-#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4269 ../src/wxMaxima.cpp:5115
+#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4281 ../src/wxMaxima.cpp:5127
 msgid "Plot 3D"
 msgstr "Gráficos 3D"
 
-#: ../src/wxMaximaFrame.cpp:1228
+#: ../src/wxMaximaFrame.cpp:1227
 msgid "Plot 3D..."
 msgstr "Gráficos 3D"
 
-#: ../src/MathCtrl.cpp:1004
+#: ../src/MathCtrl.cpp:1046
 msgid "Plot 3d..."
 msgstr "Gráficos 3D"
 
-#: ../src/wxMaxima.cpp:4296
+#: ../src/wxMaxima.cpp:4308
 msgid "Plot format"
 msgstr "Formato dos gráficos"
 
-#: ../src/wxMaximaFrame.cpp:924
+#: ../src/wxMaximaFrame.cpp:923
 msgid "Plot in 2 dimensions"
 msgstr "Gráfico en 2 dimensións"
 
-#: ../src/wxMaximaFrame.cpp:926
+#: ../src/wxMaximaFrame.cpp:925
 msgid "Plot in 3 dimensions"
 msgstr "Gráfico en 3 dimensións"
 
@@ -3233,8 +3236,8 @@ msgid "Plot to file:"
 msgstr "Gráfico a arquivo:"
 
 #: ../src/BC2Wiz.cpp:30 ../src/BC2Wiz.cpp:36 ../src/LimitWiz.cpp:33
-#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
-#: ../src/wxMaxima.cpp:3648
+#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
+#: ../src/wxMaxima.cpp:3660
 msgid "Point:"
 msgstr "Punto:"
 
@@ -3242,11 +3245,11 @@ msgstr "Punto:"
 msgid "Polish"
 msgstr "Polaco"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 1:"
 msgstr "Polinomio 1:"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 2:"
 msgstr "Polinomio 2:"
 
@@ -3258,11 +3261,11 @@ msgstr "Portugués (Brasileiro)"
 msgid "Postscript file (*.eps)|*.eps|All|*"
 msgstr "Archivo postscript (*.eps)|*.eps|Todos|*"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Precision"
 msgstr "Precisión"
 
-#: ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:536
 msgid "Preferences...\tCtrl+,"
 msgstr "Preferencias...\tCtrl+,"
 
@@ -3274,7 +3277,7 @@ msgid ""
 "packages and from functions that are defined in the current file."
 msgstr "Premendo Ctrl+Space ou Ctrl+Tab iníciase a autocompleción."
 
-#: ../src/wxMaximaFrame.cpp:628
+#: ../src/wxMaximaFrame.cpp:627
 msgid "Previous Command\tAlt-Up"
 msgstr "Instrución anterior\tAlt-Arriba"
 
@@ -3282,11 +3285,11 @@ msgstr "Instrución anterior\tAlt-Arriba"
 msgid "Print"
 msgstr "Imprime"
 
-#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:484
+#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:483
 msgid "Print document"
 msgstr "Imprime documento"
 
-#: ../src/wxMaxima.cpp:4242
+#: ../src/wxMaxima.cpp:4254
 msgid "Product"
 msgstr "Produto"
 
@@ -3294,35 +3297,35 @@ msgstr "Produto"
 msgid "Product sign"
 msgstr "Símbolo de produto"
 
-#: ../src/wxMaximaFrame.cpp:1386
+#: ../src/wxMaximaFrame.cpp:1385
 msgid "Psi"
 msgstr "Psi"
 
-#: ../src/wxMaximaFrame.cpp:331
+#: ../src/wxMaximaFrame.cpp:330
 msgid "Raw XML monitor"
 msgstr "Monitor XML"
 
-#: ../src/wxMaximaFrame.cpp:592
+#: ../src/wxMaximaFrame.cpp:591
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr "Avaliar todas as celas por riba do cursor"
 
-#: ../src/wxMaximaFrame.cpp:1278
+#: ../src/wxMaximaFrame.cpp:1277
 msgid "Read Matrix..."
 msgstr "Le matriz"
 
-#: ../src/wxMaximaFrame.cpp:177
+#: ../src/wxMaximaFrame.cpp:176
 msgid "Reading Maxima output"
 msgstr "Lendo saída de Maxima"
 
-#: ../src/wxMaximaFrame.cpp:153
+#: ../src/wxMaximaFrame.cpp:152
 msgid "Ready for user input"
 msgstr "Preparado para a entrada de usuario"
 
-#: ../src/wxMaximaFrame.cpp:631
+#: ../src/wxMaximaFrame.cpp:630
 msgid "Recall next command from history"
 msgstr "Chama á seguinte instrución do historial"
 
-#: ../src/wxMaximaFrame.cpp:629
+#: ../src/wxMaximaFrame.cpp:628
 msgid "Recall previous command from history"
 msgstr "Chama á instrución anterior do historial"
 
@@ -3330,35 +3333,35 @@ msgstr "Chama á instrución anterior do historial"
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1215
+#: ../src/wxMaximaFrame.cpp:1214
 msgid "Rectform"
 msgstr "Forma cartesiá"
 
-#: ../src/wxMaximaFrame.cpp:495
+#: ../src/wxMaximaFrame.cpp:494
 msgid "Redo\tCtrl-Y"
 msgstr "Voltar a facer\tCtrl-Y"
 
-#: ../src/wxMaximaFrame.cpp:496
+#: ../src/wxMaximaFrame.cpp:495
 msgid "Redo last change"
 msgstr "Desfai último cambio"
 
-#: ../src/wxMaximaFrame.cpp:1220
+#: ../src/wxMaximaFrame.cpp:1219
 msgid "Reduce (tr)"
 msgstr "Reduce (tr)"
 
-#: ../src/wxMaximaFrame.cpp:871
+#: ../src/wxMaximaFrame.cpp:870
 msgid "Reduce trigonometric expression"
 msgstr "Simplifica expresión trigonométrica"
 
-#: ../src/wxMaxima.cpp:622 ../src/wxMaxima.cpp:5495
+#: ../src/wxMaxima.cpp:627 ../src/wxMaxima.cpp:5511
 msgid "Refusing to send cell to maxima: "
 msgstr "Rexeitando enviar unha cela a Maxima: "
 
-#: ../src/wxMaximaFrame.cpp:594
+#: ../src/wxMaximaFrame.cpp:593
 msgid "Remove All Output"
 msgstr "&Borra todos os resultados"
 
-#: ../src/wxMaximaFrame.cpp:595
+#: ../src/wxMaximaFrame.cpp:594
 msgid "Remove output from input cells"
 msgstr "Borra resultados das celas de entrada"
 
@@ -3367,7 +3370,7 @@ msgstr "Borra resultados das celas de entrada"
 msgid "Replace All"
 msgstr "Selecciona todo"
 
-#: ../src/wxMaxima.cpp:3282
+#: ../src/wxMaxima.cpp:3294
 #, c-format
 msgid "Replaced %d occurrences."
 msgstr "Reemplazadas %d coincidencias."
@@ -3376,11 +3379,11 @@ msgstr "Reemplazadas %d coincidencias."
 msgid "Replacement:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:976
+#: ../src/wxMaximaFrame.cpp:975
 msgid "Report bug"
 msgstr "Informe de erro"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "Restart Maxima"
 msgstr "Reinicia maxima"
 
@@ -3388,7 +3391,7 @@ msgstr "Reinicia maxima"
 msgid "Restart maxima"
 msgstr "Reiniciar Maxima"
 
-#: ../src/MathCtrl.cpp:4442
+#: ../src/MathCtrl.cpp:4497
 msgid "Result"
 msgstr "Resultado"
 
@@ -3396,7 +3399,7 @@ msgstr "Resultado"
 msgid "Return to the cell that is currently being evaluated"
 msgstr "Voltar á cela que se está a avaliar actualmente"
 
-#: ../src/wxMaximaFrame.cpp:1380
+#: ../src/wxMaximaFrame.cpp:1379
 msgid "Rho"
 msgstr "Ro"
 
@@ -3404,19 +3407,19 @@ msgstr "Ro"
 msgid "Right arrow"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:779
+#: ../src/wxMaximaFrame.cpp:778
 msgid "Risch Integration..."
 msgstr "Integración &Risch"
 
-#: ../src/wxMaximaFrame.cpp:694
+#: ../src/wxMaximaFrame.cpp:693
 msgid "Roots of &Polynomial"
 msgstr "Raíces dun &polinomio"
 
-#: ../src/wxMaximaFrame.cpp:697
+#: ../src/wxMaximaFrame.cpp:696
 msgid "Roots of Polynomial (bfloat)"
 msgstr "Raíces reais &grandes dun polinomio"
 
-#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Rows:"
 msgstr "Filas:"
 
@@ -3424,56 +3427,56 @@ msgstr "Filas:"
 msgid "Russian"
 msgstr "Ruso"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 1:"
 msgstr "Exemplo 1:"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 2:"
 msgstr "Exemplo 2:"
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Sample:"
 msgstr "Mostra:"
 
 #: ../src/ConfigDialogue.cpp:781 ../src/ToolBar.cpp:122
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Save"
 msgstr "Garda"
 
-#: ../src/MathCtrl.cpp:921
+#: ../src/MathCtrl.cpp:963
 msgid "Save Animation..."
 msgstr "Garda animación"
 
-#: ../src/wxMaxima.cpp:2565
+#: ../src/wxMaxima.cpp:2572
 msgid "Save As"
 msgstr "Garda como"
 
-#: ../src/wxMaximaFrame.cpp:474
+#: ../src/wxMaximaFrame.cpp:473
 msgid "Save As...\tShift-Ctrl-S"
 msgstr "Garda &como\tShift-Ctrl-S"
 
-#: ../src/MathCtrl.cpp:919
+#: ../src/MathCtrl.cpp:961
 msgid "Save Image..."
 msgstr "Garda imaxe..."
 
-#: ../src/wxMaxima.cpp:3130
+#: ../src/wxMaxima.cpp:3139
 msgid "Save Selection to Image"
 msgstr "Garda selección en imaxen"
 
-#: ../src/wxMaximaFrame.cpp:528
+#: ../src/wxMaximaFrame.cpp:527
 msgid "Save Selection to Image..."
 msgstr "G&ardar selección en imaxe"
 
-#: ../src/wxMaxima.cpp:5150
+#: ../src/wxMaxima.cpp:5162
 msgid "Save animation to file"
 msgstr "Garda animación no arquivo"
 
-#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:473
+#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:472
 msgid "Save document"
 msgstr "Garda documento"
 
-#: ../src/wxMaximaFrame.cpp:475
+#: ../src/wxMaximaFrame.cpp:474
 msgid "Save document as"
 msgstr "Garda documento como"
 
@@ -3497,11 +3500,11 @@ msgstr "Garda disposición de paneis entre sesións."
 msgid "Save plot to file"
 msgstr "Garda gráfico nun arquivo"
 
-#: ../src/wxMaximaFrame.cpp:529
+#: ../src/wxMaximaFrame.cpp:528
 msgid "Save selection from document to an image file"
 msgstr "Copia selección do documento a imaxe"
 
-#: ../src/wxMaxima.cpp:5131
+#: ../src/wxMaxima.cpp:5143
 msgid "Save selection to file"
 msgstr "Garda selección nun arquivo"
 
@@ -3517,27 +3520,27 @@ msgstr "Garda o tamaño/posición da xanela de wxMaxima"
 msgid "Save wxMaxima window size/position between sessions."
 msgstr "Garda tamaño/posición da xanela de wxMaxima entre sesións."
 
-#: ../src/wxMaximaFrame.cpp:246
+#: ../src/wxMaximaFrame.cpp:245
 msgid "Saving failed."
 msgstr "Fallou ó gardar"
 
-#: ../src/wxMaximaFrame.cpp:222
+#: ../src/wxMaximaFrame.cpp:221
 msgid "Saving successful."
 msgstr "Gardado correcto."
 
-#: ../src/wxMaximaFrame.cpp:212
+#: ../src/wxMaximaFrame.cpp:211
 msgid "Saving..."
 msgstr "Gardando..."
 
-#: ../src/wxMaxima.cpp:4699
+#: ../src/wxMaxima.cpp:4711
 msgid "Scatterplot"
 msgstr "Diagrama dispersión"
 
-#: ../src/wxMaximaFrame.cpp:1271
+#: ../src/wxMaximaFrame.cpp:1270
 msgid "Scatterplot..."
 msgstr "Diagrama dispersión"
 
-#: ../src/wxMaximaFrame.cpp:1498
+#: ../src/wxMaximaFrame.cpp:1517
 msgid "Section"
 msgstr "Sección"
 
@@ -3545,8 +3548,8 @@ msgstr "Sección"
 msgid "Section cell"
 msgstr "Cela de sección"
 
-#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:292 ../src/TextCell.cpp:306
-#: ../src/TextCell.cpp:322 ../src/TextCell.cpp:334
+#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:290 ../src/TextCell.cpp:304
+#: ../src/TextCell.cpp:320 ../src/TextCell.cpp:332
 msgid ""
 "Seems like something is broken with a font. Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
@@ -3556,7 +3559,7 @@ msgstr ""
 "jsmath/download/jsMath-fonts.html e comprobando \"Use JSmath fonts\" no "
 "diálogo de configuración debería resolver o problema."
 
-#: ../src/TextCell.cpp:139
+#: ../src/TextCell.cpp:137
 msgid ""
 "Seems like something is broken with the maths font. Installing http://www."
 "math.union.edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use "
@@ -3566,11 +3569,11 @@ msgstr ""
 "~dpvc/jsmath/download/jsMath-fonts.html e comprobando \"Use JSmath fonts\" "
 "no diálogo de configuración debería resolver o problema."
 
-#: ../src/MathCtrl.cpp:1011 ../src/MathCtrl.cpp:1027
+#: ../src/MathCtrl.cpp:1053 ../src/MathCtrl.cpp:1069
 msgid "Select All"
 msgstr "Selecciona todo"
 
-#: ../src/wxMaximaFrame.cpp:525
+#: ../src/wxMaximaFrame.cpp:524
 msgid "Select All\tCtrl-A"
 msgstr "&Selecciona todo\tCtrl-A"
 
@@ -3578,7 +3581,7 @@ msgstr "&Selecciona todo\tCtrl-A"
 msgid "Select Maxima program"
 msgstr "Selecciona o programa Maxima"
 
-#: ../src/wxMaxima.cpp:4860
+#: ../src/wxMaxima.cpp:4872
 msgid "Select Subsample"
 msgstr "Selecciona submostra"
 
@@ -3587,11 +3590,11 @@ msgstr "Selecciona submostra"
 msgid "Select a constant"
 msgstr "Selecciona unha constante"
 
-#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:526
+#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:525
 msgid "Select all"
 msgstr "Selecciona todo"
 
-#: ../src/wxMaxima.cpp:3319
+#: ../src/wxMaxima.cpp:3331
 msgid "Select math display algorithm"
 msgstr "Selecciona o formato de saída matemático"
 
@@ -3608,23 +3611,23 @@ msgstr ""
 msgid "Selection"
 msgstr "Selección"
 
-#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4178
+#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4190
 msgid "Series"
 msgstr "Serie"
 
-#: ../src/wxMaximaFrame.cpp:1226
+#: ../src/wxMaximaFrame.cpp:1225
 msgid "Series..."
 msgstr "Serie"
 
-#: ../src/wxMaxima.cpp:863
+#: ../src/wxMaxima.cpp:868
 msgid "Server started"
 msgstr "Servidor iniciado"
 
-#: ../src/wxMaximaFrame.cpp:575
+#: ../src/wxMaximaFrame.cpp:574
 msgid "Set Zoom"
 msgstr "Establece au&mento"
 
-#: ../src/wxMaximaFrame.cpp:944
+#: ../src/wxMaximaFrame.cpp:943
 msgid "Set bigfloat &Precision..."
 msgstr "Establecer a precisión bigfloat"
 
@@ -3632,11 +3635,11 @@ msgstr "Establecer a precisión bigfloat"
 msgid "Set fixed font in text controls."
 msgstr "Establece tipografía fixa nos controis de texto."
 
-#: ../src/wxMaximaFrame.cpp:928
+#: ../src/wxMaximaFrame.cpp:927
 msgid "Set plot format"
 msgstr "Establece o formato dos gráficos"
 
-#: ../src/wxMaximaFrame.cpp:945
+#: ../src/wxMaximaFrame.cpp:944
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can "
 "be generated by entering 1.5b12 or as bfloat(1.234)"
@@ -3644,53 +3647,53 @@ msgstr ""
 "Axustar a precisión dos números que se definen como bigfloat. Estes números "
 "se poden xerar escribindo 1.5b12 ou bfloat(1.234)"
 
-#: ../src/wxMaximaFrame.cpp:569
+#: ../src/wxMaximaFrame.cpp:568
 msgid "Set zoom to 100%"
 msgstr "Establece ampliación a 100%"
 
-#: ../src/wxMaximaFrame.cpp:570
+#: ../src/wxMaximaFrame.cpp:569
 msgid "Set zoom to 120%"
 msgstr "Establece ampliación a 120%"
 
-#: ../src/wxMaximaFrame.cpp:571
+#: ../src/wxMaximaFrame.cpp:570
 msgid "Set zoom to 150%"
 msgstr "Establece ampliación a 150%"
 
-#: ../src/wxMaximaFrame.cpp:572
+#: ../src/wxMaximaFrame.cpp:571
 msgid "Set zoom to 200%"
 msgstr "Establece ampliación a 200%"
 
-#: ../src/wxMaximaFrame.cpp:573
+#: ../src/wxMaximaFrame.cpp:572
 msgid "Set zoom to 300%"
 msgstr "Establece ampliación a 300%"
 
-#: ../src/wxMaximaFrame.cpp:568
+#: ../src/wxMaximaFrame.cpp:567
 msgid "Set zoom to 80%"
 msgstr "Establece disminución a 80%"
 
-#: ../src/wxMaximaFrame.cpp:732
+#: ../src/wxMaximaFrame.cpp:731
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
 "Establece condicións iniciais para resolver EDOs mediante a transformada de "
 "Laplace"
 
-#: ../src/wxMaximaFrame.cpp:918
+#: ../src/wxMaximaFrame.cpp:917
 msgid "Setup modulus computation"
 msgstr "Configura cálculo de módulo"
 
-#: ../src/wxMaximaFrame.cpp:662
+#: ../src/wxMaximaFrame.cpp:661
 msgid "Show &Definition..."
 msgstr "Amosa &definición"
 
-#: ../src/wxMaximaFrame.cpp:660
+#: ../src/wxMaximaFrame.cpp:659
 msgid "Show &Functions"
 msgstr "Amosa &funcións"
 
-#: ../src/wxMaximaFrame.cpp:967
+#: ../src/wxMaximaFrame.cpp:966
 msgid "Show &Tips..."
 msgstr "Amosa &suxerencias"
 
-#: ../src/wxMaximaFrame.cpp:665
+#: ../src/wxMaximaFrame.cpp:664
 msgid "Show &Variables"
 msgstr "Amosa &variables"
 
@@ -3698,43 +3701,43 @@ msgstr "Amosa &variables"
 msgid "Show Maxima help"
 msgstr "Amosa a axuda de Maxima"
 
-#: ../src/wxMaximaFrame.cpp:603
+#: ../src/wxMaximaFrame.cpp:602
 msgid "Show Template\tCtrl-Shift-K"
 msgstr "&Amosa plantilla\tCtrl-Shift-K"
 
-#: ../src/wxMaximaFrame.cpp:968
+#: ../src/wxMaximaFrame.cpp:967
 msgid "Show a tip"
 msgstr "Amosa unha suxerencia"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Show all commands similar to:"
 msgstr "Amosa todos os comandos similares a:"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Show an example for the command:"
 msgstr "Amosa un exemplo para a instrución:"
 
-#: ../src/wxMaximaFrame.cpp:962
+#: ../src/wxMaximaFrame.cpp:961
 msgid "Show an example of usage"
 msgstr "Amosa un exemplo de uso"
 
-#: ../src/wxMaximaFrame.cpp:965
+#: ../src/wxMaximaFrame.cpp:964
 msgid "Show commands similar to"
 msgstr "Amosa instrucións similares a"
 
-#: ../src/wxMaximaFrame.cpp:661
+#: ../src/wxMaximaFrame.cpp:660
 msgid "Show defined functions"
 msgstr "Amosa as funcións definidas"
 
-#: ../src/wxMaximaFrame.cpp:666
+#: ../src/wxMaximaFrame.cpp:665
 msgid "Show defined variables"
 msgstr "Amosa as variables definidas"
 
-#: ../src/wxMaximaFrame.cpp:663
+#: ../src/wxMaximaFrame.cpp:662
 msgid "Show definition of a function"
 msgstr "Amosa a definición dunha función"
 
-#: ../src/wxMaximaFrame.cpp:604
+#: ../src/wxMaximaFrame.cpp:603
 msgid "Show function template"
 msgstr "Amosa plantilla de función"
 
@@ -3747,7 +3750,7 @@ msgstr "Amosa expresións longas no documento de wxMaxima."
 msgid "Show long expressions:"
 msgstr "Amosa expresións longas"
 
-#: ../src/wxMaxima.cpp:3341
+#: ../src/wxMaxima.cpp:3353
 msgid "Show the definition of function:"
 msgstr "Amosa a definición da función:"
 
@@ -3756,43 +3759,43 @@ msgstr "Amosa a definición da función:"
 msgid "Show user-defined labels instead of (%oxx)"
 msgstr "Amosar etiquetas definidas polo usuario en lugar de (%oxx)"
 
-#: ../src/wxMaximaFrame.cpp:953 ../src/wxMaximaFrame.cpp:956
+#: ../src/wxMaximaFrame.cpp:952 ../src/wxMaximaFrame.cpp:955
 msgid "Show wxMaxima help"
 msgstr "Axuda de wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:1381
+#: ../src/wxMaximaFrame.cpp:1380
 msgid "Sigma"
 msgstr "Sigma"
 
-#: ../src/wxMaximaFrame.cpp:1211
+#: ../src/wxMaximaFrame.cpp:1210
 msgid "Simplify"
 msgstr "Simplifica"
 
-#: ../src/wxMaximaFrame.cpp:831
+#: ../src/wxMaximaFrame.cpp:830
 msgid "Simplify &Radicals"
 msgstr "Simplifica &radicais"
 
-#: ../src/wxMaximaFrame.cpp:1212
+#: ../src/wxMaximaFrame.cpp:1211
 msgid "Simplify (r)"
 msgstr "Simplifica (r)"
 
-#: ../src/wxMaximaFrame.cpp:1218
+#: ../src/wxMaximaFrame.cpp:1217
 msgid "Simplify (tr)"
 msgstr "Simplifica (tr)"
 
-#: ../src/MathCtrl.cpp:995
+#: ../src/MathCtrl.cpp:1037
 msgid "Simplify Expression"
 msgstr "Simplifica expresión"
 
-#: ../src/wxMaximaFrame.cpp:857
+#: ../src/wxMaximaFrame.cpp:856
 msgid "Simplify an expression containing factorials"
 msgstr "Simplifica unha expresión que contén factoriais"
 
-#: ../src/wxMaximaFrame.cpp:832
+#: ../src/wxMaximaFrame.cpp:831
 msgid "Simplify expression containing radicals"
 msgstr "Simplifica unha expresión que contén radicais"
 
-#: ../src/wxMaximaFrame.cpp:830
+#: ../src/wxMaximaFrame.cpp:829
 msgid "Simplify rational expression"
 msgstr "Simplifica expresión racional"
 
@@ -3800,7 +3803,7 @@ msgstr "Simplifica expresión racional"
 msgid "Simplify the sum"
 msgstr "Simplifica a suma"
 
-#: ../src/wxMaximaFrame.cpp:868
+#: ../src/wxMaximaFrame.cpp:867
 msgid "Simplify trigonometric expression"
 msgstr "Simplifica unha expresión trigonométrica"
 
@@ -3816,87 +3819,87 @@ msgstr ""
 "formato 'Documento xml wxMaxima' se quere que se almacene a imaxe xunto co "
 "resto do documento."
 
-#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
+#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
 msgid "Solution:"
 msgstr "Solución:"
 
-#: ../src/wxMaxima.cpp:3461 ../src/wxMaxima.cpp:3475 ../src/wxMaxima.cpp:5020
+#: ../src/wxMaxima.cpp:3473 ../src/wxMaxima.cpp:3487 ../src/wxMaxima.cpp:5032
 msgid "Solve"
 msgstr "Resolve"
 
-#: ../src/wxMaximaFrame.cpp:706
+#: ../src/wxMaximaFrame.cpp:705
 msgid "Solve &Algebraic System..."
 msgstr "Reso&lve sistema alxébrico"
 
-#: ../src/wxMaximaFrame.cpp:703
+#: ../src/wxMaximaFrame.cpp:702
 msgid "Solve &Linear System..."
 msgstr "Resolve &sistema linear"
 
-#: ../src/wxMaximaFrame.cpp:714
+#: ../src/wxMaximaFrame.cpp:713
 msgid "Solve &ODE..."
 msgstr "Resolve &EDO"
 
-#: ../src/wxMaximaFrame.cpp:690
+#: ../src/wxMaximaFrame.cpp:689
 msgid "Solve (to_poly)..."
 msgstr "Res&olve (to_poly)"
 
-#: ../src/wxMaxima.cpp:3511 ../src/wxMaxima.cpp:3635
+#: ../src/wxMaxima.cpp:3523 ../src/wxMaxima.cpp:3647
 msgid "Solve ODE"
 msgstr "Resolve EDO"
 
-#: ../src/wxMaximaFrame.cpp:728
+#: ../src/wxMaximaFrame.cpp:727
 msgid "Solve ODE with Lapla&ce..."
 msgstr "Resolve E&DO con Laplace"
 
-#: ../src/wxMaximaFrame.cpp:1222
+#: ../src/wxMaximaFrame.cpp:1221
 msgid "Solve ODE..."
 msgstr "Resolve EDO"
 
-#: ../src/wxMaxima.cpp:3586 ../src/wxMaxima.cpp:3597
+#: ../src/wxMaxima.cpp:3598 ../src/wxMaxima.cpp:3609
 msgid "Solve algebraic system"
 msgstr "Resolve sistema alxébrico"
 
-#: ../src/wxMaximaFrame.cpp:707
+#: ../src/wxMaximaFrame.cpp:706
 msgid "Solve algebraic system of equations"
 msgstr "Resolve sistema alxébrico de ecuacións"
 
-#: ../src/wxMaximaFrame.cpp:725
+#: ../src/wxMaximaFrame.cpp:724
 msgid "Solve boundary value problem for second degree ODE"
 msgstr "Resolve problema de contorna para unha EDO de segundo orde"
 
-#: ../src/wxMaximaFrame.cpp:689
+#: ../src/wxMaximaFrame.cpp:688
 msgid "Solve equation(s)"
 msgstr "Resolve ecuación(s)"
 
-#: ../src/wxMaximaFrame.cpp:691
+#: ../src/wxMaximaFrame.cpp:690
 msgid "Solve equation(s) with to_poly_solve"
 msgstr "Resolve ecuación con to_poly_solve"
 
-#: ../src/wxMaximaFrame.cpp:719
+#: ../src/wxMaximaFrame.cpp:718
 msgid "Solve initial value problem for first degree ODE"
 msgstr "Resolve problema de valor inicial para EDO de primeiro orde"
 
-#: ../src/wxMaximaFrame.cpp:722
+#: ../src/wxMaximaFrame.cpp:721
 msgid "Solve initial value problem for second degree ODE"
 msgstr "Resolve problema de valor inicial para EDO de segundo orde"
 
-#: ../src/wxMaxima.cpp:3610 ../src/wxMaxima.cpp:3621
+#: ../src/wxMaxima.cpp:3622 ../src/wxMaxima.cpp:3633
 msgid "Solve linear system"
 msgstr "Resolve sistema linear"
 
-#: ../src/wxMaximaFrame.cpp:704
+#: ../src/wxMaximaFrame.cpp:703
 msgid "Solve linear system of equations"
 msgstr "Resolve sistema de ecuacións lineares"
 
-#: ../src/wxMaximaFrame.cpp:715
+#: ../src/wxMaximaFrame.cpp:714
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr "Resolve ecuación diferencial ordinaria de orden máximo 2"
 
-#: ../src/wxMaximaFrame.cpp:729
+#: ../src/wxMaximaFrame.cpp:728
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr "Resolve  ecuacións diferenciais ordinarias ca transformada de Laplace"
 
-#: ../src/wxMaximaFrame.cpp:1221 ../src/MathCtrl.cpp:992
+#: ../src/MathCtrl.cpp:1034 ../src/wxMaximaFrame.cpp:1220
 msgid "Solve..."
 msgstr "Resolve"
 
@@ -3923,7 +3926,7 @@ msgstr "Especial"
 msgid "Special constants"
 msgstr "Constantes especiais"
 
-#: ../src/MathCtrl.cpp:922
+#: ../src/MathCtrl.cpp:964
 msgid "Start Animation"
 msgstr "Comeza animación"
 
@@ -3943,28 +3946,28 @@ msgstr ""
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:294
+#: ../src/wxMaxima.cpp:295
 msgid "Starting Maxima process failed"
 msgstr "Fallou o inicio de Maxima"
 
-#: ../src/wxMaxima.cpp:928
+#: ../src/wxMaxima.cpp:933
 msgid "Starting Maxima..."
 msgstr "Iniciando Maxima..."
 
-#: ../src/wxMaxima.cpp:292 ../src/wxMaxima.cpp:860
+#: ../src/wxMaxima.cpp:293 ../src/wxMaxima.cpp:865
 msgid "Starting server failed"
 msgstr "Fallou o inicio do servidor"
 
-#: ../src/wxMaxima.cpp:841
+#: ../src/wxMaxima.cpp:846
 #, c-format
 msgid "Starting server on port %d"
 msgstr "Iniciando servidor no puerto %d"
 
-#: ../src/wxMaximaFrame.cpp:342
+#: ../src/wxMaximaFrame.cpp:341
 msgid "Statistics"
 msgstr "Estatística"
 
-#: ../src/wxMaximaFrame.cpp:550
+#: ../src/wxMaximaFrame.cpp:549
 msgid "Statistics\tAlt-Shift-S"
 msgstr "&Estatística\tAlt-Shift-S"
 
@@ -3980,11 +3983,11 @@ msgstr "Estilo"
 msgid "Styles"
 msgstr "Estilos"
 
-#: ../src/wxMaximaFrame.cpp:1283
+#: ../src/wxMaximaFrame.cpp:1282
 msgid "Subsample..."
 msgstr "Submostra"
 
-#: ../src/wxMaximaFrame.cpp:1496
+#: ../src/wxMaximaFrame.cpp:1515
 msgid "Subsection"
 msgstr "Subsección"
 
@@ -3992,20 +3995,20 @@ msgstr "Subsección"
 msgid "Subsection cell"
 msgstr "Cela de subsección"
 
-#: ../src/wxMaximaFrame.cpp:1216
+#: ../src/wxMaximaFrame.cpp:1215
 msgid "Subst..."
 msgstr "S&ubstitúe"
 
-#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3423
-#: ../src/wxMaxima.cpp:5089
+#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3435
+#: ../src/wxMaxima.cpp:5101
 msgid "Substitute"
 msgstr "Substitúe"
 
-#: ../src/wxMaximaFrame.cpp:906 ../src/MathCtrl.cpp:998
+#: ../src/MathCtrl.cpp:1040 ../src/wxMaximaFrame.cpp:905
 msgid "Substitute..."
 msgstr "Substitúe"
 
-#: ../src/wxMaximaFrame.cpp:1497
+#: ../src/wxMaximaFrame.cpp:1516
 msgid "Subsubsection"
 msgstr "Subsubsección"
 
@@ -4013,7 +4016,7 @@ msgstr "Subsubsección"
 msgid "Subsubsection cell"
 msgstr "Cela de subsubsección"
 
-#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4226
+#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4238
 msgid "Sum"
 msgstr "Suma"
 
@@ -4021,36 +4024,36 @@ msgstr "Suma"
 msgid "Sum sign"
 msgstr "Símbolo de suma"
 
-#: ../src/wxMaximaFrame.cpp:553
+#: ../src/wxMaximaFrame.cpp:552
 msgid "Symbols\tAlt-Shift-Y"
 msgstr "Símbolos\tAlt-Shift-Y"
 
-#: ../src/wxMaxima.cpp:4456
+#: ../src/wxMaxima.cpp:4468
 msgid "System info"
 msgstr "Información do sistema"
 
-#: ../src/wxMaximaFrame.cpp:320
+#: ../src/wxMaximaFrame.cpp:319
 msgid "Table of Contents"
 msgstr "Táboa de contidos"
 
-#: ../src/wxMaximaFrame.cpp:556
+#: ../src/wxMaximaFrame.cpp:555
 #, fuzzy
 msgid "Table of Contents\tAlt-Shift-T"
 msgstr "Táboa de contidos\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:1382
+#: ../src/wxMaximaFrame.cpp:1381
 msgid "Tau"
 msgstr "Tau"
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Taylor series:"
 msgstr "Serie de Taylor:"
 
-#: ../src/wxMaxima.cpp:3963
+#: ../src/wxMaxima.cpp:3975
 msgid "Tellrat"
 msgstr "Tellrat"
 
-#: ../src/wxMaximaFrame.cpp:1494
+#: ../src/wxMaximaFrame.cpp:1513
 msgid "Text"
 msgstr "Texto"
 
@@ -4099,7 +4102,7 @@ msgstr ""
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr "A clase de documento que utilizará LaTeX para os nosos documentos."
 
-#: ../src/TextCell.cpp:136
+#: ../src/TextCell.cpp:134
 msgid ""
 "The letter \"X\" is of width zero. Installing http://www.math.union.edu/"
 "~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts\" in "
@@ -4119,7 +4122,7 @@ msgstr ""
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:959
+#: ../src/wxMaximaFrame.cpp:958
 msgid "The offline manual of maxima"
 msgstr "Manual de Maxima fóra de liña"
 
@@ -4158,7 +4161,7 @@ msgstr ""
 "andrejv.github.com/wxmaxima/help.html para máis información sobre como "
 "utilizar wxMaxima e Maxima."
 
-#: ../src/SlideShowCell.cpp:332
+#: ../src/SlideShowCell.cpp:336
 msgid ""
 "There was an error during GIF export!\n"
 "\n"
@@ -4169,7 +4172,7 @@ msgstr ""
 "Asegúrese que ImageMagick está instalado e que wxMaxima ten acceso ó "
 "programa 'convert'."
 
-#: ../src/wxMaxima.cpp:442
+#: ../src/wxMaxima.cpp:447
 msgid ""
 "There was an error in generated XML!\n"
 "\n"
@@ -4179,7 +4182,7 @@ msgstr ""
 "\n"
 "Prégase informar deste erro."
 
-#: ../src/wxMaximaFrame.cpp:1371
+#: ../src/wxMaximaFrame.cpp:1370
 msgid "Theta"
 msgstr "Theta"
 
@@ -4187,7 +4190,7 @@ msgstr "Theta"
 msgid "Ticks:"
 msgstr "Marcas de eixes:"
 
-#: ../src/wxMaxima.cpp:4153 ../src/wxMaxima.cpp:5065
+#: ../src/wxMaxima.cpp:4165 ../src/wxMaxima.cpp:5077
 msgid "Times:"
 msgstr "Veces:"
 
@@ -4195,7 +4198,7 @@ msgstr "Veces:"
 msgid "Tips not available, sorry!"
 msgstr "Suxerencia non dispoñible, síntoo!"
 
-#: ../src/wxMaximaFrame.cpp:1495
+#: ../src/wxMaximaFrame.cpp:1514
 msgid "Title"
 msgstr "Título"
 
@@ -4214,19 +4217,19 @@ msgstr ""
 "contiguo á cela. Se ó mesmo tempo se preme 'Maiúsculas', todos os subniveis "
 "serán pregados/despregados."
 
-#: ../src/wxMaximaFrame.cpp:938
+#: ../src/wxMaximaFrame.cpp:937
 msgid "To &Bigfloat"
 msgstr "A real grande (&bigfloat)"
 
-#: ../src/wxMaximaFrame.cpp:935
+#: ../src/wxMaximaFrame.cpp:934
 msgid "To &Float"
 msgstr "A &real"
 
-#: ../src/MathCtrl.cpp:990
+#: ../src/MathCtrl.cpp:1032
 msgid "To Float"
 msgstr "A real"
 
-#: ../src/wxMaximaFrame.cpp:941
+#: ../src/wxMaximaFrame.cpp:940
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr "A numérico\tCtrl+Shift+N"
 
@@ -4268,51 +4271,51 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:41 ../src/Plot2dWiz.cpp:40 ../src/Plot2dWiz.cpp:50
 #: ../src/Plot2dWiz.cpp:539 ../src/Plot3dWiz.cpp:39 ../src/Plot3dWiz.cpp:48
-#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4241
+#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4253
 msgid "To:"
 msgstr "Ata:"
 
-#: ../src/wxMaximaFrame.cpp:912
+#: ../src/wxMaximaFrame.cpp:911
 msgid "Toggle &Algebraic Flag"
 msgstr "Conmuta álxe&bra"
 
-#: ../src/wxMaximaFrame.cpp:933
+#: ../src/wxMaximaFrame.cpp:932
 msgid "Toggle &Numeric Output"
 msgstr "Conmuta saída &numérica"
 
-#: ../src/wxMaximaFrame.cpp:673
+#: ../src/wxMaximaFrame.cpp:672
 msgid "Toggle &Time Display"
 msgstr "Conmuta pantalla de &tempo"
 
-#: ../src/wxMaximaFrame.cpp:913
+#: ../src/wxMaximaFrame.cpp:912
 msgid "Toggle algebraic flag"
 msgstr "Conmuta álge&bra"
 
-#: ../src/wxMaximaFrame.cpp:577
+#: ../src/wxMaximaFrame.cpp:576
 msgid "Toggle full screen editing"
 msgstr "Conmuta edición de pantalla completa"
 
-#: ../src/wxMaximaFrame.cpp:934
+#: ../src/wxMaximaFrame.cpp:933
 msgid "Toggle numeric output"
 msgstr "Conmuta saída numérica"
 
-#: ../src/wxMaxima.cpp:4464
+#: ../src/wxMaxima.cpp:4476
 msgid "Toolbar icons"
 msgstr "Iconas da barra de ferramentas"
 
-#: ../src/wxMaxima.cpp:4465
+#: ../src/wxMaxima.cpp:4477
 msgid "Translated by"
 msgstr "Traducido por"
 
-#: ../src/wxMaximaFrame.cpp:763
+#: ../src/wxMaximaFrame.cpp:762
 msgid "Transpose a matrix"
 msgstr "Transpón unha matriz"
 
-#: ../src/MathCtrl.cpp:5834
+#: ../src/MathCtrl.cpp:5886
 msgid "Trying to undo an action without starting cell."
 msgstr "Intentando desfacer unha acción sen cela de comezo."
 
-#: ../src/MathCtrl.cpp:5901
+#: ../src/MathCtrl.cpp:5953
 msgid "Trying to undo something but the undo action is empty."
 msgstr "Intentando desfacer unha acción que non existe."
 
@@ -4320,11 +4323,11 @@ msgstr "Intentando desfacer unha acción que non existe."
 msgid "Turkish"
 msgstr "Turco"
 
-#: ../src/wxMaximaFrame.cpp:970
+#: ../src/wxMaximaFrame.cpp:969
 msgid "Tutorials"
 msgstr "&Tutoriais"
 
-#: ../src/wxMaxima.cpp:4778
+#: ../src/wxMaxima.cpp:4790
 msgid "Two sample t-test"
 msgstr "Contrataste t de dúas mostras"
 
@@ -4336,15 +4339,15 @@ msgstr "Tipo:"
 msgid "Ukrainian"
 msgstr "Ucraíno"
 
-#: ../src/wxMaxima.cpp:5356
+#: ../src/wxMaxima.cpp:5372
 msgid "Un-closed parenthesis"
 msgstr "Parénteses non pechado"
 
-#: ../src/wxMaxima.cpp:5323
+#: ../src/wxMaxima.cpp:5335
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr "Paréntese mal pareado ou hai un ; o $ antes de tempo"
 
-#: ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5889
 msgid ""
 "Unable to interpret the version info I got from http://andrejv.github.io//"
 "wxmaxima/version.txt: "
@@ -4361,11 +4364,11 @@ msgstr "Subraiado"
 msgid "Underscore converts to subscripts:"
 msgstr "Guión baixo converte a subíndices"
 
-#: ../src/wxMaximaFrame.cpp:492
+#: ../src/wxMaximaFrame.cpp:491
 msgid "Undo\tCtrl-Z"
 msgstr "D&esfacer\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:493
+#: ../src/wxMaximaFrame.cpp:492
 msgid "Undo last change"
 msgstr "Desfacer último cambio"
 
@@ -4374,23 +4377,23 @@ msgstr "Desfacer último cambio"
 msgid "Undo limit (0 for none):"
 msgstr "Límite de desfacer (0 para ningún)"
 
-#: ../src/wxMaximaFrame.cpp:625
+#: ../src/wxMaximaFrame.cpp:624
 msgid "Unfold All\tCtrl-Alt-]"
 msgstr "Despregar todo\tCtrl-Alt-]"
 
-#: ../src/wxMaximaFrame.cpp:626
+#: ../src/wxMaximaFrame.cpp:625
 msgid "Unfold all folded sections"
 msgstr "Despregar todas as seccións"
 
-#: ../src/wxMaxima.cpp:4458
+#: ../src/wxMaxima.cpp:4470
 msgid "Unicode Support"
 msgstr "Soporte Unicode"
 
-#: ../src/wxMaxima.cpp:5335
+#: ../src/wxMaxima.cpp:5347
 msgid "Unterminated comment."
 msgstr "Comentario sen rematar"
 
-#: ../src/wxMaxima.cpp:5309
+#: ../src/wxMaxima.cpp:5321
 msgid "Unterminated string."
 msgstr "Cadea de texto sen rematar."
 
@@ -4398,15 +4401,15 @@ msgstr "Cadea de texto sen rematar."
 msgid "Up"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5859 ../src/wxMaxima.cpp:5866 ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5874 ../src/wxMaxima.cpp:5881 ../src/wxMaxima.cpp:5889
 msgid "Upgrade"
 msgstr "Actualiza"
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Upper bound:"
 msgstr "Cota superior:"
 
-#: ../src/wxMaximaFrame.cpp:1383
+#: ../src/wxMaximaFrame.cpp:1382
 #, fuzzy
 msgid "Upsilon"
 msgstr "Épsilon"
@@ -4454,22 +4457,22 @@ msgstr ""
 msgid "User-defined labels"
 msgstr "Etiquetas definidas polo usuario"
 
-#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3525
-#: ../src/wxMaxima.cpp:3541 ../src/wxMaxima.cpp:3649
+#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3537
+#: ../src/wxMaxima.cpp:3553 ../src/wxMaxima.cpp:3661
 msgid "Value:"
 msgstr "Valor:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:5019 ../src/wxMaxima.cpp:5064
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:5031 ../src/wxMaxima.cpp:5076
 msgid "Variable(s):"
 msgstr "Incógnita(s):"
 
 #: ../src/IntegrateWiz.cpp:33 ../src/LimitWiz.cpp:30 ../src/Plot2dWiz.cpp:34
 #: ../src/Plot2dWiz.cpp:44 ../src/Plot2dWiz.cpp:533 ../src/Plot3dWiz.cpp:33
 #: ../src/Plot3dWiz.cpp:42 ../src/SeriesWiz.cpp:36 ../src/SumWiz.cpp:30
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3749
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3761
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5045
 msgid "Variable:"
 msgstr "Variable:"
 
@@ -4477,25 +4480,25 @@ msgstr "Variable:"
 msgid "Variables"
 msgstr "Variables"
 
-#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3571 ../src/wxMaxima.cpp:4206
-#: ../src/wxMaxima.cpp:4807
+#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3583 ../src/wxMaxima.cpp:4218
+#: ../src/wxMaxima.cpp:4819
 msgid "Variables:"
 msgstr "Variables:"
 
-#: ../src/wxMaximaFrame.cpp:1257
+#: ../src/wxMaximaFrame.cpp:1256
 msgid "Variance..."
 msgstr "Varianza"
 
-#: ../src/wxMaximaFrame.cpp:580
+#: ../src/wxMaximaFrame.cpp:579
 msgid "View"
 msgstr "Ver"
 
-#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1674 ../src/wxMaxima.cpp:1769
-#: ../src/wxMaxima.cpp:1950
+#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1679 ../src/wxMaxima.cpp:1774
+#: ../src/wxMaxima.cpp:1955
 msgid "Warning"
 msgstr "Aviso"
 
-#: ../src/wxMaximaFrame.cpp:109 ../src/wxMaximaFrame.cpp:295
+#: ../src/wxMaximaFrame.cpp:108 ../src/wxMaximaFrame.cpp:294
 msgid "Welcome to wxMaxima"
 msgstr "Benvido a wxMaxima"
 
@@ -4521,7 +4524,7 @@ msgstr ""
 "puntos que na folla de traballo. Se a opción non se activa, os saltos de "
 "liña se poden facer manualmente introducindo unha liña en branco."
 
-#: ../src/wxMaxima.cpp:2567
+#: ../src/wxMaxima.cpp:2574
 #, fuzzy
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) "
@@ -4540,7 +4543,7 @@ msgstr ""
 "Envolver ecuacións exportadas coa opción \"copiar como LaTeX\" entre "
 "corchetes como marcadores de ecuacións"
 
-#: ../src/MathCtrl.cpp:6798
+#: ../src/MathCtrl.cpp:6856
 msgid "Wrapped search"
 msgstr ""
 
@@ -4548,15 +4551,15 @@ msgstr ""
 msgid "Write matching parenthesis in text controls."
 msgstr "Escribe parénteses coincidentes nos controis de texto."
 
-#: ../src/wxMaxima.cpp:4461
+#: ../src/wxMaxima.cpp:4473
 msgid "Written by"
 msgstr "Escrito por"
 
-#: ../src/wxMaximaFrame.cpp:557
+#: ../src/wxMaximaFrame.cpp:556
 msgid "XML Inspector"
 msgstr "Inspector XML"
 
-#: ../src/wxMaximaFrame.cpp:1377
+#: ../src/wxMaximaFrame.cpp:1376
 msgid "Xi"
 msgstr "Xi"
 
@@ -4627,7 +4630,7 @@ msgstr ""
 "selección. Isto será útil cando se queiran borrar ou avaliar varias celas a "
 "un tempo."
 
-#: ../src/wxMaxima.cpp:5856
+#: ../src/wxMaxima.cpp:5871
 #, c-format
 msgid ""
 "You have version %s. Current version is %s.\n"
@@ -4638,39 +4641,39 @@ msgstr ""
 "\n"
 "Selecciónese OK para acceder á páxina de wxMaxima."
 
-#: ../src/wxMaxima.cpp:5921
+#: ../src/wxMaxima.cpp:5936
 msgid "Your changes will be lost if you don't save them."
 msgstr "Perderanse os cambios se non se gardan."
 
-#: ../src/wxMaxima.cpp:5866
+#: ../src/wxMaxima.cpp:5881
 msgid "Your version of wxMaxima is up to date."
 msgstr "A versión de wxMaxima está actualizada"
 
-#: ../src/wxMaximaFrame.cpp:1369
+#: ../src/wxMaximaFrame.cpp:1368
 msgid "Zeta"
 msgstr "Zeta"
 
-#: ../src/wxMaximaFrame.cpp:562
+#: ../src/wxMaximaFrame.cpp:561
 msgid "Zoom &In\tCtrl-+"
 msgstr "Ampliar\tCtrl-+"
 
-#: ../src/wxMaximaFrame.cpp:564
+#: ../src/wxMaximaFrame.cpp:563
 msgid "Zoom Ou&t\tCtrl--"
 msgstr "Disminuir\tCtrl--"
 
-#: ../src/wxMaximaFrame.cpp:563
+#: ../src/wxMaximaFrame.cpp:562
 msgid "Zoom in 10%"
 msgstr "Disminuir 10%"
 
-#: ../src/wxMaximaFrame.cpp:565
+#: ../src/wxMaximaFrame.cpp:564
 msgid "Zoom out 10%"
 msgstr "Ampliar 10%"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaximaFrame.cpp:287
 msgid "[ unsaved ]"
 msgstr "[non gardado]"
 
-#: ../src/wxMaxima.cpp:5700
+#: ../src/wxMaxima.cpp:5715
 msgid "[ unsaved* ]"
 msgstr "[non gardado*]"
 
@@ -4679,17 +4682,17 @@ msgstr "[non gardado*]"
 msgid "[%i digits]"
 msgstr "[%i díxitos]"
 
-#: ../src/MathCtrl.cpp:4392
+#: ../src/MathCtrl.cpp:4447
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" style=\"max-width:90%%;\" >\n"
 msgstr "_%d.gif\"  alt=\"Diagrama animado\" style=\"max-width:90%%;\" >\n"
 
-#: ../src/MathCtrl.cpp:4517
+#: ../src/MathCtrl.cpp:4572
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" >"
 msgstr "_%d.gif\" alt=\"Diagrama animado\" style=\"max-width:90%%;\" >"
 
-#: ../src/wxMaximaFrame.cpp:1333
+#: ../src/wxMaximaFrame.cpp:1332
 msgid "alpha"
 msgstr "alfa"
 
@@ -4701,7 +4704,7 @@ msgstr "and"
 msgid "antisymmetric"
 msgstr "antisimétrica"
 
-#: ../src/wxMaximaFrame.cpp:1334
+#: ../src/wxMaximaFrame.cpp:1333
 msgid "beta"
 msgstr "beta"
 
@@ -4745,7 +4748,7 @@ msgstr ""
 msgid "bug:Invalid sup tag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1354
+#: ../src/wxMaximaFrame.cpp:1353
 msgid "chi"
 msgstr "ji"
 
@@ -4758,7 +4761,7 @@ msgstr "escoller a contorna Lisp coa que se compilou Maxima"
 msgid "default"
 msgstr "predeterminado"
 
-#: ../src/wxMaximaFrame.cpp:1336
+#: ../src/wxMaximaFrame.cpp:1335
 msgid "delta"
 msgstr "delta"
 
@@ -4770,7 +4773,7 @@ msgstr "diagonal"
 msgid "empty"
 msgstr "baleiro"
 
-#: ../src/wxMaximaFrame.cpp:1337
+#: ../src/wxMaximaFrame.cpp:1336
 msgid "epsilon"
 msgstr "épsilon"
 
@@ -4778,7 +4781,7 @@ msgstr "épsilon"
 msgid "equivalent"
 msgstr "equivalente"
 
-#: ../src/wxMaximaFrame.cpp:1339
+#: ../src/wxMaximaFrame.cpp:1338
 msgid "eta"
 msgstr "eta"
 
@@ -4798,7 +4801,7 @@ msgstr ""
 "se trata de números ou letras simples\n"
 "all=_ marcar subíndices."
 
-#: ../src/wxMaximaFrame.cpp:1335
+#: ../src/wxMaximaFrame.cpp:1334
 msgid "gamma"
 msgstr "gamma"
 
@@ -4824,15 +4827,15 @@ msgstr "en liña"
 msgid "intersection"
 msgstr "intersección"
 
-#: ../src/wxMaximaFrame.cpp:1341
+#: ../src/wxMaximaFrame.cpp:1340
 msgid "iota"
 msgstr "iota"
 
-#: ../src/wxMaximaFrame.cpp:1342
+#: ../src/wxMaximaFrame.cpp:1341
 msgid "kappa"
 msgstr "kappa"
 
-#: ../src/wxMaximaFrame.cpp:1343
+#: ../src/wxMaximaFrame.cpp:1342
 msgid "lambda"
 msgstr "lambda"
 
@@ -4848,7 +4851,7 @@ msgstr "menor ou igual"
 msgid "logscale"
 msgstr "escala logarítmica"
 
-#: ../src/wxMaxima.cpp:3783
+#: ../src/wxMaxima.cpp:3795
 msgid "matrix[i,j]:"
 msgstr "matriz[i,j]:"
 
@@ -4856,7 +4859,7 @@ msgstr "matriz[i,j]:"
 msgid "maxima's pwd is path to document"
 msgstr "O pwd de Maxima é a rota ó documento"
 
-#: ../src/wxMaximaFrame.cpp:1344
+#: ../src/wxMaximaFrame.cpp:1343
 msgid "mu"
 msgstr ""
 
@@ -4872,7 +4875,7 @@ msgstr "moito menor que"
 msgid "nand"
 msgstr "nand"
 
-#: ../src/wxMaxima.cpp:4524
+#: ../src/wxMaxima.cpp:4536
 msgid "no"
 msgstr "non"
 
@@ -4896,15 +4899,15 @@ msgstr "non subconxunto"
 msgid "not subset or equal"
 msgstr "non subconxunto ou igual"
 
-#: ../src/wxMaximaFrame.cpp:1345
+#: ../src/wxMaximaFrame.cpp:1344
 msgid "nu"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1356
+#: ../src/wxMaximaFrame.cpp:1355
 msgid "omega"
 msgstr "omega"
 
-#: ../src/wxMaximaFrame.cpp:1347
+#: ../src/wxMaximaFrame.cpp:1346
 msgid "omicron"
 msgstr ""
 
@@ -4916,11 +4919,11 @@ msgstr "or"
 msgid "partial sign"
 msgstr "símbolo parcial"
 
-#: ../src/wxMaximaFrame.cpp:1353
+#: ../src/wxMaximaFrame.cpp:1352
 msgid "phi"
 msgstr "fi"
 
-#: ../src/wxMaximaFrame.cpp:1348
+#: ../src/wxMaximaFrame.cpp:1347
 msgid "pi"
 msgstr "pi"
 
@@ -4932,11 +4935,11 @@ msgstr ""
 msgid "proportional to"
 msgstr "proporcional a"
 
-#: ../src/wxMaximaFrame.cpp:1355
+#: ../src/wxMaximaFrame.cpp:1354
 msgid "psi"
 msgstr "psi"
 
-#: ../src/wxMaximaFrame.cpp:1349
+#: ../src/wxMaximaFrame.cpp:1348
 msgid "rho"
 msgstr "ro"
 
@@ -4944,7 +4947,7 @@ msgstr "ro"
 msgid "right"
 msgstr "dereita"
 
-#: ../src/wxMaximaFrame.cpp:1350
+#: ../src/wxMaximaFrame.cpp:1349
 msgid "sigma"
 msgstr "sigma"
 
@@ -4964,7 +4967,7 @@ msgstr "subconxunto ou igual"
 msgid "symmetric"
 msgstr "simétrica"
 
-#: ../src/wxMaximaFrame.cpp:1351
+#: ../src/wxMaximaFrame.cpp:1350
 msgid "tau"
 msgstr "tau"
 
@@ -4977,7 +4980,7 @@ msgstr "Indicarlle a sbcl que utilice <int>Mbytes na pila de memoria"
 msgid "there is no"
 msgstr "non hai"
 
-#: ../src/wxMaximaFrame.cpp:1340
+#: ../src/wxMaximaFrame.cpp:1339
 msgid "theta"
 msgstr "theta"
 
@@ -4993,12 +4996,12 @@ msgstr "á terceira potencia"
 msgid "union"
 msgstr "unión"
 
-#: ../src/wxMaxima.cpp:5903
+#: ../src/wxMaxima.cpp:5918
 msgid "unsaved"
 msgstr "non gardado"
 
-#: ../src/wxMaximaFrame.cpp:290 ../src/wxMaxima.cpp:2559
-#: ../src/wxMaxima.cpp:2826
+#: ../src/wxMaxima.cpp:2566 ../src/wxMaxima.cpp:2834
+#: ../src/wxMaximaFrame.cpp:289
 msgid "untitled"
 msgstr "sen título"
 
@@ -5007,26 +5010,26 @@ msgstr "sen título"
 msgid "untitled %d"
 msgstr "sen título %d"
 
-#: ../src/wxMaximaFrame.cpp:1352
+#: ../src/wxMaximaFrame.cpp:1351
 #, fuzzy
 msgid "upsilon"
 msgstr "Épsilon"
 
-#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4538
+#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4550
 msgid "wxMaxima"
 msgstr "wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
-#: ../src/wxMaxima.cpp:5700 ../src/wxMaxima.cpp:5709 ../src/wxMaxima.cpp:5712
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaxima.cpp:5715 ../src/wxMaxima.cpp:5724
+#: ../src/wxMaxima.cpp:5727 ../src/wxMaximaFrame.cpp:287
 #, c-format
 msgid "wxMaxima %s "
 msgstr "wxMaxima %s "
 
-#: ../src/wxMaximaFrame.cpp:952
+#: ../src/wxMaximaFrame.cpp:951
 msgid "wxMaxima &Help\tCtrl+?"
 msgstr "Axuda de wxMaxima\tCtrl+?"
 
-#: ../src/wxMaximaFrame.cpp:955
+#: ../src/wxMaximaFrame.cpp:954
 msgid "wxMaxima &Help\tF1"
 msgstr "Axuda de Maxima\tF1"
 
@@ -5040,11 +5043,11 @@ msgstr ""
 "wxMaxima pode executar instruccións ó arrincar, gardadas no arquivo wxmaxima."
 "rc do directorio cuxa ruta almacénase na variable global maxima_userdir"
 
-#: ../src/wxMaxima.cpp:1619
+#: ../src/wxMaxima.cpp:1624
 msgid "wxMaxima cannot open content.xml in the .wxmx zip archive "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1633
+#: ../src/wxMaxima.cpp:1638
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
@@ -5052,7 +5055,7 @@ msgstr ""
 msgid "wxMaxima configuration"
 msgstr "Configuración de wxMaxima"
 
-#: ../src/wxMaxima.cpp:1947
+#: ../src/wxMaxima.cpp:1952
 msgid ""
 "wxMaxima could not find Maxima!\n"
 "\n"
@@ -5064,7 +5067,7 @@ msgstr ""
 "Configure wxMaxima con 'Edita->Configura.\n"
 "A continuación inicie Maxima con 'Maxima->Reinicia maxima'."
 
-#: ../src/wxMaxima.cpp:2204
+#: ../src/wxMaxima.cpp:2209
 msgid ""
 "wxMaxima could not find help files.\n"
 "\n"
@@ -5073,7 +5076,7 @@ msgstr ""
 "wxMaxima non puido atopar os arquivos de axuda.\n"
 "Comprobe a súa instalación."
 
-#: ../src/wxMaxima.cpp:2032
+#: ../src/wxMaxima.cpp:2037
 msgid ""
 "wxMaxima could not find tip files.\n"
 "\n"
@@ -5083,7 +5086,7 @@ msgstr ""
 "\n"
 "Comprobe a súa instalación."
 
-#: ../src/wxMaxima.cpp:282
+#: ../src/wxMaxima.cpp:283
 msgid ""
 "wxMaxima could not start the server.\n"
 "\n"
@@ -5105,23 +5108,23 @@ msgstr ""
 "das cales é '%'. Se fixo unha selección no documento, esta será utilizada en "
 "lugar de '%'."
 
-#: ../src/wxMaxima.cpp:2330
+#: ../src/wxMaxima.cpp:2336
 msgid "wxMaxima document"
 msgstr "Documento wxMaxima"
 
-#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2799
+#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2807
 msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 msgstr "Documento wxMaxima (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 
-#: ../src/wxMaxima.cpp:1455 ../src/wxMaxima.cpp:1469
+#: ../src/wxMaxima.cpp:1460 ../src/wxMaxima.cpp:1474
 msgid "wxMaxima encountered an error loading "
 msgstr "wxMaxima atopou un erro durante a carga "
 
-#: ../src/wxMaxima.cpp:4463
+#: ../src/wxMaxima.cpp:4475
 msgid "wxMaxima icon"
 msgstr "Icona de wxMaxima"
 
-#: ../src/wxMaxima.cpp:4455
+#: ../src/wxMaxima.cpp:4467
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "MAXIMA based on wxWidgets."
@@ -5129,7 +5132,7 @@ msgstr ""
 "wxMaxima é unha interface gráfica de usuario para o Sistema de Álxebra "
 "Simbólica (CAS) Maxima, basado en wxWidgets."
 
-#: ../src/wxMaxima.cpp:4516
+#: ../src/wxMaxima.cpp:4528
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "Maxima based on wxWidgets."
@@ -5149,11 +5152,11 @@ msgstr ""
 msgid "x"
 msgstr "x"
 
-#: ../src/wxMaximaFrame.cpp:1346
+#: ../src/wxMaximaFrame.cpp:1345
 msgid "xi"
 msgstr "xi"
 
-#: ../src/wxMaxima.cpp:1643
+#: ../src/wxMaxima.cpp:1648
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
@@ -5161,11 +5164,11 @@ msgstr ""
 msgid "xor"
 msgstr "xor"
 
-#: ../src/wxMaxima.cpp:4522
+#: ../src/wxMaxima.cpp:4534
 msgid "yes"
 msgstr "si"
 
-#: ../src/wxMaximaFrame.cpp:1338
+#: ../src/wxMaximaFrame.cpp:1337
 msgid "zeta"
 msgstr "zeta"
 

--- a/locales/hu.po
+++ b/locales/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: hu\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-07 21:42+0200\n"
+"POT-Creation-Date: 2016-10-16 17:47+0900\n"
 "PO-Revision-Date: 2016-08-15 11:27+0200\n"
 "Last-Translator: Blahota István <blahota@fsf.hu>\n"
 "Language-Team: Hungarian\n"
@@ -18,7 +18,7 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../src/wxMaxima.cpp:4519
+#: ../src/wxMaxima.cpp:4531
 #, c-format
 msgid ""
 "\n"
@@ -31,7 +31,7 @@ msgstr ""
 "wxWidgets: %d.%d.%d\n"
 "Unicode támogatás: %s"
 
-#: ../src/wxMaxima.cpp:4532
+#: ../src/wxMaxima.cpp:4544
 msgid ""
 "\n"
 "Lisp: "
@@ -39,7 +39,7 @@ msgstr ""
 "\n"
 "Lisp: "
 
-#: ../src/wxMaxima.cpp:4528
+#: ../src/wxMaxima.cpp:4540
 msgid ""
 "\n"
 "Maxima version: "
@@ -47,7 +47,7 @@ msgstr ""
 "\n"
 "Maxima verzió: "
 
-#: ../src/wxMaxima.cpp:5381
+#: ../src/wxMaxima.cpp:5397
 msgid ""
 "\n"
 "Not connected to Maxima!\n"
@@ -55,7 +55,7 @@ msgstr ""
 "\n"
 "Nem csatlakozott a Maximához!\n"
 
-#: ../src/wxMaxima.cpp:4530
+#: ../src/wxMaxima.cpp:4542
 msgid ""
 "\n"
 "Not connected."
@@ -75,7 +75,7 @@ msgstr "      -l <név>"
 msgid " (Graphics) "
 msgstr "(Grafika)"
 
-#: ../src/EditorCell.cpp:3045 ../src/EditorCell.cpp:3227
+#: ../src/EditorCell.cpp:3088 ../src/EditorCell.cpp:3270
 #, c-format
 msgid " ... + %i hidden lines"
 msgstr " ... + %i rejtett sorok"
@@ -84,7 +84,7 @@ msgstr " ... + %i rejtett sorok"
 msgid " << Expression longer than allowed by the configuration setting! >>"
 msgstr "<<A kifejezés hosszabb a beállításokban megengedettnél! >>"
 
-#: ../src/wxMaxima.cpp:1673
+#: ../src/wxMaxima.cpp:1678
 msgid ""
 " was saved using a newer version of wxMaxima so it may not load correctly. "
 "Please update your wxMaxima."
@@ -92,7 +92,7 @@ msgstr ""
 " a wxMaxima egy újabb verziójával lett elmentve, ezért nem biztos hogy "
 "tökéletesen töltődik be. Kérem frissítse a wxMaximát!"
 
-#: ../src/wxMaxima.cpp:1665
+#: ../src/wxMaxima.cpp:1670
 msgid ""
 " was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr ""
@@ -106,64 +106,64 @@ msgstr "A \"LaTeX másolás\" hozzáadja a kiemelt matematikai mód jeleit"
 msgid "\"implies\" symbol"
 msgstr "\"következik\" jel"
 
-#: ../src/wxMaximaFrame.cpp:101
+#: ../src/wxMaximaFrame.cpp:100
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr "%i cella a végrehajtási sorban"
 
-#: ../src/wxMaximaFrame.cpp:773
+#: ../src/wxMaximaFrame.cpp:772
 msgid "&Algebra"
 msgstr "&Algebra"
 
-#: ../src/wxMaximaFrame.cpp:767
+#: ../src/wxMaximaFrame.cpp:766
 msgid "&Apply to List..."
 msgstr "&Alkalmazás listán..."
 
-#: ../src/wxMaximaFrame.cpp:964
+#: ../src/wxMaximaFrame.cpp:963
 msgid "&Apropos..."
 msgstr "&Apropó..."
 
-#: ../src/wxMaximaFrame.cpp:478
+#: ../src/wxMaximaFrame.cpp:477
 msgid "&Batch File...\tCtrl-B"
 msgstr "&Batch fájl...\tCtrl-B"
 
-#: ../src/wxMaximaFrame.cpp:724
+#: ../src/wxMaximaFrame.cpp:723
 msgid "&Boundary Value Problem..."
 msgstr "Pe&remérték probléma..."
 
-#: ../src/wxMaximaFrame.cpp:975
+#: ../src/wxMaximaFrame.cpp:974
 msgid "&Bug Report"
 msgstr "&Hibabejelentés"
 
-#: ../src/wxMaximaFrame.cpp:825
+#: ../src/wxMaximaFrame.cpp:824
 msgid "&Calculus"
 msgstr "Ana&lízis"
 
-#: ../src/wxMaximaFrame.cpp:876
+#: ../src/wxMaximaFrame.cpp:875
 msgid "&Canonical Form"
 msgstr "&Kanonikus alak"
 
-#: ../src/wxMaximaFrame.cpp:749
+#: ../src/wxMaximaFrame.cpp:748
 msgid "&Characteristic Polynomial..."
 msgstr "&Karakterisztikus polinom..."
 
-#: ../src/wxMaximaFrame.cpp:654
+#: ../src/wxMaximaFrame.cpp:653
 msgid "&Clear Memory"
 msgstr "M&emória törlése"
 
-#: ../src/wxMaximaFrame.cpp:859
+#: ../src/wxMaximaFrame.cpp:858
 msgid "&Combine Factorials"
 msgstr "&Számolás faktoriálisokkal"
 
-#: ../src/wxMaximaFrame.cpp:902
+#: ../src/wxMaximaFrame.cpp:901
 msgid "&Complex Simplification"
 msgstr "Kom&plex átalakítás"
 
-#: ../src/wxMaximaFrame.cpp:822
+#: ../src/wxMaximaFrame.cpp:821
 msgid "&Continued Fraction"
 msgstr "Lán&ctörtté alakítás"
 
-#: ../src/wxMaximaFrame.cpp:502
+#: ../src/wxMaximaFrame.cpp:501
 msgid "&Copy\tCtrl-C"
 msgstr "&Másolás\tCtrl-C"
 
@@ -171,107 +171,107 @@ msgstr "&Másolás\tCtrl-C"
 msgid "&Definite integration"
 msgstr "&Határozott integrál"
 
-#: ../src/wxMaximaFrame.cpp:896
+#: ../src/wxMaximaFrame.cpp:895
 msgid "&Demoivre"
 msgstr "&Demoivre"
 
-#: ../src/wxMaximaFrame.cpp:752
+#: ../src/wxMaximaFrame.cpp:751
 msgid "&Determinant"
 msgstr "&Determináns"
 
-#: ../src/wxMaximaFrame.cpp:785
+#: ../src/wxMaximaFrame.cpp:784
 msgid "&Differentiate..."
 msgstr "&Differenciálás..."
 
-#: ../src/wxMaximaFrame.cpp:543
+#: ../src/wxMaximaFrame.cpp:542
 msgid "&Edit"
 msgstr "S&zerkesztés"
 
-#: ../src/wxMaximaFrame.cpp:709
+#: ../src/wxMaximaFrame.cpp:708
 msgid "&Eliminate Variable..."
 msgstr "&Változó kiküszöbölése..."
 
-#: ../src/wxMaximaFrame.cpp:744
+#: ../src/wxMaximaFrame.cpp:743
 msgid "&Enter Matrix..."
 msgstr "Má&trix bevitele..."
 
-#: ../src/wxMaximaFrame.cpp:961
+#: ../src/wxMaximaFrame.cpp:960
 msgid "&Example..."
 msgstr "&Példa..."
 
-#: ../src/wxMaximaFrame.cpp:839
+#: ../src/wxMaximaFrame.cpp:838
 msgid "&Expand Expression"
 msgstr "Kifejezé&s felbontása"
 
-#: ../src/wxMaximaFrame.cpp:873
+#: ../src/wxMaximaFrame.cpp:872
 msgid "&Expand Trigonometric"
 msgstr "Tr&igonometrikus felbontás"
 
-#: ../src/wxMaximaFrame.cpp:899
+#: ../src/wxMaximaFrame.cpp:898
 msgid "&Exponentialize"
 msgstr "E&xponenciálissá alakítás"
 
-#: ../src/wxMaximaFrame.cpp:480
+#: ../src/wxMaximaFrame.cpp:479
 msgid "&Export..."
 msgstr "E&xportálás..."
 
-#: ../src/wxMaximaFrame.cpp:834
+#: ../src/wxMaximaFrame.cpp:833
 msgid "&Factor Expression"
 msgstr "Kife&jezés faktorizálása"
 
-#: ../src/wxMaximaFrame.cpp:489
+#: ../src/wxMaximaFrame.cpp:488
 msgid "&File"
 msgstr "&Fájl"
 
-#: ../src/wxMaximaFrame.cpp:692
+#: ../src/wxMaximaFrame.cpp:691
 msgid "&Find Root..."
 msgstr "M&egoldás numerikusan..."
 
-#: ../src/wxMaximaFrame.cpp:738
+#: ../src/wxMaximaFrame.cpp:737
 msgid "&Generate Matrix..."
 msgstr "&Mátrix generálása sorozatból..."
 
-#: ../src/wxMaximaFrame.cpp:809
+#: ../src/wxMaximaFrame.cpp:808
 msgid "&Greatest Common Divisor..."
 msgstr "&Legnagyobb közös osztó..."
 
-#: ../src/wxMaximaFrame.cpp:994
+#: ../src/wxMaximaFrame.cpp:993
 msgid "&Help"
 msgstr "&Súgó"
 
-#: ../src/wxMaximaFrame.cpp:777
+#: ../src/wxMaximaFrame.cpp:776
 msgid "&Integrate..."
 msgstr "&Integrálás..."
 
-#: ../src/wxMaximaFrame.cpp:645
+#: ../src/wxMaximaFrame.cpp:644
 msgid "&Interrupt\tCtrl-."
 msgstr "&Megszakítás\tCtrl-."
 
-#: ../src/wxMaximaFrame.cpp:649
+#: ../src/wxMaximaFrame.cpp:648
 msgid "&Interrupt\tCtrl-G"
 msgstr "&Megszakítás\tCtrl-G"
 
-#: ../src/wxMaximaFrame.cpp:746
+#: ../src/wxMaximaFrame.cpp:745
 msgid "&Invert Matrix"
 msgstr "Mát&rix invertálás"
 
-#: ../src/wxMaximaFrame.cpp:476
+#: ../src/wxMaximaFrame.cpp:475
 msgid "&Load Package...\tCtrl-L"
 msgstr "&Csomag betöltése...\tCtrl-L"
 
-#: ../src/wxMaximaFrame.cpp:769
+#: ../src/wxMaximaFrame.cpp:768
 msgid "&Map to List(s)..."
 msgstr "Leké&pezés listá(k)ba..."
 
-#: ../src/wxMaximaFrame.cpp:684
+#: ../src/wxMaximaFrame.cpp:683
 msgid "&Maxima"
 msgstr "&Maxima"
 
-#: ../src/wxMaximaFrame.cpp:958
+#: ../src/wxMaximaFrame.cpp:957
 msgid "&Maxima help"
 msgstr "&Maxima súgó"
 
-#: ../src/wxMaximaFrame.cpp:917
+#: ../src/wxMaximaFrame.cpp:916
 msgid "&Modulus Computation..."
 msgstr "&Modulus beállítása..."
 
@@ -279,7 +279,7 @@ msgstr "&Modulus beállítása..."
 msgid "&New\tCtrl-N"
 msgstr "&Új\tCtrl-N"
 
-#: ../src/wxMaximaFrame.cpp:947
+#: ../src/wxMaximaFrame.cpp:946
 msgid "&Numeric"
 msgstr "&Numerikus"
 
@@ -295,11 +295,11 @@ msgstr "&Numerikus összegzés"
 msgid "&Open\tCtrl-O"
 msgstr "&Megnyitás\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:463
+#: ../src/wxMaximaFrame.cpp:462
 msgid "&Open...\tCtrl-O"
 msgstr "&Megnyitás...\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:929
+#: ../src/wxMaximaFrame.cpp:928
 msgid "&Plot"
 msgstr "Á&brázolás"
 
@@ -307,7 +307,7 @@ msgstr "Á&brázolás"
 msgid "&Power series"
 msgstr "&Hatványsor"
 
-#: ../src/wxMaximaFrame.cpp:483
+#: ../src/wxMaximaFrame.cpp:482
 msgid "&Print...\tCtrl-P"
 msgstr "&Nyomtatás...\tCtrl-P"
 
@@ -315,39 +315,39 @@ msgstr "&Nyomtatás...\tCtrl-P"
 msgid "&Rational"
 msgstr "&Értelemszerűen (nem formálisan)"
 
-#: ../src/wxMaximaFrame.cpp:870
+#: ../src/wxMaximaFrame.cpp:869
 msgid "&Reduce Trigonometric"
 msgstr "T&rigonometrikus redukálás"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "&Restart Maxima"
 msgstr "&A Maxima újraindítása"
 
-#: ../src/wxMaximaFrame.cpp:700
+#: ../src/wxMaximaFrame.cpp:699
 msgid "&Roots of Polynomial (Real)"
 msgstr "Poli&nom valós gyökei"
 
-#: ../src/wxMaximaFrame.cpp:472
+#: ../src/wxMaximaFrame.cpp:471
 msgid "&Save\tCtrl-S"
 msgstr "M&entés\tCtrl-S"
 
-#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:919
+#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:918
 msgid "&Simplify"
 msgstr "E&gyszerűsítés"
 
-#: ../src/wxMaximaFrame.cpp:829
+#: ../src/wxMaximaFrame.cpp:828
 msgid "&Simplify Expression"
 msgstr "&Kifejezés egyszerűsítése"
 
-#: ../src/wxMaximaFrame.cpp:856
+#: ../src/wxMaximaFrame.cpp:855
 msgid "&Simplify Factorials"
 msgstr "F&aktoriális egyszerűsítése"
 
-#: ../src/wxMaximaFrame.cpp:867
+#: ../src/wxMaximaFrame.cpp:866
 msgid "&Simplify Trigonometric"
 msgstr "&Trigonometrikus egyszerűsítés"
 
-#: ../src/wxMaximaFrame.cpp:688
+#: ../src/wxMaximaFrame.cpp:687
 msgid "&Solve..."
 msgstr "&Megoldás..."
 
@@ -359,11 +359,11 @@ msgstr "&Különleges"
 msgid "&Taylor series"
 msgstr "Taylor-sor használatával"
 
-#: ../src/wxMaximaFrame.cpp:762
+#: ../src/wxMaximaFrame.cpp:761
 msgid "&Transpose Matrix"
 msgstr "Mátri&x transzponálás"
 
-#: ../src/wxMaximaFrame.cpp:879
+#: ../src/wxMaximaFrame.cpp:878
 msgid "&Trigonometric Simplification"
 msgstr "&Trigonometrikus átalakítás"
 
@@ -381,7 +381,7 @@ msgstr "(Alapértelmezett nyelv)"
 msgid "- Infinity"
 msgstr "- Végtelen"
 
-#: ../src/wxMaxima.cpp:351
+#: ../src/wxMaxima.cpp:356
 msgid ""
 "... [suppressed additional lines since the output is longer than allowed in "
 "the configuration] "
@@ -393,16 +393,16 @@ msgstr ""
 msgid "1/2"
 msgstr "1/2"
 
-#: ../src/wxMaximaFrame.cpp:103
+#: ../src/wxMaximaFrame.cpp:102
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4601
+#: ../src/wxMaxima.cpp:4613
 msgid "<br>Lisp: "
 msgstr "<br>Lisp: "
 
-#: ../src/wxMaxima.cpp:5487
+#: ../src/wxMaxima.cpp:5503
 msgid ""
 "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
@@ -436,11 +436,11 @@ msgid ""
 "\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1472
+#: ../src/wxMaximaFrame.cpp:1495
 msgid "A symbol from the configuration dialogue"
 msgstr "Egy szimbólum a beállításokból"
 
-#: ../src/wxMaximaFrame.cpp:731
+#: ../src/wxMaximaFrame.cpp:730
 msgid "A&t Value..."
 msgstr "Ér&tékadás..."
 
@@ -448,12 +448,12 @@ msgstr "Ér&tékadás..."
 msgid "Abort evaluation on error"
 msgstr "Kiértékelés megszakítása hiba esetén "
 
-#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaxima.cpp:4603
+#: ../src/wxMaxima.cpp:4615 ../src/wxMaximaFrame.cpp:985
 msgid "About"
 msgstr "Névjegy"
 
-#: ../src/wxMaximaFrame.cpp:987 ../src/wxMaximaFrame.cpp:990
-#: ../src/wxMaximaFrame.cpp:991
+#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaximaFrame.cpp:989
+#: ../src/wxMaximaFrame.cpp:990
 msgid "About wxMaxima"
 msgstr "Névjegy: wxMaxima"
 
@@ -461,23 +461,23 @@ msgstr "Névjegy: wxMaxima"
 msgid "Active cell bracket"
 msgstr "Aktív cella zárójele"
 
-#: ../src/wxMaximaFrame.cpp:760
+#: ../src/wxMaximaFrame.cpp:759
 msgid "Ad&joint Matrix"
 msgstr "Mátr&ix adjungálás"
 
-#: ../src/wxMaximaFrame.cpp:914
+#: ../src/wxMaximaFrame.cpp:913
 msgid "Add Algebraic E&quality..."
 msgstr "Alg&ebrai egyenlet hozzáadása..."
 
-#: ../src/wxMaximaFrame.cpp:657
+#: ../src/wxMaximaFrame.cpp:656
 msgid "Add a directory to search path"
 msgstr "Könyvtár hozzáadása a keresési úthoz"
 
-#: ../src/wxMaxima.cpp:3353
+#: ../src/wxMaxima.cpp:3365
 msgid "Add dir to path:"
 msgstr "Könyvtár hozzáadása az elérési úthoz:"
 
-#: ../src/wxMaximaFrame.cpp:915
+#: ../src/wxMaximaFrame.cpp:914
 msgid "Add equality to the rational simplifier"
 msgstr "Egyenlőség hozzáadása racionális egyszerűsítéshez"
 
@@ -485,7 +485,7 @@ msgstr "Egyenlőség hozzáadása racionális egyszerűsítéshez"
 msgid "Add the .wxmx file to the HTML export"
 msgstr "wxmx fájl HTML exportja"
 
-#: ../src/wxMaximaFrame.cpp:656
+#: ../src/wxMaximaFrame.cpp:655
 msgid "Add to &Path..."
 msgstr "&Hozzáadás az elérési úthoz..."
 
@@ -526,27 +526,27 @@ msgstr "Összes változónév"
 msgid "All|*"
 msgstr "Minden fájl|*"
 
-#: ../src/wxMaximaFrame.cpp:1364
+#: ../src/wxMaximaFrame.cpp:1363
 msgid "Alpha"
 msgstr "Alfa"
 
-#: ../src/wxMaxima.cpp:3838
+#: ../src/wxMaxima.cpp:3850
 msgid "Apply"
 msgstr "Alkalmaz"
 
-#: ../src/wxMaximaFrame.cpp:768
+#: ../src/wxMaximaFrame.cpp:767
 msgid "Apply function to a list"
 msgstr "Függvény alkalmazása a listára"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Apropos"
 msgstr "Apropó"
 
-#: ../src/wxMaxima.cpp:3764
+#: ../src/wxMaxima.cpp:3776
 msgid "Array:"
 msgstr "Sorozat:"
 
-#: ../src/wxMaxima.cpp:4462
+#: ../src/wxMaxima.cpp:4474
 msgid "Artwork by"
 msgstr "Grafika"
 
@@ -554,7 +554,7 @@ msgstr "Grafika"
 msgid "Ask to save untitled documents"
 msgstr "Rákérdez név nélküli dokumentum mentésére"
 
-#: ../src/wxMaxima.cpp:3650
+#: ../src/wxMaxima.cpp:3662
 msgid "At value"
 msgstr "Értékadás"
 
@@ -579,11 +579,11 @@ msgstr ""
 msgid "Autosave interval (minutes, 0 means: off):"
 msgstr "Automatikus mentés (percben, 0: ki):"
 
-#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3557
+#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3569
 msgid "BC2"
 msgstr "Peremérték probléma"
 
-#: ../src/wxMaximaFrame.cpp:1272
+#: ../src/wxMaximaFrame.cpp:1271
 msgid "Barsplot..."
 msgstr "Oszlopdiagram..."
 
@@ -591,7 +591,7 @@ msgstr "Oszlopdiagram..."
 msgid "Bat files (*.bat)|*.bat|All|*"
 msgstr "Batch fájlok (*.bat)|*.bat|Minden fájl|*"
 
-#: ../src/wxMaxima.cpp:2943
+#: ../src/wxMaxima.cpp:2951
 msgid "Batch File"
 msgstr "Batch fájl"
 
@@ -609,7 +609,7 @@ msgstr ""
 "cellán belül van és Ctrl+Z-t nyomunk, egy olyan visszavonást kapunk, mely "
 "nem aktív a cellán kívül."
 
-#: ../src/wxMaximaFrame.cpp:1365
+#: ../src/wxMaximaFrame.cpp:1364
 msgid "Beta"
 msgstr "Béta"
 
@@ -621,11 +621,11 @@ msgstr "Bitmap skála exportáláshoz:"
 msgid "Bold"
 msgstr "Félkövér"
 
-#: ../src/wxMaxima.cpp:2359
+#: ../src/wxMaxima.cpp:2366
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr "A vízszintes és a függőleges kurzor is aktív legyen egy időben"
 
-#: ../src/wxMaximaFrame.cpp:1274
+#: ../src/wxMaximaFrame.cpp:1273
 msgid "Boxplot..."
 msgstr "Doboz ábra..."
 
@@ -637,15 +637,15 @@ msgstr "Böngészés"
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr "Hiba: Automatikus kiegészítési kérés ismeretlen típusú elemhez."
 
-#: ../src/MathCtrl.cpp:2080
+#: ../src/MathCtrl.cpp:2127
 msgid "Bug: Cell left but not entered."
 msgstr "Hiba: Cella elhagyása belépés nélkül."
 
-#: ../src/wxMaxima.cpp:1178
+#: ../src/wxMaxima.cpp:1183
 msgid "Bug: Found a math end marker without any start marker."
 msgstr "Hiba: matematika mód végjel található nyitójel nélkül."
 
-#: ../src/wxMaxima.cpp:1222
+#: ../src/wxMaxima.cpp:1227
 msgid "Bug: Found the end of autocompletion symbols but no beginning"
 msgstr "Hiba: automatikus kiegészítési végjel található kezdőjel nélkül"
 
@@ -657,23 +657,23 @@ msgstr "Hiba: Tört nevező nélkül"
 msgid "Bug: Fraction without enumerator"
 msgstr "Hiba: Tört számláló nélkül"
 
-#: ../src/MathCtrl.cpp:2312
+#: ../src/MathCtrl.cpp:2359
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr "Hiba: Kérdés merült fel, de nincs cella a válaszhoz"
 
-#: ../src/MathCtrl.cpp:5839
+#: ../src/MathCtrl.cpp:5891
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of "
 "the worksheet."
 msgstr ""
 "Hiba: Kérés egy munkalap kezdete előtti cella tartalmának megváltoztatására."
 
-#: ../src/MathCtrl.cpp:5913
+#: ../src/MathCtrl.cpp:5965
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr "Hiba: Kérés egy munkalap kezdete előtti cella törlésére."
 
-#: ../src/MathCtrl.cpp:5882
+#: ../src/MathCtrl.cpp:5934
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
@@ -687,53 +687,53 @@ msgstr ""
 "Hiba: a matematika cella azt állítja, hogy nem tartozik egyetlen "
 "cellacsoporthoz sem."
 
-#: ../src/GroupCell.cpp:780 ../src/GroupCell.cpp:951
+#: ../src/GroupCell.cpp:781 ../src/GroupCell.cpp:952
 msgid "Bug: No image counter to write to!"
 msgstr ""
 
-#: ../src/AbsCell.cpp:193
+#: ../src/AbsCell.cpp:199
 msgid "Bug: No last cell in an absCell!"
 msgstr ""
 
-#: ../src/ConjugateCell.cpp:185
+#: ../src/ConjugateCell.cpp:194
 msgid "Bug: No last cell in an conjugateCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:471
+#: ../src/FracCell.cpp:472
 #, fuzzy
 msgid "Bug: No last cell in an denominator!"
 msgstr "Hiba: Tört nevező nélkül"
 
-#: ../src/ExptCell.cpp:267
+#: ../src/ExptCell.cpp:270
 msgid "Bug: No last cell in an exponent of an exptCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:459
+#: ../src/FracCell.cpp:460
 #, fuzzy
 msgid "Bug: No last cell in an numerator!"
 msgstr "Hiba: Tört számláló nélkül"
 
-#: ../src/ExptCell.cpp:257
+#: ../src/ExptCell.cpp:260
 msgid "Bug: No last cell in the base of an exptCell!"
 msgstr ""
 
-#: ../src/ParenCell.cpp:534
+#: ../src/ParenCell.cpp:535
 msgid "Bug: No last cell inside a parenthesis!"
 msgstr ""
 
-#: ../src/SqrtCell.cpp:312
+#: ../src/SqrtCell.cpp:317
 #, fuzzy
 msgid "Bug: No last cell inside a square root!"
 msgstr "Hiba: Tört számláló nélkül"
 
-#: ../src/MathCtrl.cpp:2123
+#: ../src/MathCtrl.cpp:2170
 msgid ""
 "Bug: Start or end of merging of subsequent editing actions was requested two "
 "times in a row."
 msgstr ""
 "Hiba: Egy sorban két kérés érkezett összefűzés elkezdésére vagy befejezésére."
 
-#: ../src/MathCtrl.cpp:2090
+#: ../src/MathCtrl.cpp:2137
 msgid "Bug: Text changed, but no active cell."
 msgstr "Hiba: A szöveg megváltozott, de nincs aktív cella."
 
@@ -741,13 +741,13 @@ msgstr "Hiba: A szöveg megváltozott, de nincs aktív cella."
 msgid "Bug: Trying to append NULL to a group cell."
 msgstr "Hiba: Üres elemet kísérelt meg hozzáfűzni egy csoportcellához. "
 
-#: ../src/MathCtrl.cpp:555
+#: ../src/MathCtrl.cpp:600
 msgid "Bug: Trying to append maxima's output to a cell outside the worksheet."
 msgstr ""
 "Hiba: A Maxima kimenetét megkísérelte hozzáfűzni egy munkalapon kívüli "
 "cellához."
 
-#: ../src/MathCtrl.cpp:2014
+#: ../src/MathCtrl.cpp:2061
 msgid ""
 "Bug: Trying to merge individual cell adds to a region in the undo buffer but "
 "there are other cells between them."
@@ -755,32 +755,32 @@ msgstr ""
 "Hiba: Kísérlet különálló cellák összevonására, melyek között további cellák "
 "vannak."
 
-#: ../src/MathCtrl.cpp:6522
+#: ../src/MathCtrl.cpp:6577
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr "Hiba: Vízszintes kurzort nem lehet egy csoportcellába helyezni."
 
-#: ../src/MathCtrl.cpp:2092
+#: ../src/MathCtrl.cpp:2139
 msgid "Bug: Trying to record a cell contents change without a cell."
 msgstr ""
 "Hiba: Megkísérelte elmenti egy cella tartalmának változását cella nélkül. "
 
-#: ../src/MathCtrl.cpp:1495
+#: ../src/MathCtrl.cpp:1540
 msgid "Bug: Trying to select inside a cell without having a current cell"
 msgstr "Hiba: Kijelölést kísérelt meg egy cellában, annak kijelölése nélkül. "
 
-#: ../src/MathCtrl.cpp:5883
+#: ../src/MathCtrl.cpp:5935
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
 "Hiba: Visszavonási esemény cella tartalmának változásához és cella "
 "hozzáadásához"
 
-#: ../src/MathCtrl.cpp:5844 ../src/MathCtrl.cpp:5918 ../src/MathCtrl.cpp:5952
+#: ../src/MathCtrl.cpp:5896 ../src/MathCtrl.cpp:5970 ../src/MathCtrl.cpp:6004
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr "Hiba: Munkalapon kívüli cella visszaállítási kérelme."
 
-#: ../src/wxMaximaFrame.cpp:973
+#: ../src/wxMaximaFrame.cpp:972
 msgid "Build &Info"
 msgstr "&Verzióinformációk"
 
@@ -797,51 +797,51 @@ msgstr ""
 "parancsok az Enter lenyomására hajtódnak végre' tulajdonságot, amely "
 "felcseréli a két billentyűparancs hatását."
 
-#: ../src/wxMaximaFrame.cpp:782
+#: ../src/wxMaximaFrame.cpp:781
 msgid "C&hange Variable..."
 msgstr "&Változócsere..."
 
-#: ../src/wxMaximaFrame.cpp:540
+#: ../src/wxMaximaFrame.cpp:539
 msgid "C&onfigure"
 msgstr "B&eállítás"
 
-#: ../src/wxMaximaFrame.cpp:801
+#: ../src/wxMaximaFrame.cpp:800
 msgid "Calculate &Product..."
 msgstr "&Szorzat számítása..."
 
-#: ../src/wxMaximaFrame.cpp:799
+#: ../src/wxMaximaFrame.cpp:798
 msgid "Calculate Su&m..."
 msgstr "Öss&zeg számítása..."
 
-#: ../src/wxMaximaFrame.cpp:939
+#: ../src/wxMaximaFrame.cpp:938
 msgid "Calculate bigfloat value of the last result"
 msgstr "Szám hosszú tizedes tört alakja"
 
-#: ../src/wxMaximaFrame.cpp:936
+#: ../src/wxMaximaFrame.cpp:935
 msgid "Calculate float value of the last result"
 msgstr "Szám tizedes tört alakja"
 
-#: ../src/wxMaxima.cpp:3971
+#: ../src/wxMaxima.cpp:3983
 msgid "Calculate modulus:"
 msgstr "Modulus értékének beállítása:"
 
-#: ../src/wxMaximaFrame.cpp:942
+#: ../src/wxMaximaFrame.cpp:941
 msgid "Calculate numeric value of the last result"
 msgstr "Az utolsó eredmény tizedes tört alakjának kiszámolása"
 
-#: ../src/wxMaximaFrame.cpp:802
+#: ../src/wxMaximaFrame.cpp:801
 msgid "Calculate products"
 msgstr "Szorzat számítása"
 
-#: ../src/wxMaximaFrame.cpp:800
+#: ../src/wxMaximaFrame.cpp:799
 msgid "Calculate sums"
 msgstr "Összeg számítása"
 
-#: ../src/wxMaxima.cpp:5830
+#: ../src/wxMaxima.cpp:5845
 msgid "Can not connect to the web server."
 msgstr "Nem lehet a webszerverhez kapcsolódni"
 
-#: ../src/wxMaxima.cpp:5881
+#: ../src/wxMaxima.cpp:5896
 msgid "Can not download version info."
 msgstr "A verzióinformáció nem elérhető."
 
@@ -857,15 +857,15 @@ msgstr "A verzióinformáció nem elérhető."
 #: ../src/PlotFormatWiz.cpp:48 ../src/SeriesWiz.cpp:49 ../src/SeriesWiz.cpp:51
 #: ../src/SubstituteWiz.cpp:41 ../src/SubstituteWiz.cpp:43 ../src/SumWiz.cpp:44
 #: ../src/SumWiz.cpp:46 ../src/SystemWiz.cpp:38 ../src/SystemWiz.cpp:40
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Cancel"
 msgstr "Mégsem"
 
-#: ../src/wxMaximaFrame.cpp:126 ../src/wxMaxima.cpp:932
+#: ../src/wxMaxima.cpp:937 ../src/wxMaximaFrame.cpp:125
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1217
+#: ../src/wxMaximaFrame.cpp:1216
 msgid "Canonical (tr)"
 msgstr "Kanonikus (tr)"
 
@@ -873,7 +873,7 @@ msgstr "Kanonikus (tr)"
 msgid "Catalan"
 msgstr "Katalán"
 
-#: ../src/wxMaximaFrame.cpp:638
+#: ../src/wxMaximaFrame.cpp:637
 msgid "Ce&ll"
 msgstr "Ce&lla"
 
@@ -881,39 +881,39 @@ msgstr "Ce&lla"
 msgid "Cell bracket"
 msgstr "Cella zárójel"
 
-#: ../src/wxMaxima.cpp:5261
+#: ../src/wxMaxima.cpp:5273
 msgid "Cell ends in a backslash"
 msgstr "A cella visszaperre (backslash-re) végződik."
 
-#: ../src/wxMaximaFrame.cpp:676
+#: ../src/wxMaximaFrame.cpp:675
 msgid "Change &2d Display"
 msgstr "&2d-s megjelenítés változtatása"
 
-#: ../src/wxMaximaFrame.cpp:677
+#: ../src/wxMaximaFrame.cpp:676
 msgid "Change the 2d display algorithm used to display math output"
 msgstr "Matematikai jelek 2d-s megjelenítési algoritmusának megváltoztatása"
 
-#: ../src/wxMaxima.cpp:3995
+#: ../src/wxMaxima.cpp:4007
 msgid "Change variable"
 msgstr "Változócsere"
 
-#: ../src/wxMaximaFrame.cpp:783
+#: ../src/wxMaximaFrame.cpp:782
 msgid "Change variable in integral or sum"
 msgstr "Változócsere integrálban vagy összegben"
 
-#: ../src/wxMaxima.cpp:3751
+#: ../src/wxMaxima.cpp:3763
 msgid "Char poly"
 msgstr "Karakterisztikus polinom"
 
-#: ../src/wxMaximaFrame.cpp:978
+#: ../src/wxMaximaFrame.cpp:977
 msgid "Check for Updates"
 msgstr "&Frissítések keresése"
 
-#: ../src/wxMaximaFrame.cpp:979
+#: ../src/wxMaximaFrame.cpp:978
 msgid "Check if a newer version of wxMaxima/Maxima exist."
 msgstr " A wxMaxima/Maxima újabb verziójának keresése."
 
-#: ../src/wxMaximaFrame.cpp:1385
+#: ../src/wxMaximaFrame.cpp:1384
 msgid "Chi"
 msgstr "Khí"
 
@@ -934,15 +934,15 @@ msgstr "Betűtípus választás"
 msgid "Choose new plot format:"
 msgstr "Új ábrázolási mód választása:"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710
 msgid "Classes:"
 msgstr "Osztályok:"
 
-#: ../src/wxMaximaFrame.cpp:469
+#: ../src/wxMaximaFrame.cpp:468
 msgid "Close\tCtrl-W"
 msgstr "Bezárás\tCtrl-W"
 
-#: ../src/wxMaximaFrame.cpp:470
+#: ../src/wxMaximaFrame.cpp:469
 msgid "Close window"
 msgstr "Ablak bezárása"
 
@@ -974,19 +974,19 @@ msgstr "Kód kiemelése: Szövegek"
 msgid "Code highlighting: Variables"
 msgstr "Kód kiemelése: Változók"
 
-#: ../src/wxMaxima.cpp:4806
+#: ../src/wxMaxima.cpp:4818
 msgid "Col. names:"
 msgstr "Oszlopok nevei:"
 
-#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Columns:"
 msgstr "Oszlopok:"
 
-#: ../src/wxMaximaFrame.cpp:860
+#: ../src/wxMaximaFrame.cpp:859
 msgid "Combine factorials in an expression"
 msgstr "Faktoriálisokkal számol egy kifejezésben"
 
-#: ../src/wxMaxima.cpp:5293
+#: ../src/wxMaxima.cpp:5305
 msgid "Comma directly followed by a closing parenthesis"
 msgstr "A vesszőt közvetlenül egy bezáró zárójel követi"
 
@@ -998,23 +998,23 @@ msgstr "Vesszővel válassza el az x koordinátákat"
 msgid "Comma separated y coordinates"
 msgstr "Vesszővel válassza el az y koordinátákat"
 
-#: ../src/MathCtrl.cpp:1030
+#: ../src/MathCtrl.cpp:1072
 msgid "Comment Selection"
 msgstr "Megjegyzés kiválasztása"
 
-#: ../src/wxMaximaFrame.cpp:533
+#: ../src/wxMaximaFrame.cpp:532
 msgid "Comment out the currently selected text"
 msgstr "A megjegyzés a kiválasztott szövegen kívül van."
 
-#: ../src/wxMaximaFrame.cpp:532
+#: ../src/wxMaximaFrame.cpp:531
 msgid "Comment selection\tCtrl-/"
 msgstr "Megjegyzés kiválasztása\tCtrl-/"
 
-#: ../src/wxMaximaFrame.cpp:601
+#: ../src/wxMaximaFrame.cpp:600
 msgid "Complete Word\tCtrl-K"
 msgstr "Szó &kiegészítése\tCtrl-K"
 
-#: ../src/wxMaximaFrame.cpp:602
+#: ../src/wxMaximaFrame.cpp:601
 msgid "Complete word"
 msgstr "Szó automatikus kiegészítése"
 
@@ -1022,37 +1022,37 @@ msgstr "Szó automatikus kiegészítése"
 msgid "Completely stop maxima and restart it"
 msgstr "A Maxima teljes leállítása és újraindítása"
 
-#: ../src/wxMaximaFrame.cpp:823
+#: ../src/wxMaximaFrame.cpp:822
 msgid "Compute continued fraction of a value"
 msgstr "Egy lista lánctörtté alakítása"
 
-#: ../src/wxMaximaFrame.cpp:761
+#: ../src/wxMaximaFrame.cpp:760
 msgid "Compute the adjoint matrix"
 msgstr "Mátrix adjungáltjának kiszámolása"
 
-#: ../src/wxMaximaFrame.cpp:750
+#: ../src/wxMaximaFrame.cpp:749
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr "Mátrix karakterisztikus polinomjának kiszámolása"
 
-#: ../src/wxMaximaFrame.cpp:753
+#: ../src/wxMaximaFrame.cpp:752
 msgid "Compute the determinant of a matrix"
 msgstr "Mátrix determinánsának kiszámolása"
 
-#: ../src/wxMaximaFrame.cpp:810
+#: ../src/wxMaximaFrame.cpp:809
 msgid "Compute the greatest common divisor"
 msgstr "Legnagyobb közös osztó kiszámolása"
 
-#: ../src/wxMaximaFrame.cpp:747
+#: ../src/wxMaximaFrame.cpp:746
 msgid "Compute the inverse of a matrix"
 msgstr "Mátrix inverzének kiszámolása"
 
-#: ../src/wxMaximaFrame.cpp:813
+#: ../src/wxMaximaFrame.cpp:812
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
 "Legkisebb közös többszörös kiszámolása (használata előtt hajtsd végre a "
 "load(functs) parancsot)"
 
-#: ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4868
 msgid "Condition:"
 msgstr "Feltétel:"
 
@@ -1064,8 +1064,8 @@ msgstr "Konfigurációs fájl (*.ini)|*.ini"
 msgid "Configuration warning"
 msgstr "Figyelmeztetés a beállításokkal kapcsolatban"
 
-#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:538
-#: ../src/wxMaximaFrame.cpp:541
+#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:540
 msgid "Configure wxMaxima"
 msgstr "A wxMaxima beállítása"
 
@@ -1074,118 +1074,120 @@ msgstr "A wxMaxima beállítása"
 msgid "Constant"
 msgstr "Állandó"
 
-#: ../src/wxMaximaFrame.cpp:844
+#: ../src/wxMaximaFrame.cpp:843
 msgid "Contract Logarithms"
 msgstr "Loga&ritmikus összevonás"
 
-#: ../src/wxMaximaFrame.cpp:851
+#: ../src/wxMaximaFrame.cpp:850
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr "Binomiális-, béta- és gamma-függvények faktoriálissá alakítása"
 
-#: ../src/wxMaximaFrame.cpp:854
+#: ../src/wxMaximaFrame.cpp:853
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr "Binomiális-, faktoriális- és béta-függvényeket gamma-függvénnyé alakít"
 
-#: ../src/wxMaximaFrame.cpp:888
+#: ../src/wxMaximaFrame.cpp:887
 msgid "Convert complex expression to polar form"
 msgstr "Komplex kifejezés exponenciálissá alakítása"
 
-#: ../src/wxMaximaFrame.cpp:885
+#: ../src/wxMaximaFrame.cpp:884
 msgid "Convert complex expression to rect form"
 msgstr "Komplex kifejezés algebraivá alakítása"
 
-#: ../src/wxMaximaFrame.cpp:897
+#: ../src/wxMaximaFrame.cpp:896
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr "Komplex exponenciális függvény alakítása trigonometrikus formává"
 
-#: ../src/wxMaximaFrame.cpp:842
+#: ../src/wxMaximaFrame.cpp:841
 msgid "Convert logarithm of product to sum of logarithms"
 msgstr "Szorzat logaritmusának logaritmusok összegévé való alakítása"
 
-#: ../src/wxMaximaFrame.cpp:845
+#: ../src/wxMaximaFrame.cpp:844
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "Logaritmusok összegének szorzat logaritmusává való alakítása"
 
-#: ../src/wxMaximaFrame.cpp:850
+#: ../src/wxMaximaFrame.cpp:849
 msgid "Convert to &Factorials"
 msgstr "&Faktoriálisokká alakítás"
 
-#: ../src/wxMaximaFrame.cpp:853
+#: ../src/wxMaximaFrame.cpp:852
 msgid "Convert to &Gamma"
 msgstr "&Gamma-függvénnyé alakítás"
 
-#: ../src/wxMaximaFrame.cpp:887
+#: ../src/wxMaximaFrame.cpp:886
 msgid "Convert to &Polarform"
 msgstr "Polárformává alakítás"
 
-#: ../src/wxMaximaFrame.cpp:884
+#: ../src/wxMaximaFrame.cpp:883
 msgid "Convert to &Rectform"
 msgstr "&Algebraivá alakítás"
 
-#: ../src/wxMaximaFrame.cpp:877
+#: ../src/wxMaximaFrame.cpp:876
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr "Trigonometrikus kifejezés kanonikus kvázilineáris formává alakítása"
 
-#: ../src/wxMaximaFrame.cpp:900
+#: ../src/wxMaximaFrame.cpp:899
 msgid "Convert trigonometric functions to exponential form"
 msgstr "Trigonometrikus függvény exponenciális formává alakítása"
 
-#: ../src/ToolBar.cpp:140 ../src/MathCtrl.cpp:918 ../src/MathCtrl.cpp:931
-#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1024
+#: ../src/MathCtrl.cpp:960 ../src/MathCtrl.cpp:973 ../src/MathCtrl.cpp:1019
+#: ../src/MathCtrl.cpp:1066 ../src/ToolBar.cpp:140
 msgid "Copy"
 msgstr "Másolás"
 
-#: ../src/wxMaximaFrame.cpp:597
+#: ../src/wxMaximaFrame.cpp:596
 msgid "Copy Previous Input\tCtrl-I"
 msgstr "E&lőző bemenet másolása\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:599
+#: ../src/wxMaximaFrame.cpp:598
 msgid "Copy Previous Output\tCtrl-U"
 msgstr "E&lőző kimenet másolása\tCtrl-U"
 
-#: ../src/wxMaximaFrame.cpp:514 ../src/MathCtrl.cpp:936 ../src/MathCtrl.cpp:982
+#: ../src/MathCtrl.cpp:978 ../src/MathCtrl.cpp:1024
+#: ../src/wxMaximaFrame.cpp:513
 msgid "Copy as Image"
 msgstr "Másolás képként"
 
-#: ../src/wxMaximaFrame.cpp:507 ../src/MathCtrl.cpp:932 ../src/MathCtrl.cpp:978
+#: ../src/MathCtrl.cpp:974 ../src/MathCtrl.cpp:1020
+#: ../src/wxMaximaFrame.cpp:506
 msgid "Copy as LaTeX"
 msgstr "&LaTeX másolás"
 
-#: ../src/wxMaximaFrame.cpp:510
+#: ../src/wxMaximaFrame.cpp:509
 msgid "Copy as MathML"
 msgstr "Másolás MathML-ként"
 
-#: ../src/MathCtrl.cpp:935 ../src/MathCtrl.cpp:980
+#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1022
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr "Másolás MathML-ként (pl. szövegszerkesztőbe)"
 
-#: ../src/wxMaximaFrame.cpp:504
+#: ../src/wxMaximaFrame.cpp:503
 msgid "Copy as Text\tCtrl-Shift-C"
 msgstr "&Szöveg másolása\tCtrl-Shift-C"
 
-#: ../src/MathCtrl.cpp:933 ../src/MathCtrl.cpp:979
+#: ../src/MathCtrl.cpp:975 ../src/MathCtrl.cpp:1021
 #, fuzzy
 msgid "Copy as plain text"
 msgstr "Másolás képként"
 
-#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:503
+#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:502
 msgid "Copy selection"
 msgstr "Kijelölt rész másolása"
 
-#: ../src/wxMaximaFrame.cpp:515
+#: ../src/wxMaximaFrame.cpp:514
 msgid "Copy selection from document as an image"
 msgstr "Kijelölt rész képként másolása a domumentumból"
 
-#: ../src/wxMaximaFrame.cpp:505
+#: ../src/wxMaximaFrame.cpp:504
 msgid "Copy selection from document as text"
 msgstr "Kijelölt rész másolása a dokumentumból"
 
-#: ../src/wxMaximaFrame.cpp:508
+#: ../src/wxMaximaFrame.cpp:507
 msgid "Copy selection from document in LaTeX format"
 msgstr "Kijelölt rész másolása a dokumentumból LaTeX formátumban"
 
-#: ../src/wxMaximaFrame.cpp:511
+#: ../src/wxMaximaFrame.cpp:510
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
@@ -1193,11 +1195,11 @@ msgstr ""
 "A dokumentumból MathML formátumban kimásolt részt sok szövegszerkesztő 2d-s "
 "egyenletként tudja megjeleníteni"
 
-#: ../src/wxMaximaFrame.cpp:598
+#: ../src/wxMaximaFrame.cpp:597
 msgid "Create a new cell with previous input"
 msgstr "Létrehoz egy új cellát az előző bemenet tartalmával"
 
-#: ../src/wxMaximaFrame.cpp:600
+#: ../src/wxMaximaFrame.cpp:599
 msgid "Create a new cell with previous output"
 msgstr "Létrehoz egy új cellát az előző kimenet tartalmával"
 
@@ -1205,15 +1207,15 @@ msgstr "Létrehoz egy új cellát az előző kimenet tartalmával"
 msgid "Cursor"
 msgstr "Kurzor"
 
-#: ../src/ToolBar.cpp:137 ../src/MathCtrl.cpp:1023
+#: ../src/MathCtrl.cpp:1065 ../src/ToolBar.cpp:137
 msgid "Cut"
 msgstr "Kivágás"
 
-#: ../src/wxMaximaFrame.cpp:499
+#: ../src/wxMaximaFrame.cpp:498
 msgid "Cut\tCtrl-X"
 msgstr "&Kivágás\tCtrl-X"
 
-#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:500
+#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:499
 msgid "Cut selection"
 msgstr "Kijelölt rész kivágása"
 
@@ -1225,18 +1227,18 @@ msgstr "Cseh"
 msgid "Danish"
 msgstr "Dán"
 
-#: ../src/wxMaxima.cpp:4799 ../src/wxMaxima.cpp:4806 ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4811 ../src/wxMaxima.cpp:4818 ../src/wxMaxima.cpp:4868
 msgid "Data Matrix:"
 msgstr "Adat mátrix:"
 
-#: ../src/wxMaxima.cpp:4826
+#: ../src/wxMaxima.cpp:4838
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr "Adat fájlok (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698 ../src/wxMaxima.cpp:4712
-#: ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726 ../src/wxMaxima.cpp:4734
-#: ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748 ../src/wxMaxima.cpp:4755
-#: ../src/wxMaxima.cpp:4791
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710 ../src/wxMaxima.cpp:4724
+#: ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738 ../src/wxMaxima.cpp:4746
+#: ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760 ../src/wxMaxima.cpp:4767
+#: ../src/wxMaxima.cpp:4803
 msgid "Data:"
 msgstr "Adat:"
 
@@ -1244,7 +1246,7 @@ msgstr "Adat:"
 msgid "Debug: watch maxima's stdout stream"
 msgstr "Hibakeresés: figyelje a Maxima kimenetét"
 
-#: ../src/wxMaximaFrame.cpp:820
+#: ../src/wxMaximaFrame.cpp:819
 msgid "Decompose rational function to partial fractions"
 msgstr "Racionális törtfüggvény parciális törtekre bontása"
 
@@ -1278,47 +1280,47 @@ msgstr ""
 "Az animációk lejátszásának alapértelmezett sebessége (képkocka per "
 "másodperc)."
 
-#: ../src/wxMaxima.cpp:3403 ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3415 ../src/wxMaxima.cpp:3424
 msgid "Delete"
 msgstr "Törlés"
 
-#: ../src/wxMaximaFrame.cpp:667
+#: ../src/wxMaximaFrame.cpp:666
 msgid "Delete F&unction..."
 msgstr "Fü&ggvény törlése..."
 
-#: ../src/MathCtrl.cpp:939 ../src/MathCtrl.cpp:985
+#: ../src/MathCtrl.cpp:981 ../src/MathCtrl.cpp:1027
 msgid "Delete Selection"
 msgstr "Kijelölt rész törlése"
 
-#: ../src/wxMaximaFrame.cpp:669
+#: ../src/wxMaximaFrame.cpp:668
 msgid "Delete V&ariable..."
 msgstr "Vá&ltozó törlése..."
 
-#: ../src/wxMaximaFrame.cpp:668
+#: ../src/wxMaximaFrame.cpp:667
 msgid "Delete a function"
 msgstr "Függvény törlése"
 
-#: ../src/wxMaximaFrame.cpp:670
+#: ../src/wxMaximaFrame.cpp:669
 msgid "Delete a variable"
 msgstr "Változó törlése"
 
-#: ../src/wxMaximaFrame.cpp:655
+#: ../src/wxMaximaFrame.cpp:654
 msgid "Delete all values from memory"
 msgstr "Minden tartalom törlése a memóriából"
 
-#: ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3424
 msgid "Delete function(s):"
 msgstr "Függvény(ek) törlése:"
 
-#: ../src/wxMaxima.cpp:3403
+#: ../src/wxMaxima.cpp:3415
 msgid "Delete variable(s):"
 msgstr "Változó(k) törlése:"
 
-#: ../src/wxMaximaFrame.cpp:1367
+#: ../src/wxMaximaFrame.cpp:1366
 msgid "Delta"
 msgstr "Delta"
 
-#: ../src/wxMaxima.cpp:4011
+#: ../src/wxMaxima.cpp:4023
 msgid "Denom. deg:"
 msgstr "Nevező foka:"
 
@@ -1326,35 +1328,35 @@ msgstr "Nevező foka:"
 msgid "Depth:"
 msgstr "Fokszám:"
 
-#: ../src/wxMaxima.cpp:3541
+#: ../src/wxMaxima.cpp:3553
 msgid "Derivative:"
 msgstr "Derivált:"
 
-#: ../src/wxMaximaFrame.cpp:1258
+#: ../src/wxMaximaFrame.cpp:1257
 msgid "Deviation..."
 msgstr "Szórás..."
 
-#: ../src/wxMaximaFrame.cpp:816
+#: ../src/wxMaximaFrame.cpp:815
 msgid "Di&vide Polynomials..."
 msgstr "P&olinomok osztása..."
 
-#: ../src/wxMaximaFrame.cpp:1223
+#: ../src/wxMaximaFrame.cpp:1222
 msgid "Diff..."
 msgstr "Differenciál..."
 
-#: ../src/wxMaxima.cpp:4154 ../src/wxMaxima.cpp:5066
+#: ../src/wxMaxima.cpp:4166 ../src/wxMaxima.cpp:5078
 msgid "Differentiate"
 msgstr "Differenciálás"
 
-#: ../src/wxMaximaFrame.cpp:786
+#: ../src/wxMaximaFrame.cpp:785
 msgid "Differentiate expression"
 msgstr "Kifejezés differenciálása"
 
-#: ../src/MathCtrl.cpp:1001
+#: ../src/MathCtrl.cpp:1043
 msgid "Differentiate..."
 msgstr "Differenciálás..."
 
-#: ../src/LimitWiz.cpp:37 ../src/FindReplacePane.cpp:76
+#: ../src/FindReplacePane.cpp:76 ../src/LimitWiz.cpp:37
 msgid "Direction:"
 msgstr "Irány:"
 
@@ -1362,48 +1364,49 @@ msgstr "Irány:"
 msgid "Discrete plot"
 msgstr "Diszkrét pontok"
 
-#: ../src/wxMaximaFrame.cpp:679
+#: ../src/wxMaximaFrame.cpp:678
 msgid "Display Te&X Form"
 msgstr "Meg&jelenítés TeX formátumban"
 
-#: ../src/wxMaxima.cpp:3320
+#: ../src/wxMaxima.cpp:3332
 msgid "Display algorithm"
 msgstr "Megjelenítő algoritmus"
 
-#: ../src/wxMaximaFrame.cpp:680
+#: ../src/wxMaximaFrame.cpp:679
 msgid "Display last result in TeX form"
 msgstr "Kifejezés megjelenítése TeX formátumban"
 
-#: ../src/wxMaximaFrame.cpp:674
+#: ../src/wxMaximaFrame.cpp:673
 msgid "Display time used for evaluation"
 msgstr "Megjeleníti mennyi idő alatt fut le az eljárás"
 
-#: ../src/wxMaxima.cpp:4061
+#: ../src/wxMaxima.cpp:4073
 msgid "Divide"
 msgstr "Osztás"
 
-#: ../src/MathCtrl.cpp:1032
+#: ../src/MathCtrl.cpp:1074
 msgid "Divide Cell"
 msgstr "Cella kettéosztása"
 
-#: ../src/wxMaximaFrame.cpp:635
+#: ../src/wxMaximaFrame.cpp:634
 #, fuzzy
 msgid "Divide Cell\tCtrl-D"
 msgstr "Cella kettéosztása"
 
-#: ../src/wxMaximaFrame.cpp:817
+#: ../src/wxMaximaFrame.cpp:816
 msgid "Divide numbers or polynomials"
 msgstr "Számok vagy polinomok osztása"
 
-#: ../src/wxMaximaFrame.cpp:636
+#: ../src/wxMaximaFrame.cpp:635
 msgid "Divide this input cell into two cells"
 msgstr "Bemeneti cella kettéosztása"
 
-#: ../src/wxMaxima.cpp:5917
-msgid "Do you want to save the changes you made in the document \""
+#: ../src/wxMaxima.cpp:5932
+#, fuzzy, c-format
+msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr "Akarja menteni a változásokat az alábbi dokumentumban \""
 
-#: ../src/wxMaxima.cpp:1664 ../src/wxMaxima.cpp:1672
+#: ../src/wxMaxima.cpp:1669 ../src/wxMaxima.cpp:1677
 msgid "Document "
 msgstr "Dokumentum"
 
@@ -1425,7 +1428,7 @@ msgstr ""
 "verziókövető rendszereket (mint pl. a git és svn) a különbségek "
 "felismerésében."
 
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Don't save"
 msgstr "Nem ment"
 
@@ -1433,27 +1436,27 @@ msgstr "Nem ment"
 msgid "Down"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:734
+#: ../src/wxMaximaFrame.cpp:733
 msgid "E&quations"
 msgstr "&Egyenletek"
 
-#: ../src/wxMaximaFrame.cpp:487
+#: ../src/wxMaximaFrame.cpp:486
 msgid "E&xit\tCtrl-Q"
 msgstr "&Kilépés\tCtrl-Q"
 
-#: ../src/wxMaximaFrame.cpp:757
+#: ../src/wxMaximaFrame.cpp:756
 msgid "Eige&nvectors"
 msgstr "Saját&vektorok"
 
-#: ../src/wxMaximaFrame.cpp:755
+#: ../src/wxMaximaFrame.cpp:754
 msgid "Eigen&values"
 msgstr "&Sajátértékek"
 
-#: ../src/wxMaxima.cpp:3572
+#: ../src/wxMaxima.cpp:3584
 msgid "Eliminate"
 msgstr "Kiküszöbölés"
 
-#: ../src/wxMaximaFrame.cpp:710
+#: ../src/wxMaximaFrame.cpp:709
 msgid "Eliminate a variable from a system of equations"
 msgstr "Változó kiküszöbölése egyenletrendszerből"
 
@@ -1465,21 +1468,21 @@ msgstr "Bizonyítás vége"
 msgid "English"
 msgstr "Angol"
 
-#: ../src/wxMaxima.cpp:4712 ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726
-#: ../src/wxMaxima.cpp:4734 ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748
-#: ../src/wxMaxima.cpp:4755 ../src/wxMaxima.cpp:4791 ../src/wxMaxima.cpp:4799
+#: ../src/wxMaxima.cpp:4724 ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738
+#: ../src/wxMaxima.cpp:4746 ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760
+#: ../src/wxMaxima.cpp:4767 ../src/wxMaxima.cpp:4803 ../src/wxMaxima.cpp:4811
 msgid "Enter Data"
 msgstr "Adatbevitel"
 
-#: ../src/wxMaximaFrame.cpp:1279
+#: ../src/wxMaximaFrame.cpp:1278
 msgid "Enter Matrix..."
 msgstr "Mátrix bevitele..."
 
-#: ../src/wxMaximaFrame.cpp:745
+#: ../src/wxMaximaFrame.cpp:744
 msgid "Enter a matrix"
 msgstr "Mátrix bevitele"
 
-#: ../src/wxMaxima.cpp:3962
+#: ../src/wxMaxima.cpp:3974
 msgid "Enter an equation for rational simplification:"
 msgstr "Írja be a listába felvenni kívánt algebrai egyenletet:"
 
@@ -1491,11 +1494,11 @@ msgstr "A változókat vesszővel válassza el egymástól."
 msgid "Enter evaluates cells"
 msgstr "A parancsok az Enter lenyomására hajtódnak végre"
 
-#: ../src/wxMaxima.cpp:3734
+#: ../src/wxMaxima.cpp:3746
 msgid "Enter matrix"
 msgstr "Mátrix bevitele"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Enter new precision for bigfloats:"
 msgstr "Új pontosság bevitele:"
 
@@ -1503,11 +1506,11 @@ msgstr "Új pontosság bevitele:"
 msgid "Enter the path to the Maxima executable."
 msgstr "A Maxima elérési útjának beírása."
 
-#: ../src/wxMaximaFrame.cpp:1368
+#: ../src/wxMaximaFrame.cpp:1367
 msgid "Epsilon"
 msgstr "Epszilon"
 
-#: ../src/wxMaxima.cpp:4208
+#: ../src/wxMaxima.cpp:4220
 msgid "Epsilon:"
 msgstr "Epszilon:"
 
@@ -1516,13 +1519,13 @@ msgstr "Epszilon:"
 msgid "Equation %d:"
 msgstr "Egyenlet %d:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:3633
-#: ../src/wxMaxima.cpp:5019
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:3645
+#: ../src/wxMaxima.cpp:5031
 msgid "Equation(s):"
 msgstr "Egyenlet(ek):"
 
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3993
-#: ../src/wxMaxima.cpp:4807 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:4005
+#: ../src/wxMaxima.cpp:4819 ../src/wxMaxima.cpp:5045
 msgid "Equation:"
 msgstr "Egyenlet:"
 
@@ -1533,76 +1536,76 @@ msgid ""
 "be introduced one into another. Also they are always printed out as 2D maths."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3570
+#: ../src/wxMaxima.cpp:3582
 msgid "Equations:"
 msgstr "Egyenletek:"
 
-#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1455
-#: ../src/wxMaxima.cpp:1469 ../src/wxMaxima.cpp:1620 ../src/wxMaxima.cpp:1633
-#: ../src/wxMaxima.cpp:1643 ../src/wxMaxima.cpp:1666 ../src/wxMaxima.cpp:2034
-#: ../src/wxMaxima.cpp:2206 ../src/wxMaxima.cpp:5381 ../src/wxMaxima.cpp:5830
-#: ../src/wxMaxima.cpp:5881
+#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1460
+#: ../src/wxMaxima.cpp:1474 ../src/wxMaxima.cpp:1625 ../src/wxMaxima.cpp:1638
+#: ../src/wxMaxima.cpp:1648 ../src/wxMaxima.cpp:1671 ../src/wxMaxima.cpp:2039
+#: ../src/wxMaxima.cpp:2211 ../src/wxMaxima.cpp:5397 ../src/wxMaxima.cpp:5845
+#: ../src/wxMaxima.cpp:5896
 msgid "Error"
 msgstr "Hiba"
 
-#: ../src/wxMaxima.cpp:2886 ../src/wxMaxima.cpp:2900 ../src/wxMaxima.cpp:2913
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617 ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:2894 ../src/wxMaxima.cpp:2908 ../src/wxMaxima.cpp:2921
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629 ../src/wxMaxima.cpp:3740
 msgid "Error!"
 msgstr "Hiba!"
 
-#: ../src/wxMaximaFrame.cpp:1370
+#: ../src/wxMaximaFrame.cpp:1369
 msgid "Eta"
 msgstr "Éta"
 
-#: ../src/wxMaximaFrame.cpp:909
+#: ../src/wxMaximaFrame.cpp:908
 msgid "Evaluate &Noun Forms"
 msgstr "K&iértékeletlen formák kiértékelése"
 
-#: ../src/wxMaximaFrame.cpp:589
+#: ../src/wxMaximaFrame.cpp:588
 msgid "Evaluate All Cells\tCtrl-Shift-R"
 msgstr "&Minden cella újraszámolása\tCtrl-Shift-R"
 
-#: ../src/wxMaximaFrame.cpp:587
+#: ../src/wxMaximaFrame.cpp:586
 msgid "Evaluate All Visible Cells\tCtrl-R"
 msgstr "&Minden látható cella újraszámolása\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:585 ../src/MathCtrl.cpp:942
+#: ../src/MathCtrl.cpp:984 ../src/wxMaximaFrame.cpp:584
 msgid "Evaluate Cell(s)"
 msgstr "C&ellák újraszámolása"
 
-#: ../src/wxMaximaFrame.cpp:591
+#: ../src/wxMaximaFrame.cpp:590
 msgid "Evaluate Cells Above\tCtrl-Shift-P"
 msgstr "Az aktuális hely feletti cellák újraszámolása\tCtrl-Shift-P"
 
-#: ../src/MathCtrl.cpp:956 ../src/MathCtrl.cpp:1051
+#: ../src/MathCtrl.cpp:998 ../src/MathCtrl.cpp:1093
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr "Rész kiértékelése\tShift+Ctrl+Enter"
 
-#: ../src/MathCtrl.cpp:961 ../src/MathCtrl.cpp:1053
+#: ../src/MathCtrl.cpp:1003 ../src/MathCtrl.cpp:1095
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr "Fejezet kiértékelése\tShift+Ctrl+Enter"
 
-#: ../src/MathCtrl.cpp:971 ../src/MathCtrl.cpp:1057
+#: ../src/MathCtrl.cpp:1013 ../src/MathCtrl.cpp:1099
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr "Al-alfejezet kiértékelése\tShift+Ctrl+Enter"
 
-#: ../src/MathCtrl.cpp:966 ../src/MathCtrl.cpp:1055
+#: ../src/MathCtrl.cpp:1008 ../src/MathCtrl.cpp:1097
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr "Alfejezet kiértékelése\tShift+Ctrl+Enter"
 
-#: ../src/wxMaximaFrame.cpp:586
+#: ../src/wxMaximaFrame.cpp:585
 msgid "Evaluate active or selected cell(s)"
 msgstr "Kijelölt cellák újraszámolása"
 
-#: ../src/wxMaximaFrame.cpp:590
+#: ../src/wxMaximaFrame.cpp:589
 msgid "Evaluate all cells in the document"
 msgstr "A dokumentum összes cellájának újraszámolása"
 
-#: ../src/wxMaximaFrame.cpp:910
+#: ../src/wxMaximaFrame.cpp:909
 msgid "Evaluate all noun forms in expression"
 msgstr "Nem kiértékelésre szánt formákat is kiértékel"
 
-#: ../src/wxMaximaFrame.cpp:588
+#: ../src/wxMaximaFrame.cpp:587
 msgid "Evaluate all visible cells in the document"
 msgstr "A dokumentum összes látható cellájának újraszámolása"
 
@@ -1614,7 +1617,7 @@ msgstr "Fájl kiértékelése annak kezdetétől a kurzor feletti celláig"
 msgid "Evaluate to point"
 msgstr "Kiértékelés eddig"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Example"
 msgstr "Példa"
 
@@ -1626,31 +1629,31 @@ msgstr "Példaszöveg"
 msgid "Examples:"
 msgstr "Példák:"
 
-#: ../src/wxMaximaFrame.cpp:488
+#: ../src/wxMaximaFrame.cpp:487
 msgid "Exit wxMaxima"
 msgstr "Kilépés a wxMaximából"
 
-#: ../src/wxMaximaFrame.cpp:1214
+#: ../src/wxMaximaFrame.cpp:1213
 msgid "Expand"
 msgstr "Felbont"
 
-#: ../src/wxMaximaFrame.cpp:1219
+#: ../src/wxMaximaFrame.cpp:1218
 msgid "Expand (tr)"
 msgstr "Felbont (tr)"
 
-#: ../src/MathCtrl.cpp:997
+#: ../src/MathCtrl.cpp:1039
 msgid "Expand Expression"
 msgstr "Kifejezés felbontása"
 
-#: ../src/wxMaximaFrame.cpp:841
+#: ../src/wxMaximaFrame.cpp:840
 msgid "Expand Logarithms"
 msgstr "&Logaritmikus felbontás"
 
-#: ../src/wxMaximaFrame.cpp:840
+#: ../src/wxMaximaFrame.cpp:839
 msgid "Expand an expression"
 msgstr "Egy kifejezés felbontása"
 
-#: ../src/wxMaximaFrame.cpp:874
+#: ../src/wxMaximaFrame.cpp:873
 msgid "Expand trigonometric expression"
 msgstr "Trigonometrikus kifejezés felbontása"
 
@@ -1658,7 +1661,7 @@ msgstr "Trigonometrikus kifejezés felbontása"
 msgid "Expected the icon files to be found at"
 msgstr "Ikon fájlok szükségesek"
 
-#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2834
+#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2842
 msgid "Export"
 msgstr "Exportálás"
 
@@ -1669,31 +1672,31 @@ msgstr ""
 "Animációk exportálása TeX-be (a kép csak akkor mozog, ha a PDF néző ezt "
 "támogatja)"
 
-#: ../src/wxMaximaFrame.cpp:481
+#: ../src/wxMaximaFrame.cpp:480
 msgid "Export document to a HTML or pdfLaTeX file"
 msgstr "Dokumentum exportálása HTML vagy pdfLaTeX formátumba"
 
-#: ../src/wxMaximaFrame.cpp:253
+#: ../src/wxMaximaFrame.cpp:252
 msgid "Export failed."
 msgstr "Az exportálás meghiúsult."
 
-#: ../src/wxMaximaFrame.cpp:239
+#: ../src/wxMaximaFrame.cpp:238
 msgid "Export successful."
 msgstr "Sikeres export."
 
-#: ../src/wxMaxima.cpp:2913
+#: ../src/wxMaxima.cpp:2921
 msgid "Exporting to HTML failed!"
 msgstr "A HTML-be való exportálás meghiúsult!"
 
-#: ../src/wxMaxima.cpp:2886
+#: ../src/wxMaxima.cpp:2894
 msgid "Exporting to TeX failed!"
 msgstr "A TeX-be való exportálás meghiúsult!"
 
-#: ../src/wxMaxima.cpp:2900
+#: ../src/wxMaxima.cpp:2908
 msgid "Exporting to maxima batch file failed!"
 msgstr "Maxima batch fájlba való exportálás meghiúsult!"
 
-#: ../src/wxMaximaFrame.cpp:229
+#: ../src/wxMaximaFrame.cpp:228
 msgid "Exporting..."
 msgstr "Exportálás..."
 
@@ -1706,42 +1709,42 @@ msgid "Expression(s):"
 msgstr "Függvény(ek):"
 
 #: ../src/IntegrateWiz.cpp:30 ../src/LimitWiz.cpp:27 ../src/SeriesWiz.cpp:33
-#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3648
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:4205 ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5064
+#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3660
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:4217 ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5076
 msgid "Expression:"
 msgstr "Kifejezés:"
 
-#: ../src/wxMaximaFrame.cpp:1213
+#: ../src/wxMaximaFrame.cpp:1212
 msgid "Factor"
 msgstr "Faktorizál"
 
-#: ../src/wxMaximaFrame.cpp:836
+#: ../src/wxMaximaFrame.cpp:835
 msgid "Factor Complex"
 msgstr "K&omplex faktorizáció"
 
-#: ../src/MathCtrl.cpp:996
+#: ../src/MathCtrl.cpp:1038
 msgid "Factor Expression"
 msgstr "Kifejezés faktorizálása"
 
-#: ../src/wxMaximaFrame.cpp:835
+#: ../src/wxMaximaFrame.cpp:834
 msgid "Factor an expression"
 msgstr "Egy kifejezés faktorizálása"
 
-#: ../src/wxMaximaFrame.cpp:837
+#: ../src/wxMaximaFrame.cpp:836
 msgid "Factor an expression in Gaussian numbers"
 msgstr "Kifejezés faktorizálása Gauss-egészekre"
 
-#: ../src/wxMaximaFrame.cpp:862
+#: ../src/wxMaximaFrame.cpp:861
 msgid "Factorials and &Gamma"
 msgstr "&Faktoriális- és gamma-függvény"
 
-#: ../src/wxMaxima.cpp:285
+#: ../src/wxMaxima.cpp:286
 msgid "Fatal error"
 msgstr "Végzetes hiba"
 
-#: ../src/GroupCell.cpp:1571
+#: ../src/GroupCell.cpp:1572
 #, c-format
 msgid "Figure %d:"
 msgstr "%d. ábra:"
@@ -1750,20 +1753,20 @@ msgstr "%d. ábra:"
 msgid "File"
 msgstr "Fájl"
 
-#: ../src/wxMaxima.cpp:1457 ../src/wxMaxima.cpp:1623 ../src/wxMaxima.cpp:1636
-#: ../src/wxMaxima.cpp:1646 ../src/wxMaxima.cpp:1668
+#: ../src/wxMaxima.cpp:1462 ../src/wxMaxima.cpp:1628 ../src/wxMaxima.cpp:1641
+#: ../src/wxMaxima.cpp:1651 ../src/wxMaxima.cpp:1673
 msgid "File could not be opened"
 msgstr "A fájlt nem lehetett megnyitni"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File not found"
 msgstr "A fájl nem található"
 
-#: ../src/wxMaxima.cpp:1511 ../src/wxMaxima.cpp:1729
+#: ../src/wxMaxima.cpp:1516 ../src/wxMaxima.cpp:1734
 msgid "File opened"
 msgstr "Fájl megnyitva"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File you tried to open does not exist."
 msgstr "A megnyitni próbált fájl nem található."
 
@@ -1775,67 +1778,67 @@ msgstr "Fájl:"
 msgid "Find"
 msgstr "Keresés..."
 
-#: ../src/wxMaximaFrame.cpp:523
+#: ../src/wxMaximaFrame.cpp:522
 msgid "Find\tCtrl-F"
 msgstr "Ke&resés...\tCtrl-F"
 
-#: ../src/wxMaximaFrame.cpp:787
+#: ../src/wxMaximaFrame.cpp:786
 msgid "Find &Limit..."
 msgstr "&Határérték számolása..."
 
-#: ../src/wxMaximaFrame.cpp:790
+#: ../src/wxMaximaFrame.cpp:789
 msgid "Find Minimum..."
 msgstr "&Minimum keresése..."
 
-#: ../src/MathCtrl.cpp:993
+#: ../src/MathCtrl.cpp:1035
 msgid "Find Root..."
 msgstr "Megoldás numerikusan..."
 
-#: ../src/wxMaximaFrame.cpp:791
+#: ../src/wxMaximaFrame.cpp:790
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr "Kifejezés minimumának meghatározása"
 
-#: ../src/wxMaximaFrame.cpp:788
+#: ../src/wxMaximaFrame.cpp:787
 msgid "Find a limit of an expression"
 msgstr "Kifejezés határértékének számolása"
 
-#: ../src/wxMaximaFrame.cpp:693
+#: ../src/wxMaximaFrame.cpp:692
 msgid "Find a root of an equation on an interval"
 msgstr "Egyenlet adott intervallumba eső gyökének meghatározása"
 
-#: ../src/wxMaximaFrame.cpp:695
+#: ../src/wxMaximaFrame.cpp:694
 msgid "Find all roots of a polynomial"
 msgstr "Polinom összes gyökének meghatározása"
 
-#: ../src/wxMaximaFrame.cpp:698
+#: ../src/wxMaximaFrame.cpp:697
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr "Polinom összes gyökének meghatározása (bfloat)"
 
-#: ../src/wxMaxima.cpp:3220
+#: ../src/wxMaxima.cpp:3215
 msgid "Find and Replace"
 msgstr "Keresés és csere"
 
-#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:523
+#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:522
 msgid "Find and replace"
 msgstr "Keresés és csere"
 
-#: ../src/wxMaximaFrame.cpp:756
+#: ../src/wxMaximaFrame.cpp:755
 msgid "Find eigenvalues of a matrix"
 msgstr "Mátrix sajátértékeinek kiszámolása"
 
-#: ../src/wxMaximaFrame.cpp:758
+#: ../src/wxMaximaFrame.cpp:757
 msgid "Find eigenvectors of a matrix"
 msgstr "Mátrix sajátvektorainak kiszámolása"
 
-#: ../src/wxMaxima.cpp:4210
+#: ../src/wxMaxima.cpp:4222
 msgid "Find minimum"
 msgstr "Minimum keresése"
 
-#: ../src/wxMaximaFrame.cpp:701
+#: ../src/wxMaximaFrame.cpp:700
 msgid "Find real roots of a polynomial"
 msgstr "Polinom valós gyökeinek meghatározása"
 
-#: ../src/wxMaxima.cpp:3493 ../src/wxMaxima.cpp:5036
+#: ../src/wxMaxima.cpp:3505 ../src/wxMaxima.cpp:5048
 msgid "Find root"
 msgstr "Megoldás numerikusan"
 
@@ -1857,11 +1860,11 @@ msgstr "Mentés előtt rögzíti a (%i, %o) indexek hivatkozását"
 msgid "Fixed font in text controls"
 msgstr "Rögzített szélességű betűtípus a bemeneti sorban"
 
-#: ../src/wxMaximaFrame.cpp:623
+#: ../src/wxMaximaFrame.cpp:622
 msgid "Fold All\tCtrl-Alt-["
 msgstr "&Minden kiválasztása\tCtrl-Alt-["
 
-#: ../src/wxMaximaFrame.cpp:624
+#: ../src/wxMaximaFrame.cpp:623
 msgid "Fold all sections"
 msgstr "Minden fejezet elrejtése"
 
@@ -1869,11 +1872,11 @@ msgstr "Minden fejezet elrejtése"
 msgid "Follow"
 msgstr "Követés"
 
-#: ../src/ParenCell.cpp:319
+#: ../src/ParenCell.cpp:320
 msgid "Font issue: The Parenthesis sign is too small!"
 msgstr "Betűtípus probléma: a zárójel túl kicsi!"
 
-#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:381
+#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:382
 msgid ""
 "Font issue: The char height is too small! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
@@ -1884,7 +1887,7 @@ msgstr ""
 "és a \"jsMath karakterek használata\" bejelölése a beállításoknál megoldást "
 "jelenthet."
 
-#: ../src/SqrtCell.cpp:199
+#: ../src/SqrtCell.cpp:202
 msgid ""
 "Font issue: The sqrt() sign has the size 0! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
@@ -1895,7 +1898,7 @@ msgstr ""
 "html oldalról és a \"jsMath karakterek használata\" bejelölése a "
 "beállításoknál megoldást jelenthet."
 
-#: ../src/SqrtCell.cpp:198
+#: ../src/SqrtCell.cpp:201
 msgid "Font issue? The contents of a sqrt() has the size 0."
 msgstr "Betűtípus probléma? Az sqrt() mérete nulla."
 
@@ -1927,15 +1930,15 @@ msgstr "Francia"
 
 #: ../src/IntegrateWiz.cpp:37 ../src/Plot2dWiz.cpp:37 ../src/Plot2dWiz.cpp:47
 #: ../src/Plot2dWiz.cpp:536 ../src/Plot3dWiz.cpp:36 ../src/Plot3dWiz.cpp:45
-#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4240
+#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4252
 msgid "From:"
 msgstr "Mettől:"
 
-#: ../src/wxMaximaFrame.cpp:576
+#: ../src/wxMaximaFrame.cpp:575
 msgid "Full Screen\tAlt-Enter"
 msgstr "&Teljes képernyő\tAlt-Enter"
 
-#: ../src/wxMaxima.cpp:3342
+#: ../src/wxMaxima.cpp:3354
 msgid "Function"
 msgstr "Függvény"
 
@@ -1943,32 +1946,32 @@ msgstr "Függvény"
 msgid "Function names"
 msgstr "Függvénynevek"
 
-#: ../src/wxMaxima.cpp:3633
+#: ../src/wxMaxima.cpp:3645
 msgid "Function(s):"
 msgstr "Függvény(ek):"
 
-#: ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3803
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3815
+#: ../src/wxMaxima.cpp:3848
 msgid "Function:"
 msgstr "Függvény:"
 
-#: ../src/wxMaximaFrame.cpp:904
+#: ../src/wxMaximaFrame.cpp:903
 msgid "Functions for complex simplification"
 msgstr "Eljárások komplex átalakításokra"
 
-#: ../src/wxMaximaFrame.cpp:864
+#: ../src/wxMaximaFrame.cpp:863
 msgid "Functions for simplifying factorials and gamma function"
 msgstr "Eljárások faktoriális- és gamma-függvény átalakításokra"
 
-#: ../src/wxMaximaFrame.cpp:881
+#: ../src/wxMaximaFrame.cpp:880
 msgid "Functions for simplifying trigonometric expressions"
 msgstr "Eljárások trigonometrikus átalakításokra"
 
-#: ../src/wxMaxima.cpp:4046
+#: ../src/wxMaxima.cpp:4058
 msgid "GCD"
 msgstr "Legnagyobb közös osztó"
 
-#: ../src/wxMaxima.cpp:5152
+#: ../src/wxMaxima.cpp:5164
 msgid "GIF image (*.gif)|*.gif"
 msgstr "GIF képfájl (*.gif)|*.gif"
 
@@ -1976,31 +1979,31 @@ msgstr "GIF képfájl (*.gif)|*.gif"
 msgid "Galician"
 msgstr "Galíciai"
 
-#: ../src/wxMaximaFrame.cpp:1366
+#: ../src/wxMaximaFrame.cpp:1365
 msgid "Gamma"
 msgstr "Gamma"
 
-#: ../src/wxMaximaFrame.cpp:391
+#: ../src/wxMaximaFrame.cpp:390
 msgid "General Math"
 msgstr "Általános matematika"
 
-#: ../src/wxMaximaFrame.cpp:549
+#: ../src/wxMaximaFrame.cpp:548
 msgid "General Math\tAlt-Shift-M"
 msgstr "Általános matematika\tAlt-Shift-M"
 
-#: ../src/wxMaxima.cpp:3766 ../src/wxMaxima.cpp:3785
+#: ../src/wxMaxima.cpp:3778 ../src/wxMaxima.cpp:3797
 msgid "Generate Matrix"
 msgstr "Mátrix generálása"
 
-#: ../src/wxMaximaFrame.cpp:741
+#: ../src/wxMaximaFrame.cpp:740
 msgid "Generate Matrix from Expression..."
 msgstr "Mátrix &generálása kifejezésből..."
 
-#: ../src/wxMaximaFrame.cpp:739
+#: ../src/wxMaximaFrame.cpp:738
 msgid "Generate a matrix from a 2-dimensional array"
 msgstr "Mátrix generálása kétdimenziós sorozatból"
 
-#: ../src/wxMaximaFrame.cpp:742
+#: ../src/wxMaximaFrame.cpp:741
 msgid "Generate a matrix from a lambda expression"
 msgstr "Mátrix generálása kétdimenziós kifejezésből"
 
@@ -2008,39 +2011,39 @@ msgstr "Mátrix generálása kétdimenziós kifejezésből"
 msgid "German"
 msgstr "Német"
 
-#: ../src/wxMaximaFrame.cpp:893
+#: ../src/wxMaximaFrame.cpp:892
 msgid "Get &Imaginary Part"
 msgstr "&Képzetes rész"
 
-#: ../src/wxMaximaFrame.cpp:793
+#: ../src/wxMaximaFrame.cpp:792
 msgid "Get &Series..."
 msgstr "&Taylor- és hatványsor..."
 
-#: ../src/wxMaximaFrame.cpp:804
+#: ../src/wxMaximaFrame.cpp:803
 msgid "Get Laplace transformation of an expression"
 msgstr "Kifejezés Laplace-transzformáltja"
 
-#: ../src/wxMaximaFrame.cpp:890
+#: ../src/wxMaximaFrame.cpp:889
 msgid "Get Real P&art"
 msgstr "&Valós rész"
 
-#: ../src/wxMaximaFrame.cpp:807
+#: ../src/wxMaximaFrame.cpp:806
 msgid "Get inverse Laplace transformation of an expression"
 msgstr "Kifejezés inverz Laplace-transzformáltja"
 
-#: ../src/wxMaximaFrame.cpp:794
+#: ../src/wxMaximaFrame.cpp:793
 msgid "Get the Taylor or power series of expression"
 msgstr "Függvény Taylor- és hatványsora"
 
-#: ../src/wxMaximaFrame.cpp:894
+#: ../src/wxMaximaFrame.cpp:893
 msgid "Get the imaginary part of complex expression"
 msgstr "Komplex kifejezés képzetes része"
 
-#: ../src/wxMaximaFrame.cpp:891
+#: ../src/wxMaximaFrame.cpp:890
 msgid "Get the real part of complex expression"
 msgstr "Komplex kifejezés valós része"
 
-#: ../src/MathCtrl.cpp:5932
+#: ../src/MathCtrl.cpp:5984
 msgid ""
 "Got a request to undo an action that involves an delete which isn't possible "
 "at this moment."
@@ -2052,11 +2055,11 @@ msgstr ""
 msgid "Greek"
 msgstr "Görög"
 
-#: ../src/wxMaximaFrame.cpp:356
+#: ../src/wxMaximaFrame.cpp:355
 msgid "Greek Letters"
 msgstr "Görög betűk"
 
-#: ../src/wxMaximaFrame.cpp:552
+#: ../src/wxMaximaFrame.cpp:551
 msgid "Greek Letters\tAlt-Shift-G"
 msgstr "Görög betűk\tAlt-Shift-G"
 
@@ -2068,7 +2071,7 @@ msgstr "Görög betűk"
 msgid "Grid:"
 msgstr "Háló:"
 
-#: ../src/wxMaxima.cpp:2836
+#: ../src/wxMaxima.cpp:2844
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|pdfLaTeX file (*."
 "tex)|*.tex"
@@ -2084,11 +2087,11 @@ msgstr "HTML/Szöveg cellák: Minden sortörés exportja"
 msgid "Help"
 msgstr "Súgó"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide All Toolbars\tAlt-Shift--"
 msgstr "Összes eszköztár elrejtése\tAlt-Shift--"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide all panes"
 msgstr "Összes panel elrejtése"
 
@@ -2096,19 +2099,19 @@ msgstr "Összes panel elrejtése"
 msgid "Highlight (dpart)"
 msgstr "Kiemelés"
 
-#: ../src/wxMaxima.cpp:4685
+#: ../src/wxMaxima.cpp:4697
 msgid "Histogram"
 msgstr "Hisztogram"
 
-#: ../src/wxMaximaFrame.cpp:1270
+#: ../src/wxMaximaFrame.cpp:1269
 msgid "Histogram..."
 msgstr "Hisztogram..."
 
-#: ../src/wxMaximaFrame.cpp:309
+#: ../src/wxMaximaFrame.cpp:308
 msgid "History"
 msgstr "Előzmények"
 
-#: ../src/wxMaximaFrame.cpp:555
+#: ../src/wxMaximaFrame.cpp:554
 msgid "History\tAlt-Shift-I"
 msgstr "Előzmények\tAlt-Shift-I"
 
@@ -2127,11 +2130,11 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Magyar"
 
-#: ../src/wxMaxima.cpp:3527
+#: ../src/wxMaxima.cpp:3539
 msgid "IC1"
 msgstr "Kezdetiérték-probléma (1)"
 
-#: ../src/wxMaxima.cpp:3543
+#: ../src/wxMaxima.cpp:3555
 msgid "IC2"
 msgstr "Kezdetiérték-probléma (2)"
 
@@ -2150,7 +2153,7 @@ msgstr ""
 "címkét fogja mutatni a Maxima általi %o stílusú kimeneti cellamegjelenítés "
 "helyett."
 
-#: ../src/wxMaximaFrame.cpp:683
+#: ../src/wxMaximaFrame.cpp:682
 msgid ""
 "If maxima ever finishes evaluating without wxMaxima realizing this this menu "
 "item can force wxMaxima to try to send commands to maxima again."
@@ -2228,11 +2231,11 @@ msgstr ""
 ">Megszakítás' vagy a 'Maxima->A Maxima újraindítása' menüparancsok "
 "használatát."
 
-#: ../src/wxMaximaFrame.cpp:1499
+#: ../src/wxMaximaFrame.cpp:1518
 msgid "Image"
 msgstr "Kép"
 
-#: ../src/wxMaxima.cpp:5644
+#: ../src/wxMaxima.cpp:5659
 msgid "Image files (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 msgstr "Kép fájlok (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 
@@ -2262,7 +2265,7 @@ msgstr ""
 "hogy a kifejezés fölé tenné. Ez javíthatja az olvashatóságot egyes "
 "betűtípusok és rövid indexek esetén."
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Include columns:"
 msgstr "Tartalmazott oszlopok:"
 
@@ -2281,19 +2284,19 @@ msgstr ""
 msgid "Infinity"
 msgstr "Végtelen"
 
-#: ../src/wxMaximaFrame.cpp:974
+#: ../src/wxMaximaFrame.cpp:973
 msgid "Info about Maxima build"
 msgstr "Információ a Maxima fordításáról"
 
-#: ../src/wxMaxima.cpp:4207
+#: ../src/wxMaxima.cpp:4219
 msgid "Initial Estimates:"
 msgstr "Kezdeti becslések:"
 
-#: ../src/wxMaximaFrame.cpp:718
+#: ../src/wxMaximaFrame.cpp:717
 msgid "Initial Value Problem (&1)..."
 msgstr "Kezdetiérték-probléma (&1)..."
 
-#: ../src/wxMaximaFrame.cpp:721
+#: ../src/wxMaximaFrame.cpp:720
 msgid "Initial Value Problem (&2)..."
 msgstr "Kezdetiérték-probléma (&2)..."
 
@@ -2301,7 +2304,7 @@ msgstr "Kezdetiérték-probléma (&2)..."
 msgid "Input labels"
 msgstr "Bemeneti címkék"
 
-#: ../src/wxMaximaFrame.cpp:403
+#: ../src/wxMaximaFrame.cpp:402
 msgid "Insert"
 msgstr "Beszúrás"
 
@@ -2309,95 +2312,95 @@ msgstr "Beszúrás"
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr "Beszúr egy %-jelet a cella elején található műveleti jel elé"
 
-#: ../src/wxMaximaFrame.cpp:612
+#: ../src/wxMaximaFrame.cpp:611
 msgid "Insert &Section Cell\tCtrl-3"
 msgstr "&Fejezetcella beszúrása\tCtrl-3"
 
-#: ../src/wxMaximaFrame.cpp:608
+#: ../src/wxMaximaFrame.cpp:607
 msgid "Insert &Text Cell\tCtrl-1"
 msgstr "&Szövegcella beszúrása\tCtrl-1"
 
-#: ../src/wxMaximaFrame.cpp:558
+#: ../src/wxMaximaFrame.cpp:557
 msgid "Insert Cell\tAlt-Shift-C"
 msgstr "Cella beillesztése\tAlt-Shift-C"
 
-#: ../src/wxMaxima.cpp:5642
+#: ../src/wxMaxima.cpp:5657
 msgid "Insert Image"
 msgstr "Kép beszúrása"
 
-#: ../src/wxMaximaFrame.cpp:620
+#: ../src/wxMaximaFrame.cpp:619
 msgid "Insert Image..."
 msgstr "Kép beszú&rása..."
 
-#: ../src/wxMaximaFrame.cpp:606
+#: ../src/wxMaximaFrame.cpp:605
 msgid "Insert Input &Cell"
 msgstr "&Bemeneti cella beszúrása"
 
-#: ../src/wxMaximaFrame.cpp:618
+#: ../src/wxMaximaFrame.cpp:617
 msgid "Insert Page Break"
 msgstr "La&ptörés beszúrása"
 
-#: ../src/wxMaximaFrame.cpp:614
+#: ../src/wxMaximaFrame.cpp:613
 msgid "Insert S&ubsection Cell\tCtrl-4"
 msgstr "&Alfejezetcella beszúrása\tCtrl-4"
 
-#: ../src/wxMaximaFrame.cpp:616
+#: ../src/wxMaximaFrame.cpp:615
 msgid "Insert S&ubsubsection Cell\tCtrl-5"
 msgstr "&Al-alfejezetcella beszúrása\tCtrl-5"
 
-#: ../src/MathCtrl.cpp:1015
+#: ../src/MathCtrl.cpp:1057
 msgid "Insert Section Cell"
 msgstr "&Fejezetcella beszúrása"
 
-#: ../src/MathCtrl.cpp:1016
+#: ../src/MathCtrl.cpp:1058
 msgid "Insert Subsection Cell"
 msgstr "&Alfejezetcella beszúrása"
 
-#: ../src/MathCtrl.cpp:1017
+#: ../src/MathCtrl.cpp:1059
 msgid "Insert Subsubsection Cell"
 msgstr "&Al-alfejezetcella beszúrása"
 
-#: ../src/wxMaximaFrame.cpp:610
+#: ../src/wxMaximaFrame.cpp:609
 msgid "Insert T&itle Cell\tCtrl-2"
 msgstr "&Címcella beszúrása\tCtrl-2"
 
-#: ../src/MathCtrl.cpp:1013
+#: ../src/MathCtrl.cpp:1055
 msgid "Insert Text Cell"
 msgstr "&Szövegcella beszúrása"
 
-#: ../src/MathCtrl.cpp:1014
+#: ../src/MathCtrl.cpp:1056
 msgid "Insert Title Cell"
 msgstr "&Címcella beszúrása"
 
-#: ../src/wxMaximaFrame.cpp:607
+#: ../src/wxMaximaFrame.cpp:606
 msgid "Insert a new input cell"
 msgstr "Új bemeneti cella beszúrása"
 
-#: ../src/wxMaximaFrame.cpp:613
+#: ../src/wxMaximaFrame.cpp:612
 msgid "Insert a new section cell"
 msgstr "Új fejezetcella beszúrása"
 
-#: ../src/wxMaximaFrame.cpp:615
+#: ../src/wxMaximaFrame.cpp:614
 msgid "Insert a new subsection cell"
 msgstr "Új alfejezetcella beszúrása"
 
-#: ../src/wxMaximaFrame.cpp:617
+#: ../src/wxMaximaFrame.cpp:616
 msgid "Insert a new subsubsection cell"
 msgstr "Új al-alfejezetcella beszúrása"
 
-#: ../src/wxMaximaFrame.cpp:609
+#: ../src/wxMaximaFrame.cpp:608
 msgid "Insert a new text cell"
 msgstr "Új szövegcella beszúrása"
 
-#: ../src/wxMaximaFrame.cpp:611
+#: ../src/wxMaximaFrame.cpp:610
 msgid "Insert a new title cell"
 msgstr "Új címcella beszúrása"
 
-#: ../src/wxMaximaFrame.cpp:619
+#: ../src/wxMaximaFrame.cpp:618
 msgid "Insert a page break"
 msgstr "Laptörés beszúrása"
 
-#: ../src/wxMaximaFrame.cpp:621
+#: ../src/wxMaximaFrame.cpp:620
 msgid "Insert image"
 msgstr "Kép beszúrása"
 
@@ -2409,27 +2412,27 @@ msgstr "Egészek és egyedi betűk"
 msgid "Integral sign"
 msgstr "Integráljel"
 
-#: ../src/wxMaxima.cpp:3992
+#: ../src/wxMaxima.cpp:4004
 msgid "Integral/Sum:"
 msgstr "Integrál/összeg:"
 
-#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4105 ../src/wxMaxima.cpp:5051
+#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4117 ../src/wxMaxima.cpp:5063
 msgid "Integrate"
 msgstr "Integrál"
 
-#: ../src/wxMaxima.cpp:4091
+#: ../src/wxMaxima.cpp:4103
 msgid "Integrate (risch)"
 msgstr "Integrál (Risch)"
 
-#: ../src/wxMaximaFrame.cpp:778
+#: ../src/wxMaximaFrame.cpp:777
 msgid "Integrate expression"
 msgstr "Függvény integrálása"
 
-#: ../src/wxMaximaFrame.cpp:780
+#: ../src/wxMaximaFrame.cpp:779
 msgid "Integrate expression with Risch algorithm"
 msgstr "Függvény integrálása Risch-algoritmussal"
 
-#: ../src/wxMaximaFrame.cpp:1224 ../src/MathCtrl.cpp:1000
+#: ../src/MathCtrl.cpp:1042 ../src/wxMaximaFrame.cpp:1223
 msgid "Integrate..."
 msgstr "Integrál..."
 
@@ -2437,7 +2440,7 @@ msgstr "Integrál..."
 msgid "Interrupt"
 msgstr "Megszakítás"
 
-#: ../src/wxMaximaFrame.cpp:646 ../src/wxMaximaFrame.cpp:650
+#: ../src/wxMaximaFrame.cpp:645 ../src/wxMaximaFrame.cpp:649
 msgid "Interrupt current computation"
 msgstr "Jelenlegi számítás megszakítása"
 
@@ -2459,15 +2462,15 @@ msgstr ""
 "\n"
 "Írja be a Maxima futtatható fájl elérési útját újra."
 
-#: ../src/wxMaxima.cpp:4137
+#: ../src/wxMaxima.cpp:4149
 msgid "Inverse Laplace"
 msgstr "Inverz Laplace"
 
-#: ../src/wxMaximaFrame.cpp:806
+#: ../src/wxMaximaFrame.cpp:805
 msgid "Inverse Laplace T&ransform..."
 msgstr "I&nverz Laplace-transzformáció..."
 
-#: ../src/wxMaximaFrame.cpp:1372
+#: ../src/wxMaximaFrame.cpp:1371
 msgid "Iota"
 msgstr "Ióta"
 
@@ -2505,7 +2508,7 @@ msgstr "Japán"
 msgid "Kabyle"
 msgstr "Kabil"
 
-#: ../src/wxMaximaFrame.cpp:1373
+#: ../src/wxMaximaFrame.cpp:1372
 msgid "Kappa"
 msgstr "Kappa"
 
@@ -2514,7 +2517,7 @@ msgstr "Kappa"
 msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr "Százalékjel használata speciális , mint például %e, %i, stb."
 
-#: ../src/wxMaxima.cpp:4031
+#: ../src/wxMaxima.cpp:4043
 msgid "LCM"
 msgstr "Legkisebb közös többszörös"
 
@@ -2532,7 +2535,7 @@ msgstr ""
 msgid "Label width:"
 msgstr "Címke szélesség:"
 
-#: ../src/wxMaximaFrame.cpp:1374
+#: ../src/wxMaximaFrame.cpp:1373
 msgid "Lambda"
 msgstr "Lambda"
 
@@ -2544,11 +2547,11 @@ msgstr "A wxMaxima grafikus felület nyelve."
 msgid "Language:"
 msgstr "Nyelv:"
 
-#: ../src/wxMaxima.cpp:4120
+#: ../src/wxMaxima.cpp:4132
 msgid "Laplace"
 msgstr "Laplace"
 
-#: ../src/wxMaximaFrame.cpp:803
+#: ../src/wxMaximaFrame.cpp:802
 msgid "Laplace &Transform..."
 msgstr "L&aplace-transzformáció..."
 
@@ -2556,15 +2559,15 @@ msgstr "L&aplace-transzformáció..."
 msgid "Leads to"
 msgstr "Vezet"
 
-#: ../src/wxMaximaFrame.cpp:812
+#: ../src/wxMaximaFrame.cpp:811
 msgid "Least Common Multiple..."
 msgstr "L&egkisebb közös többszörös..."
 
-#: ../src/wxMaxima.cpp:4809
+#: ../src/wxMaxima.cpp:4821
 msgid "Least Squares Fit"
 msgstr "Legkisebb négyzetes közelítés"
 
-#: ../src/wxMaximaFrame.cpp:1266
+#: ../src/wxMaximaFrame.cpp:1265
 msgid "Least Squares Fit..."
 msgstr "Legkisebb négyzetes közelítés..."
 
@@ -2579,23 +2582,23 @@ msgstr ""
 "felhasználói könyvtárban helyeztük el azokat. A felhasználói könyvtár "
 "elérési útját a maxima_userdir parancs végrehajtásával tudhatjuk meg."
 
-#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4192
+#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4204
 msgid "Limit"
 msgstr "Határérték"
 
-#: ../src/wxMaximaFrame.cpp:1225
+#: ../src/wxMaximaFrame.cpp:1224
 msgid "Limit..."
 msgstr "Határérték..."
 
-#: ../src/wxMaximaFrame.cpp:1265
+#: ../src/wxMaximaFrame.cpp:1264
 msgid "Linear Regression..."
 msgstr "Lineáris regresszió..."
 
-#: ../src/wxMaxima.cpp:3803
+#: ../src/wxMaxima.cpp:3815
 msgid "List(s):"
 msgstr "Listák:"
 
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3848
 msgid "List:"
 msgstr "Erre a listára:"
 
@@ -2603,15 +2606,15 @@ msgstr "Erre a listára:"
 msgid "Load"
 msgstr "Betöltés"
 
-#: ../src/wxMaxima.cpp:2932
+#: ../src/wxMaxima.cpp:2940
 msgid "Load Package"
 msgstr "Csomag betöltése"
 
-#: ../src/wxMaximaFrame.cpp:479
+#: ../src/wxMaximaFrame.cpp:478
 msgid "Load a Maxima file using the batch command"
 msgstr "Batch parancsokat használó Maxima fájl betöltése"
 
-#: ../src/wxMaximaFrame.cpp:477
+#: ../src/wxMaximaFrame.cpp:476
 msgid "Load a Maxima package file"
 msgstr "Maxima csomagfájl betöltése"
 
@@ -2623,47 +2626,47 @@ msgstr "Stílusfájl betöltése"
 msgid "Long Right arrow"
 msgstr "Hosszú jobbra nyíl"
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Lower bound:"
 msgstr "Alsó végpont:"
 
-#: ../src/wxMaximaFrame.cpp:771
+#: ../src/wxMaximaFrame.cpp:770
 msgid "Ma&p to Matrix..."
 msgstr "Mátrix leképe&zése..."
 
-#: ../src/wxMaximaFrame.cpp:547
+#: ../src/wxMaximaFrame.cpp:546
 msgid "Main Toolbar\tAlt-Shift-B"
 msgstr "Fő eszköztár\tAlt-Shift-B"
 
-#: ../src/wxMaximaFrame.cpp:765
+#: ../src/wxMaximaFrame.cpp:764
 msgid "Make &List..."
 msgstr "&Lista készítése..."
 
-#: ../src/wxMaxima.cpp:3821
+#: ../src/wxMaxima.cpp:3833
 msgid "Make list"
 msgstr "Lista készítése"
 
-#: ../src/wxMaximaFrame.cpp:766
+#: ../src/wxMaximaFrame.cpp:765
 msgid "Make list from expression"
 msgstr "Lista készítése kifejezésből"
 
-#: ../src/wxMaximaFrame.cpp:907
+#: ../src/wxMaximaFrame.cpp:906
 msgid "Make substitution in expression"
 msgstr "Behelyettesítés kifejezésbe"
 
-#: ../src/wxMaximaFrame.cpp:682
+#: ../src/wxMaximaFrame.cpp:681
 msgid "Manually Trigger Evaluation"
 msgstr "Trigger manuális végrehajtása"
 
-#: ../src/wxMaxima.cpp:3805
+#: ../src/wxMaxima.cpp:3817
 msgid "Map"
 msgstr "Leképezés"
 
-#: ../src/wxMaximaFrame.cpp:770
+#: ../src/wxMaximaFrame.cpp:769
 msgid "Map function to a list"
 msgstr "Lista leképezése listába"
 
-#: ../src/wxMaximaFrame.cpp:772
+#: ../src/wxMaximaFrame.cpp:771
 msgid "Map function to a matrix"
 msgstr "Mátrix leképezése mátrixba"
 
@@ -2680,23 +2683,23 @@ msgstr "Nyitó zárójelek párjának automatikus beírása"
 msgid "Math font:"
 msgstr "Matematika betűtípus:"
 
-#: ../src/wxMaximaFrame.cpp:374
+#: ../src/wxMaximaFrame.cpp:373
 msgid "Mathematical Symbols"
 msgstr "Matematikai szimbólumok"
 
-#: ../src/wxMaxima.cpp:3716
+#: ../src/wxMaxima.cpp:3728
 msgid "Matrix"
 msgstr "Mátrix"
 
-#: ../src/wxMaxima.cpp:3702
+#: ../src/wxMaxima.cpp:3714
 msgid "Matrix map"
 msgstr "Mátrix leképezés"
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Matrix name:"
 msgstr "Mátrix neve:"
 
-#: ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3749
+#: ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3761
 msgid "Matrix:"
 msgstr "Mátrix:"
 
@@ -2704,7 +2707,7 @@ msgstr "Mátrix:"
 msgid "Maxima"
 msgstr "Maxima"
 
-#: ../src/wxMaximaFrame.cpp:137
+#: ../src/wxMaximaFrame.cpp:136
 msgid "Maxima has a question"
 msgstr "A Maxima kapott egy kérdést"
 
@@ -2712,24 +2715,24 @@ msgstr "A Maxima kapott egy kérdést"
 msgid "Maxima input"
 msgstr "Maxima bemenet"
 
-#: ../src/wxMaximaFrame.cpp:166
+#: ../src/wxMaximaFrame.cpp:165
 msgid "Maxima is calculating"
 msgstr "A Maxima számol"
 
-#: ../src/wxMaximaFrame.cpp:111
+#: ../src/wxMaximaFrame.cpp:110
 #, fuzzy
 msgid "Maxima is ready for input."
 msgstr "Maxima bemenet"
 
-#: ../src/wxMaxima.cpp:2945
+#: ../src/wxMaxima.cpp:2953
 msgid "Maxima package (*.mac)|*.mac"
 msgstr "Maxima csomag (*.mac)|*.mac|"
 
-#: ../src/wxMaxima.cpp:2934
+#: ../src/wxMaxima.cpp:2942
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr "Maxima csomag (*.mac)|*.mac|Lisp csomag (*.lisp)|*.lisp|Minden fájl|*"
 
-#: ../src/wxMaxima.cpp:1014
+#: ../src/wxMaxima.cpp:1019
 msgid "Maxima process terminated."
 msgstr "A Maxima eljárásának futása megszakadt."
 
@@ -2741,7 +2744,7 @@ msgstr "Maxima program:"
 msgid "Maxima questions"
 msgstr "Maxima kérdései"
 
-#: ../src/wxMaxima.cpp:942
+#: ../src/wxMaxima.cpp:947
 msgid "Maxima started. Waiting for connection..."
 msgstr "A Maxima elindult és vár a kapcsolatra..."
 
@@ -2773,7 +2776,7 @@ msgstr ""
 "A Maxima a ':' jelet használja változó értékadására ('a : 3;') és a ':=' "
 "jelet függvény definiálására ('f(x) := x^2;'). "
 
-#: ../src/wxMaxima.cpp:4597
+#: ../src/wxMaxima.cpp:4609
 msgid "Maxima version: "
 msgstr "Maxima verzió: "
 
@@ -2810,40 +2813,40 @@ msgstr ""
 msgid "Maximum displayed number of digits:"
 msgstr "Maximálisan megjelenített számjegyek száma:"
 
-#: ../src/wxMaximaFrame.cpp:1263
+#: ../src/wxMaximaFrame.cpp:1262
 msgid "Mean Difference Test..."
 msgstr "Kétmintás t-próba..."
 
-#: ../src/wxMaximaFrame.cpp:1262
+#: ../src/wxMaximaFrame.cpp:1261
 msgid "Mean Test..."
 msgstr "Egymintás t-próba..."
 
-#: ../src/wxMaximaFrame.cpp:1255
+#: ../src/wxMaximaFrame.cpp:1254
 msgid "Mean..."
 msgstr "Átlag..."
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Mean:"
 msgstr "Átlag:"
 
-#: ../src/wxMaximaFrame.cpp:1256
+#: ../src/wxMaximaFrame.cpp:1255
 msgid "Median..."
 msgstr "Medián..."
 
-#: ../src/MathCtrl.cpp:945
+#: ../src/MathCtrl.cpp:987
 msgid "Merge Cells"
 msgstr "Cellák egyesítése"
 
-#: ../src/wxMaximaFrame.cpp:633
+#: ../src/wxMaximaFrame.cpp:632
 #, fuzzy
 msgid "Merge Cells\tCtrl-M"
 msgstr "Cellák egyesítése"
 
-#: ../src/wxMaximaFrame.cpp:634
+#: ../src/wxMaximaFrame.cpp:633
 msgid "Merge the text from two input cells into one"
 msgstr "Két bemeneti cella tartalmának összefűzése"
 
-#: ../src/wxMaxima.cpp:2668
+#: ../src/wxMaxima.cpp:2676
 msgid "Message from the stdout of Maxima: "
 msgstr "Üzenet a Maxima kimenetéről:"
 
@@ -2851,19 +2854,19 @@ msgstr "Üzenet a Maxima kimenetéről:"
 msgid "Method:"
 msgstr "Eljárás:"
 
-#: ../src/wxMaxima.cpp:5289
+#: ../src/wxMaxima.cpp:5301
 msgid "Mismatched parenthesis"
 msgstr "Hiányzó zárójel"
 
-#: ../src/wxMaxima.cpp:3972
+#: ../src/wxMaxima.cpp:3984
 msgid "Modulus"
 msgstr "Modulus"
 
-#: ../src/wxMaximaFrame.cpp:1375
+#: ../src/wxMaximaFrame.cpp:1374
 msgid "Mu"
 msgstr "Mű"
 
-#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Name:"
 msgstr "Név:"
 
@@ -2871,7 +2874,7 @@ msgstr "Név:"
 msgid "New"
 msgstr "Új"
 
-#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
+#: ../src/wxMaximaFrame.cpp:456 ../src/wxMaximaFrame.cpp:459
 msgid "New\tCtrl-N"
 msgstr "Ú&j\tCtrl-N"
 
@@ -2887,11 +2890,11 @@ msgstr "Új sorok: Ugrás a szövegre"
 msgid "New value:"
 msgstr "Új érték:"
 
-#: ../src/wxMaxima.cpp:3993 ../src/wxMaxima.cpp:4119 ../src/wxMaxima.cpp:4136
+#: ../src/wxMaxima.cpp:4005 ../src/wxMaxima.cpp:4131 ../src/wxMaxima.cpp:4148
 msgid "New variable:"
 msgstr "Új változó:"
 
-#: ../src/wxMaximaFrame.cpp:630
+#: ../src/wxMaximaFrame.cpp:629
 msgid "Next Command\tAlt-Down"
 msgstr "Kö&vetkező parancs\tAlt-Down"
 
@@ -2899,15 +2902,15 @@ msgstr "Kö&vetkező parancs\tAlt-Down"
 msgid "No"
 msgstr "Nincs"
 
-#: ../src/wxMaxima.cpp:5362
+#: ../src/wxMaxima.cpp:5378
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr "Nincs dollár ($) vagy pontosvessző (;) a parancsok végén"
 
-#: ../src/wxMaxima.cpp:3249 ../src/wxMaxima.cpp:3271
+#: ../src/wxMaxima.cpp:3260 ../src/wxMaxima.cpp:3283
 msgid "No matches found!"
 msgstr "A kifejezés nem található"
 
-#: ../src/wxMaximaFrame.cpp:1264
+#: ../src/wxMaximaFrame.cpp:1263
 msgid "Normality Test..."
 msgstr "Normalitás vizsgálat..."
 
@@ -2937,31 +2940,31 @@ msgstr ""
 msgid "Norwegian"
 msgstr "Norvég"
 
-#: ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:3740
 msgid "Not a valid matrix dimension!"
 msgstr "Hibás mátrixdimenzió!"
 
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629
 msgid "Not a valid number of equations!"
 msgstr "Az egyenletek száma hibás!"
 
-#: ../src/wxMaximaFrame.cpp:197
+#: ../src/wxMaximaFrame.cpp:196
 msgid "Not connected to maxima"
 msgstr "Nem csatlakozott a Maximához!"
 
-#: ../src/wxMaxima.cpp:4599
+#: ../src/wxMaxima.cpp:4611
 msgid "Not connected."
 msgstr "Nem csatlakozott."
 
-#: ../src/wxMaximaFrame.cpp:1376
+#: ../src/wxMaximaFrame.cpp:1375
 msgid "Nu"
 msgstr "Nű"
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Num. deg:"
 msgstr "Számláló foka:"
 
-#: ../src/wxMaxima.cpp:3585 ../src/wxMaxima.cpp:3609
+#: ../src/wxMaxima.cpp:3597 ../src/wxMaxima.cpp:3621
 msgid "Number of equations:"
 msgstr "Egyenletek száma:"
 
@@ -2988,15 +2991,15 @@ msgstr "OK"
 msgid "Old value:"
 msgstr "Régi érték:"
 
-#: ../src/wxMaxima.cpp:3992 ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135
+#: ../src/wxMaxima.cpp:4004 ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147
 msgid "Old variable:"
 msgstr "Régi változó:"
 
-#: ../src/wxMaximaFrame.cpp:1387
+#: ../src/wxMaximaFrame.cpp:1386
 msgid "Omega"
 msgstr "Ómega"
 
-#: ../src/wxMaximaFrame.cpp:1378
+#: ../src/wxMaximaFrame.cpp:1377
 msgid "Omicron"
 msgstr "Omikron"
 
@@ -3015,20 +3018,20 @@ msgstr ""
 "hibacsatornáján fogja küldeni. Ha ez a opció be van állítva, mindenképpen "
 "figyelni fogjuk a Maxima rendszerkimeneti csatornáját."
 
-#: ../src/wxMaxima.cpp:4763
+#: ../src/wxMaxima.cpp:4775
 msgid "One sample t-test"
 msgstr "Egymintás t-próba"
 
-#: ../src/wxMaximaFrame.cpp:971
+#: ../src/wxMaximaFrame.cpp:970
 msgid "Online tutorials"
 msgstr "Online ismertetők"
 
 #: ../src/ConfigDialogue.cpp:656 ../src/main.cpp:347 ../src/ToolBar.cpp:119
-#: ../src/wxMaxima.cpp:2797
+#: ../src/wxMaxima.cpp:2805
 msgid "Open"
 msgstr "Megnyitás"
 
-#: ../src/wxMaximaFrame.cpp:466
+#: ../src/wxMaximaFrame.cpp:465
 msgid "Open Recent"
 msgstr "Me&gnyitás"
 
@@ -3036,11 +3039,11 @@ msgstr "Me&gnyitás"
 msgid "Open a cell when Maxima expects input"
 msgstr "Nyit egy cellát, amikor a Maxima bemenetet vár"
 
-#: ../src/wxMaximaFrame.cpp:464
+#: ../src/wxMaximaFrame.cpp:463
 msgid "Open a document"
 msgstr "Dokumentum megnyitása"
 
-#: ../src/wxMaximaFrame.cpp:458 ../src/wxMaximaFrame.cpp:461
+#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
 msgid "Open a new window"
 msgstr "Új ablak"
 
@@ -3048,11 +3051,11 @@ msgstr "Új ablak"
 msgid "Open document"
 msgstr "Dokumentum megnyitása"
 
-#: ../src/wxMaxima.cpp:4824
+#: ../src/wxMaxima.cpp:4836
 msgid "Open matrix"
 msgstr "Mátrix megnyitása"
 
-#: ../src/wxMaxima.cpp:1446 ../src/wxMaxima.cpp:1518
+#: ../src/wxMaxima.cpp:1451 ../src/wxMaxima.cpp:1523
 msgid "Opening file"
 msgstr "Fájl megnyitása"
 
@@ -3076,11 +3079,11 @@ msgstr "Elavult cellák"
 msgid "Output labels"
 msgstr "Kimeneti címkék"
 
-#: ../src/wxMaximaFrame.cpp:796
+#: ../src/wxMaximaFrame.cpp:795
 msgid "P&ade Approximation..."
 msgstr "Padé-appro&ximáció..."
 
-#: ../src/wxMaxima.cpp:3132 ../src/wxMaxima.cpp:5133
+#: ../src/wxMaxima.cpp:3141 ../src/wxMaxima.cpp:5145
 msgid ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
 "bmp|Portable animap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X "
@@ -3090,15 +3093,15 @@ msgstr ""
 "*.bmp|Hordozható animap (*.pnm)|*.pnm|Címkézett kép fájlformátum (*.tif)|*."
 "tif|X pixmap (*.xpm)|*.xpm"
 
-#: ../src/wxMaxima.cpp:4012
+#: ../src/wxMaxima.cpp:4024
 msgid "Pade approximation"
 msgstr "Padé-approximáció"
 
-#: ../src/wxMaximaFrame.cpp:797
+#: ../src/wxMaximaFrame.cpp:796
 msgid "Pade approximation of a Taylor series"
 msgstr "Taylor-sor Padé-approximációja"
 
-#: ../src/wxMaximaFrame.cpp:1500
+#: ../src/wxMaximaFrame.cpp:1519
 msgid "Pagebreak"
 msgstr "Laptörés"
 
@@ -3110,19 +3113,19 @@ msgstr "Párhuzamos"
 msgid "Parametric plot"
 msgstr "Paraméteres ábrázolás"
 
-#: ../src/wxMaximaFrame.cpp:188
+#: ../src/wxMaximaFrame.cpp:187
 msgid "Parsing output"
 msgstr "Kimenet elemzése"
 
-#: ../src/wxMaximaFrame.cpp:819
+#: ../src/wxMaximaFrame.cpp:818
 msgid "Partial &Fractions..."
 msgstr "&Parciális törtek..."
 
-#: ../src/wxMaxima.cpp:4076
+#: ../src/wxMaxima.cpp:4088
 msgid "Partial fractions"
 msgstr "Parciális törtek"
 
-#: ../src/wxMaxima.cpp:1769
+#: ../src/wxMaxima.cpp:1774
 msgid "Parts of the document will not be loaded correctly!"
 msgstr "A dokumentum egyes részei nem töltődtek be!"
 
@@ -3134,11 +3137,11 @@ msgstr ""
 "A dokumentum egyes részei nem töltődnek be helyesen,\n"
 "mivel az ismeretlen XML címkenevet tartalmaz"
 
-#: ../src/ToolBar.cpp:143 ../src/MathCtrl.cpp:1010 ../src/MathCtrl.cpp:1025
+#: ../src/MathCtrl.cpp:1052 ../src/MathCtrl.cpp:1067 ../src/ToolBar.cpp:143
 msgid "Paste"
 msgstr "Beillesztés"
 
-#: ../src/wxMaximaFrame.cpp:518
+#: ../src/wxMaximaFrame.cpp:517
 msgid "Paste\tCtrl-V"
 msgstr "&Beillesztés\tCtrl-V"
 
@@ -3146,7 +3149,7 @@ msgstr "&Beillesztés\tCtrl-V"
 msgid "Paste from clipboard"
 msgstr "Szöveg beillesztése vágólapról"
 
-#: ../src/wxMaximaFrame.cpp:519
+#: ../src/wxMaximaFrame.cpp:518
 msgid "Paste text from clipboard"
 msgstr "Szöveg beillesztése vágólapról"
 
@@ -3154,19 +3157,19 @@ msgstr "Szöveg beillesztése vágólapról"
 msgid "Perpendicular to"
 msgstr "Merőleges"
 
-#: ../src/wxMaximaFrame.cpp:1384
+#: ../src/wxMaximaFrame.cpp:1383
 msgid "Phi"
 msgstr "Fí"
 
-#: ../src/wxMaximaFrame.cpp:1379
+#: ../src/wxMaximaFrame.cpp:1378
 msgid "Pi"
 msgstr "Pí"
 
-#: ../src/wxMaximaFrame.cpp:1273
+#: ../src/wxMaximaFrame.cpp:1272
 msgid "Piechart..."
 msgstr "Tortadiagram..."
 
-#: ../src/wxMaxima.cpp:1952
+#: ../src/wxMaxima.cpp:1957
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr "Kérem állítsa be a wxMaximát a 'Szerkesztés->Beállítás' menüpontban."
 
@@ -3174,52 +3177,52 @@ msgstr "Kérem állítsa be a wxMaximát a 'Szerkesztés->Beállítás' menüpon
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr "A változások életbe lépéséhez indítsa újra a wxMaximát!"
 
-#: ../src/wxMaximaFrame.cpp:923
+#: ../src/wxMaximaFrame.cpp:922
 msgid "Plot &2d..."
 msgstr "&2d-s ábrázolás..."
 
-#: ../src/wxMaximaFrame.cpp:925
+#: ../src/wxMaximaFrame.cpp:924
 msgid "Plot &3d..."
 msgstr "&3d-s ábrázolás..."
 
-#: ../src/wxMaximaFrame.cpp:927
+#: ../src/wxMaximaFrame.cpp:926
 msgid "Plot &Format..."
 msgstr "Á&brázolási mód..."
 
 #: ../src/Plot2dWiz.cpp:104 ../src/Plot2dWiz.cpp:450 ../src/Plot2dWiz.cpp:464
-#: ../src/wxMaxima.cpp:4283 ../src/wxMaxima.cpp:5102
+#: ../src/wxMaxima.cpp:4295 ../src/wxMaxima.cpp:5114
 msgid "Plot 2D"
 msgstr "Kétdimenziós ábrázolás"
 
-#: ../src/wxMaximaFrame.cpp:1227
+#: ../src/wxMaximaFrame.cpp:1226
 msgid "Plot 2D..."
 msgstr "2D..."
 
-#: ../src/MathCtrl.cpp:1003
+#: ../src/MathCtrl.cpp:1045
 msgid "Plot 2d..."
 msgstr "2d-s ábrázolás..."
 
-#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4269 ../src/wxMaxima.cpp:5115
+#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4281 ../src/wxMaxima.cpp:5127
 msgid "Plot 3D"
 msgstr "Háromdimenziós ábrázolás"
 
-#: ../src/wxMaximaFrame.cpp:1228
+#: ../src/wxMaximaFrame.cpp:1227
 msgid "Plot 3D..."
 msgstr "3D..."
 
-#: ../src/MathCtrl.cpp:1004
+#: ../src/MathCtrl.cpp:1046
 msgid "Plot 3d..."
 msgstr "3d-s ábrázolás..."
 
-#: ../src/wxMaxima.cpp:4296
+#: ../src/wxMaxima.cpp:4308
 msgid "Plot format"
 msgstr "Ábrázolási mód"
 
-#: ../src/wxMaximaFrame.cpp:924
+#: ../src/wxMaximaFrame.cpp:923
 msgid "Plot in 2 dimensions"
 msgstr "Ábrázolás két dimenzióban"
 
-#: ../src/wxMaximaFrame.cpp:926
+#: ../src/wxMaximaFrame.cpp:925
 msgid "Plot in 3 dimensions"
 msgstr "Ábrázolás három dimenzióban"
 
@@ -3228,8 +3231,8 @@ msgid "Plot to file:"
 msgstr "Ábrázolás fájlba:"
 
 #: ../src/BC2Wiz.cpp:30 ../src/BC2Wiz.cpp:36 ../src/LimitWiz.cpp:33
-#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
-#: ../src/wxMaxima.cpp:3648
+#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
+#: ../src/wxMaxima.cpp:3660
 msgid "Point:"
 msgstr "Hely:"
 
@@ -3237,11 +3240,11 @@ msgstr "Hely:"
 msgid "Polish"
 msgstr "Lengyel"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 1:"
 msgstr "1. polinom:"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 2:"
 msgstr "2. polinom:"
 
@@ -3253,11 +3256,11 @@ msgstr "Portugál (Brazil)"
 msgid "Postscript file (*.eps)|*.eps|All|*"
 msgstr "Postscript fájl (*.eps)|*.eps|Minden fájl|*"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Precision"
 msgstr "Pontosság"
 
-#: ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:536
 msgid "Preferences...\tCtrl+,"
 msgstr "Beállítások...\tCtrl+,"
 
@@ -3273,7 +3276,7 @@ msgstr ""
 "paramétereit ismeri, hanem a betöltött csomagokéit és az aktuális fájlon "
 "belül definiáltakéit is."
 
-#: ../src/wxMaximaFrame.cpp:628
+#: ../src/wxMaximaFrame.cpp:627
 msgid "Previous Command\tAlt-Up"
 msgstr "Előző parancs\tAlt-Up"
 
@@ -3281,11 +3284,11 @@ msgstr "Előző parancs\tAlt-Up"
 msgid "Print"
 msgstr "Nyomtatás"
 
-#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:484
+#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:483
 msgid "Print document"
 msgstr "Dokumentum nyomtatása"
 
-#: ../src/wxMaxima.cpp:4242
+#: ../src/wxMaxima.cpp:4254
 msgid "Product"
 msgstr "Szorzat"
 
@@ -3293,35 +3296,35 @@ msgstr "Szorzat"
 msgid "Product sign"
 msgstr "Szorzás jele"
 
-#: ../src/wxMaximaFrame.cpp:1386
+#: ../src/wxMaximaFrame.cpp:1385
 msgid "Psi"
 msgstr "Pszí"
 
-#: ../src/wxMaximaFrame.cpp:331
+#: ../src/wxMaximaFrame.cpp:330
 msgid "Raw XML monitor"
 msgstr "Nyers XML monitor"
 
-#: ../src/wxMaximaFrame.cpp:592
+#: ../src/wxMaximaFrame.cpp:591
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr "A kurzor feletti cellák újraszámolása"
 
-#: ../src/wxMaximaFrame.cpp:1278
+#: ../src/wxMaximaFrame.cpp:1277
 msgid "Read Matrix..."
 msgstr "Mátrix beolvasása..."
 
-#: ../src/wxMaximaFrame.cpp:177
+#: ../src/wxMaximaFrame.cpp:176
 msgid "Reading Maxima output"
 msgstr "Maxima kimenetelének olvasása"
 
-#: ../src/wxMaximaFrame.cpp:153
+#: ../src/wxMaximaFrame.cpp:152
 msgid "Ready for user input"
 msgstr "Bemeneti adatok fogadása"
 
-#: ../src/wxMaximaFrame.cpp:631
+#: ../src/wxMaximaFrame.cpp:630
 msgid "Recall next command from history"
 msgstr "A következő parancs előhozása az előzmények közül"
 
-#: ../src/wxMaximaFrame.cpp:629
+#: ../src/wxMaximaFrame.cpp:628
 msgid "Recall previous command from history"
 msgstr "Az előző parancs előhozása az előzmények közül"
 
@@ -3329,35 +3332,35 @@ msgstr "Az előző parancs előhozása az előzmények közül"
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1215
+#: ../src/wxMaximaFrame.cpp:1214
 msgid "Rectform"
 msgstr "Alg.-i alak"
 
-#: ../src/wxMaximaFrame.cpp:495
+#: ../src/wxMaximaFrame.cpp:494
 msgid "Redo\tCtrl-Y"
 msgstr "Ismételt végrehajtás\tCtrl-Y"
 
-#: ../src/wxMaximaFrame.cpp:496
+#: ../src/wxMaximaFrame.cpp:495
 msgid "Redo last change"
 msgstr "Utolsó változtatás visszavonása"
 
-#: ../src/wxMaximaFrame.cpp:1220
+#: ../src/wxMaximaFrame.cpp:1219
 msgid "Reduce (tr)"
 msgstr "Redukál (tr)"
 
-#: ../src/wxMaximaFrame.cpp:871
+#: ../src/wxMaximaFrame.cpp:870
 msgid "Reduce trigonometric expression"
 msgstr "Trigonometrikus kifejezés redukált alakra hozása"
 
-#: ../src/wxMaxima.cpp:622 ../src/wxMaxima.cpp:5495
+#: ../src/wxMaxima.cpp:627 ../src/wxMaxima.cpp:5511
 msgid "Refusing to send cell to maxima: "
 msgstr "A cella Maximához küldésének megtagadása"
 
-#: ../src/wxMaximaFrame.cpp:594
+#: ../src/wxMaximaFrame.cpp:593
 msgid "Remove All Output"
 msgstr "A&z összes kimenet eltávolítása"
 
-#: ../src/wxMaximaFrame.cpp:595
+#: ../src/wxMaximaFrame.cpp:594
 msgid "Remove output from input cells"
 msgstr "A kimenet eltávolítása a bemeneti cellákból"
 
@@ -3366,7 +3369,7 @@ msgstr "A kimenet eltávolítása a bemeneti cellákból"
 msgid "Replace All"
 msgstr "Cellatartalom kijelölése"
 
-#: ../src/wxMaxima.cpp:3282
+#: ../src/wxMaxima.cpp:3294
 #, c-format
 msgid "Replaced %d occurrences."
 msgstr "%d egyezés kicserélve"
@@ -3375,11 +3378,11 @@ msgstr "%d egyezés kicserélve"
 msgid "Replacement:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:976
+#: ../src/wxMaximaFrame.cpp:975
 msgid "Report bug"
 msgstr "Rendszerinformációk hiba bejelentéséhez"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "Restart Maxima"
 msgstr "A Maxima újraindítása"
 
@@ -3387,7 +3390,7 @@ msgstr "A Maxima újraindítása"
 msgid "Restart maxima"
 msgstr "A Maxima újraindítása"
 
-#: ../src/MathCtrl.cpp:4442
+#: ../src/MathCtrl.cpp:4497
 msgid "Result"
 msgstr "Eredmény"
 
@@ -3395,7 +3398,7 @@ msgstr "Eredmény"
 msgid "Return to the cell that is currently being evaluated"
 msgstr "Visszatérés a most kiértékelt cellára"
 
-#: ../src/wxMaximaFrame.cpp:1380
+#: ../src/wxMaximaFrame.cpp:1379
 msgid "Rho"
 msgstr "Ró"
 
@@ -3403,19 +3406,19 @@ msgstr "Ró"
 msgid "Right arrow"
 msgstr "Jobbra nyíl"
 
-#: ../src/wxMaximaFrame.cpp:779
+#: ../src/wxMaximaFrame.cpp:778
 msgid "Risch Integration..."
 msgstr "&Risch-integrálás..."
 
-#: ../src/wxMaximaFrame.cpp:694
+#: ../src/wxMaximaFrame.cpp:693
 msgid "Roots of &Polynomial"
 msgstr "&Polinom gyökei"
 
-#: ../src/wxMaximaFrame.cpp:697
+#: ../src/wxMaximaFrame.cpp:696
 msgid "Roots of Polynomial (bfloat)"
 msgstr "P&olinom gyökei (bfloat)"
 
-#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Rows:"
 msgstr "Sorok:"
 
@@ -3423,56 +3426,56 @@ msgstr "Sorok:"
 msgid "Russian"
 msgstr "Orosz"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 1:"
 msgstr "1. minta:"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 2:"
 msgstr "2. minta:"
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Sample:"
 msgstr "Minta:"
 
 #: ../src/ConfigDialogue.cpp:781 ../src/ToolBar.cpp:122
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Save"
 msgstr "Mentés"
 
-#: ../src/MathCtrl.cpp:921
+#: ../src/MathCtrl.cpp:963
 msgid "Save Animation..."
 msgstr "Animáció mentése..."
 
-#: ../src/wxMaxima.cpp:2565
+#: ../src/wxMaxima.cpp:2572
 msgid "Save As"
 msgstr "Mentés másként"
 
-#: ../src/wxMaximaFrame.cpp:474
+#: ../src/wxMaximaFrame.cpp:473
 msgid "Save As...\tShift-Ctrl-S"
 msgstr "Men&tés másként...\tShift-Ctrl-S"
 
-#: ../src/MathCtrl.cpp:919
+#: ../src/MathCtrl.cpp:961
 msgid "Save Image..."
 msgstr "Kép mentése..."
 
-#: ../src/wxMaxima.cpp:3130
+#: ../src/wxMaxima.cpp:3139
 msgid "Save Selection to Image"
 msgstr "Kijelölés mentése képbe"
 
-#: ../src/wxMaximaFrame.cpp:528
+#: ../src/wxMaximaFrame.cpp:527
 msgid "Save Selection to Image..."
 msgstr "Ki&jelölés mentése képbe..."
 
-#: ../src/wxMaxima.cpp:5150
+#: ../src/wxMaxima.cpp:5162
 msgid "Save animation to file"
 msgstr "Animáció mentése fájlba"
 
-#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:473
+#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:472
 msgid "Save document"
 msgstr "Dokumentum mentése"
 
-#: ../src/wxMaximaFrame.cpp:475
+#: ../src/wxMaximaFrame.cpp:474
 msgid "Save document as"
 msgstr "Mentés másként"
 
@@ -3496,11 +3499,11 @@ msgstr "Panelek állapotának mentése."
 msgid "Save plot to file"
 msgstr "Kép mentése fájlba"
 
-#: ../src/wxMaximaFrame.cpp:529
+#: ../src/wxMaximaFrame.cpp:528
 msgid "Save selection from document to an image file"
 msgstr "Kijelölt rész fájlba másolása a dokumentumból"
 
-#: ../src/wxMaxima.cpp:5131
+#: ../src/wxMaxima.cpp:5143
 msgid "Save selection to file"
 msgstr "Kijelölt rész mentése fájlba"
 
@@ -3516,27 +3519,27 @@ msgstr "Ablak méret/pozíció mentése"
 msgid "Save wxMaxima window size/position between sessions."
 msgstr "wxMaxima ablak méret/pozíció mentése."
 
-#: ../src/wxMaximaFrame.cpp:246
+#: ../src/wxMaximaFrame.cpp:245
 msgid "Saving failed."
 msgstr "A mentés meghiúsult"
 
-#: ../src/wxMaximaFrame.cpp:222
+#: ../src/wxMaximaFrame.cpp:221
 msgid "Saving successful."
 msgstr "Sikeres mentés."
 
-#: ../src/wxMaximaFrame.cpp:212
+#: ../src/wxMaximaFrame.cpp:211
 msgid "Saving..."
 msgstr "Mentés..."
 
-#: ../src/wxMaxima.cpp:4699
+#: ../src/wxMaxima.cpp:4711
 msgid "Scatterplot"
 msgstr "Szóródási pont"
 
-#: ../src/wxMaximaFrame.cpp:1271
+#: ../src/wxMaximaFrame.cpp:1270
 msgid "Scatterplot..."
 msgstr "Szóródási pont..."
 
-#: ../src/wxMaximaFrame.cpp:1498
+#: ../src/wxMaximaFrame.cpp:1517
 msgid "Section"
 msgstr "Fejezet"
 
@@ -3544,8 +3547,8 @@ msgstr "Fejezet"
 msgid "Section cell"
 msgstr "Fejezetcella"
 
-#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:292 ../src/TextCell.cpp:306
-#: ../src/TextCell.cpp:322 ../src/TextCell.cpp:334
+#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:290 ../src/TextCell.cpp:304
+#: ../src/TextCell.cpp:320 ../src/TextCell.cpp:332
 msgid ""
 "Seems like something is broken with a font. Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
@@ -3556,7 +3559,7 @@ msgstr ""
 "és a \"jsMath karakterek használata\" bejelölése a beállításoknál megoldást "
 "jelenthet."
 
-#: ../src/TextCell.cpp:139
+#: ../src/TextCell.cpp:137
 msgid ""
 "Seems like something is broken with the maths font. Installing http://www."
 "math.union.edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use "
@@ -3567,11 +3570,11 @@ msgstr ""
 "html oldalról és a \"jsMath karakterek használata\" bejelölése a "
 "beállításoknál megoldást jelenthet."
 
-#: ../src/MathCtrl.cpp:1011 ../src/MathCtrl.cpp:1027
+#: ../src/MathCtrl.cpp:1053 ../src/MathCtrl.cpp:1069
 msgid "Select All"
 msgstr "Cellatartalom kijelölése"
 
-#: ../src/wxMaximaFrame.cpp:525
+#: ../src/wxMaximaFrame.cpp:524
 msgid "Select All\tCtrl-A"
 msgstr "&Minden kiválasztása\tCtrl-A"
 
@@ -3579,7 +3582,7 @@ msgstr "&Minden kiválasztása\tCtrl-A"
 msgid "Select Maxima program"
 msgstr "A Maxima program kiválasztása"
 
-#: ../src/wxMaxima.cpp:4860
+#: ../src/wxMaxima.cpp:4872
 msgid "Select Subsample"
 msgstr "Részminta kiválasztása"
 
@@ -3588,11 +3591,11 @@ msgstr "Részminta kiválasztása"
 msgid "Select a constant"
 msgstr "Állandó kiválasztása"
 
-#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:526
+#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:525
 msgid "Select all"
 msgstr "Minden kiválasztása"
 
-#: ../src/wxMaxima.cpp:3319
+#: ../src/wxMaxima.cpp:3331
 msgid "Select math display algorithm"
 msgstr "Matematikai megjelenítés algoritmusának kiválasztása"
 
@@ -3608,23 +3611,23 @@ msgstr ""
 msgid "Selection"
 msgstr "Kijelölt rész másolása"
 
-#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4178
+#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4190
 msgid "Series"
 msgstr "Taylor- és hatványsor"
 
-#: ../src/wxMaximaFrame.cpp:1226
+#: ../src/wxMaximaFrame.cpp:1225
 msgid "Series..."
 msgstr "Hatv.sor..."
 
-#: ../src/wxMaxima.cpp:863
+#: ../src/wxMaxima.cpp:868
 msgid "Server started"
 msgstr "A kiszolgáló elindult"
 
-#: ../src/wxMaximaFrame.cpp:575
+#: ../src/wxMaximaFrame.cpp:574
 msgid "Set Zoom"
 msgstr "Nagyítás beállítása"
 
-#: ../src/wxMaximaFrame.cpp:944
+#: ../src/wxMaximaFrame.cpp:943
 msgid "Set bigfloat &Precision..."
 msgstr "Hosszú lebegőpontos műveletek &pontosságának állítása..."
 
@@ -3632,11 +3635,11 @@ msgstr "Hosszú lebegőpontos műveletek &pontosságának állítása..."
 msgid "Set fixed font in text controls."
 msgstr "Rögzített szélességű betűtípus beállítása a bemeneti sorban."
 
-#: ../src/wxMaximaFrame.cpp:928
+#: ../src/wxMaximaFrame.cpp:927
 msgid "Set plot format"
 msgstr "Ábrázolás módjának állítása"
 
-#: ../src/wxMaximaFrame.cpp:945
+#: ../src/wxMaximaFrame.cpp:944
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can "
 "be generated by entering 1.5b12 or as bfloat(1.234)"
@@ -3644,53 +3647,53 @@ msgstr ""
 "A bigfloat eljárással definiált számok pontosságának állítása. Ilyen "
 "számokat például 1.5b12 vagy bfloat(1.234) beírásával generálhatunk."
 
-#: ../src/wxMaximaFrame.cpp:569
+#: ../src/wxMaximaFrame.cpp:568
 msgid "Set zoom to 100%"
 msgstr "Nagyítás beállítása 100%-ra"
 
-#: ../src/wxMaximaFrame.cpp:570
+#: ../src/wxMaximaFrame.cpp:569
 msgid "Set zoom to 120%"
 msgstr "Nagyítás beállítása 120%-ra"
 
-#: ../src/wxMaximaFrame.cpp:571
+#: ../src/wxMaximaFrame.cpp:570
 msgid "Set zoom to 150%"
 msgstr "Nagyítás beállítása 150%-ra"
 
-#: ../src/wxMaximaFrame.cpp:572
+#: ../src/wxMaximaFrame.cpp:571
 msgid "Set zoom to 200%"
 msgstr "Nagyítás beállítása 200%-ra"
 
-#: ../src/wxMaximaFrame.cpp:573
+#: ../src/wxMaximaFrame.cpp:572
 msgid "Set zoom to 300%"
 msgstr "Nagyítás beállítása 300%-ra"
 
-#: ../src/wxMaximaFrame.cpp:568
+#: ../src/wxMaximaFrame.cpp:567
 msgid "Set zoom to 80%"
 msgstr "Nagyítás beállítása 80%-ra"
 
-#: ../src/wxMaximaFrame.cpp:732
+#: ../src/wxMaximaFrame.cpp:731
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
 "Laplace-transzformációval megoldani próbált kezdetiérték-probléma kezdeti "
 "helyének és értékének beállítása"
 
-#: ../src/wxMaximaFrame.cpp:918
+#: ../src/wxMaximaFrame.cpp:917
 msgid "Setup modulus computation"
 msgstr "Modulus értékének beállítása"
 
-#: ../src/wxMaximaFrame.cpp:662
+#: ../src/wxMaximaFrame.cpp:661
 msgid "Show &Definition..."
 msgstr "&Definíció..."
 
-#: ../src/wxMaximaFrame.cpp:660
+#: ../src/wxMaximaFrame.cpp:659
 msgid "Show &Functions"
 msgstr "&Függvények"
 
-#: ../src/wxMaximaFrame.cpp:967
+#: ../src/wxMaximaFrame.cpp:966
 msgid "Show &Tips..."
 msgstr "&Tippek..."
 
-#: ../src/wxMaximaFrame.cpp:665
+#: ../src/wxMaximaFrame.cpp:664
 msgid "Show &Variables"
 msgstr "&Változók"
 
@@ -3698,43 +3701,43 @@ msgstr "&Változók"
 msgid "Show Maxima help"
 msgstr "Maxima súgó"
 
-#: ../src/wxMaximaFrame.cpp:603
+#: ../src/wxMaximaFrame.cpp:602
 msgid "Show Template\tCtrl-Shift-K"
 msgstr "K&iegészítés sablonnal\tCtrl-Shift-K"
 
-#: ../src/wxMaximaFrame.cpp:968
+#: ../src/wxMaximaFrame.cpp:967
 msgid "Show a tip"
 msgstr "Tippet mutat"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Show all commands similar to:"
 msgstr "Megmutat minden parancsot, ami hasonlít erre:"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Show an example for the command:"
 msgstr "Példa az alábbi parancsra:"
 
-#: ../src/wxMaximaFrame.cpp:962
+#: ../src/wxMaximaFrame.cpp:961
 msgid "Show an example of usage"
 msgstr "Példa a parancs használatára"
 
-#: ../src/wxMaximaFrame.cpp:965
+#: ../src/wxMaximaFrame.cpp:964
 msgid "Show commands similar to"
 msgstr "Megmutat minden parancsot, ami hasonlít erre"
 
-#: ../src/wxMaximaFrame.cpp:661
+#: ../src/wxMaximaFrame.cpp:660
 msgid "Show defined functions"
 msgstr "Megmutatja a definiált függvényeket"
 
-#: ../src/wxMaximaFrame.cpp:666
+#: ../src/wxMaximaFrame.cpp:665
 msgid "Show defined variables"
 msgstr "Megmutatja a definiált változókat"
 
-#: ../src/wxMaximaFrame.cpp:663
+#: ../src/wxMaximaFrame.cpp:662
 msgid "Show definition of a function"
 msgstr "Megmutatja a függvény definícióját"
 
-#: ../src/wxMaximaFrame.cpp:604
+#: ../src/wxMaximaFrame.cpp:603
 msgid "Show function template"
 msgstr "Függvény automatikus kiegészítése sablonnal"
 
@@ -3746,7 +3749,7 @@ msgstr "A wxMaxima konzolja megjeleníti a hosszú kifejezéseket."
 msgid "Show long expressions:"
 msgstr "Hosszú kifejezések megjelenítése:"
 
-#: ../src/wxMaxima.cpp:3341
+#: ../src/wxMaxima.cpp:3353
 msgid "Show the definition of function:"
 msgstr "Megmutatja a függvény definícióját:"
 
@@ -3755,43 +3758,43 @@ msgstr "Megmutatja a függvény definícióját:"
 msgid "Show user-defined labels instead of (%oxx)"
 msgstr "Mutassa a felhasználó által definiált címkéket (%oxx) helyett"
 
-#: ../src/wxMaximaFrame.cpp:953 ../src/wxMaximaFrame.cpp:956
+#: ../src/wxMaximaFrame.cpp:952 ../src/wxMaximaFrame.cpp:955
 msgid "Show wxMaxima help"
 msgstr "Maxima súgó"
 
-#: ../src/wxMaximaFrame.cpp:1381
+#: ../src/wxMaximaFrame.cpp:1380
 msgid "Sigma"
 msgstr "Szigma"
 
-#: ../src/wxMaximaFrame.cpp:1211
+#: ../src/wxMaximaFrame.cpp:1210
 msgid "Simplify"
 msgstr "Egyszerűsít"
 
-#: ../src/wxMaximaFrame.cpp:831
+#: ../src/wxMaximaFrame.cpp:830
 msgid "Simplify &Radicals"
 msgstr "&Gyökös egyszerűsítés"
 
-#: ../src/wxMaximaFrame.cpp:1212
+#: ../src/wxMaximaFrame.cpp:1211
 msgid "Simplify (r)"
 msgstr "Egysz. (r)"
 
-#: ../src/wxMaximaFrame.cpp:1218
+#: ../src/wxMaximaFrame.cpp:1217
 msgid "Simplify (tr)"
 msgstr "Egysz. (tr)"
 
-#: ../src/MathCtrl.cpp:995
+#: ../src/MathCtrl.cpp:1037
 msgid "Simplify Expression"
 msgstr "Kifejezés egyszerűsítése"
 
-#: ../src/wxMaximaFrame.cpp:857
+#: ../src/wxMaximaFrame.cpp:856
 msgid "Simplify an expression containing factorials"
 msgstr "Faktoriálisokat tartalmazó kifejezések egyszerűsítése"
 
-#: ../src/wxMaximaFrame.cpp:832
+#: ../src/wxMaximaFrame.cpp:831
 msgid "Simplify expression containing radicals"
 msgstr "Gyököket tartalmazó kifejezések egyszerűsítése"
 
-#: ../src/wxMaximaFrame.cpp:830
+#: ../src/wxMaximaFrame.cpp:829
 msgid "Simplify rational expression"
 msgstr "Racionális kifejezések egyszerűsítése"
 
@@ -3799,7 +3802,7 @@ msgstr "Racionális kifejezések egyszerűsítése"
 msgid "Simplify the sum"
 msgstr "Egyszerűsíti az összeget"
 
-#: ../src/wxMaximaFrame.cpp:868
+#: ../src/wxMaximaFrame.cpp:867
 msgid "Simplify trigonometric expression"
 msgstr "Trigonometrikus kifejezést egyszerűbb alakra hoz"
 
@@ -3815,94 +3818,94 @@ msgstr ""
 "Megjegyezzük, hogy ahhoz, hogy a kép is mentve legyen, a dokumentumot "
 "'wxMaxima XML dokumentum' formátumban kell menteni."
 
-#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
+#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
 msgid "Solution:"
 msgstr "Megoldás:"
 
-#: ../src/wxMaxima.cpp:3461 ../src/wxMaxima.cpp:3475 ../src/wxMaxima.cpp:5020
+#: ../src/wxMaxima.cpp:3473 ../src/wxMaxima.cpp:3487 ../src/wxMaxima.cpp:5032
 msgid "Solve"
 msgstr "Megoldás"
 
-#: ../src/wxMaximaFrame.cpp:706
+#: ../src/wxMaximaFrame.cpp:705
 msgid "Solve &Algebraic System..."
 msgstr "&Algebrai egyenletrendszer megoldása..."
 
-#: ../src/wxMaximaFrame.cpp:703
+#: ../src/wxMaximaFrame.cpp:702
 msgid "Solve &Linear System..."
 msgstr "&Lineáris egyenletrendszer megoldása..."
 
-#: ../src/wxMaximaFrame.cpp:714
+#: ../src/wxMaximaFrame.cpp:713
 msgid "Solve &ODE..."
 msgstr "&Differenciálegyenlet megoldása..."
 
-#: ../src/wxMaximaFrame.cpp:690
+#: ../src/wxMaximaFrame.cpp:689
 msgid "Solve (to_poly)..."
 msgstr "Me&goldás (to_poly)..."
 
-#: ../src/wxMaxima.cpp:3511 ../src/wxMaxima.cpp:3635
+#: ../src/wxMaxima.cpp:3523 ../src/wxMaxima.cpp:3647
 msgid "Solve ODE"
 msgstr "Differenciálegyenlet megoldása"
 
-#: ../src/wxMaximaFrame.cpp:728
+#: ../src/wxMaximaFrame.cpp:727
 msgid "Solve ODE with Lapla&ce..."
 msgstr "D&ifferenciálegyenlet megoldása (Laplace)..."
 
-#: ../src/wxMaximaFrame.cpp:1222
+#: ../src/wxMaximaFrame.cpp:1221
 msgid "Solve ODE..."
 msgstr "Differenciálegyenletek megoldása...."
 
-#: ../src/wxMaxima.cpp:3586 ../src/wxMaxima.cpp:3597
+#: ../src/wxMaxima.cpp:3598 ../src/wxMaxima.cpp:3609
 msgid "Solve algebraic system"
 msgstr "Algebrai egyenletrendszer"
 
-#: ../src/wxMaximaFrame.cpp:707
+#: ../src/wxMaximaFrame.cpp:706
 msgid "Solve algebraic system of equations"
 msgstr "Algebrai egyenletrendszer megoldása"
 
-#: ../src/wxMaximaFrame.cpp:725
+#: ../src/wxMaximaFrame.cpp:724
 msgid "Solve boundary value problem for second degree ODE"
 msgstr ""
 "Peremérték probléma megoldása másodrendű közönséges differenciálegyenlet "
 "esetén"
 
-#: ../src/wxMaximaFrame.cpp:689
+#: ../src/wxMaximaFrame.cpp:688
 msgid "Solve equation(s)"
 msgstr "Egyenletet(rendszer) megoldása"
 
-#: ../src/wxMaximaFrame.cpp:691
+#: ../src/wxMaximaFrame.cpp:690
 msgid "Solve equation(s) with to_poly_solve"
 msgstr "Egyenletet(rendszer)ek megoldása a to_poly_solve eljárással"
 
-#: ../src/wxMaximaFrame.cpp:719
+#: ../src/wxMaximaFrame.cpp:718
 msgid "Solve initial value problem for first degree ODE"
 msgstr ""
 "Kezdetiérték-probléma megoldása elsőrendű közönséges differenciálegyenlet "
 "esetén"
 
-#: ../src/wxMaximaFrame.cpp:722
+#: ../src/wxMaximaFrame.cpp:721
 msgid "Solve initial value problem for second degree ODE"
 msgstr ""
 "Kezdetiérték-probléma megoldása másodrendű közönséges differenciálegyenlet "
 "esetén"
 
-#: ../src/wxMaxima.cpp:3610 ../src/wxMaxima.cpp:3621
+#: ../src/wxMaxima.cpp:3622 ../src/wxMaxima.cpp:3633
 msgid "Solve linear system"
 msgstr "Lineáris egyenletrendszer"
 
-#: ../src/wxMaximaFrame.cpp:704
+#: ../src/wxMaximaFrame.cpp:703
 msgid "Solve linear system of equations"
 msgstr "Lineáris egyenletrendszer megoldása"
 
-#: ../src/wxMaximaFrame.cpp:715
+#: ../src/wxMaximaFrame.cpp:714
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr "Legfeljebb másodrendű közönséges differenciálegyenlet megoldása"
 
-#: ../src/wxMaximaFrame.cpp:729
+#: ../src/wxMaximaFrame.cpp:728
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
 "Közönséges differenciálegyenlet megoldása Laplace-transzformáció segítségével"
 
-#: ../src/wxMaximaFrame.cpp:1221 ../src/MathCtrl.cpp:992
+#: ../src/MathCtrl.cpp:1034 ../src/wxMaximaFrame.cpp:1220
 msgid "Solve..."
 msgstr "Megold..."
 
@@ -3929,7 +3932,7 @@ msgstr "Különleges"
 msgid "Special constants"
 msgstr "Különleges állandó"
 
-#: ../src/MathCtrl.cpp:922
+#: ../src/MathCtrl.cpp:964
 msgid "Start Animation"
 msgstr "Animáció indítása"
 
@@ -3949,28 +3952,28 @@ msgstr ""
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:294
+#: ../src/wxMaxima.cpp:295
 msgid "Starting Maxima process failed"
 msgstr "A Maxima folyamat leállt"
 
-#: ../src/wxMaxima.cpp:928
+#: ../src/wxMaxima.cpp:933
 msgid "Starting Maxima..."
 msgstr "Indul a Maxima..."
 
-#: ../src/wxMaxima.cpp:292 ../src/wxMaxima.cpp:860
+#: ../src/wxMaxima.cpp:293 ../src/wxMaxima.cpp:865
 msgid "Starting server failed"
 msgstr "A szerver leállt"
 
-#: ../src/wxMaxima.cpp:841
+#: ../src/wxMaxima.cpp:846
 #, c-format
 msgid "Starting server on port %d"
 msgstr "A szerver elindult és az alábbi porton figyel %d"
 
-#: ../src/wxMaximaFrame.cpp:342
+#: ../src/wxMaximaFrame.cpp:341
 msgid "Statistics"
 msgstr "Statisztika"
 
-#: ../src/wxMaximaFrame.cpp:550
+#: ../src/wxMaximaFrame.cpp:549
 msgid "Statistics\tAlt-Shift-S"
 msgstr "Statisztika\tAlt-Shift-S"
 
@@ -3986,11 +3989,11 @@ msgstr "Stílus"
 msgid "Styles"
 msgstr "Stílusok"
 
-#: ../src/wxMaximaFrame.cpp:1283
+#: ../src/wxMaximaFrame.cpp:1282
 msgid "Subsample..."
 msgstr "Részminta..."
 
-#: ../src/wxMaximaFrame.cpp:1496
+#: ../src/wxMaximaFrame.cpp:1515
 msgid "Subsection"
 msgstr "Alfejezet"
 
@@ -3998,20 +4001,20 @@ msgstr "Alfejezet"
 msgid "Subsection cell"
 msgstr "Alfejezetcella"
 
-#: ../src/wxMaximaFrame.cpp:1216
+#: ../src/wxMaximaFrame.cpp:1215
 msgid "Subst..."
 msgstr "Behelyet...."
 
-#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3423
-#: ../src/wxMaxima.cpp:5089
+#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3435
+#: ../src/wxMaxima.cpp:5101
 msgid "Substitute"
 msgstr "Behelyettesítés"
 
-#: ../src/wxMaximaFrame.cpp:906 ../src/MathCtrl.cpp:998
+#: ../src/MathCtrl.cpp:1040 ../src/wxMaximaFrame.cpp:905
 msgid "Substitute..."
 msgstr "&Behelyettesítés..."
 
-#: ../src/wxMaximaFrame.cpp:1497
+#: ../src/wxMaximaFrame.cpp:1516
 msgid "Subsubsection"
 msgstr "Al-alfejezet"
 
@@ -4019,7 +4022,7 @@ msgstr "Al-alfejezet"
 msgid "Subsubsection cell"
 msgstr "Al-alfejezetcella"
 
-#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4226
+#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4238
 msgid "Sum"
 msgstr "Összeg"
 
@@ -4027,35 +4030,35 @@ msgstr "Összeg"
 msgid "Sum sign"
 msgstr "Szummajel"
 
-#: ../src/wxMaximaFrame.cpp:553
+#: ../src/wxMaximaFrame.cpp:552
 msgid "Symbols\tAlt-Shift-Y"
 msgstr "Szimbólumok\tAlt-Shift-Y"
 
-#: ../src/wxMaxima.cpp:4456
+#: ../src/wxMaxima.cpp:4468
 msgid "System info"
 msgstr "Rendszerinformáció"
 
-#: ../src/wxMaximaFrame.cpp:320
+#: ../src/wxMaximaFrame.cpp:319
 msgid "Table of Contents"
 msgstr "Tartalomjegyzék"
 
-#: ../src/wxMaximaFrame.cpp:556
+#: ../src/wxMaximaFrame.cpp:555
 msgid "Table of Contents\tAlt-Shift-T"
 msgstr "Tartalomjegyzék\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:1382
+#: ../src/wxMaximaFrame.cpp:1381
 msgid "Tau"
 msgstr "Tau"
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Taylor series:"
 msgstr "Taylor-sor:"
 
-#: ../src/wxMaxima.cpp:3963
+#: ../src/wxMaxima.cpp:3975
 msgid "Tellrat"
 msgstr "'tellrat' eljárás"
 
-#: ../src/wxMaximaFrame.cpp:1494
+#: ../src/wxMaximaFrame.cpp:1513
 msgid "Text"
 msgstr "Szöveg"
 
@@ -4106,7 +4109,7 @@ msgstr ""
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr "Dokumentumjainkhoz a LaTeX dokumentum osztályt használjuk. "
 
-#: ../src/TextCell.cpp:136
+#: ../src/TextCell.cpp:134
 msgid ""
 "The letter \"X\" is of width zero. Installing http://www.math.union.edu/"
 "~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts\" in "
@@ -4127,7 +4130,7 @@ msgstr ""
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:959
+#: ../src/wxMaximaFrame.cpp:958
 msgid "The offline manual of maxima"
 msgstr "A Maxima offline kézikönyve"
 
@@ -4167,7 +4170,7 @@ msgstr ""
 "További információkért és leírásokért látogasson el a http://andrejv.github."
 "com/wxmaxima/help.html címre."
 
-#: ../src/SlideShowCell.cpp:332
+#: ../src/SlideShowCell.cpp:336
 msgid ""
 "There was an error during GIF export!\n"
 "\n"
@@ -4178,7 +4181,7 @@ msgstr ""
 "Ellenőrizze, hogy az ImageMagick telepítve van, valamint elérhető a wxMaxima "
 "számára!"
 
-#: ../src/wxMaxima.cpp:442
+#: ../src/wxMaxima.cpp:447
 msgid ""
 "There was an error in generated XML!\n"
 "\n"
@@ -4188,7 +4191,7 @@ msgstr ""
 " \n"
 " Kérem jelentse a hibát."
 
-#: ../src/wxMaximaFrame.cpp:1371
+#: ../src/wxMaximaFrame.cpp:1370
 msgid "Theta"
 msgstr "Théta"
 
@@ -4196,7 +4199,7 @@ msgstr "Théta"
 msgid "Ticks:"
 msgstr "Törésvonalak:"
 
-#: ../src/wxMaxima.cpp:4153 ../src/wxMaxima.cpp:5065
+#: ../src/wxMaxima.cpp:4165 ../src/wxMaxima.cpp:5077
 msgid "Times:"
 msgstr "Ennyiszer:"
 
@@ -4204,7 +4207,7 @@ msgstr "Ennyiszer:"
 msgid "Tips not available, sorry!"
 msgstr "Sajnos nem tudok tippeket mutatni!"
 
-#: ../src/wxMaximaFrame.cpp:1495
+#: ../src/wxMaximaFrame.cpp:1514
 msgid "Title"
 msgstr "Cím"
 
@@ -4222,19 +4225,19 @@ msgstr ""
 "rákattint a sor elején látható négyzetre. A Shift+kattintás kombinációval az "
 "adott cella alatti összes tartalom láthatóvá válik."
 
-#: ../src/wxMaximaFrame.cpp:938
+#: ../src/wxMaximaFrame.cpp:937
 msgid "To &Bigfloat"
 msgstr "&Hosszú tizedestört"
 
-#: ../src/wxMaximaFrame.cpp:935
+#: ../src/wxMaximaFrame.cpp:934
 msgid "To &Float"
 msgstr "&Tizedestört"
 
-#: ../src/MathCtrl.cpp:990
+#: ../src/MathCtrl.cpp:1032
 msgid "To Float"
 msgstr "Tizedestört"
 
-#: ../src/wxMaximaFrame.cpp:941
+#: ../src/wxMaximaFrame.cpp:940
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr "Numeri&kus\tCtrl+Shift+N"
 
@@ -4276,51 +4279,51 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:41 ../src/Plot2dWiz.cpp:40 ../src/Plot2dWiz.cpp:50
 #: ../src/Plot2dWiz.cpp:539 ../src/Plot3dWiz.cpp:39 ../src/Plot3dWiz.cpp:48
-#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4241
+#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4253
 msgid "To:"
 msgstr "Meddig:"
 
-#: ../src/wxMaximaFrame.cpp:912
+#: ../src/wxMaximaFrame.cpp:911
 msgid "Toggle &Algebraic Flag"
 msgstr "&Az 'algebrai' kapcsoló állítása"
 
-#: ../src/wxMaximaFrame.cpp:933
+#: ../src/wxMaximaFrame.cpp:932
 msgid "Toggle &Numeric Output"
 msgstr "&Numerikus kimenet kapcsoló"
 
-#: ../src/wxMaximaFrame.cpp:673
+#: ../src/wxMaximaFrame.cpp:672
 msgid "Toggle &Time Display"
 msgstr "&Időkapcsoló"
 
-#: ../src/wxMaximaFrame.cpp:913
+#: ../src/wxMaximaFrame.cpp:912
 msgid "Toggle algebraic flag"
 msgstr "Az 'algebrai' kapcsoló állítása"
 
-#: ../src/wxMaximaFrame.cpp:577
+#: ../src/wxMaximaFrame.cpp:576
 msgid "Toggle full screen editing"
 msgstr "Teljes képernyős üzemmód"
 
-#: ../src/wxMaximaFrame.cpp:934
+#: ../src/wxMaximaFrame.cpp:933
 msgid "Toggle numeric output"
 msgstr "Numerikus kimenet kapcsoló"
 
-#: ../src/wxMaxima.cpp:4464
+#: ../src/wxMaxima.cpp:4476
 msgid "Toolbar icons"
 msgstr "Eszköztár ikonok"
 
-#: ../src/wxMaxima.cpp:4465
+#: ../src/wxMaxima.cpp:4477
 msgid "Translated by"
 msgstr "Fordították"
 
-#: ../src/wxMaximaFrame.cpp:763
+#: ../src/wxMaximaFrame.cpp:762
 msgid "Transpose a matrix"
 msgstr "Mátrix transzponálás"
 
-#: ../src/MathCtrl.cpp:5834
+#: ../src/MathCtrl.cpp:5886
 msgid "Trying to undo an action without starting cell."
 msgstr "Kísérlet egy esemény visszavonására cella nélkül."
 
-#: ../src/MathCtrl.cpp:5901
+#: ../src/MathCtrl.cpp:5953
 msgid "Trying to undo something but the undo action is empty."
 msgstr "Kísérlet valaminek a visszavonására, de a visszavonandó ismeretlen."
 
@@ -4328,11 +4331,11 @@ msgstr "Kísérlet valaminek a visszavonására, de a visszavonandó ismeretlen.
 msgid "Turkish"
 msgstr "Török"
 
-#: ../src/wxMaximaFrame.cpp:970
+#: ../src/wxMaximaFrame.cpp:969
 msgid "Tutorials"
 msgstr "&Ismertetők"
 
-#: ../src/wxMaxima.cpp:4778
+#: ../src/wxMaxima.cpp:4790
 msgid "Two sample t-test"
 msgstr "Kétmintás t-próba"
 
@@ -4344,15 +4347,15 @@ msgstr "Típus:"
 msgid "Ukrainian"
 msgstr "Ukrán"
 
-#: ../src/wxMaxima.cpp:5356
+#: ../src/wxMaxima.cpp:5372
 msgid "Un-closed parenthesis"
 msgstr "Bezáratlan zárójel"
 
-#: ../src/wxMaxima.cpp:5323
+#: ../src/wxMaxima.cpp:5335
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr "Bezáratlan zárójel"
 
-#: ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5889
 msgid ""
 "Unable to interpret the version info I got from http://andrejv.github.io//"
 "wxmaxima/version.txt: "
@@ -4368,11 +4371,11 @@ msgstr "Aláhúzott"
 msgid "Underscore converts to subscripts:"
 msgstr "Aláhúzást indexszé alakítja:"
 
-#: ../src/wxMaximaFrame.cpp:492
+#: ../src/wxMaximaFrame.cpp:491
 msgid "Undo\tCtrl-Z"
 msgstr "&Visszavonás\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:493
+#: ../src/wxMaximaFrame.cpp:492
 msgid "Undo last change"
 msgstr "Utolsó változtatás visszavonása"
 
@@ -4380,23 +4383,23 @@ msgstr "Utolsó változtatás visszavonása"
 msgid "Undo limit (0 for none):"
 msgstr "A visszaállítás mélysége (0: nincs visszaállítás):"
 
-#: ../src/wxMaximaFrame.cpp:625
+#: ../src/wxMaximaFrame.cpp:624
 msgid "Unfold All\tCtrl-Alt-]"
 msgstr "&Minden megjelenítése\tCtrl-Alt-]"
 
-#: ../src/wxMaximaFrame.cpp:626
+#: ../src/wxMaximaFrame.cpp:625
 msgid "Unfold all folded sections"
 msgstr "Minden fejezet megjelenítése"
 
-#: ../src/wxMaxima.cpp:4458
+#: ../src/wxMaxima.cpp:4470
 msgid "Unicode Support"
 msgstr "Unicode támogatás"
 
-#: ../src/wxMaxima.cpp:5335
+#: ../src/wxMaxima.cpp:5347
 msgid "Unterminated comment."
 msgstr "Befejezetlen megjegyzés."
 
-#: ../src/wxMaxima.cpp:5309
+#: ../src/wxMaxima.cpp:5321
 msgid "Unterminated string."
 msgstr "Befejezetlen szöveg."
 
@@ -4404,15 +4407,15 @@ msgstr "Befejezetlen szöveg."
 msgid "Up"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5859 ../src/wxMaxima.cpp:5866 ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5874 ../src/wxMaxima.cpp:5881 ../src/wxMaxima.cpp:5889
 msgid "Upgrade"
 msgstr "Frissítés"
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Upper bound:"
 msgstr "Felső végpont:"
 
-#: ../src/wxMaximaFrame.cpp:1383
+#: ../src/wxMaximaFrame.cpp:1382
 msgid "Upsilon"
 msgstr "Üpszilon"
 
@@ -4463,22 +4466,22 @@ msgstr ""
 msgid "User-defined labels"
 msgstr "Felhasználó által definiált címkék"
 
-#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3525
-#: ../src/wxMaxima.cpp:3541 ../src/wxMaxima.cpp:3649
+#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3537
+#: ../src/wxMaxima.cpp:3553 ../src/wxMaxima.cpp:3661
 msgid "Value:"
 msgstr "Érték:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:5019 ../src/wxMaxima.cpp:5064
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:5031 ../src/wxMaxima.cpp:5076
 msgid "Variable(s):"
 msgstr "Változó(k):"
 
 #: ../src/IntegrateWiz.cpp:33 ../src/LimitWiz.cpp:30 ../src/Plot2dWiz.cpp:34
 #: ../src/Plot2dWiz.cpp:44 ../src/Plot2dWiz.cpp:533 ../src/Plot3dWiz.cpp:33
 #: ../src/Plot3dWiz.cpp:42 ../src/SeriesWiz.cpp:36 ../src/SumWiz.cpp:30
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3749
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3761
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5045
 msgid "Variable:"
 msgstr "Változó:"
 
@@ -4486,25 +4489,25 @@ msgstr "Változó:"
 msgid "Variables"
 msgstr "Változók"
 
-#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3571 ../src/wxMaxima.cpp:4206
-#: ../src/wxMaxima.cpp:4807
+#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3583 ../src/wxMaxima.cpp:4218
+#: ../src/wxMaxima.cpp:4819
 msgid "Variables:"
 msgstr "Változók:"
 
-#: ../src/wxMaximaFrame.cpp:1257
+#: ../src/wxMaximaFrame.cpp:1256
 msgid "Variance..."
 msgstr "Szórásnégyzet..."
 
-#: ../src/wxMaximaFrame.cpp:580
+#: ../src/wxMaximaFrame.cpp:579
 msgid "View"
 msgstr "Nézet"
 
-#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1674 ../src/wxMaxima.cpp:1769
-#: ../src/wxMaxima.cpp:1950
+#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1679 ../src/wxMaxima.cpp:1774
+#: ../src/wxMaxima.cpp:1955
 msgid "Warning"
 msgstr "Figyelmeztetés"
 
-#: ../src/wxMaximaFrame.cpp:109 ../src/wxMaximaFrame.cpp:295
+#: ../src/wxMaximaFrame.cpp:108 ../src/wxMaximaFrame.cpp:294
 msgid "Welcome to wxMaxima"
 msgstr "A wxMaxima üdvözli Önt!"
 
@@ -4532,7 +4535,7 @@ msgstr ""
 "opció nincs kijelölve, a sortöréseket magunknak kell létrehozni üres sorok "
 "beiktatásával. "
 
-#: ../src/wxMaxima.cpp:2567
+#: ../src/wxMaxima.cpp:2574
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) "
 "(*.wxm)|*.wxm"
@@ -4550,7 +4553,7 @@ msgid ""
 "as equation markers"
 msgstr "A \"LaTeX másolás\" \\[ és \\] jelek közé rakja a kifejezéseket."
 
-#: ../src/MathCtrl.cpp:6798
+#: ../src/MathCtrl.cpp:6856
 msgid "Wrapped search"
 msgstr "Csomagolt keresés"
 
@@ -4558,15 +4561,15 @@ msgstr "Csomagolt keresés"
 msgid "Write matching parenthesis in text controls."
 msgstr "Nyitó zárójelek párjának automatikus beírása."
 
-#: ../src/wxMaxima.cpp:4461
+#: ../src/wxMaxima.cpp:4473
 msgid "Written by"
 msgstr "Írta"
 
-#: ../src/wxMaximaFrame.cpp:557
+#: ../src/wxMaximaFrame.cpp:556
 msgid "XML Inspector"
 msgstr "XML ellenőrző"
 
-#: ../src/wxMaximaFrame.cpp:1377
+#: ../src/wxMaximaFrame.cpp:1376
 msgid "Xi"
 msgstr "Kszí"
 
@@ -4639,7 +4642,7 @@ msgstr ""
 "hasznos, ha többsoros cellák parancsait akarjuk végrehajtani vagy "
 "tartalmukat törölni."
 
-#: ../src/wxMaxima.cpp:5856
+#: ../src/wxMaxima.cpp:5871
 #, c-format
 msgid ""
 "You have version %s. Current version is %s.\n"
@@ -4651,39 +4654,39 @@ msgstr ""
 "Az OK gomb megnyomására az alapértelmezett böngésző megnyitja a wxMaxima "
 "honlapját"
 
-#: ../src/wxMaxima.cpp:5921
+#: ../src/wxMaxima.cpp:5936
 msgid "Your changes will be lost if you don't save them."
 msgstr "Ha nem ment, változásai elvesznek."
 
-#: ../src/wxMaxima.cpp:5866
+#: ../src/wxMaxima.cpp:5881
 msgid "Your version of wxMaxima is up to date."
 msgstr "A wxMaxima verzió a lehető legfrissebb."
 
-#: ../src/wxMaximaFrame.cpp:1369
+#: ../src/wxMaximaFrame.cpp:1368
 msgid "Zeta"
 msgstr "Dzéta"
 
-#: ../src/wxMaximaFrame.cpp:562
+#: ../src/wxMaximaFrame.cpp:561
 msgid "Zoom &In\tCtrl-+"
 msgstr "&Nagyítás\tCtrl-+"
 
-#: ../src/wxMaximaFrame.cpp:564
+#: ../src/wxMaximaFrame.cpp:563
 msgid "Zoom Ou&t\tCtrl--"
 msgstr "K&icsinyítés\tCtrl--"
 
-#: ../src/wxMaximaFrame.cpp:563
+#: ../src/wxMaximaFrame.cpp:562
 msgid "Zoom in 10%"
 msgstr "Nagyítás 10%-kal"
 
-#: ../src/wxMaximaFrame.cpp:565
+#: ../src/wxMaximaFrame.cpp:564
 msgid "Zoom out 10%"
 msgstr "Kicsinyítés 10%-kal"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaximaFrame.cpp:287
 msgid "[ unsaved ]"
 msgstr "[ mentetlen ]"
 
-#: ../src/wxMaxima.cpp:5700
+#: ../src/wxMaxima.cpp:5715
 msgid "[ unsaved* ]"
 msgstr "[ mentetlen* ]"
 
@@ -4692,17 +4695,17 @@ msgstr "[ mentetlen* ]"
 msgid "[%i digits]"
 msgstr "[%i számjegy]"
 
-#: ../src/MathCtrl.cpp:4392
+#: ../src/MathCtrl.cpp:4447
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" style=\"max-width:90%%;\" >\n"
 msgstr "_%d.gif\"  alt=\"Animált diagram\" style=\"max-width:90%%;\" >\n"
 
-#: ../src/MathCtrl.cpp:4517
+#: ../src/MathCtrl.cpp:4572
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" >"
 msgstr "_%d.gif\" alt=\"Animált diagram\" style=\"max-width:90%%;\" >"
 
-#: ../src/wxMaximaFrame.cpp:1333
+#: ../src/wxMaximaFrame.cpp:1332
 msgid "alpha"
 msgstr "alfa"
 
@@ -4714,7 +4717,7 @@ msgstr "és"
 msgid "antisymmetric"
 msgstr "antiszimmetrikus"
 
-#: ../src/wxMaximaFrame.cpp:1334
+#: ../src/wxMaximaFrame.cpp:1333
 msgid "beta"
 msgstr "béta"
 
@@ -4758,7 +4761,7 @@ msgstr "hiba: érvénytelen sum címke"
 msgid "bug:Invalid sup tag"
 msgstr "hiba: érvénytelen sup címke"
 
-#: ../src/wxMaximaFrame.cpp:1354
+#: ../src/wxMaximaFrame.cpp:1353
 msgid "chi"
 msgstr "khí"
 
@@ -4771,7 +4774,7 @@ msgstr "válassza ki, a Maxima melyik lisp fordítóval lett buildelve"
 msgid "default"
 msgstr "alapértelmezett"
 
-#: ../src/wxMaximaFrame.cpp:1336
+#: ../src/wxMaximaFrame.cpp:1335
 msgid "delta"
 msgstr "delta"
 
@@ -4783,7 +4786,7 @@ msgstr "átlós"
 msgid "empty"
 msgstr "üres"
 
-#: ../src/wxMaximaFrame.cpp:1337
+#: ../src/wxMaximaFrame.cpp:1336
 msgid "epsilon"
 msgstr "epszilon"
 
@@ -4791,7 +4794,7 @@ msgstr "epszilon"
 msgid "equivalent"
 msgstr "ekvivalens"
 
-#: ../src/wxMaximaFrame.cpp:1339
+#: ../src/wxMaximaFrame.cpp:1338
 msgid "eta"
 msgstr "éta"
 
@@ -4811,7 +4814,7 @@ msgstr ""
 "indexekké konvertálja\n"
 "mind=_ jelek indexek."
 
-#: ../src/wxMaximaFrame.cpp:1335
+#: ../src/wxMaximaFrame.cpp:1334
 msgid "gamma"
 msgstr "gamma"
 
@@ -4837,15 +4840,15 @@ msgstr "sorok között"
 msgid "intersection"
 msgstr "metszet"
 
-#: ../src/wxMaximaFrame.cpp:1341
+#: ../src/wxMaximaFrame.cpp:1340
 msgid "iota"
 msgstr "ióta"
 
-#: ../src/wxMaximaFrame.cpp:1342
+#: ../src/wxMaximaFrame.cpp:1341
 msgid "kappa"
 msgstr "kappa"
 
-#: ../src/wxMaximaFrame.cpp:1343
+#: ../src/wxMaximaFrame.cpp:1342
 msgid "lambda"
 msgstr "lambda"
 
@@ -4861,7 +4864,7 @@ msgstr "kisebb vagy egyenlő"
 msgid "logscale"
 msgstr "logaritmikus skála"
 
-#: ../src/wxMaxima.cpp:3783
+#: ../src/wxMaxima.cpp:3795
 msgid "matrix[i,j]:"
 msgstr "matrix[i,j]:"
 
@@ -4869,7 +4872,7 @@ msgstr "matrix[i,j]:"
 msgid "maxima's pwd is path to document"
 msgstr "A Maxima pwd-je a dokumentum elérési útvonala"
 
-#: ../src/wxMaximaFrame.cpp:1344
+#: ../src/wxMaximaFrame.cpp:1343
 msgid "mu"
 msgstr "mű"
 
@@ -4885,7 +4888,7 @@ msgstr "sokkal kevesebb"
 msgid "nand"
 msgstr "negált és"
 
-#: ../src/wxMaxima.cpp:4524
+#: ../src/wxMaxima.cpp:4536
 msgid "no"
 msgstr "nem"
 
@@ -4909,15 +4912,15 @@ msgstr "nem részhalmaza"
 msgid "not subset or equal"
 msgstr "nem részhalmaza vagy egyenlő"
 
-#: ../src/wxMaximaFrame.cpp:1345
+#: ../src/wxMaximaFrame.cpp:1344
 msgid "nu"
 msgstr "nű"
 
-#: ../src/wxMaximaFrame.cpp:1356
+#: ../src/wxMaximaFrame.cpp:1355
 msgid "omega"
 msgstr "ómega"
 
-#: ../src/wxMaximaFrame.cpp:1347
+#: ../src/wxMaximaFrame.cpp:1346
 msgid "omicron"
 msgstr "omikron"
 
@@ -4929,11 +4932,11 @@ msgstr "vagy"
 msgid "partial sign"
 msgstr "parciális jele"
 
-#: ../src/wxMaximaFrame.cpp:1353
+#: ../src/wxMaximaFrame.cpp:1352
 msgid "phi"
 msgstr "fí"
 
-#: ../src/wxMaximaFrame.cpp:1348
+#: ../src/wxMaximaFrame.cpp:1347
 msgid "pi"
 msgstr "pí"
 
@@ -4945,11 +4948,11 @@ msgstr "plusz vagy mínusz"
 msgid "proportional to"
 msgstr "aránylik"
 
-#: ../src/wxMaximaFrame.cpp:1355
+#: ../src/wxMaximaFrame.cpp:1354
 msgid "psi"
 msgstr "pszí"
 
-#: ../src/wxMaximaFrame.cpp:1349
+#: ../src/wxMaximaFrame.cpp:1348
 msgid "rho"
 msgstr "ró"
 
@@ -4957,7 +4960,7 @@ msgstr "ró"
 msgid "right"
 msgstr "jobbról"
 
-#: ../src/wxMaximaFrame.cpp:1350
+#: ../src/wxMaximaFrame.cpp:1349
 msgid "sigma"
 msgstr "szigma"
 
@@ -4978,7 +4981,7 @@ msgstr "részhalmaz vagy egyenlő"
 msgid "symmetric"
 msgstr "szimmetrikus"
 
-#: ../src/wxMaximaFrame.cpp:1351
+#: ../src/wxMaximaFrame.cpp:1350
 msgid "tau"
 msgstr "tau"
 
@@ -4990,7 +4993,7 @@ msgstr "az sbcl <int> megabájt heap-et használjon"
 msgid "there is no"
 msgstr "nincs"
 
-#: ../src/wxMaximaFrame.cpp:1340
+#: ../src/wxMaximaFrame.cpp:1339
 msgid "theta"
 msgstr "théta"
 
@@ -5006,12 +5009,12 @@ msgstr "köbre emel"
 msgid "union"
 msgstr "unió"
 
-#: ../src/wxMaxima.cpp:5903
+#: ../src/wxMaxima.cpp:5918
 msgid "unsaved"
 msgstr "mentetlen"
 
-#: ../src/wxMaximaFrame.cpp:290 ../src/wxMaxima.cpp:2559
-#: ../src/wxMaxima.cpp:2826
+#: ../src/wxMaxima.cpp:2566 ../src/wxMaxima.cpp:2834
+#: ../src/wxMaximaFrame.cpp:289
 msgid "untitled"
 msgstr "névtelen"
 
@@ -5020,25 +5023,25 @@ msgstr "névtelen"
 msgid "untitled %d"
 msgstr "névtelen %d"
 
-#: ../src/wxMaximaFrame.cpp:1352
+#: ../src/wxMaximaFrame.cpp:1351
 msgid "upsilon"
 msgstr "üpszilon"
 
-#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4538
+#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4550
 msgid "wxMaxima"
 msgstr "wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
-#: ../src/wxMaxima.cpp:5700 ../src/wxMaxima.cpp:5709 ../src/wxMaxima.cpp:5712
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaxima.cpp:5715 ../src/wxMaxima.cpp:5724
+#: ../src/wxMaxima.cpp:5727 ../src/wxMaximaFrame.cpp:287
 #, c-format
 msgid "wxMaxima %s "
 msgstr "wxMaxima %s "
 
-#: ../src/wxMaximaFrame.cpp:952
+#: ../src/wxMaximaFrame.cpp:951
 msgid "wxMaxima &Help\tCtrl+?"
 msgstr "&wxMaxima Súgó\tCtrl+?"
 
-#: ../src/wxMaximaFrame.cpp:955
+#: ../src/wxMaximaFrame.cpp:954
 msgid "wxMaxima &Help\tF1"
 msgstr "&wxMaxima súgó\tF1"
 
@@ -5053,11 +5056,11 @@ msgstr ""
 "felhasználói könyvtár elérési útját a maxima_userdir parancs végrehajtásával "
 "tudhatjuk meg."
 
-#: ../src/wxMaxima.cpp:1619
+#: ../src/wxMaxima.cpp:1624
 msgid "wxMaxima cannot open content.xml in the .wxmx zip archive "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1633
+#: ../src/wxMaxima.cpp:1638
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
@@ -5065,7 +5068,7 @@ msgstr ""
 msgid "wxMaxima configuration"
 msgstr "A wxMaxima beállítása"
 
-#: ../src/wxMaxima.cpp:1947
+#: ../src/wxMaxima.cpp:1952
 msgid ""
 "wxMaxima could not find Maxima!\n"
 "\n"
@@ -5077,7 +5080,7 @@ msgstr ""
 "Kérem adja meg az elérési útját a 'Szerkesztés->Beállítás' menüpont alatt.\n"
 "Ezután indítsa el a Maximát a 'Maxima->Maxima újraindítása' segítségével."
 
-#: ../src/wxMaxima.cpp:2204
+#: ../src/wxMaxima.cpp:2209
 msgid ""
 "wxMaxima could not find help files.\n"
 "\n"
@@ -5087,7 +5090,7 @@ msgstr ""
 " \n"
 "Kérem ellenőrizze a wxMaxima telepítését."
 
-#: ../src/wxMaxima.cpp:2032
+#: ../src/wxMaxima.cpp:2037
 msgid ""
 "wxMaxima could not find tip files.\n"
 "\n"
@@ -5097,7 +5100,7 @@ msgstr ""
 " \n"
 "Kérem ellenőrizze a wxMaxima telepítését."
 
-#: ../src/wxMaxima.cpp:282
+#: ../src/wxMaxima.cpp:283
 msgid ""
 "wxMaxima could not start the server.\n"
 "\n"
@@ -5119,23 +5122,23 @@ msgstr ""
 "kijelölünk egy részt a dokumentumunkban, a menüparancs ezt fogja "
 "argumentumként használni a '%' helyett."
 
-#: ../src/wxMaxima.cpp:2330
+#: ../src/wxMaxima.cpp:2336
 msgid "wxMaxima document"
 msgstr "wxMaxima dokumentum"
 
-#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2799
+#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2807
 msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 msgstr "wxMaxima dokumentum (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 
-#: ../src/wxMaxima.cpp:1455 ../src/wxMaxima.cpp:1469
+#: ../src/wxMaxima.cpp:1460 ../src/wxMaxima.cpp:1474
 msgid "wxMaxima encountered an error loading "
 msgstr "A wxMaxima nem tudta betölteni a következő fájlt:"
 
-#: ../src/wxMaxima.cpp:4463
+#: ../src/wxMaxima.cpp:4475
 msgid "wxMaxima icon"
 msgstr "wxMaxima ikon"
 
-#: ../src/wxMaxima.cpp:4455
+#: ../src/wxMaxima.cpp:4467
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "MAXIMA based on wxWidgets."
@@ -5143,7 +5146,7 @@ msgstr ""
 "A wxMaxima egy wxWidgets-en alapuló grafikus felhasználói felület a Maxima "
 "komputeralgebrai rendszer számára."
 
-#: ../src/wxMaxima.cpp:4516
+#: ../src/wxMaxima.cpp:4528
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "Maxima based on wxWidgets."
@@ -5163,11 +5166,11 @@ msgstr ""
 msgid "x"
 msgstr "x"
 
-#: ../src/wxMaximaFrame.cpp:1346
+#: ../src/wxMaximaFrame.cpp:1345
 msgid "xi"
 msgstr "kszí"
 
-#: ../src/wxMaxima.cpp:1643
+#: ../src/wxMaxima.cpp:1648
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
@@ -5175,11 +5178,11 @@ msgstr ""
 msgid "xor"
 msgstr "kizáró vagy"
 
-#: ../src/wxMaxima.cpp:4522
+#: ../src/wxMaxima.cpp:4534
 msgid "yes"
 msgstr "igen"
 
-#: ../src/wxMaximaFrame.cpp:1338
+#: ../src/wxMaximaFrame.cpp:1337
 msgid "zeta"
 msgstr "dzéta"
 

--- a/locales/it.po
+++ b/locales/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxMaxima\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-07 21:42+0200\n"
+"POT-Creation-Date: 2016-10-16 17:47+0900\n"
 "PO-Revision-Date: 2016-08-19 22:33+0200\n"
 "Last-Translator: Marco Ciampa <ciampix@libero.it>\n"
 "Language-Team: Italian <tp@lists.linux.it>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../src/wxMaxima.cpp:4519
+#: ../src/wxMaxima.cpp:4531
 #, c-format
 msgid ""
 "\n"
@@ -29,7 +29,7 @@ msgstr ""
 "wxWidgets: %d.%d.%d\n"
 "Supporto Unicode: %s"
 
-#: ../src/wxMaxima.cpp:4532
+#: ../src/wxMaxima.cpp:4544
 msgid ""
 "\n"
 "Lisp: "
@@ -37,7 +37,7 @@ msgstr ""
 "\n"
 "Lisp: "
 
-#: ../src/wxMaxima.cpp:4528
+#: ../src/wxMaxima.cpp:4540
 msgid ""
 "\n"
 "Maxima version: "
@@ -45,7 +45,7 @@ msgstr ""
 "\n"
 "Versione di Maxima: "
 
-#: ../src/wxMaxima.cpp:5381
+#: ../src/wxMaxima.cpp:5397
 msgid ""
 "\n"
 "Not connected to Maxima!\n"
@@ -53,7 +53,7 @@ msgstr ""
 "\n"
 "Non connesso a Maxima!\n"
 
-#: ../src/wxMaxima.cpp:4530
+#: ../src/wxMaxima.cpp:4542
 msgid ""
 "\n"
 "Not connected."
@@ -73,7 +73,7 @@ msgstr ""
 msgid " (Graphics) "
 msgstr ""
 
-#: ../src/EditorCell.cpp:3045 ../src/EditorCell.cpp:3227
+#: ../src/EditorCell.cpp:3088 ../src/EditorCell.cpp:3270
 #, c-format
 msgid " ... + %i hidden lines"
 msgstr ""
@@ -82,7 +82,7 @@ msgstr ""
 msgid " << Expression longer than allowed by the configuration setting! >>"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1673
+#: ../src/wxMaxima.cpp:1678
 msgid ""
 " was saved using a newer version of wxMaxima so it may not load correctly. "
 "Please update your wxMaxima."
@@ -90,7 +90,7 @@ msgstr ""
 " era stato salvato usando una versione più recente di wxMaxima perciò "
 "potrebbe non caricarsi correttamente. Si consiglia di aggiornare wxMaxima."
 
-#: ../src/wxMaxima.cpp:1665
+#: ../src/wxMaxima.cpp:1670
 msgid ""
 " was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr ""
@@ -105,64 +105,64 @@ msgstr ""
 msgid "\"implies\" symbol"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:101
+#: ../src/wxMaximaFrame.cpp:100
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:773
+#: ../src/wxMaximaFrame.cpp:772
 msgid "&Algebra"
 msgstr "&Algebra"
 
-#: ../src/wxMaximaFrame.cpp:767
+#: ../src/wxMaximaFrame.cpp:766
 msgid "&Apply to List..."
 msgstr "&Applica alla lista..."
 
-#: ../src/wxMaximaFrame.cpp:964
+#: ../src/wxMaximaFrame.cpp:963
 msgid "&Apropos..."
 msgstr "&A proposito di..."
 
-#: ../src/wxMaximaFrame.cpp:478
+#: ../src/wxMaximaFrame.cpp:477
 msgid "&Batch File...\tCtrl-B"
 msgstr "File &batch...\tCtrl-B"
 
-#: ../src/wxMaximaFrame.cpp:724
+#: ../src/wxMaximaFrame.cpp:723
 msgid "&Boundary Value Problem..."
 msgstr "Pro&blema del valore al contorno ..."
 
-#: ../src/wxMaximaFrame.cpp:975
+#: ../src/wxMaximaFrame.cpp:974
 msgid "&Bug Report"
 msgstr "Rapporto &bug"
 
-#: ../src/wxMaximaFrame.cpp:825
+#: ../src/wxMaximaFrame.cpp:824
 msgid "&Calculus"
 msgstr "&Calcolo"
 
-#: ../src/wxMaximaFrame.cpp:876
+#: ../src/wxMaximaFrame.cpp:875
 msgid "&Canonical Form"
 msgstr "Forma &canonica"
 
-#: ../src/wxMaximaFrame.cpp:749
+#: ../src/wxMaximaFrame.cpp:748
 msgid "&Characteristic Polynomial..."
 msgstr "Polinomiale &caratteristico ..."
 
-#: ../src/wxMaximaFrame.cpp:654
+#: ../src/wxMaximaFrame.cpp:653
 msgid "&Clear Memory"
 msgstr "&Cancella la memoria"
 
-#: ../src/wxMaximaFrame.cpp:859
+#: ../src/wxMaximaFrame.cpp:858
 msgid "&Combine Factorials"
 msgstr "&Combina i fattoriali"
 
-#: ../src/wxMaximaFrame.cpp:902
+#: ../src/wxMaximaFrame.cpp:901
 msgid "&Complex Simplification"
 msgstr "Semplificazione &Complessa"
 
-#: ../src/wxMaximaFrame.cpp:822
+#: ../src/wxMaximaFrame.cpp:821
 msgid "&Continued Fraction"
 msgstr "Frazione &continua"
 
-#: ../src/wxMaximaFrame.cpp:502
+#: ../src/wxMaximaFrame.cpp:501
 msgid "&Copy\tCtrl-C"
 msgstr "&Copia\tCtrl-C"
 
@@ -170,108 +170,108 @@ msgstr "&Copia\tCtrl-C"
 msgid "&Definite integration"
 msgstr "Integrazione &definita"
 
-#: ../src/wxMaximaFrame.cpp:896
+#: ../src/wxMaximaFrame.cpp:895
 msgid "&Demoivre"
 msgstr "&Demoivre"
 
-#: ../src/wxMaximaFrame.cpp:752
+#: ../src/wxMaximaFrame.cpp:751
 msgid "&Determinant"
 msgstr "&Determinante"
 
-#: ../src/wxMaximaFrame.cpp:785
+#: ../src/wxMaximaFrame.cpp:784
 msgid "&Differentiate..."
 msgstr "&Differenzia..."
 
-#: ../src/wxMaximaFrame.cpp:543
+#: ../src/wxMaximaFrame.cpp:542
 msgid "&Edit"
 msgstr "&Modifica"
 
-#: ../src/wxMaximaFrame.cpp:709
+#: ../src/wxMaximaFrame.cpp:708
 msgid "&Eliminate Variable..."
 msgstr "&Elimina la variabile..."
 
-#: ../src/wxMaximaFrame.cpp:744
+#: ../src/wxMaximaFrame.cpp:743
 msgid "&Enter Matrix..."
 msgstr "Ins&erire la matrice..."
 
-#: ../src/wxMaximaFrame.cpp:961
+#: ../src/wxMaximaFrame.cpp:960
 msgid "&Example..."
 msgstr "&Esempio..."
 
-#: ../src/wxMaximaFrame.cpp:839
+#: ../src/wxMaximaFrame.cpp:838
 msgid "&Expand Expression"
 msgstr "&Espandi l'espressione"
 
-#: ../src/wxMaximaFrame.cpp:873
+#: ../src/wxMaximaFrame.cpp:872
 msgid "&Expand Trigonometric"
 msgstr "&Espandi trigonometrica"
 
-#: ../src/wxMaximaFrame.cpp:899
+#: ../src/wxMaximaFrame.cpp:898
 msgid "&Exponentialize"
 msgstr "&Esponenzializza"
 
-#: ../src/wxMaximaFrame.cpp:480
+#: ../src/wxMaximaFrame.cpp:479
 msgid "&Export..."
 msgstr "&Esporta..."
 
-#: ../src/wxMaximaFrame.cpp:834
+#: ../src/wxMaximaFrame.cpp:833
 msgid "&Factor Expression"
 msgstr "Scomponi in &fattori"
 
-#: ../src/wxMaximaFrame.cpp:489
+#: ../src/wxMaximaFrame.cpp:488
 msgid "&File"
 msgstr "&File"
 
-#: ../src/wxMaximaFrame.cpp:692
+#: ../src/wxMaximaFrame.cpp:691
 msgid "&Find Root..."
 msgstr "&Trova la radice..."
 
-#: ../src/wxMaximaFrame.cpp:738
+#: ../src/wxMaximaFrame.cpp:737
 msgid "&Generate Matrix..."
 msgstr "&Genera la matrice..."
 
-#: ../src/wxMaximaFrame.cpp:809
+#: ../src/wxMaximaFrame.cpp:808
 msgid "&Greatest Common Divisor..."
 msgstr "&Massimo comun denominatore..."
 
-#: ../src/wxMaximaFrame.cpp:994
+#: ../src/wxMaximaFrame.cpp:993
 msgid "&Help"
 msgstr "&Aiuto"
 
-#: ../src/wxMaximaFrame.cpp:777
+#: ../src/wxMaximaFrame.cpp:776
 msgid "&Integrate..."
 msgstr "&Integra..."
 
-#: ../src/wxMaximaFrame.cpp:645
+#: ../src/wxMaximaFrame.cpp:644
 msgid "&Interrupt\tCtrl-."
 msgstr "&Interrompi\tCtrl-."
 
-#: ../src/wxMaximaFrame.cpp:649
+#: ../src/wxMaximaFrame.cpp:648
 msgid "&Interrupt\tCtrl-G"
 msgstr "&Interrompi\tCtrl-G"
 
-#: ../src/wxMaximaFrame.cpp:746
+#: ../src/wxMaximaFrame.cpp:745
 msgid "&Invert Matrix"
 msgstr "&Inverti la matrice"
 
-#: ../src/wxMaximaFrame.cpp:476
+#: ../src/wxMaximaFrame.cpp:475
 msgid "&Load Package...\tCtrl-L"
 msgstr "Carica i&l pacchetto\tCtrl-L"
 
-#: ../src/wxMaximaFrame.cpp:769
+#: ../src/wxMaximaFrame.cpp:768
 #, fuzzy
 msgid "&Map to List(s)..."
 msgstr "&Mappa in una lista..."
 
-#: ../src/wxMaximaFrame.cpp:684
+#: ../src/wxMaximaFrame.cpp:683
 msgid "&Maxima"
 msgstr "&Maxima"
 
-#: ../src/wxMaximaFrame.cpp:958
+#: ../src/wxMaximaFrame.cpp:957
 msgid "&Maxima help"
 msgstr "Guida di &Maxima"
 
-#: ../src/wxMaximaFrame.cpp:917
+#: ../src/wxMaximaFrame.cpp:916
 msgid "&Modulus Computation..."
 msgstr "Calcolo &modulo..."
 
@@ -279,7 +279,7 @@ msgstr "Calcolo &modulo..."
 msgid "&New\tCtrl-N"
 msgstr "&Apri\tCtrl-N"
 
-#: ../src/wxMaximaFrame.cpp:947
+#: ../src/wxMaximaFrame.cpp:946
 msgid "&Numeric"
 msgstr "&Numerico"
 
@@ -295,11 +295,11 @@ msgstr "Som&nu"
 msgid "&Open\tCtrl-O"
 msgstr "&Apri\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:463
+#: ../src/wxMaximaFrame.cpp:462
 msgid "&Open...\tCtrl-O"
 msgstr "&Apri...\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:929
+#: ../src/wxMaximaFrame.cpp:928
 msgid "&Plot"
 msgstr "&Disegno"
 
@@ -307,7 +307,7 @@ msgstr "&Disegno"
 msgid "&Power series"
 msgstr "Serie di &potenze"
 
-#: ../src/wxMaximaFrame.cpp:483
+#: ../src/wxMaximaFrame.cpp:482
 msgid "&Print...\tCtrl-P"
 msgstr "Stam&pa...\tCtrl-P"
 
@@ -315,39 +315,39 @@ msgstr "Stam&pa...\tCtrl-P"
 msgid "&Rational"
 msgstr "&Razionale"
 
-#: ../src/wxMaximaFrame.cpp:870
+#: ../src/wxMaximaFrame.cpp:869
 msgid "&Reduce Trigonometric"
 msgstr "&Riduci trigonometrica"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "&Restart Maxima"
 msgstr "&Riavvia Maxima"
 
-#: ../src/wxMaximaFrame.cpp:700
+#: ../src/wxMaximaFrame.cpp:699
 msgid "&Roots of Polynomial (Real)"
 msgstr "&Radici della polinomiale (reali)"
 
-#: ../src/wxMaximaFrame.cpp:472
+#: ../src/wxMaximaFrame.cpp:471
 msgid "&Save\tCtrl-S"
 msgstr "&Salva\tCtrl-S"
 
-#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:919
+#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:918
 msgid "&Simplify"
 msgstr "&Semplifica"
 
-#: ../src/wxMaximaFrame.cpp:829
+#: ../src/wxMaximaFrame.cpp:828
 msgid "&Simplify Expression"
 msgstr "&Semplifica l'espressione"
 
-#: ../src/wxMaximaFrame.cpp:856
+#: ../src/wxMaximaFrame.cpp:855
 msgid "&Simplify Factorials"
 msgstr "&Semplifica fattoriali"
 
-#: ../src/wxMaximaFrame.cpp:867
+#: ../src/wxMaximaFrame.cpp:866
 msgid "&Simplify Trigonometric"
 msgstr "&Semplifica trigonometrica"
 
-#: ../src/wxMaximaFrame.cpp:688
+#: ../src/wxMaximaFrame.cpp:687
 msgid "&Solve..."
 msgstr "Ris&olvi..."
 
@@ -359,11 +359,11 @@ msgstr "&Speciale"
 msgid "&Taylor series"
 msgstr "Serie di &Taylor:"
 
-#: ../src/wxMaximaFrame.cpp:762
+#: ../src/wxMaximaFrame.cpp:761
 msgid "&Transpose Matrix"
 msgstr "&Trasponi la matrice"
 
-#: ../src/wxMaximaFrame.cpp:879
+#: ../src/wxMaximaFrame.cpp:878
 msgid "&Trigonometric Simplification"
 msgstr "Semplificazione &trigonometrica"
 
@@ -381,7 +381,7 @@ msgstr "(usa la lingua predefinita)"
 msgid "- Infinity"
 msgstr "- infinito"
 
-#: ../src/wxMaxima.cpp:351
+#: ../src/wxMaxima.cpp:356
 msgid ""
 "... [suppressed additional lines since the output is longer than allowed in "
 "the configuration] "
@@ -391,16 +391,16 @@ msgstr ""
 msgid "1/2"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:103
+#: ../src/wxMaximaFrame.cpp:102
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4601
+#: ../src/wxMaxima.cpp:4613
 msgid "<br>Lisp: "
 msgstr "<br>Lisp: "
 
-#: ../src/wxMaxima.cpp:5487
+#: ../src/wxMaxima.cpp:5503
 msgid ""
 "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
@@ -434,11 +434,11 @@ msgid ""
 "\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1472
+#: ../src/wxMaximaFrame.cpp:1495
 msgid "A symbol from the configuration dialogue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:731
+#: ../src/wxMaximaFrame.cpp:730
 msgid "A&t Value..."
 msgstr "A&l valore..."
 
@@ -446,12 +446,12 @@ msgstr "A&l valore..."
 msgid "Abort evaluation on error"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaxima.cpp:4603
+#: ../src/wxMaxima.cpp:4615 ../src/wxMaximaFrame.cpp:985
 msgid "About"
 msgstr "Informazioni"
 
-#: ../src/wxMaximaFrame.cpp:987 ../src/wxMaximaFrame.cpp:990
-#: ../src/wxMaximaFrame.cpp:991
+#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaximaFrame.cpp:989
+#: ../src/wxMaximaFrame.cpp:990
 msgid "About wxMaxima"
 msgstr "Informazioni su wxMaxima"
 
@@ -459,23 +459,23 @@ msgstr "Informazioni su wxMaxima"
 msgid "Active cell bracket"
 msgstr "Parentesi cella attiva"
 
-#: ../src/wxMaximaFrame.cpp:760
+#: ../src/wxMaximaFrame.cpp:759
 msgid "Ad&joint Matrix"
 msgstr "Matrice ag&giunta"
 
-#: ../src/wxMaximaFrame.cpp:914
+#: ../src/wxMaximaFrame.cpp:913
 msgid "Add Algebraic E&quality..."
 msgstr "Aggiungi &uguaglianza algebrica..."
 
-#: ../src/wxMaximaFrame.cpp:657
+#: ../src/wxMaximaFrame.cpp:656
 msgid "Add a directory to search path"
 msgstr "Aggiungi una directory al percorso di ricerca"
 
-#: ../src/wxMaxima.cpp:3353
+#: ../src/wxMaxima.cpp:3365
 msgid "Add dir to path:"
 msgstr "Aggiungi una directory al percorso:"
 
-#: ../src/wxMaximaFrame.cpp:915
+#: ../src/wxMaximaFrame.cpp:914
 msgid "Add equality to the rational simplifier"
 msgstr "Aggiungi uguaglianza al semplificatore razionale"
 
@@ -483,7 +483,7 @@ msgstr "Aggiungi uguaglianza al semplificatore razionale"
 msgid "Add the .wxmx file to the HTML export"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:656
+#: ../src/wxMaximaFrame.cpp:655
 msgid "Add to &Path..."
 msgstr "Aggiungi al &percorso..."
 
@@ -526,27 +526,27 @@ msgstr "Vecchia variabile:"
 msgid "All|*"
 msgstr "Tutti|*"
 
-#: ../src/wxMaximaFrame.cpp:1364
+#: ../src/wxMaximaFrame.cpp:1363
 msgid "Alpha"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3838
+#: ../src/wxMaxima.cpp:3850
 msgid "Apply"
 msgstr "Applica"
 
-#: ../src/wxMaximaFrame.cpp:768
+#: ../src/wxMaximaFrame.cpp:767
 msgid "Apply function to a list"
 msgstr "Applica funzione ad una lista"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Apropos"
 msgstr "Aproposito"
 
-#: ../src/wxMaxima.cpp:3764
+#: ../src/wxMaxima.cpp:3776
 msgid "Array:"
 msgstr "Array:"
 
-#: ../src/wxMaxima.cpp:4462
+#: ../src/wxMaxima.cpp:4474
 msgid "Artwork by"
 msgstr "Design grafico di"
 
@@ -554,7 +554,7 @@ msgstr "Design grafico di"
 msgid "Ask to save untitled documents"
 msgstr "Richiedi il salvataggio dei documenti senza nome"
 
-#: ../src/wxMaxima.cpp:3650
+#: ../src/wxMaxima.cpp:3662
 msgid "At value"
 msgstr "Al valore"
 
@@ -575,11 +575,11 @@ msgstr ""
 msgid "Autosave interval (minutes, 0 means: off):"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3557
+#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3569
 msgid "BC2"
 msgstr "BC2"
 
-#: ../src/wxMaximaFrame.cpp:1272
+#: ../src/wxMaximaFrame.cpp:1271
 msgid "Barsplot..."
 msgstr "Grafico a barre..."
 
@@ -587,7 +587,7 @@ msgstr "Grafico a barre..."
 msgid "Bat files (*.bat)|*.bat|All|*"
 msgstr "File bat (*.bat)|*.bat|Tutti|*"
 
-#: ../src/wxMaxima.cpp:2943
+#: ../src/wxMaxima.cpp:2951
 msgid "Batch File"
 msgstr "File batch"
 
@@ -600,7 +600,7 @@ msgid ""
 "cells."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1365
+#: ../src/wxMaximaFrame.cpp:1364
 msgid "Beta"
 msgstr ""
 
@@ -612,11 +612,11 @@ msgstr ""
 msgid "Bold"
 msgstr "Grassetto"
 
-#: ../src/wxMaxima.cpp:2359
+#: ../src/wxMaxima.cpp:2366
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1274
+#: ../src/wxMaximaFrame.cpp:1273
 msgid "Boxplot..."
 msgstr "Grafico a blocchi..."
 
@@ -628,15 +628,15 @@ msgstr "Naviga"
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2080
+#: ../src/MathCtrl.cpp:2127
 msgid "Bug: Cell left but not entered."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1178
+#: ../src/wxMaxima.cpp:1183
 msgid "Bug: Found a math end marker without any start marker."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1222
+#: ../src/wxMaxima.cpp:1227
 msgid "Bug: Found the end of autocompletion symbols but no beginning"
 msgstr ""
 
@@ -648,22 +648,22 @@ msgstr ""
 msgid "Bug: Fraction without enumerator"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2312
+#: ../src/MathCtrl.cpp:2359
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5839
+#: ../src/MathCtrl.cpp:5891
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of "
 "the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5913
+#: ../src/MathCtrl.cpp:5965
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5882
+#: ../src/MathCtrl.cpp:5934
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
@@ -673,49 +673,49 @@ msgstr ""
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
 msgstr ""
 
-#: ../src/GroupCell.cpp:780 ../src/GroupCell.cpp:951
+#: ../src/GroupCell.cpp:781 ../src/GroupCell.cpp:952
 msgid "Bug: No image counter to write to!"
 msgstr ""
 
-#: ../src/AbsCell.cpp:193
+#: ../src/AbsCell.cpp:199
 msgid "Bug: No last cell in an absCell!"
 msgstr ""
 
-#: ../src/ConjugateCell.cpp:185
+#: ../src/ConjugateCell.cpp:194
 msgid "Bug: No last cell in an conjugateCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:471
+#: ../src/FracCell.cpp:472
 msgid "Bug: No last cell in an denominator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:267
+#: ../src/ExptCell.cpp:270
 msgid "Bug: No last cell in an exponent of an exptCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:459
+#: ../src/FracCell.cpp:460
 msgid "Bug: No last cell in an numerator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:257
+#: ../src/ExptCell.cpp:260
 msgid "Bug: No last cell in the base of an exptCell!"
 msgstr ""
 
-#: ../src/ParenCell.cpp:534
+#: ../src/ParenCell.cpp:535
 msgid "Bug: No last cell inside a parenthesis!"
 msgstr ""
 
-#: ../src/SqrtCell.cpp:312
+#: ../src/SqrtCell.cpp:317
 msgid "Bug: No last cell inside a square root!"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2123
+#: ../src/MathCtrl.cpp:2170
 msgid ""
 "Bug: Start or end of merging of subsequent editing actions was requested two "
 "times in a row."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2090
+#: ../src/MathCtrl.cpp:2137
 msgid "Bug: Text changed, but no active cell."
 msgstr ""
 
@@ -723,39 +723,39 @@ msgstr ""
 msgid "Bug: Trying to append NULL to a group cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:555
+#: ../src/MathCtrl.cpp:600
 msgid "Bug: Trying to append maxima's output to a cell outside the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2014
+#: ../src/MathCtrl.cpp:2061
 msgid ""
 "Bug: Trying to merge individual cell adds to a region in the undo buffer but "
 "there are other cells between them."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6522
+#: ../src/MathCtrl.cpp:6577
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2092
+#: ../src/MathCtrl.cpp:2139
 msgid "Bug: Trying to record a cell contents change without a cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1495
+#: ../src/MathCtrl.cpp:1540
 msgid "Bug: Trying to select inside a cell without having a current cell"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5883
+#: ../src/MathCtrl.cpp:5935
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5844 ../src/MathCtrl.cpp:5918 ../src/MathCtrl.cpp:5952
+#: ../src/MathCtrl.cpp:5896 ../src/MathCtrl.cpp:5970 ../src/MathCtrl.cpp:6004
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:973
+#: ../src/wxMaximaFrame.cpp:972
 msgid "Build &Info"
 msgstr "&Informazioni sulla compilazione"
 
@@ -774,51 +774,51 @@ msgstr ""
 "selezionando 'Invio elabora le celle'. Questa impostazione scambia il "
 "comportamento di queste due combinazioni di tasti."
 
-#: ../src/wxMaximaFrame.cpp:782
+#: ../src/wxMaximaFrame.cpp:781
 msgid "C&hange Variable..."
 msgstr "Cambia la &variabile..."
 
-#: ../src/wxMaximaFrame.cpp:540
+#: ../src/wxMaximaFrame.cpp:539
 msgid "C&onfigure"
 msgstr "C&onfigura"
 
-#: ../src/wxMaximaFrame.cpp:801
+#: ../src/wxMaximaFrame.cpp:800
 msgid "Calculate &Product..."
 msgstr "Calcola il &prodotto..."
 
-#: ../src/wxMaximaFrame.cpp:799
+#: ../src/wxMaximaFrame.cpp:798
 msgid "Calculate Su&m..."
 msgstr "Calcola la so&mma..."
 
-#: ../src/wxMaximaFrame.cpp:939
+#: ../src/wxMaximaFrame.cpp:938
 msgid "Calculate bigfloat value of the last result"
 msgstr "Calcola il valore dell'ultimo risultato in virgola mobile precisa"
 
-#: ../src/wxMaximaFrame.cpp:936
+#: ../src/wxMaximaFrame.cpp:935
 msgid "Calculate float value of the last result"
 msgstr "Calcola il valore dell'ultimo risultato in virgola mobile"
 
-#: ../src/wxMaxima.cpp:3971
+#: ../src/wxMaxima.cpp:3983
 msgid "Calculate modulus:"
 msgstr "Calcola il modulo:"
 
-#: ../src/wxMaximaFrame.cpp:942
+#: ../src/wxMaximaFrame.cpp:941
 msgid "Calculate numeric value of the last result"
 msgstr "Calcola il valore numeric dell'ultimo risultato"
 
-#: ../src/wxMaximaFrame.cpp:802
+#: ../src/wxMaximaFrame.cpp:801
 msgid "Calculate products"
 msgstr "Calcola i prodotti"
 
-#: ../src/wxMaximaFrame.cpp:800
+#: ../src/wxMaximaFrame.cpp:799
 msgid "Calculate sums"
 msgstr "Calcola le somme"
 
-#: ../src/wxMaxima.cpp:5830
+#: ../src/wxMaxima.cpp:5845
 msgid "Can not connect to the web server."
 msgstr "Impossibile connettersi al server web."
 
-#: ../src/wxMaxima.cpp:5881
+#: ../src/wxMaxima.cpp:5896
 msgid "Can not download version info."
 msgstr "Impossibile scaricare le informazioni di versione."
 
@@ -834,15 +834,15 @@ msgstr "Impossibile scaricare le informazioni di versione."
 #: ../src/PlotFormatWiz.cpp:48 ../src/SeriesWiz.cpp:49 ../src/SeriesWiz.cpp:51
 #: ../src/SubstituteWiz.cpp:41 ../src/SubstituteWiz.cpp:43 ../src/SumWiz.cpp:44
 #: ../src/SumWiz.cpp:46 ../src/SystemWiz.cpp:38 ../src/SystemWiz.cpp:40
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Cancel"
 msgstr "Annulla"
 
-#: ../src/wxMaximaFrame.cpp:126 ../src/wxMaxima.cpp:932
+#: ../src/wxMaxima.cpp:937 ../src/wxMaximaFrame.cpp:125
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1217
+#: ../src/wxMaximaFrame.cpp:1216
 msgid "Canonical (tr)"
 msgstr "Canonica (tr)"
 
@@ -850,7 +850,7 @@ msgstr "Canonica (tr)"
 msgid "Catalan"
 msgstr "Catalano"
 
-#: ../src/wxMaximaFrame.cpp:638
+#: ../src/wxMaximaFrame.cpp:637
 msgid "Ce&ll"
 msgstr "Ce&lla"
 
@@ -858,40 +858,40 @@ msgstr "Ce&lla"
 msgid "Cell bracket"
 msgstr "Parentesi cella"
 
-#: ../src/wxMaxima.cpp:5261
+#: ../src/wxMaxima.cpp:5273
 msgid "Cell ends in a backslash"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:676
+#: ../src/wxMaximaFrame.cpp:675
 msgid "Change &2d Display"
 msgstr "Cambia la finestra &2d"
 
-#: ../src/wxMaximaFrame.cpp:677
+#: ../src/wxMaximaFrame.cpp:676
 msgid "Change the 2d display algorithm used to display math output"
 msgstr ""
 "Cambia l'algoritmo della finestra 2d usato per visualizzare il risultato."
 
-#: ../src/wxMaxima.cpp:3995
+#: ../src/wxMaxima.cpp:4007
 msgid "Change variable"
 msgstr "Cambia la variabile"
 
-#: ../src/wxMaximaFrame.cpp:783
+#: ../src/wxMaximaFrame.cpp:782
 msgid "Change variable in integral or sum"
 msgstr "Cambia variabile nell'integrale o nella somma"
 
-#: ../src/wxMaxima.cpp:3751
+#: ../src/wxMaxima.cpp:3763
 msgid "Char poly"
 msgstr "Polin. caratt."
 
-#: ../src/wxMaximaFrame.cpp:978
+#: ../src/wxMaximaFrame.cpp:977
 msgid "Check for Updates"
 msgstr "Controlla gli aggiornamenti"
 
-#: ../src/wxMaximaFrame.cpp:979
+#: ../src/wxMaximaFrame.cpp:978
 msgid "Check if a newer version of wxMaxima/Maxima exist."
 msgstr "Controlla se esiste una versione più recente di wxMaxima/Maxima."
 
-#: ../src/wxMaximaFrame.cpp:1385
+#: ../src/wxMaximaFrame.cpp:1384
 msgid "Chi"
 msgstr ""
 
@@ -912,15 +912,15 @@ msgstr "Scegli font"
 msgid "Choose new plot format:"
 msgstr "Scegliere un nuovo formato per il grafico:"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710
 msgid "Classes:"
 msgstr "Classi:"
 
-#: ../src/wxMaximaFrame.cpp:469
+#: ../src/wxMaximaFrame.cpp:468
 msgid "Close\tCtrl-W"
 msgstr "Chiudi\tCtrl-W"
 
-#: ../src/wxMaximaFrame.cpp:470
+#: ../src/wxMaximaFrame.cpp:469
 msgid "Close window"
 msgstr "Chiudi la finestra"
 
@@ -952,19 +952,19 @@ msgstr ""
 msgid "Code highlighting: Variables"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4806
+#: ../src/wxMaxima.cpp:4818
 msgid "Col. names:"
 msgstr "Nomi colonne:"
 
-#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Columns:"
 msgstr "Colonne:"
 
-#: ../src/wxMaximaFrame.cpp:860
+#: ../src/wxMaximaFrame.cpp:859
 msgid "Combine factorials in an expression"
 msgstr "Combina i fattoriali in un'espressione"
 
-#: ../src/wxMaxima.cpp:5293
+#: ../src/wxMaxima.cpp:5305
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
@@ -976,24 +976,24 @@ msgstr "Coordinate x separate da virgole"
 msgid "Comma separated y coordinates"
 msgstr "Coordinate y separate da virgole"
 
-#: ../src/MathCtrl.cpp:1030
+#: ../src/MathCtrl.cpp:1072
 msgid "Comment Selection"
 msgstr "Commenta la selezione"
 
-#: ../src/wxMaximaFrame.cpp:533
+#: ../src/wxMaximaFrame.cpp:532
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:532
+#: ../src/wxMaximaFrame.cpp:531
 #, fuzzy
 msgid "Comment selection\tCtrl-/"
 msgstr "Commenta la selezione"
 
-#: ../src/wxMaximaFrame.cpp:601
+#: ../src/wxMaximaFrame.cpp:600
 msgid "Complete Word\tCtrl-K"
 msgstr "Complete a parola\tCtrl-K"
 
-#: ../src/wxMaximaFrame.cpp:602
+#: ../src/wxMaximaFrame.cpp:601
 msgid "Complete word"
 msgstr "Completa la parola"
 
@@ -1001,36 +1001,36 @@ msgstr "Completa la parola"
 msgid "Completely stop maxima and restart it"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:823
+#: ../src/wxMaximaFrame.cpp:822
 msgid "Compute continued fraction of a value"
 msgstr "Calcola la frazione continua di un valore"
 
-#: ../src/wxMaximaFrame.cpp:761
+#: ../src/wxMaximaFrame.cpp:760
 msgid "Compute the adjoint matrix"
 msgstr "Calcola la matrice aggiunta"
 
-#: ../src/wxMaximaFrame.cpp:750
+#: ../src/wxMaximaFrame.cpp:749
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr "Calcola la polinomiale caratteristica di una matrice"
 
-#: ../src/wxMaximaFrame.cpp:753
+#: ../src/wxMaximaFrame.cpp:752
 msgid "Compute the determinant of a matrix"
 msgstr "Calcola il determinante di una matrice"
 
-#: ../src/wxMaximaFrame.cpp:810
+#: ../src/wxMaximaFrame.cpp:809
 msgid "Compute the greatest common divisor"
 msgstr "Calcola il massimo comun denominatore"
 
-#: ../src/wxMaximaFrame.cpp:747
+#: ../src/wxMaximaFrame.cpp:746
 msgid "Compute the inverse of a matrix"
 msgstr "Calcola l'inversa di una matrice"
 
-#: ../src/wxMaximaFrame.cpp:813
+#: ../src/wxMaximaFrame.cpp:812
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
 "Calcola il minimo comune multiplo (esegui load(functs) prima di usarlo)"
 
-#: ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4868
 msgid "Condition:"
 msgstr "Condizione:"
 
@@ -1042,8 +1042,8 @@ msgstr "File di configurazione (*.ini)|*.ini"
 msgid "Configuration warning"
 msgstr "Avvertenze di configurazione"
 
-#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:538
-#: ../src/wxMaximaFrame.cpp:541
+#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:540
 msgid "Configure wxMaxima"
 msgstr "Configura wxMaxima"
 
@@ -1052,131 +1052,133 @@ msgstr "Configura wxMaxima"
 msgid "Constant"
 msgstr "Costante"
 
-#: ../src/wxMaximaFrame.cpp:844
+#: ../src/wxMaximaFrame.cpp:843
 msgid "Contract Logarithms"
 msgstr "Contrai i logaritmi"
 
-#: ../src/wxMaximaFrame.cpp:851
+#: ../src/wxMaximaFrame.cpp:850
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr "Converti binomiali, funzioni beta e gamma in fattoriali"
 
-#: ../src/wxMaximaFrame.cpp:854
+#: ../src/wxMaximaFrame.cpp:853
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr "Converti binomiali, fattoriali e funzione beta in funzione gamma"
 
-#: ../src/wxMaximaFrame.cpp:888
+#: ../src/wxMaximaFrame.cpp:887
 msgid "Convert complex expression to polar form"
 msgstr "Converti l'espressione complessa nella forma polare"
 
-#: ../src/wxMaximaFrame.cpp:885
+#: ../src/wxMaximaFrame.cpp:884
 msgid "Convert complex expression to rect form"
 msgstr "Converti l'espressione complessa nella forma normale"
 
-#: ../src/wxMaximaFrame.cpp:897
+#: ../src/wxMaximaFrame.cpp:896
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
 "Converti la funzione esponenziale dell'argomento immaginario nella forma "
 "trigonometrica"
 
-#: ../src/wxMaximaFrame.cpp:842
+#: ../src/wxMaximaFrame.cpp:841
 msgid "Convert logarithm of product to sum of logarithms"
 msgstr "Converti il logaritmo del prodotto in somma di logaritmi"
 
-#: ../src/wxMaximaFrame.cpp:845
+#: ../src/wxMaximaFrame.cpp:844
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "Converti la somma dei logaritmi in logaritmo del prodotto"
 
-#: ../src/wxMaximaFrame.cpp:850
+#: ../src/wxMaximaFrame.cpp:849
 msgid "Convert to &Factorials"
 msgstr "Converti in &fattoriali"
 
-#: ../src/wxMaximaFrame.cpp:853
+#: ../src/wxMaximaFrame.cpp:852
 msgid "Convert to &Gamma"
 msgstr "Converti in &gamma"
 
-#: ../src/wxMaximaFrame.cpp:887
+#: ../src/wxMaximaFrame.cpp:886
 msgid "Convert to &Polarform"
 msgstr "Converti in forma &polare"
 
-#: ../src/wxMaximaFrame.cpp:884
+#: ../src/wxMaximaFrame.cpp:883
 msgid "Convert to &Rectform"
 msgstr "Converti in forma no&rmale"
 
-#: ../src/wxMaximaFrame.cpp:877
+#: ../src/wxMaximaFrame.cpp:876
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr ""
 "Converti l'espressione trigonometrica nella forma canonica quasilineare"
 
-#: ../src/wxMaximaFrame.cpp:900
+#: ../src/wxMaximaFrame.cpp:899
 msgid "Convert trigonometric functions to exponential form"
 msgstr "Converti le funzioni trigonometriche nella forma esponenziale"
 
-#: ../src/ToolBar.cpp:140 ../src/MathCtrl.cpp:918 ../src/MathCtrl.cpp:931
-#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1024
+#: ../src/MathCtrl.cpp:960 ../src/MathCtrl.cpp:973 ../src/MathCtrl.cpp:1019
+#: ../src/MathCtrl.cpp:1066 ../src/ToolBar.cpp:140
 msgid "Copy"
 msgstr "Copia"
 
-#: ../src/wxMaximaFrame.cpp:597
+#: ../src/wxMaximaFrame.cpp:596
 msgid "Copy Previous Input\tCtrl-I"
 msgstr "Copia l'inserimento precedente\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:599
+#: ../src/wxMaximaFrame.cpp:598
 msgid "Copy Previous Output\tCtrl-U"
 msgstr "Copia il risultato precedente\tCtrl-U"
 
-#: ../src/wxMaximaFrame.cpp:514 ../src/MathCtrl.cpp:936 ../src/MathCtrl.cpp:982
+#: ../src/MathCtrl.cpp:978 ../src/MathCtrl.cpp:1024
+#: ../src/wxMaximaFrame.cpp:513
 msgid "Copy as Image"
 msgstr "Copia come immagine"
 
-#: ../src/wxMaximaFrame.cpp:507 ../src/MathCtrl.cpp:932 ../src/MathCtrl.cpp:978
+#: ../src/MathCtrl.cpp:974 ../src/MathCtrl.cpp:1020
+#: ../src/wxMaximaFrame.cpp:506
 msgid "Copy as LaTeX"
 msgstr "Copia come LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:510
+#: ../src/wxMaximaFrame.cpp:509
 #, fuzzy
 msgid "Copy as MathML"
 msgstr "Copia come immagine"
 
-#: ../src/MathCtrl.cpp:935 ../src/MathCtrl.cpp:980
+#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1022
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:504
+#: ../src/wxMaximaFrame.cpp:503
 msgid "Copy as Text\tCtrl-Shift-C"
 msgstr "Copia come testo\tCtrl-Shift-C"
 
-#: ../src/MathCtrl.cpp:933 ../src/MathCtrl.cpp:979
+#: ../src/MathCtrl.cpp:975 ../src/MathCtrl.cpp:1021
 msgid "Copy as plain text"
 msgstr "Copia come immagine"
 
-#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:503
+#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:502
 msgid "Copy selection"
 msgstr "Copia la selezione"
 
-#: ../src/wxMaximaFrame.cpp:515
+#: ../src/wxMaximaFrame.cpp:514
 msgid "Copy selection from document as an image"
 msgstr "Copia la selezione dal documento come immagine"
 
-#: ../src/wxMaximaFrame.cpp:505
+#: ../src/wxMaximaFrame.cpp:504
 msgid "Copy selection from document as text"
 msgstr "Copia la selezione dal documento come testo"
 
-#: ../src/wxMaximaFrame.cpp:508
+#: ../src/wxMaximaFrame.cpp:507
 msgid "Copy selection from document in LaTeX format"
 msgstr "Copia la selezione dal documento in formato LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:511
+#: ../src/wxMaximaFrame.cpp:510
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:598
+#: ../src/wxMaximaFrame.cpp:597
 msgid "Create a new cell with previous input"
 msgstr "Crea una nuova cella con i dati inseriti precedentemente"
 
-#: ../src/wxMaximaFrame.cpp:600
+#: ../src/wxMaximaFrame.cpp:599
 msgid "Create a new cell with previous output"
 msgstr "Crea una nuova cella con il risultato precedente"
 
@@ -1184,15 +1186,15 @@ msgstr "Crea una nuova cella con il risultato precedente"
 msgid "Cursor"
 msgstr "Cursore"
 
-#: ../src/ToolBar.cpp:137 ../src/MathCtrl.cpp:1023
+#: ../src/MathCtrl.cpp:1065 ../src/ToolBar.cpp:137
 msgid "Cut"
 msgstr "Taglia"
 
-#: ../src/wxMaximaFrame.cpp:499
+#: ../src/wxMaximaFrame.cpp:498
 msgid "Cut\tCtrl-X"
 msgstr "Taglia\tCtrl-X"
 
-#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:500
+#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:499
 msgid "Cut selection"
 msgstr "Taglia la selezione"
 
@@ -1204,18 +1206,18 @@ msgstr "Ceco"
 msgid "Danish"
 msgstr "Danese"
 
-#: ../src/wxMaxima.cpp:4799 ../src/wxMaxima.cpp:4806 ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4811 ../src/wxMaxima.cpp:4818 ../src/wxMaxima.cpp:4868
 msgid "Data Matrix:"
 msgstr "Matrice dati:"
 
-#: ../src/wxMaxima.cpp:4826
+#: ../src/wxMaxima.cpp:4838
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr "File dati (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698 ../src/wxMaxima.cpp:4712
-#: ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726 ../src/wxMaxima.cpp:4734
-#: ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748 ../src/wxMaxima.cpp:4755
-#: ../src/wxMaxima.cpp:4791
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710 ../src/wxMaxima.cpp:4724
+#: ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738 ../src/wxMaxima.cpp:4746
+#: ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760 ../src/wxMaxima.cpp:4767
+#: ../src/wxMaxima.cpp:4803
 msgid "Data:"
 msgstr "Dati:"
 
@@ -1223,7 +1225,7 @@ msgstr "Dati:"
 msgid "Debug: watch maxima's stdout stream"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:820
+#: ../src/wxMaximaFrame.cpp:819
 msgid "Decompose rational function to partial fractions"
 msgstr "Decomponi la funzione razionale in frazioni parziali"
 
@@ -1255,47 +1257,47 @@ msgstr ""
 "Definisce la velocità predefinita (in quadri al secondo) alla quale sono "
 "eseguite le animazioni."
 
-#: ../src/wxMaxima.cpp:3403 ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3415 ../src/wxMaxima.cpp:3424
 msgid "Delete"
 msgstr "Elimina"
 
-#: ../src/wxMaximaFrame.cpp:667
+#: ../src/wxMaximaFrame.cpp:666
 msgid "Delete F&unction..."
 msgstr "Elimina una f&unzione..."
 
-#: ../src/MathCtrl.cpp:939 ../src/MathCtrl.cpp:985
+#: ../src/MathCtrl.cpp:981 ../src/MathCtrl.cpp:1027
 msgid "Delete Selection"
 msgstr "Elimina la selezione"
 
-#: ../src/wxMaximaFrame.cpp:669
+#: ../src/wxMaximaFrame.cpp:668
 msgid "Delete V&ariable..."
 msgstr "Elimina la v&ariabile..."
 
-#: ../src/wxMaximaFrame.cpp:668
+#: ../src/wxMaximaFrame.cpp:667
 msgid "Delete a function"
 msgstr "Elimina una funzione"
 
-#: ../src/wxMaximaFrame.cpp:670
+#: ../src/wxMaximaFrame.cpp:669
 msgid "Delete a variable"
 msgstr "Elimina una variabile"
 
-#: ../src/wxMaximaFrame.cpp:655
+#: ../src/wxMaximaFrame.cpp:654
 msgid "Delete all values from memory"
 msgstr "Cancella tutti i valori dalla memoria"
 
-#: ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3424
 msgid "Delete function(s):"
 msgstr "Elimina le funzioni:"
 
-#: ../src/wxMaxima.cpp:3403
+#: ../src/wxMaxima.cpp:3415
 msgid "Delete variable(s):"
 msgstr "Elimina le variabili:"
 
-#: ../src/wxMaximaFrame.cpp:1367
+#: ../src/wxMaximaFrame.cpp:1366
 msgid "Delta"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4011
+#: ../src/wxMaxima.cpp:4023
 msgid "Denom. deg:"
 msgstr "Denom. deg:"
 
@@ -1303,35 +1305,35 @@ msgstr "Denom. deg:"
 msgid "Depth:"
 msgstr "profondità:"
 
-#: ../src/wxMaxima.cpp:3541
+#: ../src/wxMaxima.cpp:3553
 msgid "Derivative:"
 msgstr "Derivata:"
 
-#: ../src/wxMaximaFrame.cpp:1258
+#: ../src/wxMaximaFrame.cpp:1257
 msgid "Deviation..."
 msgstr "Deviazione..."
 
-#: ../src/wxMaximaFrame.cpp:816
+#: ../src/wxMaximaFrame.cpp:815
 msgid "Di&vide Polynomials..."
 msgstr "Di&vidi le polinomiali..."
 
-#: ../src/wxMaximaFrame.cpp:1223
+#: ../src/wxMaximaFrame.cpp:1222
 msgid "Diff..."
 msgstr "Diff..."
 
-#: ../src/wxMaxima.cpp:4154 ../src/wxMaxima.cpp:5066
+#: ../src/wxMaxima.cpp:4166 ../src/wxMaxima.cpp:5078
 msgid "Differentiate"
 msgstr "Differenzia"
 
-#: ../src/wxMaximaFrame.cpp:786
+#: ../src/wxMaximaFrame.cpp:785
 msgid "Differentiate expression"
 msgstr "Differenzia l'espressione"
 
-#: ../src/MathCtrl.cpp:1001
+#: ../src/MathCtrl.cpp:1043
 msgid "Differentiate..."
 msgstr "Deriva..."
 
-#: ../src/LimitWiz.cpp:37 ../src/FindReplacePane.cpp:76
+#: ../src/FindReplacePane.cpp:76 ../src/LimitWiz.cpp:37
 msgid "Direction:"
 msgstr "Direzione:"
 
@@ -1339,48 +1341,49 @@ msgstr "Direzione:"
 msgid "Discrete plot"
 msgstr "Grafico discreto"
 
-#: ../src/wxMaximaFrame.cpp:679
+#: ../src/wxMaximaFrame.cpp:678
 msgid "Display Te&X Form"
 msgstr "Mostra in Te&X"
 
-#: ../src/wxMaxima.cpp:3320
+#: ../src/wxMaxima.cpp:3332
 msgid "Display algorithm"
 msgstr "Mostra l'algoritmo"
 
-#: ../src/wxMaximaFrame.cpp:680
+#: ../src/wxMaximaFrame.cpp:679
 msgid "Display last result in TeX form"
 msgstr "Mostra l'espressione precedente in TeX"
 
-#: ../src/wxMaximaFrame.cpp:674
+#: ../src/wxMaximaFrame.cpp:673
 msgid "Display time used for evaluation"
 msgstr "Mostra il tempo impiegato per l'esecuzione"
 
-#: ../src/wxMaxima.cpp:4061
+#: ../src/wxMaxima.cpp:4073
 msgid "Divide"
 msgstr "Dividi"
 
-#: ../src/MathCtrl.cpp:1032
+#: ../src/MathCtrl.cpp:1074
 msgid "Divide Cell"
 msgstr "Dividi cella"
 
-#: ../src/wxMaximaFrame.cpp:635
+#: ../src/wxMaximaFrame.cpp:634
 #, fuzzy
 msgid "Divide Cell\tCtrl-D"
 msgstr "Dividi cella"
 
-#: ../src/wxMaximaFrame.cpp:817
+#: ../src/wxMaximaFrame.cpp:816
 msgid "Divide numbers or polynomials"
 msgstr "Dividi i numeri o i polinomiali"
 
-#: ../src/wxMaximaFrame.cpp:636
+#: ../src/wxMaximaFrame.cpp:635
 msgid "Divide this input cell into two cells"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5917
-msgid "Do you want to save the changes you made in the document \""
+#: ../src/wxMaxima.cpp:5932
+#, fuzzy, c-format
+msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr "Salvare i cambiamenti effettuati nel documento \""
 
-#: ../src/wxMaxima.cpp:1664 ../src/wxMaxima.cpp:1672
+#: ../src/wxMaxima.cpp:1669 ../src/wxMaxima.cpp:1677
 msgid "Document "
 msgstr "Documento "
 
@@ -1402,7 +1405,7 @@ msgstr ""
 "individualmente: ciò permette ai sistemi di controllo di versione come git e "
 "svn di individuare efficacemente le differenze."
 
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Don't save"
 msgstr "Non salvare"
 
@@ -1410,27 +1413,27 @@ msgstr "Non salvare"
 msgid "Down"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:734
+#: ../src/wxMaximaFrame.cpp:733
 msgid "E&quations"
 msgstr "E&quazioni"
 
-#: ../src/wxMaximaFrame.cpp:487
+#: ../src/wxMaximaFrame.cpp:486
 msgid "E&xit\tCtrl-Q"
 msgstr "&Esci\tCtrl-Q"
 
-#: ../src/wxMaximaFrame.cpp:757
+#: ../src/wxMaximaFrame.cpp:756
 msgid "Eige&nvectors"
 msgstr "&Autovettori"
 
-#: ../src/wxMaximaFrame.cpp:755
+#: ../src/wxMaximaFrame.cpp:754
 msgid "Eigen&values"
 msgstr "Auto&valori"
 
-#: ../src/wxMaxima.cpp:3572
+#: ../src/wxMaxima.cpp:3584
 msgid "Eliminate"
 msgstr "Annulla"
 
-#: ../src/wxMaximaFrame.cpp:710
+#: ../src/wxMaximaFrame.cpp:709
 msgid "Eliminate a variable from a system of equations"
 msgstr "Annulla una variabile da un sistema di equazioni"
 
@@ -1442,21 +1445,21 @@ msgstr ""
 msgid "English"
 msgstr "Inglese"
 
-#: ../src/wxMaxima.cpp:4712 ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726
-#: ../src/wxMaxima.cpp:4734 ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748
-#: ../src/wxMaxima.cpp:4755 ../src/wxMaxima.cpp:4791 ../src/wxMaxima.cpp:4799
+#: ../src/wxMaxima.cpp:4724 ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738
+#: ../src/wxMaxima.cpp:4746 ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760
+#: ../src/wxMaxima.cpp:4767 ../src/wxMaxima.cpp:4803 ../src/wxMaxima.cpp:4811
 msgid "Enter Data"
 msgstr "Inserire i dati"
 
-#: ../src/wxMaximaFrame.cpp:1279
+#: ../src/wxMaximaFrame.cpp:1278
 msgid "Enter Matrix..."
 msgstr "Inserire la matrice..."
 
-#: ../src/wxMaximaFrame.cpp:745
+#: ../src/wxMaximaFrame.cpp:744
 msgid "Enter a matrix"
 msgstr "Inserisci una matrice"
 
-#: ../src/wxMaxima.cpp:3962
+#: ../src/wxMaxima.cpp:3974
 msgid "Enter an equation for rational simplification:"
 msgstr "Inserire un'equazione per la semplificazione razionale:"
 
@@ -1468,11 +1471,11 @@ msgstr "Inserire la lista di variabili separate dalla virgola."
 msgid "Enter evaluates cells"
 msgstr "Invio elabora le celle"
 
-#: ../src/wxMaxima.cpp:3734
+#: ../src/wxMaxima.cpp:3746
 msgid "Enter matrix"
 msgstr "Inserire la matrice"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 #, fuzzy
 msgid "Enter new precision for bigfloats:"
 msgstr "Inserisci nuova precisione:"
@@ -1481,11 +1484,11 @@ msgstr "Inserisci nuova precisione:"
 msgid "Enter the path to the Maxima executable."
 msgstr "Inserire il percorso dell'eseguibile Maxima."
 
-#: ../src/wxMaximaFrame.cpp:1368
+#: ../src/wxMaximaFrame.cpp:1367
 msgid "Epsilon"
 msgstr "Epsilon"
 
-#: ../src/wxMaxima.cpp:4208
+#: ../src/wxMaxima.cpp:4220
 msgid "Epsilon:"
 msgstr "Epsilon:"
 
@@ -1494,13 +1497,13 @@ msgstr "Epsilon:"
 msgid "Equation %d:"
 msgstr "Equazione %d:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:3633
-#: ../src/wxMaxima.cpp:5019
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:3645
+#: ../src/wxMaxima.cpp:5031
 msgid "Equation(s):"
 msgstr "Equazione(i):"
 
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3993
-#: ../src/wxMaxima.cpp:4807 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:4005
+#: ../src/wxMaxima.cpp:4819 ../src/wxMaxima.cpp:5045
 msgid "Equation:"
 msgstr "Equazione:"
 
@@ -1511,77 +1514,77 @@ msgid ""
 "be introduced one into another. Also they are always printed out as 2D maths."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3570
+#: ../src/wxMaxima.cpp:3582
 msgid "Equations:"
 msgstr "Equazioni:"
 
-#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1455
-#: ../src/wxMaxima.cpp:1469 ../src/wxMaxima.cpp:1620 ../src/wxMaxima.cpp:1633
-#: ../src/wxMaxima.cpp:1643 ../src/wxMaxima.cpp:1666 ../src/wxMaxima.cpp:2034
-#: ../src/wxMaxima.cpp:2206 ../src/wxMaxima.cpp:5381 ../src/wxMaxima.cpp:5830
-#: ../src/wxMaxima.cpp:5881
+#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1460
+#: ../src/wxMaxima.cpp:1474 ../src/wxMaxima.cpp:1625 ../src/wxMaxima.cpp:1638
+#: ../src/wxMaxima.cpp:1648 ../src/wxMaxima.cpp:1671 ../src/wxMaxima.cpp:2039
+#: ../src/wxMaxima.cpp:2211 ../src/wxMaxima.cpp:5397 ../src/wxMaxima.cpp:5845
+#: ../src/wxMaxima.cpp:5896
 msgid "Error"
 msgstr "Errore"
 
-#: ../src/wxMaxima.cpp:2886 ../src/wxMaxima.cpp:2900 ../src/wxMaxima.cpp:2913
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617 ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:2894 ../src/wxMaxima.cpp:2908 ../src/wxMaxima.cpp:2921
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629 ../src/wxMaxima.cpp:3740
 msgid "Error!"
 msgstr "Errore!"
 
-#: ../src/wxMaximaFrame.cpp:1370
+#: ../src/wxMaximaFrame.cpp:1369
 msgid "Eta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:909
+#: ../src/wxMaximaFrame.cpp:908
 msgid "Evaluate &Noun Forms"
 msgstr "Elabora le forme &nominali"
 
-#: ../src/wxMaximaFrame.cpp:589
+#: ../src/wxMaximaFrame.cpp:588
 msgid "Evaluate All Cells\tCtrl-Shift-R"
 msgstr "Elabora tutte le celle\tCtrl-Maiusc-R"
 
-#: ../src/wxMaximaFrame.cpp:587
+#: ../src/wxMaximaFrame.cpp:586
 msgid "Evaluate All Visible Cells\tCtrl-R"
 msgstr "Elabora tutte le celle visibili\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:585 ../src/MathCtrl.cpp:942
+#: ../src/MathCtrl.cpp:984 ../src/wxMaximaFrame.cpp:584
 msgid "Evaluate Cell(s)"
 msgstr "Elabora le celle"
 
-#: ../src/wxMaximaFrame.cpp:591
+#: ../src/wxMaximaFrame.cpp:590
 #, fuzzy
 msgid "Evaluate Cells Above\tCtrl-Shift-P"
 msgstr "Elabora tutte le celle\tCtrl-Maiusc-R"
 
-#: ../src/MathCtrl.cpp:956 ../src/MathCtrl.cpp:1051
+#: ../src/MathCtrl.cpp:998 ../src/MathCtrl.cpp:1093
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:961 ../src/MathCtrl.cpp:1053
+#: ../src/MathCtrl.cpp:1003 ../src/MathCtrl.cpp:1095
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:971 ../src/MathCtrl.cpp:1057
+#: ../src/MathCtrl.cpp:1013 ../src/MathCtrl.cpp:1099
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:966 ../src/MathCtrl.cpp:1055
+#: ../src/MathCtrl.cpp:1008 ../src/MathCtrl.cpp:1097
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:586
+#: ../src/wxMaximaFrame.cpp:585
 msgid "Evaluate active or selected cell(s)"
 msgstr "Elabora le celle attive o selezionate"
 
-#: ../src/wxMaximaFrame.cpp:590
+#: ../src/wxMaximaFrame.cpp:589
 msgid "Evaluate all cells in the document"
 msgstr "Elabora tutte le celle nel documento"
 
-#: ../src/wxMaximaFrame.cpp:910
+#: ../src/wxMaximaFrame.cpp:909
 msgid "Evaluate all noun forms in expression"
 msgstr "Elabora tutte le forme nominali nell'espressione"
 
-#: ../src/wxMaximaFrame.cpp:588
+#: ../src/wxMaximaFrame.cpp:587
 msgid "Evaluate all visible cells in the document"
 msgstr "Elabora tutte le celle visibili nel documento"
 
@@ -1594,7 +1597,7 @@ msgstr ""
 msgid "Evaluate to point"
 msgstr "Elabora le forme &nominali"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Example"
 msgstr "Esempio"
 
@@ -1607,31 +1610,31 @@ msgstr "Esempio di testo"
 msgid "Examples:"
 msgstr "Esempio"
 
-#: ../src/wxMaximaFrame.cpp:488
+#: ../src/wxMaximaFrame.cpp:487
 msgid "Exit wxMaxima"
 msgstr "Esci da wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:1214
+#: ../src/wxMaximaFrame.cpp:1213
 msgid "Expand"
 msgstr "Espandi"
 
-#: ../src/wxMaximaFrame.cpp:1219
+#: ../src/wxMaximaFrame.cpp:1218
 msgid "Expand (tr)"
 msgstr "Espandi (tr)"
 
-#: ../src/MathCtrl.cpp:997
+#: ../src/MathCtrl.cpp:1039
 msgid "Expand Expression"
 msgstr "Espandi l'espressione"
 
-#: ../src/wxMaximaFrame.cpp:841
+#: ../src/wxMaximaFrame.cpp:840
 msgid "Expand Logarithms"
 msgstr "Espandi i logaritmi"
 
-#: ../src/wxMaximaFrame.cpp:840
+#: ../src/wxMaximaFrame.cpp:839
 msgid "Expand an expression"
 msgstr "Espandi un'espressione"
 
-#: ../src/wxMaximaFrame.cpp:874
+#: ../src/wxMaximaFrame.cpp:873
 msgid "Expand trigonometric expression"
 msgstr "Espandi l'espressione trigonometrica"
 
@@ -1639,7 +1642,7 @@ msgstr "Espandi l'espressione trigonometrica"
 msgid "Expected the icon files to be found at"
 msgstr ""
 
-#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2834
+#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2842
 msgid "Export"
 msgstr "Esporta"
 
@@ -1650,33 +1653,33 @@ msgstr ""
 "Esporta le animazioni in TeX (le immagini si muoveranno solo se il "
 "visualizzatore PDF lo supporterà)"
 
-#: ../src/wxMaximaFrame.cpp:481
+#: ../src/wxMaximaFrame.cpp:480
 msgid "Export document to a HTML or pdfLaTeX file"
 msgstr "Esporta il documento in un file HTML o pdfLaTeX"
 
-#: ../src/wxMaximaFrame.cpp:253
+#: ../src/wxMaximaFrame.cpp:252
 #, fuzzy
 msgid "Export failed."
 msgstr "Esportazione in TeX fallita!"
 
-#: ../src/wxMaximaFrame.cpp:239
+#: ../src/wxMaximaFrame.cpp:238
 msgid "Export successful."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2913
+#: ../src/wxMaxima.cpp:2921
 msgid "Exporting to HTML failed!"
 msgstr "Esportazione su HTML fallita!"
 
-#: ../src/wxMaxima.cpp:2886
+#: ../src/wxMaxima.cpp:2894
 msgid "Exporting to TeX failed!"
 msgstr "Esportazione in TeX fallita!"
 
-#: ../src/wxMaxima.cpp:2900
+#: ../src/wxMaxima.cpp:2908
 #, fuzzy
 msgid "Exporting to maxima batch file failed!"
 msgstr "Esportazione in TeX fallita!"
 
-#: ../src/wxMaximaFrame.cpp:229
+#: ../src/wxMaximaFrame.cpp:228
 #, fuzzy
 msgid "Exporting..."
 msgstr "&Esporta..."
@@ -1690,42 +1693,42 @@ msgid "Expression(s):"
 msgstr "Espressioni:"
 
 #: ../src/IntegrateWiz.cpp:30 ../src/LimitWiz.cpp:27 ../src/SeriesWiz.cpp:33
-#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3648
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:4205 ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5064
+#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3660
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:4217 ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5076
 msgid "Expression:"
 msgstr "Espressione:"
 
-#: ../src/wxMaximaFrame.cpp:1213
+#: ../src/wxMaximaFrame.cpp:1212
 msgid "Factor"
 msgstr "Fattorizza"
 
-#: ../src/wxMaximaFrame.cpp:836
+#: ../src/wxMaximaFrame.cpp:835
 msgid "Factor Complex"
 msgstr "Fattorizza in numeri complessi"
 
-#: ../src/MathCtrl.cpp:996
+#: ../src/MathCtrl.cpp:1038
 msgid "Factor Expression"
 msgstr "Fattorizza l'espressione"
 
-#: ../src/wxMaximaFrame.cpp:835
+#: ../src/wxMaximaFrame.cpp:834
 msgid "Factor an expression"
 msgstr "Fattorizza un'espressione"
 
-#: ../src/wxMaximaFrame.cpp:837
+#: ../src/wxMaximaFrame.cpp:836
 msgid "Factor an expression in Gaussian numbers"
 msgstr "Fattorizza un'espressione di numeri Gaussiani"
 
-#: ../src/wxMaximaFrame.cpp:862
+#: ../src/wxMaximaFrame.cpp:861
 msgid "Factorials and &Gamma"
 msgstr "Fattoriali e &gamma"
 
-#: ../src/wxMaxima.cpp:285
+#: ../src/wxMaxima.cpp:286
 msgid "Fatal error"
 msgstr "Errore fatale"
 
-#: ../src/GroupCell.cpp:1571
+#: ../src/GroupCell.cpp:1572
 #, c-format
 msgid "Figure %d:"
 msgstr "Figura %d:"
@@ -1734,22 +1737,22 @@ msgstr "Figura %d:"
 msgid "File"
 msgstr "File"
 
-#: ../src/wxMaxima.cpp:1457 ../src/wxMaxima.cpp:1623 ../src/wxMaxima.cpp:1636
-#: ../src/wxMaxima.cpp:1646 ../src/wxMaxima.cpp:1668
+#: ../src/wxMaxima.cpp:1462 ../src/wxMaxima.cpp:1628 ../src/wxMaxima.cpp:1641
+#: ../src/wxMaxima.cpp:1651 ../src/wxMaxima.cpp:1673
 #, fuzzy
 msgid "File could not be opened"
 msgstr "File non trovato"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File not found"
 msgstr "File non trovato"
 
-#: ../src/wxMaxima.cpp:1511 ../src/wxMaxima.cpp:1729
+#: ../src/wxMaxima.cpp:1516 ../src/wxMaxima.cpp:1734
 #, fuzzy
 msgid "File opened"
 msgstr "File non trovato"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File you tried to open does not exist."
 msgstr "Il file che si sta provando ad aprire non esiste."
 
@@ -1761,67 +1764,67 @@ msgstr "File:"
 msgid "Find"
 msgstr "Trova"
 
-#: ../src/wxMaximaFrame.cpp:523
+#: ../src/wxMaximaFrame.cpp:522
 msgid "Find\tCtrl-F"
 msgstr "Trova\tCtrl-F"
 
-#: ../src/wxMaximaFrame.cpp:787
+#: ../src/wxMaximaFrame.cpp:786
 msgid "Find &Limit..."
 msgstr "Trova il &limite..."
 
-#: ../src/wxMaximaFrame.cpp:790
+#: ../src/wxMaximaFrame.cpp:789
 msgid "Find Minimum..."
 msgstr "Trova il minimo..."
 
-#: ../src/MathCtrl.cpp:993
+#: ../src/MathCtrl.cpp:1035
 msgid "Find Root..."
 msgstr "Trova la radice..."
 
-#: ../src/wxMaximaFrame.cpp:791
+#: ../src/wxMaximaFrame.cpp:790
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr "Trova un minimo (libero) di un'espressione"
 
-#: ../src/wxMaximaFrame.cpp:788
+#: ../src/wxMaximaFrame.cpp:787
 msgid "Find a limit of an expression"
 msgstr "Trova il limite di un'espressione"
 
-#: ../src/wxMaximaFrame.cpp:693
+#: ../src/wxMaximaFrame.cpp:692
 msgid "Find a root of an equation on an interval"
 msgstr "Trova la radice di un'equazione in un intervallo"
 
-#: ../src/wxMaximaFrame.cpp:695
+#: ../src/wxMaximaFrame.cpp:694
 msgid "Find all roots of a polynomial"
 msgstr "Trova tutte le radici di una polinomiale"
 
-#: ../src/wxMaximaFrame.cpp:698
+#: ../src/wxMaximaFrame.cpp:697
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr "Trova tutte le radici di una polinomiale (alta precisione)"
 
-#: ../src/wxMaxima.cpp:3220
+#: ../src/wxMaxima.cpp:3215
 msgid "Find and Replace"
 msgstr "Cerca e sostituisci"
 
-#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:523
+#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:522
 msgid "Find and replace"
 msgstr "Cerca e sostituisci"
 
-#: ../src/wxMaximaFrame.cpp:756
+#: ../src/wxMaximaFrame.cpp:755
 msgid "Find eigenvalues of a matrix"
 msgstr "Trova gli autovalori di una matrice"
 
-#: ../src/wxMaximaFrame.cpp:758
+#: ../src/wxMaximaFrame.cpp:757
 msgid "Find eigenvectors of a matrix"
 msgstr "Trova gli autovettori di una matrice"
 
-#: ../src/wxMaxima.cpp:4210
+#: ../src/wxMaxima.cpp:4222
 msgid "Find minimum"
 msgstr "Trova il minimo"
 
-#: ../src/wxMaximaFrame.cpp:701
+#: ../src/wxMaximaFrame.cpp:700
 msgid "Find real roots of a polynomial"
 msgstr "Trova le radici reali di una polinomiale"
 
-#: ../src/wxMaxima.cpp:3493 ../src/wxMaxima.cpp:5036
+#: ../src/wxMaxima.cpp:3505 ../src/wxMaxima.cpp:5048
 msgid "Find root"
 msgstr "Trova la radice"
 
@@ -1845,11 +1848,11 @@ msgstr ""
 msgid "Fixed font in text controls"
 msgstr "Carattere di ampiezza fissa nei controlli di testo."
 
-#: ../src/wxMaximaFrame.cpp:623
+#: ../src/wxMaximaFrame.cpp:622
 msgid "Fold All\tCtrl-Alt-["
 msgstr "Ripiega tutto\tCtrl-["
 
-#: ../src/wxMaximaFrame.cpp:624
+#: ../src/wxMaximaFrame.cpp:623
 msgid "Fold all sections"
 msgstr "Ripiega tutte le sezioni"
 
@@ -1857,25 +1860,25 @@ msgstr "Ripiega tutte le sezioni"
 msgid "Follow"
 msgstr ""
 
-#: ../src/ParenCell.cpp:319
+#: ../src/ParenCell.cpp:320
 msgid "Font issue: The Parenthesis sign is too small!"
 msgstr ""
 
-#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:381
+#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:382
 msgid ""
 "Font issue: The char height is too small! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:199
+#: ../src/SqrtCell.cpp:202
 msgid ""
 "Font issue: The sqrt() sign has the size 0! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:198
+#: ../src/SqrtCell.cpp:201
 msgid "Font issue? The contents of a sqrt() has the size 0."
 msgstr ""
 
@@ -1906,15 +1909,15 @@ msgstr "Francese"
 
 #: ../src/IntegrateWiz.cpp:37 ../src/Plot2dWiz.cpp:37 ../src/Plot2dWiz.cpp:47
 #: ../src/Plot2dWiz.cpp:536 ../src/Plot3dWiz.cpp:36 ../src/Plot3dWiz.cpp:45
-#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4240
+#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4252
 msgid "From:"
 msgstr "Da:"
 
-#: ../src/wxMaximaFrame.cpp:576
+#: ../src/wxMaximaFrame.cpp:575
 msgid "Full Screen\tAlt-Enter"
 msgstr "Pieno schermo\tAlt-Invio"
 
-#: ../src/wxMaxima.cpp:3342
+#: ../src/wxMaxima.cpp:3354
 msgid "Function"
 msgstr "Funzione"
 
@@ -1922,32 +1925,32 @@ msgstr "Funzione"
 msgid "Function names"
 msgstr "Nomi funzione"
 
-#: ../src/wxMaxima.cpp:3633
+#: ../src/wxMaxima.cpp:3645
 msgid "Function(s):"
 msgstr "Funzione(i):"
 
-#: ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3803
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3815
+#: ../src/wxMaxima.cpp:3848
 msgid "Function:"
 msgstr "Funzione:"
 
-#: ../src/wxMaximaFrame.cpp:904
+#: ../src/wxMaximaFrame.cpp:903
 msgid "Functions for complex simplification"
 msgstr "Funzioni per la semplificazione complessa"
 
-#: ../src/wxMaximaFrame.cpp:864
+#: ../src/wxMaximaFrame.cpp:863
 msgid "Functions for simplifying factorials and gamma function"
 msgstr "Funzioni per semplificare fattoriali e funzione gamma"
 
-#: ../src/wxMaximaFrame.cpp:881
+#: ../src/wxMaximaFrame.cpp:880
 msgid "Functions for simplifying trigonometric expressions"
 msgstr "Funzioni per semplificare le espressioni trigonometriche"
 
-#: ../src/wxMaxima.cpp:4046
+#: ../src/wxMaxima.cpp:4058
 msgid "GCD"
 msgstr "MCD"
 
-#: ../src/wxMaxima.cpp:5152
+#: ../src/wxMaxima.cpp:5164
 msgid "GIF image (*.gif)|*.gif"
 msgstr "Immagine GIF (*.gif)|*.gif"
 
@@ -1955,31 +1958,31 @@ msgstr "Immagine GIF (*.gif)|*.gif"
 msgid "Galician"
 msgstr "Galiziano"
 
-#: ../src/wxMaximaFrame.cpp:1366
+#: ../src/wxMaximaFrame.cpp:1365
 msgid "Gamma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:391
+#: ../src/wxMaximaFrame.cpp:390
 msgid "General Math"
 msgstr "Matematica generale"
 
-#: ../src/wxMaximaFrame.cpp:549
+#: ../src/wxMaximaFrame.cpp:548
 msgid "General Math\tAlt-Shift-M"
 msgstr "Matematica generale\tAlt-Shift-M"
 
-#: ../src/wxMaxima.cpp:3766 ../src/wxMaxima.cpp:3785
+#: ../src/wxMaxima.cpp:3778 ../src/wxMaxima.cpp:3797
 msgid "Generate Matrix"
 msgstr "Genera matrice"
 
-#: ../src/wxMaximaFrame.cpp:741
+#: ../src/wxMaximaFrame.cpp:740
 msgid "Generate Matrix from Expression..."
 msgstr "Genera una matrice dall'espressione..."
 
-#: ../src/wxMaximaFrame.cpp:739
+#: ../src/wxMaximaFrame.cpp:738
 msgid "Generate a matrix from a 2-dimensional array"
 msgstr "Genera una matrice da un array bidimensionale"
 
-#: ../src/wxMaximaFrame.cpp:742
+#: ../src/wxMaximaFrame.cpp:741
 msgid "Generate a matrix from a lambda expression"
 msgstr "Genera una matrice da una espressione lambda"
 
@@ -1987,39 +1990,39 @@ msgstr "Genera una matrice da una espressione lambda"
 msgid "German"
 msgstr "Tedesco"
 
-#: ../src/wxMaximaFrame.cpp:893
+#: ../src/wxMaximaFrame.cpp:892
 msgid "Get &Imaginary Part"
 msgstr "Ricava la parte &immaginaria"
 
-#: ../src/wxMaximaFrame.cpp:793
+#: ../src/wxMaximaFrame.cpp:792
 msgid "Get &Series..."
 msgstr "Ricava le &serie..."
 
-#: ../src/wxMaximaFrame.cpp:804
+#: ../src/wxMaximaFrame.cpp:803
 msgid "Get Laplace transformation of an expression"
 msgstr "Calcola la trasformata di Laplace di un'espressione"
 
-#: ../src/wxMaximaFrame.cpp:890
+#: ../src/wxMaximaFrame.cpp:889
 msgid "Get Real P&art"
 msgstr "Ricava la p&arte reale"
 
-#: ../src/wxMaximaFrame.cpp:807
+#: ../src/wxMaximaFrame.cpp:806
 msgid "Get inverse Laplace transformation of an expression"
 msgstr "Calcola la trasformata inversa di Laplace di un'espressione"
 
-#: ../src/wxMaximaFrame.cpp:794
+#: ../src/wxMaximaFrame.cpp:793
 msgid "Get the Taylor or power series of expression"
 msgstr "Calcola la serie di Taylor o la serie di potenze di un un'espressione"
 
-#: ../src/wxMaximaFrame.cpp:894
+#: ../src/wxMaximaFrame.cpp:893
 msgid "Get the imaginary part of complex expression"
 msgstr "Ricava la parte immaginaria da un'espressione complessa"
 
-#: ../src/wxMaximaFrame.cpp:891
+#: ../src/wxMaximaFrame.cpp:890
 msgid "Get the real part of complex expression"
 msgstr "Ricava la parte reale da un'espressione complessa"
 
-#: ../src/MathCtrl.cpp:5932
+#: ../src/MathCtrl.cpp:5984
 msgid ""
 "Got a request to undo an action that involves an delete which isn't possible "
 "at this moment."
@@ -2029,12 +2032,12 @@ msgstr ""
 msgid "Greek"
 msgstr "Greco"
 
-#: ../src/wxMaximaFrame.cpp:356
+#: ../src/wxMaximaFrame.cpp:355
 #, fuzzy
 msgid "Greek Letters"
 msgstr "Costanti greche"
 
-#: ../src/wxMaximaFrame.cpp:552
+#: ../src/wxMaximaFrame.cpp:551
 #, fuzzy
 msgid "Greek Letters\tAlt-Shift-G"
 msgstr "Matematica generale\tAlt-Shift-M"
@@ -2047,7 +2050,7 @@ msgstr "Costanti greche"
 msgid "Grid:"
 msgstr "Griglia:"
 
-#: ../src/wxMaxima.cpp:2836
+#: ../src/wxMaxima.cpp:2844
 #, fuzzy
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|pdfLaTeX file (*."
@@ -2064,12 +2067,12 @@ msgstr ""
 msgid "Help"
 msgstr "Aiuto"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 #, fuzzy
 msgid "Hide All Toolbars\tAlt-Shift--"
 msgstr "Nascondi tutto\tAlt-Shift--"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide all panes"
 msgstr "Nascondi tutti i pannelli"
 
@@ -2077,19 +2080,19 @@ msgstr "Nascondi tutti i pannelli"
 msgid "Highlight (dpart)"
 msgstr "Evidenzia (dpart)"
 
-#: ../src/wxMaxima.cpp:4685
+#: ../src/wxMaxima.cpp:4697
 msgid "Histogram"
 msgstr "Istogramma"
 
-#: ../src/wxMaximaFrame.cpp:1270
+#: ../src/wxMaximaFrame.cpp:1269
 msgid "Histogram..."
 msgstr "Istogramma..."
 
-#: ../src/wxMaximaFrame.cpp:309
+#: ../src/wxMaximaFrame.cpp:308
 msgid "History"
 msgstr "Cronologia"
 
-#: ../src/wxMaximaFrame.cpp:555
+#: ../src/wxMaximaFrame.cpp:554
 #, fuzzy
 msgid "History\tAlt-Shift-I"
 msgstr "Cronologia\tAlt-Shift-H"
@@ -2110,11 +2113,11 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Ungherese"
 
-#: ../src/wxMaxima.cpp:3527
+#: ../src/wxMaxima.cpp:3539
 msgid "IC1"
 msgstr "IC1"
 
-#: ../src/wxMaxima.cpp:3543
+#: ../src/wxMaxima.cpp:3555
 msgid "IC2"
 msgstr "IC2"
 
@@ -2130,7 +2133,7 @@ msgid ""
 "same output cell."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:683
+#: ../src/wxMaximaFrame.cpp:682
 msgid ""
 "If maxima ever finishes evaluating without wxMaxima realizing this this menu "
 "item can force wxMaxima to try to send commands to maxima again."
@@ -2198,11 +2201,11 @@ msgstr ""
 "Se l'elaborazione di calcolo dura troppo tempo, si può provare ad arrestarla "
 "con i comandi da menu \"Maxima->Interruzione\" o \"Maxima->Riavvia Maxima\"."
 
-#: ../src/wxMaximaFrame.cpp:1499
+#: ../src/wxMaximaFrame.cpp:1518
 msgid "Image"
 msgstr "Immagine"
 
-#: ../src/wxMaxima.cpp:5644
+#: ../src/wxMaxima.cpp:5659
 msgid "Image files (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 msgstr "File immagine (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 
@@ -2232,7 +2235,7 @@ msgstr ""
 "metterli sopra di esso. Può migliorare la leggibilità con alcuni font e con "
 "alcuni pedici corti."
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Include columns:"
 msgstr "Includi colonne:"
 
@@ -2251,19 +2254,19 @@ msgstr ""
 msgid "Infinity"
 msgstr "Infinito"
 
-#: ../src/wxMaximaFrame.cpp:974
+#: ../src/wxMaximaFrame.cpp:973
 msgid "Info about Maxima build"
 msgstr "Informazioni sulla compilazione di Maxima"
 
-#: ../src/wxMaxima.cpp:4207
+#: ../src/wxMaxima.cpp:4219
 msgid "Initial Estimates:"
 msgstr "Stime iniziali:"
 
-#: ../src/wxMaximaFrame.cpp:718
+#: ../src/wxMaximaFrame.cpp:717
 msgid "Initial Value Problem (&1)..."
 msgstr "Problema ai valori iniziali (&1)..."
 
-#: ../src/wxMaximaFrame.cpp:721
+#: ../src/wxMaximaFrame.cpp:720
 msgid "Initial Value Problem (&2)..."
 msgstr "Problema ai valori iniziali (&2)..."
 
@@ -2271,7 +2274,7 @@ msgstr "Problema ai valori iniziali (&2)..."
 msgid "Input labels"
 msgstr "Etichette d'ingresso"
 
-#: ../src/wxMaximaFrame.cpp:403
+#: ../src/wxMaximaFrame.cpp:402
 msgid "Insert"
 msgstr "Inserisci"
 
@@ -2279,98 +2282,98 @@ msgstr "Inserisci"
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr "Inserire % prima di un operatore all'inizio di una cella"
 
-#: ../src/wxMaximaFrame.cpp:612
+#: ../src/wxMaximaFrame.cpp:611
 msgid "Insert &Section Cell\tCtrl-3"
 msgstr "Inserisci cella &sezione\tCtrl-3"
 
-#: ../src/wxMaximaFrame.cpp:608
+#: ../src/wxMaximaFrame.cpp:607
 msgid "Insert &Text Cell\tCtrl-1"
 msgstr "Inserisci cella &testo\tCtrl-1"
 
-#: ../src/wxMaximaFrame.cpp:558
+#: ../src/wxMaximaFrame.cpp:557
 msgid "Insert Cell\tAlt-Shift-C"
 msgstr "Inserisci cella\tAlt-Shift-C"
 
-#: ../src/wxMaxima.cpp:5642
+#: ../src/wxMaxima.cpp:5657
 msgid "Insert Image"
 msgstr "Inserisci immagine"
 
-#: ../src/wxMaximaFrame.cpp:620
+#: ../src/wxMaximaFrame.cpp:619
 msgid "Insert Image..."
 msgstr "Inserisci immagine..."
 
-#: ../src/wxMaximaFrame.cpp:606
+#: ../src/wxMaximaFrame.cpp:605
 msgid "Insert Input &Cell"
 msgstr "Inserisci &cella d'ingresso"
 
-#: ../src/wxMaximaFrame.cpp:618
+#: ../src/wxMaximaFrame.cpp:617
 msgid "Insert Page Break"
 msgstr "Inserisci interruzione di pagina"
 
-#: ../src/wxMaximaFrame.cpp:614
+#: ../src/wxMaximaFrame.cpp:613
 msgid "Insert S&ubsection Cell\tCtrl-4"
 msgstr "Inserisci cella s&ottosezione\tCtrl-4"
 
-#: ../src/wxMaximaFrame.cpp:616
+#: ../src/wxMaximaFrame.cpp:615
 #, fuzzy
 msgid "Insert S&ubsubsection Cell\tCtrl-5"
 msgstr "Inserisci cella s&ottosezione\tCtrl-4"
 
-#: ../src/MathCtrl.cpp:1015
+#: ../src/MathCtrl.cpp:1057
 msgid "Insert Section Cell"
 msgstr "Inserisci cella sezione"
 
-#: ../src/MathCtrl.cpp:1016
+#: ../src/MathCtrl.cpp:1058
 msgid "Insert Subsection Cell"
 msgstr "Inserisci cella sottosezione"
 
-#: ../src/MathCtrl.cpp:1017
+#: ../src/MathCtrl.cpp:1059
 #, fuzzy
 msgid "Insert Subsubsection Cell"
 msgstr "Inserisci cella sottosezione"
 
-#: ../src/wxMaximaFrame.cpp:610
+#: ../src/wxMaximaFrame.cpp:609
 msgid "Insert T&itle Cell\tCtrl-2"
 msgstr "Inserisci cella t&itolo\tCtrl-2"
 
-#: ../src/MathCtrl.cpp:1013
+#: ../src/MathCtrl.cpp:1055
 msgid "Insert Text Cell"
 msgstr "Inserisci cella testo"
 
-#: ../src/MathCtrl.cpp:1014
+#: ../src/MathCtrl.cpp:1056
 msgid "Insert Title Cell"
 msgstr "Inserisci cella titolo"
 
-#: ../src/wxMaximaFrame.cpp:607
+#: ../src/wxMaximaFrame.cpp:606
 msgid "Insert a new input cell"
 msgstr "Inserisci nuova cella di ingresso"
 
-#: ../src/wxMaximaFrame.cpp:613
+#: ../src/wxMaximaFrame.cpp:612
 msgid "Insert a new section cell"
 msgstr "Inserisci nuova cella sezione"
 
-#: ../src/wxMaximaFrame.cpp:615
+#: ../src/wxMaximaFrame.cpp:614
 msgid "Insert a new subsection cell"
 msgstr "Inserisci nuova cella sottosezione"
 
-#: ../src/wxMaximaFrame.cpp:617
+#: ../src/wxMaximaFrame.cpp:616
 #, fuzzy
 msgid "Insert a new subsubsection cell"
 msgstr "Inserisci nuova cella sottosezione"
 
-#: ../src/wxMaximaFrame.cpp:609
+#: ../src/wxMaximaFrame.cpp:608
 msgid "Insert a new text cell"
 msgstr "Inserisci nuova cella testo"
 
-#: ../src/wxMaximaFrame.cpp:611
+#: ../src/wxMaximaFrame.cpp:610
 msgid "Insert a new title cell"
 msgstr "Inserisci nuova cella titolo"
 
-#: ../src/wxMaximaFrame.cpp:619
+#: ../src/wxMaximaFrame.cpp:618
 msgid "Insert a page break"
 msgstr "Inserisci un'interruzione di pagina"
 
-#: ../src/wxMaximaFrame.cpp:621
+#: ../src/wxMaximaFrame.cpp:620
 msgid "Insert image"
 msgstr "Inserisci immagine"
 
@@ -2383,27 +2386,27 @@ msgstr ""
 msgid "Integral sign"
 msgstr "Integra l'espressione"
 
-#: ../src/wxMaxima.cpp:3992
+#: ../src/wxMaxima.cpp:4004
 msgid "Integral/Sum:"
 msgstr "Integrale/somma:"
 
-#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4105 ../src/wxMaxima.cpp:5051
+#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4117 ../src/wxMaxima.cpp:5063
 msgid "Integrate"
 msgstr "Integra"
 
-#: ../src/wxMaxima.cpp:4091
+#: ../src/wxMaxima.cpp:4103
 msgid "Integrate (risch)"
 msgstr "Integra (Risch)"
 
-#: ../src/wxMaximaFrame.cpp:778
+#: ../src/wxMaximaFrame.cpp:777
 msgid "Integrate expression"
 msgstr "Integra l'espressione"
 
-#: ../src/wxMaximaFrame.cpp:780
+#: ../src/wxMaximaFrame.cpp:779
 msgid "Integrate expression with Risch algorithm"
 msgstr "Integra l'espressione con l'algoritmo di Risch"
 
-#: ../src/wxMaximaFrame.cpp:1224 ../src/MathCtrl.cpp:1000
+#: ../src/MathCtrl.cpp:1042 ../src/wxMaximaFrame.cpp:1223
 msgid "Integrate..."
 msgstr "Integra..."
 
@@ -2411,7 +2414,7 @@ msgstr "Integra..."
 msgid "Interrupt"
 msgstr "Interruzione"
 
-#: ../src/wxMaximaFrame.cpp:646 ../src/wxMaximaFrame.cpp:650
+#: ../src/wxMaximaFrame.cpp:645 ../src/wxMaximaFrame.cpp:649
 msgid "Interrupt current computation"
 msgstr "Interruzione del calcolo corrente"
 
@@ -2431,15 +2434,15 @@ msgstr ""
 "\n"
 "Inserire nuovamente il percorso per il programma Maxima."
 
-#: ../src/wxMaxima.cpp:4137
+#: ../src/wxMaxima.cpp:4149
 msgid "Inverse Laplace"
 msgstr "Inversa di Laplace"
 
-#: ../src/wxMaximaFrame.cpp:806
+#: ../src/wxMaximaFrame.cpp:805
 msgid "Inverse Laplace T&ransform..."
 msgstr "T&rasformata inversa di Laplace..."
 
-#: ../src/wxMaximaFrame.cpp:1372
+#: ../src/wxMaximaFrame.cpp:1371
 msgid "Iota"
 msgstr ""
 
@@ -2473,7 +2476,7 @@ msgstr "Giapponese"
 msgid "Kabyle"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1373
+#: ../src/wxMaximaFrame.cpp:1372
 msgid "Kappa"
 msgstr ""
 
@@ -2483,7 +2486,7 @@ msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr ""
 "Mantieni il simbolo di percentuale con i simboli speciali: %e, %i, ecc."
 
-#: ../src/wxMaxima.cpp:4031
+#: ../src/wxMaxima.cpp:4043
 msgid "LCM"
 msgstr "mcm"
 
@@ -2499,7 +2502,7 @@ msgstr ""
 msgid "Label width:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1374
+#: ../src/wxMaximaFrame.cpp:1373
 msgid "Lambda"
 msgstr ""
 
@@ -2511,11 +2514,11 @@ msgstr "Lingua usata per wxMaxima."
 msgid "Language:"
 msgstr "Lingua:"
 
-#: ../src/wxMaxima.cpp:4120
+#: ../src/wxMaxima.cpp:4132
 msgid "Laplace"
 msgstr "Laplace"
 
-#: ../src/wxMaximaFrame.cpp:803
+#: ../src/wxMaximaFrame.cpp:802
 msgid "Laplace &Transform..."
 msgstr "&Trasformata di Laplace..."
 
@@ -2523,15 +2526,15 @@ msgstr "&Trasformata di Laplace..."
 msgid "Leads to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:812
+#: ../src/wxMaximaFrame.cpp:811
 msgid "Least Common Multiple..."
 msgstr "Minimo comune multiplo..."
 
-#: ../src/wxMaxima.cpp:4809
+#: ../src/wxMaxima.cpp:4821
 msgid "Least Squares Fit"
 msgstr "Metodo dei minimi quadrati"
 
-#: ../src/wxMaximaFrame.cpp:1266
+#: ../src/wxMaximaFrame.cpp:1265
 msgid "Least Squares Fit..."
 msgstr "Metodo dei minimi quadrati..."
 
@@ -2542,24 +2545,24 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4192
+#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4204
 msgid "Limit"
 msgstr "Limite"
 
-#: ../src/wxMaximaFrame.cpp:1225
+#: ../src/wxMaximaFrame.cpp:1224
 msgid "Limit..."
 msgstr "Limite..."
 
-#: ../src/wxMaximaFrame.cpp:1265
+#: ../src/wxMaximaFrame.cpp:1264
 msgid "Linear Regression..."
 msgstr "Regressione lineare..."
 
-#: ../src/wxMaxima.cpp:3803
+#: ../src/wxMaxima.cpp:3815
 #, fuzzy
 msgid "List(s):"
 msgstr "Lista:"
 
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3848
 msgid "List:"
 msgstr "Lista:"
 
@@ -2567,15 +2570,15 @@ msgstr "Lista:"
 msgid "Load"
 msgstr "Carica"
 
-#: ../src/wxMaxima.cpp:2932
+#: ../src/wxMaxima.cpp:2940
 msgid "Load Package"
 msgstr "Carica il pacchetto"
 
-#: ../src/wxMaximaFrame.cpp:479
+#: ../src/wxMaximaFrame.cpp:478
 msgid "Load a Maxima file using the batch command"
 msgstr "Carica un file Maxima usando un comando batch"
 
-#: ../src/wxMaximaFrame.cpp:477
+#: ../src/wxMaximaFrame.cpp:476
 msgid "Load a Maxima package file"
 msgstr "Carica un file pacchetto Maxima"
 
@@ -2587,49 +2590,49 @@ msgstr "Carica lo stile da file"
 msgid "Long Right arrow"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Lower bound:"
 msgstr "Intorno basso:"
 
-#: ../src/wxMaximaFrame.cpp:771
+#: ../src/wxMaximaFrame.cpp:770
 msgid "Ma&p to Matrix..."
 msgstr "Map&pa su matrice..."
 
-#: ../src/wxMaximaFrame.cpp:547
+#: ../src/wxMaximaFrame.cpp:546
 #, fuzzy
 msgid "Main Toolbar\tAlt-Shift-B"
 msgstr "Barra strumenti\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:765
+#: ../src/wxMaximaFrame.cpp:764
 msgid "Make &List..."
 msgstr "Crea la &lista..."
 
-#: ../src/wxMaxima.cpp:3821
+#: ../src/wxMaxima.cpp:3833
 msgid "Make list"
 msgstr "Crea la lista"
 
-#: ../src/wxMaximaFrame.cpp:766
+#: ../src/wxMaximaFrame.cpp:765
 msgid "Make list from expression"
 msgstr "Crea una lista da un'espressione"
 
-#: ../src/wxMaximaFrame.cpp:907
+#: ../src/wxMaximaFrame.cpp:906
 msgid "Make substitution in expression"
 msgstr "Sostituisci in un'espressione"
 
-#: ../src/wxMaximaFrame.cpp:682
+#: ../src/wxMaximaFrame.cpp:681
 #, fuzzy
 msgid "Manually Trigger Evaluation"
 msgstr "Mostra il tempo impiegato per l'esecuzione"
 
-#: ../src/wxMaxima.cpp:3805
+#: ../src/wxMaxima.cpp:3817
 msgid "Map"
 msgstr "Mappa"
 
-#: ../src/wxMaximaFrame.cpp:770
+#: ../src/wxMaximaFrame.cpp:769
 msgid "Map function to a list"
 msgstr "Mappa la funzione su di una lista"
 
-#: ../src/wxMaximaFrame.cpp:772
+#: ../src/wxMaximaFrame.cpp:771
 msgid "Map function to a matrix"
 msgstr "Mappa la funzione su di una matrice"
 
@@ -2646,23 +2649,23 @@ msgstr "Controllo parentesi nei controlli di testo"
 msgid "Math font:"
 msgstr "Carattere matematica:"
 
-#: ../src/wxMaximaFrame.cpp:374
+#: ../src/wxMaximaFrame.cpp:373
 msgid "Mathematical Symbols"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3716
+#: ../src/wxMaxima.cpp:3728
 msgid "Matrix"
 msgstr "Matrice"
 
-#: ../src/wxMaxima.cpp:3702
+#: ../src/wxMaxima.cpp:3714
 msgid "Matrix map"
 msgstr "Mappa matrice"
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Matrix name:"
 msgstr "Nome matrice:"
 
-#: ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3749
+#: ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3761
 msgid "Matrix:"
 msgstr "Matrice:"
 
@@ -2670,7 +2673,7 @@ msgstr "Matrice:"
 msgid "Maxima"
 msgstr "Maxima"
 
-#: ../src/wxMaximaFrame.cpp:137
+#: ../src/wxMaximaFrame.cpp:136
 #, fuzzy
 msgid "Maxima has a question"
 msgstr "Domande di Maxima"
@@ -2679,24 +2682,24 @@ msgstr "Domande di Maxima"
 msgid "Maxima input"
 msgstr "Ingresso di Maxima"
 
-#: ../src/wxMaximaFrame.cpp:166
+#: ../src/wxMaximaFrame.cpp:165
 msgid "Maxima is calculating"
 msgstr "Maxima sta calcolando"
 
-#: ../src/wxMaximaFrame.cpp:111
+#: ../src/wxMaximaFrame.cpp:110
 #, fuzzy
 msgid "Maxima is ready for input."
 msgstr "Ingresso di Maxima"
 
-#: ../src/wxMaxima.cpp:2945
+#: ../src/wxMaxima.cpp:2953
 msgid "Maxima package (*.mac)|*.mac"
 msgstr "Pacchetto Maxima (*.mac)|*.mac"
 
-#: ../src/wxMaxima.cpp:2934
+#: ../src/wxMaxima.cpp:2942
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr "Pacchetto Maxima (*.mac)|*.mac|Pacchetto Lisp (*.lisp)|*.lisp|Tutti|*"
 
-#: ../src/wxMaxima.cpp:1014
+#: ../src/wxMaxima.cpp:1019
 msgid "Maxima process terminated."
 msgstr "Processo Maxima terminato."
 
@@ -2708,7 +2711,7 @@ msgstr "Programma maxima:"
 msgid "Maxima questions"
 msgstr "Domande di Maxima"
 
-#: ../src/wxMaxima.cpp:942
+#: ../src/wxMaxima.cpp:947
 msgid "Maxima started. Waiting for connection..."
 msgstr "Maxima avviato. In attesa di connessione..."
 
@@ -2732,7 +2735,7 @@ msgstr ""
 "Maxima usa \":\" per impostare i valori (\"a : 3;\") e \":=\" per definire "
 "le funzioni (\"f(x) := x^2;\")."
 
-#: ../src/wxMaxima.cpp:4597
+#: ../src/wxMaxima.cpp:4609
 msgid "Maxima version: "
 msgstr "Versione di Maxima: "
 
@@ -2769,40 +2772,40 @@ msgstr ""
 msgid "Maximum displayed number of digits:"
 msgstr "Numero massimo di cifre mostrate:"
 
-#: ../src/wxMaximaFrame.cpp:1263
+#: ../src/wxMaximaFrame.cpp:1262
 msgid "Mean Difference Test..."
 msgstr "Test della differenza della media..."
 
-#: ../src/wxMaximaFrame.cpp:1262
+#: ../src/wxMaximaFrame.cpp:1261
 msgid "Mean Test..."
 msgstr "Test della media..."
 
-#: ../src/wxMaximaFrame.cpp:1255
+#: ../src/wxMaximaFrame.cpp:1254
 msgid "Mean..."
 msgstr "Media..."
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Mean:"
 msgstr "Media:"
 
-#: ../src/wxMaximaFrame.cpp:1256
+#: ../src/wxMaximaFrame.cpp:1255
 msgid "Median..."
 msgstr "Mediana..."
 
-#: ../src/MathCtrl.cpp:945
+#: ../src/MathCtrl.cpp:987
 msgid "Merge Cells"
 msgstr "Fondi celle"
 
-#: ../src/wxMaximaFrame.cpp:633
+#: ../src/wxMaximaFrame.cpp:632
 #, fuzzy
 msgid "Merge Cells\tCtrl-M"
 msgstr "Fondi celle"
 
-#: ../src/wxMaximaFrame.cpp:634
+#: ../src/wxMaximaFrame.cpp:633
 msgid "Merge the text from two input cells into one"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2668
+#: ../src/wxMaxima.cpp:2676
 msgid "Message from the stdout of Maxima: "
 msgstr ""
 
@@ -2810,20 +2813,20 @@ msgstr ""
 msgid "Method:"
 msgstr "Metodo:"
 
-#: ../src/wxMaxima.cpp:5289
+#: ../src/wxMaxima.cpp:5301
 #, fuzzy
 msgid "Mismatched parenthesis"
 msgstr "Controllo parentesi nei controlli di testo"
 
-#: ../src/wxMaxima.cpp:3972
+#: ../src/wxMaxima.cpp:3984
 msgid "Modulus"
 msgstr "Modulo"
 
-#: ../src/wxMaximaFrame.cpp:1375
+#: ../src/wxMaximaFrame.cpp:1374
 msgid "Mu"
 msgstr ""
 
-#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Name:"
 msgstr "Nome:"
 
@@ -2831,7 +2834,7 @@ msgstr "Nome:"
 msgid "New"
 msgstr "Nuovo"
 
-#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
+#: ../src/wxMaximaFrame.cpp:456 ../src/wxMaximaFrame.cpp:459
 msgid "New\tCtrl-N"
 msgstr "Nuovo\tCtrl-N"
 
@@ -2847,11 +2850,11 @@ msgstr ""
 msgid "New value:"
 msgstr "Nuovo valore:"
 
-#: ../src/wxMaxima.cpp:3993 ../src/wxMaxima.cpp:4119 ../src/wxMaxima.cpp:4136
+#: ../src/wxMaxima.cpp:4005 ../src/wxMaxima.cpp:4131 ../src/wxMaxima.cpp:4148
 msgid "New variable:"
 msgstr "Nuova variabile:"
 
-#: ../src/wxMaximaFrame.cpp:630
+#: ../src/wxMaximaFrame.cpp:629
 msgid "Next Command\tAlt-Down"
 msgstr "Comando successivo\tAlt-Giù"
 
@@ -2859,15 +2862,15 @@ msgstr "Comando successivo\tAlt-Giù"
 msgid "No"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5362
+#: ../src/wxMaxima.cpp:5378
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3249 ../src/wxMaxima.cpp:3271
+#: ../src/wxMaxima.cpp:3260 ../src/wxMaxima.cpp:3283
 msgid "No matches found!"
 msgstr "Nessuna corrispondenza trovata!"
 
-#: ../src/wxMaximaFrame.cpp:1264
+#: ../src/wxMaximaFrame.cpp:1263
 msgid "Normality Test..."
 msgstr "Test di normalità..."
 
@@ -2890,34 +2893,34 @@ msgstr ""
 msgid "Norwegian"
 msgstr "Norvegese"
 
-#: ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:3740
 msgid "Not a valid matrix dimension!"
 msgstr "Dimensione matrice non valida!"
 
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629
 msgid "Not a valid number of equations!"
 msgstr "Numero di equazioni non valido!"
 
-#: ../src/wxMaximaFrame.cpp:197
+#: ../src/wxMaximaFrame.cpp:196
 #, fuzzy
 msgid "Not connected to maxima"
 msgstr ""
 "\n"
 "Non connesso a Maxima!\n"
 
-#: ../src/wxMaxima.cpp:4599
+#: ../src/wxMaxima.cpp:4611
 msgid "Not connected."
 msgstr "Non connesso."
 
-#: ../src/wxMaximaFrame.cpp:1376
+#: ../src/wxMaximaFrame.cpp:1375
 msgid "Nu"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Num. deg:"
 msgstr "Num. deg:"
 
-#: ../src/wxMaxima.cpp:3585 ../src/wxMaxima.cpp:3609
+#: ../src/wxMaxima.cpp:3597 ../src/wxMaxima.cpp:3621
 msgid "Number of equations:"
 msgstr "Numero di equazioni:"
 
@@ -2944,15 +2947,15 @@ msgstr "OK"
 msgid "Old value:"
 msgstr "Vecchio valore:"
 
-#: ../src/wxMaxima.cpp:3992 ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135
+#: ../src/wxMaxima.cpp:4004 ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147
 msgid "Old variable:"
 msgstr "Vecchia variabile:"
 
-#: ../src/wxMaximaFrame.cpp:1387
+#: ../src/wxMaximaFrame.cpp:1386
 msgid "Omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1378
+#: ../src/wxMaximaFrame.cpp:1377
 msgid "Omicron"
 msgstr ""
 
@@ -2966,20 +2969,20 @@ msgid ""
 "stream for messages."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4763
+#: ../src/wxMaxima.cpp:4775
 msgid "One sample t-test"
 msgstr "Test t a un campione"
 
-#: ../src/wxMaximaFrame.cpp:971
+#: ../src/wxMaximaFrame.cpp:970
 msgid "Online tutorials"
 msgstr "Guide online"
 
 #: ../src/ConfigDialogue.cpp:656 ../src/main.cpp:347 ../src/ToolBar.cpp:119
-#: ../src/wxMaxima.cpp:2797
+#: ../src/wxMaxima.cpp:2805
 msgid "Open"
 msgstr "Apri"
 
-#: ../src/wxMaximaFrame.cpp:466
+#: ../src/wxMaximaFrame.cpp:465
 msgid "Open Recent"
 msgstr "Apri recenti"
 
@@ -2987,11 +2990,11 @@ msgstr "Apri recenti"
 msgid "Open a cell when Maxima expects input"
 msgstr "Apri una cella mentre Maxima aspetta l'ingresso"
 
-#: ../src/wxMaximaFrame.cpp:464
+#: ../src/wxMaximaFrame.cpp:463
 msgid "Open a document"
 msgstr "Apri un documento"
 
-#: ../src/wxMaximaFrame.cpp:458 ../src/wxMaximaFrame.cpp:461
+#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
 msgid "Open a new window"
 msgstr "Apri una nuova finestra"
 
@@ -2999,11 +3002,11 @@ msgstr "Apri una nuova finestra"
 msgid "Open document"
 msgstr "Apri documento"
 
-#: ../src/wxMaxima.cpp:4824
+#: ../src/wxMaxima.cpp:4836
 msgid "Open matrix"
 msgstr "Apri matrice"
 
-#: ../src/wxMaxima.cpp:1446 ../src/wxMaxima.cpp:1518
+#: ../src/wxMaxima.cpp:1451 ../src/wxMaxima.cpp:1523
 msgid "Opening file"
 msgstr "Durante l'apertura del file"
 
@@ -3027,11 +3030,11 @@ msgstr "Celle non aggiornate"
 msgid "Output labels"
 msgstr "Etichette risultati"
 
-#: ../src/wxMaximaFrame.cpp:796
+#: ../src/wxMaximaFrame.cpp:795
 msgid "P&ade Approximation..."
 msgstr "Approssimazione di P&ade..."
 
-#: ../src/wxMaxima.cpp:3132 ../src/wxMaxima.cpp:5133
+#: ../src/wxMaxima.cpp:3141 ../src/wxMaxima.cpp:5145
 #, fuzzy
 msgid ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
@@ -3041,15 +3044,15 @@ msgstr ""
 "Immagine PNG (*.png)|*.png|immagine JPEG (*.jpg)|*.jpg|bitmap Windows (*."
 "bmp)|*.bmp|pixmap X (*.xpm)|*.xpm"
 
-#: ../src/wxMaxima.cpp:4012
+#: ../src/wxMaxima.cpp:4024
 msgid "Pade approximation"
 msgstr "Approssimazione di Pade"
 
-#: ../src/wxMaximaFrame.cpp:797
+#: ../src/wxMaximaFrame.cpp:796
 msgid "Pade approximation of a Taylor series"
 msgstr "Approssimazione Pade di una serie di Taylor"
 
-#: ../src/wxMaximaFrame.cpp:1500
+#: ../src/wxMaximaFrame.cpp:1519
 msgid "Pagebreak"
 msgstr "Saltopagina"
 
@@ -3061,19 +3064,19 @@ msgstr ""
 msgid "Parametric plot"
 msgstr "Stampa parametrica"
 
-#: ../src/wxMaximaFrame.cpp:188
+#: ../src/wxMaximaFrame.cpp:187
 msgid "Parsing output"
 msgstr "Analisi risultato"
 
-#: ../src/wxMaximaFrame.cpp:819
+#: ../src/wxMaximaFrame.cpp:818
 msgid "Partial &Fractions..."
 msgstr "&Frazioni parziali..."
 
-#: ../src/wxMaxima.cpp:4076
+#: ../src/wxMaxima.cpp:4088
 msgid "Partial fractions"
 msgstr "Frazioni parziali"
 
-#: ../src/wxMaxima.cpp:1769
+#: ../src/wxMaxima.cpp:1774
 msgid "Parts of the document will not be loaded correctly!"
 msgstr "Parti del documento non saranno caricate correttamente!"
 
@@ -3084,11 +3087,11 @@ msgid ""
 "Found unknown XML Tag name "
 msgstr "Parti del documento non saranno caricate correttamente!"
 
-#: ../src/ToolBar.cpp:143 ../src/MathCtrl.cpp:1010 ../src/MathCtrl.cpp:1025
+#: ../src/MathCtrl.cpp:1052 ../src/MathCtrl.cpp:1067 ../src/ToolBar.cpp:143
 msgid "Paste"
 msgstr "Incolla"
 
-#: ../src/wxMaximaFrame.cpp:518
+#: ../src/wxMaximaFrame.cpp:517
 msgid "Paste\tCtrl-V"
 msgstr "Incolla\tCtrl-V"
 
@@ -3096,7 +3099,7 @@ msgstr "Incolla\tCtrl-V"
 msgid "Paste from clipboard"
 msgstr "Incolla dagli appunti"
 
-#: ../src/wxMaximaFrame.cpp:519
+#: ../src/wxMaximaFrame.cpp:518
 msgid "Paste text from clipboard"
 msgstr "Incolla testo dagli appunti"
 
@@ -3104,19 +3107,19 @@ msgstr "Incolla testo dagli appunti"
 msgid "Perpendicular to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1384
+#: ../src/wxMaximaFrame.cpp:1383
 msgid "Phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1379
+#: ../src/wxMaximaFrame.cpp:1378
 msgid "Pi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1273
+#: ../src/wxMaximaFrame.cpp:1272
 msgid "Piechart..."
 msgstr "Diagramma a torta..."
 
-#: ../src/wxMaxima.cpp:1952
+#: ../src/wxMaxima.cpp:1957
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr "Configurare wxMaxima con \"Modifica->Configura\"."
 
@@ -3124,52 +3127,52 @@ msgstr "Configurare wxMaxima con \"Modifica->Configura\"."
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr "Riavviare wxMaxima perché i cambiamenti abbiano effetto!"
 
-#: ../src/wxMaximaFrame.cpp:923
+#: ../src/wxMaximaFrame.cpp:922
 msgid "Plot &2d..."
 msgstr "Grafico &2d..."
 
-#: ../src/wxMaximaFrame.cpp:925
+#: ../src/wxMaximaFrame.cpp:924
 msgid "Plot &3d..."
 msgstr "Grafico &3d..."
 
-#: ../src/wxMaximaFrame.cpp:927
+#: ../src/wxMaximaFrame.cpp:926
 msgid "Plot &Format..."
 msgstr "&Formato grafico..."
 
 #: ../src/Plot2dWiz.cpp:104 ../src/Plot2dWiz.cpp:450 ../src/Plot2dWiz.cpp:464
-#: ../src/wxMaxima.cpp:4283 ../src/wxMaxima.cpp:5102
+#: ../src/wxMaxima.cpp:4295 ../src/wxMaxima.cpp:5114
 msgid "Plot 2D"
 msgstr "Grafico 2D"
 
-#: ../src/wxMaximaFrame.cpp:1227
+#: ../src/wxMaximaFrame.cpp:1226
 msgid "Plot 2D..."
 msgstr "Grafico 2D..."
 
-#: ../src/MathCtrl.cpp:1003
+#: ../src/MathCtrl.cpp:1045
 msgid "Plot 2d..."
 msgstr "Grafico 2d..."
 
-#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4269 ../src/wxMaxima.cpp:5115
+#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4281 ../src/wxMaxima.cpp:5127
 msgid "Plot 3D"
 msgstr "Grafico 3D"
 
-#: ../src/wxMaximaFrame.cpp:1228
+#: ../src/wxMaximaFrame.cpp:1227
 msgid "Plot 3D..."
 msgstr "Grafico 3D..."
 
-#: ../src/MathCtrl.cpp:1004
+#: ../src/MathCtrl.cpp:1046
 msgid "Plot 3d..."
 msgstr "Grafico 3d..."
 
-#: ../src/wxMaxima.cpp:4296
+#: ../src/wxMaxima.cpp:4308
 msgid "Plot format"
 msgstr "Formato grafico"
 
-#: ../src/wxMaximaFrame.cpp:924
+#: ../src/wxMaximaFrame.cpp:923
 msgid "Plot in 2 dimensions"
 msgstr "Grafico in 2 dimensioni"
 
-#: ../src/wxMaximaFrame.cpp:926
+#: ../src/wxMaximaFrame.cpp:925
 msgid "Plot in 3 dimensions"
 msgstr "Grafico in 3 dimensioni"
 
@@ -3178,8 +3181,8 @@ msgid "Plot to file:"
 msgstr "Grafico su file:"
 
 #: ../src/BC2Wiz.cpp:30 ../src/BC2Wiz.cpp:36 ../src/LimitWiz.cpp:33
-#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
-#: ../src/wxMaxima.cpp:3648
+#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
+#: ../src/wxMaxima.cpp:3660
 msgid "Point:"
 msgstr "Punto:"
 
@@ -3187,11 +3190,11 @@ msgstr "Punto:"
 msgid "Polish"
 msgstr "Polacco"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 1:"
 msgstr "Polinomiale 1:"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 2:"
 msgstr "Polinomiale 2:"
 
@@ -3203,11 +3206,11 @@ msgstr "Portoghese (Brasiliano)"
 msgid "Postscript file (*.eps)|*.eps|All|*"
 msgstr "File postscript (*.eps)|*.eps|Tutti|"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Precision"
 msgstr "Precisione"
 
-#: ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:536
 msgid "Preferences...\tCtrl+,"
 msgstr "Preferenze...\tCtrl+,"
 
@@ -3219,7 +3222,7 @@ msgid ""
 "packages and from functions that are defined in the current file."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:628
+#: ../src/wxMaximaFrame.cpp:627
 msgid "Previous Command\tAlt-Up"
 msgstr "Comando precedente\tAlt-Su"
 
@@ -3227,11 +3230,11 @@ msgstr "Comando precedente\tAlt-Su"
 msgid "Print"
 msgstr "Stampa"
 
-#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:484
+#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:483
 msgid "Print document"
 msgstr "Stampa documento"
 
-#: ../src/wxMaxima.cpp:4242
+#: ../src/wxMaxima.cpp:4254
 msgid "Product"
 msgstr "Prodotto"
 
@@ -3240,35 +3243,35 @@ msgstr "Prodotto"
 msgid "Product sign"
 msgstr "Prodotto"
 
-#: ../src/wxMaximaFrame.cpp:1386
+#: ../src/wxMaximaFrame.cpp:1385
 msgid "Psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:331
+#: ../src/wxMaximaFrame.cpp:330
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:592
+#: ../src/wxMaximaFrame.cpp:591
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr "Ri-elabora tutte le celle sopra quella dove si trova il cursore"
 
-#: ../src/wxMaximaFrame.cpp:1278
+#: ../src/wxMaximaFrame.cpp:1277
 msgid "Read Matrix..."
 msgstr "Leggi la matrice..."
 
-#: ../src/wxMaximaFrame.cpp:177
+#: ../src/wxMaximaFrame.cpp:176
 msgid "Reading Maxima output"
 msgstr "Lettura risultati maxima"
 
-#: ../src/wxMaximaFrame.cpp:153
+#: ../src/wxMaximaFrame.cpp:152
 msgid "Ready for user input"
 msgstr "In attesa di dati dall'utente"
 
-#: ../src/wxMaximaFrame.cpp:631
+#: ../src/wxMaximaFrame.cpp:630
 msgid "Recall next command from history"
 msgstr "Richiama il comando successivo dalla cronologia"
 
-#: ../src/wxMaximaFrame.cpp:629
+#: ../src/wxMaximaFrame.cpp:628
 msgid "Recall previous command from history"
 msgstr "Richiama il comando precedente dalla cronologia"
 
@@ -3276,36 +3279,36 @@ msgstr "Richiama il comando precedente dalla cronologia"
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1215
+#: ../src/wxMaximaFrame.cpp:1214
 msgid "Rectform"
 msgstr "Formanorm"
 
-#: ../src/wxMaximaFrame.cpp:495
+#: ../src/wxMaximaFrame.cpp:494
 #, fuzzy
 msgid "Redo\tCtrl-Y"
 msgstr "Annulla\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:496
+#: ../src/wxMaximaFrame.cpp:495
 msgid "Redo last change"
 msgstr "Ripeti l'ultima modifica"
 
-#: ../src/wxMaximaFrame.cpp:1220
+#: ../src/wxMaximaFrame.cpp:1219
 msgid "Reduce (tr)"
 msgstr "Riduci (tr)"
 
-#: ../src/wxMaximaFrame.cpp:871
+#: ../src/wxMaximaFrame.cpp:870
 msgid "Reduce trigonometric expression"
 msgstr "Riduci l'espressione trigonometrica"
 
-#: ../src/wxMaxima.cpp:622 ../src/wxMaxima.cpp:5495
+#: ../src/wxMaxima.cpp:627 ../src/wxMaxima.cpp:5511
 msgid "Refusing to send cell to maxima: "
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:594
+#: ../src/wxMaximaFrame.cpp:593
 msgid "Remove All Output"
 msgstr "Elimina tutti i risultati"
 
-#: ../src/wxMaximaFrame.cpp:595
+#: ../src/wxMaximaFrame.cpp:594
 msgid "Remove output from input cells"
 msgstr "Elimina tutti i risultati dalla celle d'ingresso"
 
@@ -3314,7 +3317,7 @@ msgstr "Elimina tutti i risultati dalla celle d'ingresso"
 msgid "Replace All"
 msgstr "Seleziona tutto"
 
-#: ../src/wxMaxima.cpp:3282
+#: ../src/wxMaxima.cpp:3294
 #, c-format
 msgid "Replaced %d occurrences."
 msgstr "Rimpiazzate %d corrispondenze."
@@ -3323,11 +3326,11 @@ msgstr "Rimpiazzate %d corrispondenze."
 msgid "Replacement:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:976
+#: ../src/wxMaximaFrame.cpp:975
 msgid "Report bug"
 msgstr "Riporta un bug"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "Restart Maxima"
 msgstr "Riavvia maxima"
 
@@ -3336,7 +3339,7 @@ msgstr "Riavvia maxima"
 msgid "Restart maxima"
 msgstr "Riavvia maxima"
 
-#: ../src/MathCtrl.cpp:4442
+#: ../src/MathCtrl.cpp:4497
 msgid "Result"
 msgstr ""
 
@@ -3344,7 +3347,7 @@ msgstr ""
 msgid "Return to the cell that is currently being evaluated"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1380
+#: ../src/wxMaximaFrame.cpp:1379
 msgid "Rho"
 msgstr ""
 
@@ -3352,19 +3355,19 @@ msgstr ""
 msgid "Right arrow"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:779
+#: ../src/wxMaximaFrame.cpp:778
 msgid "Risch Integration..."
 msgstr "Integrazione di Risch..."
 
-#: ../src/wxMaximaFrame.cpp:694
+#: ../src/wxMaximaFrame.cpp:693
 msgid "Roots of &Polynomial"
 msgstr "Radici di &polinomiale"
 
-#: ../src/wxMaximaFrame.cpp:697
+#: ../src/wxMaximaFrame.cpp:696
 msgid "Roots of Polynomial (bfloat)"
 msgstr "Radici di polinomiale (bfloat)"
 
-#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Rows:"
 msgstr "Righe:"
 
@@ -3372,56 +3375,56 @@ msgstr "Righe:"
 msgid "Russian"
 msgstr "Russo"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 1:"
 msgstr "Esempio 1:"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 2:"
 msgstr "Esempio 2:"
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Sample:"
 msgstr "Esempio:"
 
 #: ../src/ConfigDialogue.cpp:781 ../src/ToolBar.cpp:122
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Save"
 msgstr "Salva"
 
-#: ../src/MathCtrl.cpp:921
+#: ../src/MathCtrl.cpp:963
 msgid "Save Animation..."
 msgstr "Salva animazione..."
 
-#: ../src/wxMaxima.cpp:2565
+#: ../src/wxMaxima.cpp:2572
 msgid "Save As"
 msgstr "Salva come"
 
-#: ../src/wxMaximaFrame.cpp:474
+#: ../src/wxMaximaFrame.cpp:473
 msgid "Save As...\tShift-Ctrl-S"
 msgstr "&Salva come...\tShift-Ctrl-S"
 
-#: ../src/MathCtrl.cpp:919
+#: ../src/MathCtrl.cpp:961
 msgid "Save Image..."
 msgstr "Salva immagine..."
 
-#: ../src/wxMaxima.cpp:3130
+#: ../src/wxMaxima.cpp:3139
 msgid "Save Selection to Image"
 msgstr "Salva la selezione su immagine"
 
-#: ../src/wxMaximaFrame.cpp:528
+#: ../src/wxMaximaFrame.cpp:527
 msgid "Save Selection to Image..."
 msgstr "Salva la selezione su immagine..."
 
-#: ../src/wxMaxima.cpp:5150
+#: ../src/wxMaxima.cpp:5162
 msgid "Save animation to file"
 msgstr "Salva l'animazione su file"
 
-#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:473
+#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:472
 msgid "Save document"
 msgstr "Salva documento"
 
-#: ../src/wxMaximaFrame.cpp:475
+#: ../src/wxMaximaFrame.cpp:474
 msgid "Save document as"
 msgstr "Salva documento come"
 
@@ -3443,11 +3446,11 @@ msgstr "Salva la disposizione dei pannelli tra le sessioni."
 msgid "Save plot to file"
 msgstr "Salva il grafico su file"
 
-#: ../src/wxMaximaFrame.cpp:529
+#: ../src/wxMaximaFrame.cpp:528
 msgid "Save selection from document to an image file"
 msgstr "Salva la selezione del documento su di un file immagine"
 
-#: ../src/wxMaxima.cpp:5131
+#: ../src/wxMaxima.cpp:5143
 msgid "Save selection to file"
 msgstr "Salva la selezione su file"
 
@@ -3463,28 +3466,28 @@ msgstr "Salva l'ampiezza/posizione della finestra di wxMaxima"
 msgid "Save wxMaxima window size/position between sessions."
 msgstr "Salva l'ampiezza/posizione della finestra di wxMaxima tra le sessioni"
 
-#: ../src/wxMaximaFrame.cpp:246
+#: ../src/wxMaximaFrame.cpp:245
 #, fuzzy
 msgid "Saving failed."
 msgstr "Avvio del server fallito"
 
-#: ../src/wxMaximaFrame.cpp:222
+#: ../src/wxMaximaFrame.cpp:221
 msgid "Saving successful."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:212
+#: ../src/wxMaximaFrame.cpp:211
 msgid "Saving..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4699
+#: ../src/wxMaxima.cpp:4711
 msgid "Scatterplot"
 msgstr "Grafico a dispersione"
 
-#: ../src/wxMaximaFrame.cpp:1271
+#: ../src/wxMaximaFrame.cpp:1270
 msgid "Scatterplot..."
 msgstr "Grafico a dispersione..."
 
-#: ../src/wxMaximaFrame.cpp:1498
+#: ../src/wxMaximaFrame.cpp:1517
 msgid "Section"
 msgstr "Sezione"
 
@@ -3492,26 +3495,26 @@ msgstr "Sezione"
 msgid "Section cell"
 msgstr "Sezione cella"
 
-#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:292 ../src/TextCell.cpp:306
-#: ../src/TextCell.cpp:322 ../src/TextCell.cpp:334
+#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:290 ../src/TextCell.cpp:304
+#: ../src/TextCell.cpp:320 ../src/TextCell.cpp:332
 msgid ""
 "Seems like something is broken with a font. Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/TextCell.cpp:139
+#: ../src/TextCell.cpp:137
 msgid ""
 "Seems like something is broken with the maths font. Installing http://www."
 "math.union.edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use "
 "JSmath fonts\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1011 ../src/MathCtrl.cpp:1027
+#: ../src/MathCtrl.cpp:1053 ../src/MathCtrl.cpp:1069
 msgid "Select All"
 msgstr "Seleziona tutto"
 
-#: ../src/wxMaximaFrame.cpp:525
+#: ../src/wxMaximaFrame.cpp:524
 msgid "Select All\tCtrl-A"
 msgstr "Seleziona tutto\tCtrl-A"
 
@@ -3519,7 +3522,7 @@ msgstr "Seleziona tutto\tCtrl-A"
 msgid "Select Maxima program"
 msgstr "Seleziona il programma maxima"
 
-#: ../src/wxMaxima.cpp:4860
+#: ../src/wxMaxima.cpp:4872
 msgid "Select Subsample"
 msgstr "Seleziona il sottocampione"
 
@@ -3528,11 +3531,11 @@ msgstr "Seleziona il sottocampione"
 msgid "Select a constant"
 msgstr "Seleziona una costante"
 
-#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:526
+#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:525
 msgid "Select all"
 msgstr "Seleziona tutto"
 
-#: ../src/wxMaxima.cpp:3319
+#: ../src/wxMaxima.cpp:3331
 msgid "Select math display algorithm"
 msgstr "Seleziona l'algoritmo di visualizzazione matematica"
 
@@ -3550,23 +3553,23 @@ msgstr ""
 msgid "Selection"
 msgstr "Selezione"
 
-#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4178
+#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4190
 msgid "Series"
 msgstr "Serie"
 
-#: ../src/wxMaximaFrame.cpp:1226
+#: ../src/wxMaximaFrame.cpp:1225
 msgid "Series..."
 msgstr "Serie..."
 
-#: ../src/wxMaxima.cpp:863
+#: ../src/wxMaxima.cpp:868
 msgid "Server started"
 msgstr "Server avviato"
 
-#: ../src/wxMaximaFrame.cpp:575
+#: ../src/wxMaximaFrame.cpp:574
 msgid "Set Zoom"
 msgstr "Imposta lo zoom"
 
-#: ../src/wxMaximaFrame.cpp:944
+#: ../src/wxMaximaFrame.cpp:943
 #, fuzzy
 msgid "Set bigfloat &Precision..."
 msgstr "Imposta la precisione bigfloat"
@@ -3575,62 +3578,62 @@ msgstr "Imposta la precisione bigfloat"
 msgid "Set fixed font in text controls."
 msgstr "Imposta carattere ad ampiezza fissa nei controlli di testo."
 
-#: ../src/wxMaximaFrame.cpp:928
+#: ../src/wxMaximaFrame.cpp:927
 msgid "Set plot format"
 msgstr "Imposta il formato del grafico"
 
-#: ../src/wxMaximaFrame.cpp:945
+#: ../src/wxMaximaFrame.cpp:944
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can "
 "be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:569
+#: ../src/wxMaximaFrame.cpp:568
 msgid "Set zoom to 100%"
 msgstr "Imposta lo zoom al 100%"
 
-#: ../src/wxMaximaFrame.cpp:570
+#: ../src/wxMaximaFrame.cpp:569
 msgid "Set zoom to 120%"
 msgstr "Imposta lo zoom al 120%"
 
-#: ../src/wxMaximaFrame.cpp:571
+#: ../src/wxMaximaFrame.cpp:570
 msgid "Set zoom to 150%"
 msgstr "Imposta lo zoom al 150%"
 
-#: ../src/wxMaximaFrame.cpp:572
+#: ../src/wxMaximaFrame.cpp:571
 msgid "Set zoom to 200%"
 msgstr "Imposta lo zoom al 200%"
 
-#: ../src/wxMaximaFrame.cpp:573
+#: ../src/wxMaximaFrame.cpp:572
 msgid "Set zoom to 300%"
 msgstr "Imposta lo zoom al 300%"
 
-#: ../src/wxMaximaFrame.cpp:568
+#: ../src/wxMaximaFrame.cpp:567
 msgid "Set zoom to 80%"
 msgstr "Imposta lo zoom al 80%"
 
-#: ../src/wxMaximaFrame.cpp:732
+#: ../src/wxMaximaFrame.cpp:731
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
 "Imposta i valori puntuali per risolvere l'ODE con la trasformata di Laplace"
 
-#: ../src/wxMaximaFrame.cpp:918
+#: ../src/wxMaximaFrame.cpp:917
 msgid "Setup modulus computation"
 msgstr "Imposta il calcolo del modulo"
 
-#: ../src/wxMaximaFrame.cpp:662
+#: ../src/wxMaximaFrame.cpp:661
 msgid "Show &Definition..."
 msgstr "Mostra la &definizione..."
 
-#: ../src/wxMaximaFrame.cpp:660
+#: ../src/wxMaximaFrame.cpp:659
 msgid "Show &Functions"
 msgstr "Mostra le &funzioni"
 
-#: ../src/wxMaximaFrame.cpp:967
+#: ../src/wxMaximaFrame.cpp:966
 msgid "Show &Tips..."
 msgstr "Mostra i suggerimen&ti..."
 
-#: ../src/wxMaximaFrame.cpp:665
+#: ../src/wxMaximaFrame.cpp:664
 msgid "Show &Variables"
 msgstr "Mostra le &variabili"
 
@@ -3638,43 +3641,43 @@ msgstr "Mostra le &variabili"
 msgid "Show Maxima help"
 msgstr "Mostra la guida di maxima"
 
-#: ../src/wxMaximaFrame.cpp:603
+#: ../src/wxMaximaFrame.cpp:602
 msgid "Show Template\tCtrl-Shift-K"
 msgstr "Mostra il modello\tCtrl-Shift-K"
 
-#: ../src/wxMaximaFrame.cpp:968
+#: ../src/wxMaximaFrame.cpp:967
 msgid "Show a tip"
 msgstr "Mostra un suggerimento"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Show all commands similar to:"
 msgstr "Mostra tutti i comandi simili a:"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Show an example for the command:"
 msgstr "Mostra un esempio per il comando:"
 
-#: ../src/wxMaximaFrame.cpp:962
+#: ../src/wxMaximaFrame.cpp:961
 msgid "Show an example of usage"
 msgstr "Mostra un esempio di uso"
 
-#: ../src/wxMaximaFrame.cpp:965
+#: ../src/wxMaximaFrame.cpp:964
 msgid "Show commands similar to"
 msgstr "Mostra comandi simili a"
 
-#: ../src/wxMaximaFrame.cpp:661
+#: ../src/wxMaximaFrame.cpp:660
 msgid "Show defined functions"
 msgstr "Mostra le funzioni definite"
 
-#: ../src/wxMaximaFrame.cpp:666
+#: ../src/wxMaximaFrame.cpp:665
 msgid "Show defined variables"
 msgstr "Mostra le variabili definite"
 
-#: ../src/wxMaximaFrame.cpp:663
+#: ../src/wxMaximaFrame.cpp:662
 msgid "Show definition of a function"
 msgstr "Mostra la definizione di una funzione"
 
-#: ../src/wxMaximaFrame.cpp:604
+#: ../src/wxMaximaFrame.cpp:603
 msgid "Show function template"
 msgstr "Mostra un modello di funzione"
 
@@ -3687,7 +3690,7 @@ msgstr "Mostra le espressione lunghe nei documenti di wxMaxima."
 msgid "Show long expressions:"
 msgstr "Mostra le espressioni lunghe"
 
-#: ../src/wxMaxima.cpp:3341
+#: ../src/wxMaxima.cpp:3353
 msgid "Show the definition of function:"
 msgstr "Mostra la definizione della funzione:"
 
@@ -3696,43 +3699,43 @@ msgstr "Mostra la definizione della funzione:"
 msgid "Show user-defined labels instead of (%oxx)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:953 ../src/wxMaximaFrame.cpp:956
+#: ../src/wxMaximaFrame.cpp:952 ../src/wxMaximaFrame.cpp:955
 msgid "Show wxMaxima help"
 msgstr "Mostra la guida di maxima"
 
-#: ../src/wxMaximaFrame.cpp:1381
+#: ../src/wxMaximaFrame.cpp:1380
 msgid "Sigma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1211
+#: ../src/wxMaximaFrame.cpp:1210
 msgid "Simplify"
 msgstr "Semplifica"
 
-#: ../src/wxMaximaFrame.cpp:831
+#: ../src/wxMaximaFrame.cpp:830
 msgid "Simplify &Radicals"
 msgstr "Semplifica i &radicali"
 
-#: ../src/wxMaximaFrame.cpp:1212
+#: ../src/wxMaximaFrame.cpp:1211
 msgid "Simplify (r)"
 msgstr "Semplifica (r)"
 
-#: ../src/wxMaximaFrame.cpp:1218
+#: ../src/wxMaximaFrame.cpp:1217
 msgid "Simplify (tr)"
 msgstr "Semplifica (tr)"
 
-#: ../src/MathCtrl.cpp:995
+#: ../src/MathCtrl.cpp:1037
 msgid "Simplify Expression"
 msgstr "Semplifica l'espressione"
 
-#: ../src/wxMaximaFrame.cpp:857
+#: ../src/wxMaximaFrame.cpp:856
 msgid "Simplify an expression containing factorials"
 msgstr "Semplifica un'espressione contenente dei fattoriali"
 
-#: ../src/wxMaximaFrame.cpp:832
+#: ../src/wxMaximaFrame.cpp:831
 msgid "Simplify expression containing radicals"
 msgstr "Semplifica un'espressione contenente dei radicali"
 
-#: ../src/wxMaximaFrame.cpp:830
+#: ../src/wxMaximaFrame.cpp:829
 msgid "Simplify rational expression"
 msgstr "Semplifica espressione razionale"
 
@@ -3740,7 +3743,7 @@ msgstr "Semplifica espressione razionale"
 msgid "Simplify the sum"
 msgstr "Semplifica la somma"
 
-#: ../src/wxMaximaFrame.cpp:868
+#: ../src/wxMaximaFrame.cpp:867
 msgid "Simplify trigonometric expression"
 msgstr "Semplifica espressione trigonometrica"
 
@@ -3756,88 +3759,88 @@ msgstr ""
 "Notare bene che è necessario salvare il documento in formato \"documento XML "
 "wxMaxima\" se si desidera che l'immagine venga salvata assieme al documento."
 
-#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
+#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
 msgid "Solution:"
 msgstr "Soluzione:"
 
-#: ../src/wxMaxima.cpp:3461 ../src/wxMaxima.cpp:3475 ../src/wxMaxima.cpp:5020
+#: ../src/wxMaxima.cpp:3473 ../src/wxMaxima.cpp:3487 ../src/wxMaxima.cpp:5032
 msgid "Solve"
 msgstr "Risolvi"
 
-#: ../src/wxMaximaFrame.cpp:706
+#: ../src/wxMaximaFrame.cpp:705
 msgid "Solve &Algebraic System..."
 msgstr "Risolvi il sistema &algebrico..."
 
-#: ../src/wxMaximaFrame.cpp:703
+#: ../src/wxMaximaFrame.cpp:702
 msgid "Solve &Linear System..."
 msgstr "Risolvi il sistema &lineare..."
 
-#: ../src/wxMaximaFrame.cpp:714
+#: ../src/wxMaximaFrame.cpp:713
 msgid "Solve &ODE..."
 msgstr "Risolvi &ODE..."
 
-#: ../src/wxMaximaFrame.cpp:690
+#: ../src/wxMaximaFrame.cpp:689
 msgid "Solve (to_poly)..."
 msgstr "Risolvi (to_poly)..."
 
-#: ../src/wxMaxima.cpp:3511 ../src/wxMaxima.cpp:3635
+#: ../src/wxMaxima.cpp:3523 ../src/wxMaxima.cpp:3647
 msgid "Solve ODE"
 msgstr "Risolvi ODE"
 
-#: ../src/wxMaximaFrame.cpp:728
+#: ../src/wxMaximaFrame.cpp:727
 msgid "Solve ODE with Lapla&ce..."
 msgstr "Risolvi ODE con Lapla&ce..."
 
-#: ../src/wxMaximaFrame.cpp:1222
+#: ../src/wxMaximaFrame.cpp:1221
 msgid "Solve ODE..."
 msgstr "Risolvi ODE..."
 
-#: ../src/wxMaxima.cpp:3586 ../src/wxMaxima.cpp:3597
+#: ../src/wxMaxima.cpp:3598 ../src/wxMaxima.cpp:3609
 msgid "Solve algebraic system"
 msgstr "Risolvi il sistema algebrico"
 
-#: ../src/wxMaximaFrame.cpp:707
+#: ../src/wxMaximaFrame.cpp:706
 msgid "Solve algebraic system of equations"
 msgstr "Risolvi il sistema algebrico di equazioni"
 
-#: ../src/wxMaximaFrame.cpp:725
+#: ../src/wxMaximaFrame.cpp:724
 msgid "Solve boundary value problem for second degree ODE"
 msgstr "Risolvi il problema del valore al contorno per un'ODE di secondo grado"
 
-#: ../src/wxMaximaFrame.cpp:689
+#: ../src/wxMaximaFrame.cpp:688
 msgid "Solve equation(s)"
 msgstr "Risolvi le equazioni"
 
-#: ../src/wxMaximaFrame.cpp:691
+#: ../src/wxMaximaFrame.cpp:690
 msgid "Solve equation(s) with to_poly_solve"
 msgstr "Risolvi le equazioni con to_poly_solve"
 
-#: ../src/wxMaximaFrame.cpp:719
+#: ../src/wxMaximaFrame.cpp:718
 msgid "Solve initial value problem for first degree ODE"
 msgstr "Risolvi problema del valore iniziale per un'ODE di primo grado"
 
-#: ../src/wxMaximaFrame.cpp:722
+#: ../src/wxMaximaFrame.cpp:721
 msgid "Solve initial value problem for second degree ODE"
 msgstr "Risolvi problema del valore iniziale per un'ODE di secondo grado"
 
-#: ../src/wxMaxima.cpp:3610 ../src/wxMaxima.cpp:3621
+#: ../src/wxMaxima.cpp:3622 ../src/wxMaxima.cpp:3633
 msgid "Solve linear system"
 msgstr "Risolvi sistema lineare"
 
-#: ../src/wxMaximaFrame.cpp:704
+#: ../src/wxMaximaFrame.cpp:703
 msgid "Solve linear system of equations"
 msgstr "Risolvi sistema lineare di equazioni"
 
-#: ../src/wxMaximaFrame.cpp:715
+#: ../src/wxMaximaFrame.cpp:714
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr "Risolvi l'equazione differenziale ordinaria per un grado massimo di 2"
 
-#: ../src/wxMaximaFrame.cpp:729
+#: ../src/wxMaximaFrame.cpp:728
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
 "Risolvi l'equazione differenziale ordinaria con la trasformata di Laplace"
 
-#: ../src/wxMaximaFrame.cpp:1221 ../src/MathCtrl.cpp:992
+#: ../src/MathCtrl.cpp:1034 ../src/wxMaximaFrame.cpp:1220
 msgid "Solve..."
 msgstr "Risolvi..."
 
@@ -3866,7 +3869,7 @@ msgstr "Speciale"
 msgid "Special constants"
 msgstr "Costanti speciali"
 
-#: ../src/MathCtrl.cpp:922
+#: ../src/MathCtrl.cpp:964
 msgid "Start Animation"
 msgstr "Avvia animazione"
 
@@ -3885,28 +3888,28 @@ msgstr ""
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:294
+#: ../src/wxMaxima.cpp:295
 msgid "Starting Maxima process failed"
 msgstr "Avvio del processo Maxima fallito"
 
-#: ../src/wxMaxima.cpp:928
+#: ../src/wxMaxima.cpp:933
 msgid "Starting Maxima..."
 msgstr "Avvio di maxima..."
 
-#: ../src/wxMaxima.cpp:292 ../src/wxMaxima.cpp:860
+#: ../src/wxMaxima.cpp:293 ../src/wxMaxima.cpp:865
 msgid "Starting server failed"
 msgstr "Avvio del server fallito"
 
-#: ../src/wxMaxima.cpp:841
+#: ../src/wxMaxima.cpp:846
 #, c-format
 msgid "Starting server on port %d"
 msgstr "Avvio del server sul port %d"
 
-#: ../src/wxMaximaFrame.cpp:342
+#: ../src/wxMaximaFrame.cpp:341
 msgid "Statistics"
 msgstr "Statistiche"
 
-#: ../src/wxMaximaFrame.cpp:550
+#: ../src/wxMaximaFrame.cpp:549
 msgid "Statistics\tAlt-Shift-S"
 msgstr "Statistiche\tAlt-Shift-S"
 
@@ -3922,11 +3925,11 @@ msgstr "Stile"
 msgid "Styles"
 msgstr "Stili"
 
-#: ../src/wxMaximaFrame.cpp:1283
+#: ../src/wxMaximaFrame.cpp:1282
 msgid "Subsample..."
 msgstr "Sottocampione..."
 
-#: ../src/wxMaximaFrame.cpp:1496
+#: ../src/wxMaximaFrame.cpp:1515
 msgid "Subsection"
 msgstr "Sottosezione"
 
@@ -3934,20 +3937,20 @@ msgstr "Sottosezione"
 msgid "Subsection cell"
 msgstr "Cella sottosezione"
 
-#: ../src/wxMaximaFrame.cpp:1216
+#: ../src/wxMaximaFrame.cpp:1215
 msgid "Subst..."
 msgstr "Sostit..."
 
-#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3423
-#: ../src/wxMaxima.cpp:5089
+#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3435
+#: ../src/wxMaxima.cpp:5101
 msgid "Substitute"
 msgstr "Sostituisci"
 
-#: ../src/wxMaximaFrame.cpp:906 ../src/MathCtrl.cpp:998
+#: ../src/MathCtrl.cpp:1040 ../src/wxMaximaFrame.cpp:905
 msgid "Substitute..."
 msgstr "Sostituisci..."
 
-#: ../src/wxMaximaFrame.cpp:1497
+#: ../src/wxMaximaFrame.cpp:1516
 #, fuzzy
 msgid "Subsubsection"
 msgstr "Sottosezione"
@@ -3957,7 +3960,7 @@ msgstr "Sottosezione"
 msgid "Subsubsection cell"
 msgstr "Cella sottosezione"
 
-#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4226
+#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4238
 msgid "Sum"
 msgstr "Somma"
 
@@ -3965,37 +3968,37 @@ msgstr "Somma"
 msgid "Sum sign"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:553
+#: ../src/wxMaximaFrame.cpp:552
 #, fuzzy
 msgid "Symbols\tAlt-Shift-Y"
 msgstr "Statistiche\tAlt-Shift-S"
 
-#: ../src/wxMaxima.cpp:4456
+#: ../src/wxMaxima.cpp:4468
 msgid "System info"
 msgstr "Informazioni sul sistema"
 
-#: ../src/wxMaximaFrame.cpp:320
+#: ../src/wxMaximaFrame.cpp:319
 msgid "Table of Contents"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:556
+#: ../src/wxMaximaFrame.cpp:555
 #, fuzzy
 msgid "Table of Contents\tAlt-Shift-T"
 msgstr "Barra strumenti\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:1382
+#: ../src/wxMaximaFrame.cpp:1381
 msgid "Tau"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Taylor series:"
 msgstr "Serie di Taylor:"
 
-#: ../src/wxMaxima.cpp:3963
+#: ../src/wxMaxima.cpp:3975
 msgid "Tellrat"
 msgstr "Sempraz"
 
-#: ../src/wxMaximaFrame.cpp:1494
+#: ../src/wxMaximaFrame.cpp:1513
 msgid "Text"
 msgstr "Testo"
 
@@ -4041,7 +4044,7 @@ msgstr ""
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr ""
 
-#: ../src/TextCell.cpp:136
+#: ../src/TextCell.cpp:134
 msgid ""
 "The letter \"X\" is of width zero. Installing http://www.math.union.edu/"
 "~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts\" in "
@@ -4058,7 +4061,7 @@ msgstr ""
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:959
+#: ../src/wxMaximaFrame.cpp:958
 msgid "The offline manual of maxima"
 msgstr "Il manuale di Maxima offline"
 
@@ -4098,7 +4101,7 @@ msgstr ""
 "andrejv.github.com/wxmaxima/help.html per ottenere ulteriori informazioni e "
 "per trovare tutorial sull'uso di wxMaxima e Maxima."
 
-#: ../src/SlideShowCell.cpp:332
+#: ../src/SlideShowCell.cpp:336
 msgid ""
 "There was an error during GIF export!\n"
 "\n"
@@ -4109,7 +4112,7 @@ msgstr ""
 "Controllare che ImageMagick sia installato e che wxMaxima possa trovare il "
 "programma \"convert\"."
 
-#: ../src/wxMaxima.cpp:442
+#: ../src/wxMaxima.cpp:447
 msgid ""
 "There was an error in generated XML!\n"
 "\n"
@@ -4119,7 +4122,7 @@ msgstr ""
 "\n"
 "Fate un rapporto di questo bug."
 
-#: ../src/wxMaximaFrame.cpp:1371
+#: ../src/wxMaximaFrame.cpp:1370
 msgid "Theta"
 msgstr ""
 
@@ -4127,7 +4130,7 @@ msgstr ""
 msgid "Ticks:"
 msgstr "Tacche:"
 
-#: ../src/wxMaxima.cpp:4153 ../src/wxMaxima.cpp:5065
+#: ../src/wxMaxima.cpp:4165 ../src/wxMaxima.cpp:5077
 msgid "Times:"
 msgstr "Volte:"
 
@@ -4135,7 +4138,7 @@ msgstr "Volte:"
 msgid "Tips not available, sorry!"
 msgstr "Spiacente, suggerimenti non disponibili!"
 
-#: ../src/wxMaximaFrame.cpp:1495
+#: ../src/wxMaximaFrame.cpp:1514
 msgid "Title"
 msgstr "Titolo"
 
@@ -4154,19 +4157,19 @@ msgstr ""
 "riquadro presso la cella. Se si preme la combinazione Maiusc-clic, anche "
 "tutti i sottolivelli delle celle verranno chiusi o aperti."
 
-#: ../src/wxMaximaFrame.cpp:938
+#: ../src/wxMaximaFrame.cpp:937
 msgid "To &Bigfloat"
 msgstr "In virgola mobile &precisa"
 
-#: ../src/wxMaximaFrame.cpp:935
+#: ../src/wxMaximaFrame.cpp:934
 msgid "To &Float"
 msgstr "In &virgola mobile"
 
-#: ../src/MathCtrl.cpp:990
+#: ../src/MathCtrl.cpp:1032
 msgid "To Float"
 msgstr "In virgola mobile"
 
-#: ../src/wxMaximaFrame.cpp:941
+#: ../src/wxMaximaFrame.cpp:940
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr "In forma numeri&ca\tCtrl+Maiusc+N"
 
@@ -4207,51 +4210,51 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:41 ../src/Plot2dWiz.cpp:40 ../src/Plot2dWiz.cpp:50
 #: ../src/Plot2dWiz.cpp:539 ../src/Plot3dWiz.cpp:39 ../src/Plot3dWiz.cpp:48
-#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4241
+#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4253
 msgid "To:"
 msgstr "A:"
 
-#: ../src/wxMaximaFrame.cpp:912
+#: ../src/wxMaximaFrame.cpp:911
 msgid "Toggle &Algebraic Flag"
 msgstr "Mostra/nascondi &algebrica"
 
-#: ../src/wxMaximaFrame.cpp:933
+#: ../src/wxMaximaFrame.cpp:932
 msgid "Toggle &Numeric Output"
 msgstr "Mostra/nascondi risultati &numerici"
 
-#: ../src/wxMaximaFrame.cpp:673
+#: ../src/wxMaximaFrame.cpp:672
 msgid "Toggle &Time Display"
 msgstr "Mostra/nascondi la visualizzazione del &tempo"
 
-#: ../src/wxMaximaFrame.cpp:913
+#: ../src/wxMaximaFrame.cpp:912
 msgid "Toggle algebraic flag"
 msgstr "Mostra/nascondi algebrica"
 
-#: ../src/wxMaximaFrame.cpp:577
+#: ../src/wxMaximaFrame.cpp:576
 msgid "Toggle full screen editing"
 msgstr "Mostra/nascondi schermo pieno"
 
-#: ../src/wxMaximaFrame.cpp:934
+#: ../src/wxMaximaFrame.cpp:933
 msgid "Toggle numeric output"
 msgstr "Mostra/nascondi i risultati numerici"
 
-#: ../src/wxMaxima.cpp:4464
+#: ../src/wxMaxima.cpp:4476
 msgid "Toolbar icons"
 msgstr "Icone della barra degli strumenti"
 
-#: ../src/wxMaxima.cpp:4465
+#: ../src/wxMaxima.cpp:4477
 msgid "Translated by"
 msgstr "Tradotto da"
 
-#: ../src/wxMaximaFrame.cpp:763
+#: ../src/wxMaximaFrame.cpp:762
 msgid "Transpose a matrix"
 msgstr "Trasponi una matrice"
 
-#: ../src/MathCtrl.cpp:5834
+#: ../src/MathCtrl.cpp:5886
 msgid "Trying to undo an action without starting cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5901
+#: ../src/MathCtrl.cpp:5953
 msgid "Trying to undo something but the undo action is empty."
 msgstr ""
 
@@ -4259,11 +4262,11 @@ msgstr ""
 msgid "Turkish"
 msgstr "Turco"
 
-#: ../src/wxMaximaFrame.cpp:970
+#: ../src/wxMaximaFrame.cpp:969
 msgid "Tutorials"
 msgstr "Tutorial"
 
-#: ../src/wxMaxima.cpp:4778
+#: ../src/wxMaxima.cpp:4790
 msgid "Two sample t-test"
 msgstr "Test t a due campioni"
 
@@ -4275,15 +4278,15 @@ msgstr "Tipo:"
 msgid "Ukrainian"
 msgstr "Ucraino"
 
-#: ../src/wxMaxima.cpp:5356
+#: ../src/wxMaxima.cpp:5372
 msgid "Un-closed parenthesis"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5323
+#: ../src/wxMaxima.cpp:5335
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5889
 msgid ""
 "Unable to interpret the version info I got from http://andrejv.github.io//"
 "wxmaxima/version.txt: "
@@ -4297,11 +4300,11 @@ msgstr "Sottolineato"
 msgid "Underscore converts to subscripts:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:492
+#: ../src/wxMaximaFrame.cpp:491
 msgid "Undo\tCtrl-Z"
 msgstr "Annulla\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:493
+#: ../src/wxMaximaFrame.cpp:492
 msgid "Undo last change"
 msgstr "Annulla l'ultima modifica"
 
@@ -4309,23 +4312,23 @@ msgstr "Annulla l'ultima modifica"
 msgid "Undo limit (0 for none):"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:625
+#: ../src/wxMaximaFrame.cpp:624
 msgid "Unfold All\tCtrl-Alt-]"
 msgstr "Spiega tutto\tCtrl-Alt-]"
 
-#: ../src/wxMaximaFrame.cpp:626
+#: ../src/wxMaximaFrame.cpp:625
 msgid "Unfold all folded sections"
 msgstr "Spiega tutte le sezioni ripiegate"
 
-#: ../src/wxMaxima.cpp:4458
+#: ../src/wxMaxima.cpp:4470
 msgid "Unicode Support"
 msgstr "Supporto caratteri unicode"
 
-#: ../src/wxMaxima.cpp:5335
+#: ../src/wxMaxima.cpp:5347
 msgid "Unterminated comment."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5309
+#: ../src/wxMaxima.cpp:5321
 msgid "Unterminated string."
 msgstr ""
 
@@ -4333,15 +4336,15 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5859 ../src/wxMaxima.cpp:5866 ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5874 ../src/wxMaxima.cpp:5881 ../src/wxMaxima.cpp:5889
 msgid "Upgrade"
 msgstr "Aggiorna"
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Upper bound:"
 msgstr "Intorno alto:"
 
-#: ../src/wxMaximaFrame.cpp:1383
+#: ../src/wxMaximaFrame.cpp:1382
 #, fuzzy
 msgid "Upsilon"
 msgstr "Epsilon:"
@@ -4386,22 +4389,22 @@ msgstr ""
 msgid "User-defined labels"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3525
-#: ../src/wxMaxima.cpp:3541 ../src/wxMaxima.cpp:3649
+#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3537
+#: ../src/wxMaxima.cpp:3553 ../src/wxMaxima.cpp:3661
 msgid "Value:"
 msgstr "Valore:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:5019 ../src/wxMaxima.cpp:5064
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:5031 ../src/wxMaxima.cpp:5076
 msgid "Variable(s):"
 msgstr "Variabile(i):"
 
 #: ../src/IntegrateWiz.cpp:33 ../src/LimitWiz.cpp:30 ../src/Plot2dWiz.cpp:34
 #: ../src/Plot2dWiz.cpp:44 ../src/Plot2dWiz.cpp:533 ../src/Plot3dWiz.cpp:33
 #: ../src/Plot3dWiz.cpp:42 ../src/SeriesWiz.cpp:36 ../src/SumWiz.cpp:30
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3749
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3761
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5045
 msgid "Variable:"
 msgstr "Variabile:"
 
@@ -4409,25 +4412,25 @@ msgstr "Variabile:"
 msgid "Variables"
 msgstr "Variabili"
 
-#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3571 ../src/wxMaxima.cpp:4206
-#: ../src/wxMaxima.cpp:4807
+#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3583 ../src/wxMaxima.cpp:4218
+#: ../src/wxMaxima.cpp:4819
 msgid "Variables:"
 msgstr "Variabili:"
 
-#: ../src/wxMaximaFrame.cpp:1257
+#: ../src/wxMaximaFrame.cpp:1256
 msgid "Variance..."
 msgstr "Varianza..."
 
-#: ../src/wxMaximaFrame.cpp:580
+#: ../src/wxMaximaFrame.cpp:579
 msgid "View"
 msgstr ""
 
-#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1674 ../src/wxMaxima.cpp:1769
-#: ../src/wxMaxima.cpp:1950
+#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1679 ../src/wxMaxima.cpp:1774
+#: ../src/wxMaxima.cpp:1955
 msgid "Warning"
 msgstr "Attenzione"
 
-#: ../src/wxMaximaFrame.cpp:109 ../src/wxMaximaFrame.cpp:295
+#: ../src/wxMaximaFrame.cpp:108 ../src/wxMaximaFrame.cpp:294
 msgid "Welcome to wxMaxima"
 msgstr "Benvenuti in wxMaxima"
 
@@ -4450,7 +4453,7 @@ msgid ""
 "introducing an empty line."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2567
+#: ../src/wxMaxima.cpp:2574
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) "
 "(*.wxm)|*.wxm"
@@ -4466,7 +4469,7 @@ msgid ""
 "as equation markers"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6798
+#: ../src/MathCtrl.cpp:6856
 msgid "Wrapped search"
 msgstr ""
 
@@ -4474,15 +4477,15 @@ msgstr ""
 msgid "Write matching parenthesis in text controls."
 msgstr "Scrivi le parentesi corrispondenti nei controlli di testo."
 
-#: ../src/wxMaxima.cpp:4461
+#: ../src/wxMaxima.cpp:4473
 msgid "Written by"
 msgstr "Scritto da"
 
-#: ../src/wxMaximaFrame.cpp:557
+#: ../src/wxMaximaFrame.cpp:556
 msgid "XML Inspector"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1377
+#: ../src/wxMaximaFrame.cpp:1376
 msgid "Xi"
 msgstr ""
 
@@ -4556,7 +4559,7 @@ msgstr ""
 "cursore orizzontale, per poi operare su di esse tramite la selezione. Ciò "
 "torna comodo quando si vuole cancellare o valutare celle multiple."
 
-#: ../src/wxMaxima.cpp:5856
+#: ../src/wxMaxima.cpp:5871
 #, c-format
 msgid ""
 "You have version %s. Current version is %s.\n"
@@ -4567,41 +4570,41 @@ msgstr ""
 "\n"
 "Selezionare OK per visitare il sito web di wxMaxima."
 
-#: ../src/wxMaxima.cpp:5921
+#: ../src/wxMaxima.cpp:5936
 msgid "Your changes will be lost if you don't save them."
 msgstr "I cambiamenti andranno persi se non vengono salvati."
 
-#: ../src/wxMaxima.cpp:5866
+#: ../src/wxMaxima.cpp:5881
 msgid "Your version of wxMaxima is up to date."
 msgstr "L'attuale versione di wxMaxima è aggiornata."
 
-#: ../src/wxMaximaFrame.cpp:1369
+#: ../src/wxMaximaFrame.cpp:1368
 msgid "Zeta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:562
+#: ../src/wxMaximaFrame.cpp:561
 #, fuzzy
 msgid "Zoom &In\tCtrl-+"
 msgstr "&Ingrandisci\tAlt-I"
 
-#: ../src/wxMaximaFrame.cpp:564
+#: ../src/wxMaximaFrame.cpp:563
 #, fuzzy
 msgid "Zoom Ou&t\tCtrl--"
 msgstr "Rimpicci&olisci\tAlt-O"
 
-#: ../src/wxMaximaFrame.cpp:563
+#: ../src/wxMaximaFrame.cpp:562
 msgid "Zoom in 10%"
 msgstr "Ingrandisci del 10%"
 
-#: ../src/wxMaximaFrame.cpp:565
+#: ../src/wxMaximaFrame.cpp:564
 msgid "Zoom out 10%"
 msgstr "Rimpicciolisci del 10%"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaximaFrame.cpp:287
 msgid "[ unsaved ]"
 msgstr "[ non salvato ]"
 
-#: ../src/wxMaxima.cpp:5700
+#: ../src/wxMaxima.cpp:5715
 msgid "[ unsaved* ]"
 msgstr "[ non salvato* ]"
 
@@ -4610,17 +4613,17 @@ msgstr "[ non salvato* ]"
 msgid "[%i digits]"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4392
+#: ../src/MathCtrl.cpp:4447
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" style=\"max-width:90%%;\" >\n"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4517
+#: ../src/MathCtrl.cpp:4572
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" >"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1333
+#: ../src/wxMaximaFrame.cpp:1332
 msgid "alpha"
 msgstr ""
 
@@ -4633,7 +4636,7 @@ msgstr "Espandi"
 msgid "antisymmetric"
 msgstr "antimmetrica"
 
-#: ../src/wxMaximaFrame.cpp:1334
+#: ../src/wxMaximaFrame.cpp:1333
 msgid "beta"
 msgstr ""
 
@@ -4677,7 +4680,7 @@ msgstr ""
 msgid "bug:Invalid sup tag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1354
+#: ../src/wxMaximaFrame.cpp:1353
 msgid "chi"
 msgstr ""
 
@@ -4690,7 +4693,7 @@ msgstr ""
 msgid "default"
 msgstr "predefinito"
 
-#: ../src/wxMaximaFrame.cpp:1336
+#: ../src/wxMaximaFrame.cpp:1335
 msgid "delta"
 msgstr ""
 
@@ -4702,7 +4705,7 @@ msgstr "diagonale"
 msgid "empty"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1337
+#: ../src/wxMaximaFrame.cpp:1336
 #, fuzzy
 msgid "epsilon"
 msgstr "Epsilon:"
@@ -4711,7 +4714,7 @@ msgstr "Epsilon:"
 msgid "equivalent"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1339
+#: ../src/wxMaximaFrame.cpp:1338
 msgid "eta"
 msgstr ""
 
@@ -4727,7 +4730,7 @@ msgid ""
 "all=_ marks subscripts."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1335
+#: ../src/wxMaximaFrame.cpp:1334
 msgid "gamma"
 msgstr ""
 
@@ -4756,15 +4759,15 @@ msgstr "inlinea"
 msgid "intersection"
 msgstr "Direzione:"
 
-#: ../src/wxMaximaFrame.cpp:1341
+#: ../src/wxMaximaFrame.cpp:1340
 msgid "iota"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1342
+#: ../src/wxMaximaFrame.cpp:1341
 msgid "kappa"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1343
+#: ../src/wxMaximaFrame.cpp:1342
 msgid "lambda"
 msgstr ""
 
@@ -4781,7 +4784,7 @@ msgstr "Cella sottosezione"
 msgid "logscale"
 msgstr "scala logaritmica"
 
-#: ../src/wxMaxima.cpp:3783
+#: ../src/wxMaxima.cpp:3795
 msgid "matrix[i,j]:"
 msgstr "matrice[i,j]:"
 
@@ -4789,7 +4792,7 @@ msgstr "matrice[i,j]:"
 msgid "maxima's pwd is path to document"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1344
+#: ../src/wxMaximaFrame.cpp:1343
 msgid "mu"
 msgstr ""
 
@@ -4806,7 +4809,7 @@ msgstr ""
 msgid "nand"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4524
+#: ../src/wxMaxima.cpp:4536
 msgid "no"
 msgstr "no"
 
@@ -4832,15 +4835,15 @@ msgstr ""
 msgid "not subset or equal"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1345
+#: ../src/wxMaximaFrame.cpp:1344
 msgid "nu"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1356
+#: ../src/wxMaximaFrame.cpp:1355
 msgid "omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1347
+#: ../src/wxMaximaFrame.cpp:1346
 msgid "omicron"
 msgstr ""
 
@@ -4853,11 +4856,11 @@ msgstr ""
 msgid "partial sign"
 msgstr "Frazioni parziali"
 
-#: ../src/wxMaximaFrame.cpp:1353
+#: ../src/wxMaximaFrame.cpp:1352
 msgid "phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1348
+#: ../src/wxMaximaFrame.cpp:1347
 msgid "pi"
 msgstr ""
 
@@ -4869,11 +4872,11 @@ msgstr ""
 msgid "proportional to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1355
+#: ../src/wxMaximaFrame.cpp:1354
 msgid "psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1349
+#: ../src/wxMaximaFrame.cpp:1348
 msgid "rho"
 msgstr ""
 
@@ -4881,7 +4884,7 @@ msgstr ""
 msgid "right"
 msgstr "destro"
 
-#: ../src/wxMaximaFrame.cpp:1350
+#: ../src/wxMaximaFrame.cpp:1349
 msgid "sigma"
 msgstr ""
 
@@ -4903,7 +4906,7 @@ msgstr "Cella sottosezione"
 msgid "symmetric"
 msgstr "simmetrica"
 
-#: ../src/wxMaximaFrame.cpp:1351
+#: ../src/wxMaximaFrame.cpp:1350
 msgid "tau"
 msgstr ""
 
@@ -4915,7 +4918,7 @@ msgstr ""
 msgid "there is no"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1340
+#: ../src/wxMaximaFrame.cpp:1339
 msgid "theta"
 msgstr ""
 
@@ -4931,12 +4934,12 @@ msgstr ""
 msgid "union"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5903
+#: ../src/wxMaxima.cpp:5918
 msgid "unsaved"
 msgstr "non salvato"
 
-#: ../src/wxMaximaFrame.cpp:290 ../src/wxMaxima.cpp:2559
-#: ../src/wxMaxima.cpp:2826
+#: ../src/wxMaxima.cpp:2566 ../src/wxMaxima.cpp:2834
+#: ../src/wxMaximaFrame.cpp:289
 msgid "untitled"
 msgstr "senzanome"
 
@@ -4945,26 +4948,26 @@ msgstr "senzanome"
 msgid "untitled %d"
 msgstr "senzanome %d"
 
-#: ../src/wxMaximaFrame.cpp:1352
+#: ../src/wxMaximaFrame.cpp:1351
 #, fuzzy
 msgid "upsilon"
 msgstr "Epsilon:"
 
-#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4538
+#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4550
 msgid "wxMaxima"
 msgstr "wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
-#: ../src/wxMaxima.cpp:5700 ../src/wxMaxima.cpp:5709 ../src/wxMaxima.cpp:5712
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaxima.cpp:5715 ../src/wxMaxima.cpp:5724
+#: ../src/wxMaxima.cpp:5727 ../src/wxMaximaFrame.cpp:287
 #, c-format
 msgid "wxMaxima %s "
 msgstr "wxMaxima %s "
 
-#: ../src/wxMaximaFrame.cpp:952
+#: ../src/wxMaximaFrame.cpp:951
 msgid "wxMaxima &Help\tCtrl+?"
 msgstr "G&uida di Maxima\tCtrl+?"
 
-#: ../src/wxMaximaFrame.cpp:955
+#: ../src/wxMaximaFrame.cpp:954
 msgid "wxMaxima &Help\tF1"
 msgstr "G&uida di Maxima\tF1"
 
@@ -4975,11 +4978,11 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1619
+#: ../src/wxMaxima.cpp:1624
 msgid "wxMaxima cannot open content.xml in the .wxmx zip archive "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1633
+#: ../src/wxMaxima.cpp:1638
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
@@ -4987,7 +4990,7 @@ msgstr ""
 msgid "wxMaxima configuration"
 msgstr "Configurazione di wxMaxima"
 
-#: ../src/wxMaxima.cpp:1947
+#: ../src/wxMaxima.cpp:1952
 msgid ""
 "wxMaxima could not find Maxima!\n"
 "\n"
@@ -4999,7 +5002,7 @@ msgstr ""
 "Configurare wxMaxima con \"Modifica->Configura\".\n"
 "Successivamente avviare maxima con \"Maxima->Riavvia maxima\"."
 
-#: ../src/wxMaxima.cpp:2204
+#: ../src/wxMaxima.cpp:2209
 msgid ""
 "wxMaxima could not find help files.\n"
 "\n"
@@ -5009,7 +5012,7 @@ msgstr ""
 "\n"
 "Controllare l'installazione."
 
-#: ../src/wxMaxima.cpp:2032
+#: ../src/wxMaxima.cpp:2037
 msgid ""
 "wxMaxima could not find tip files.\n"
 "\n"
@@ -5019,7 +5022,7 @@ msgstr ""
 "\n"
 "Controllare l'installazione."
 
-#: ../src/wxMaxima.cpp:282
+#: ../src/wxMaxima.cpp:283
 msgid ""
 "wxMaxima could not start the server.\n"
 "\n"
@@ -5041,23 +5044,23 @@ msgstr ""
 "di ingresso, uno dei quali è \"%\". Se si è effettuata una selezione nel "
 "documento corrente, questa verrà utilizzata al posto di \"%\"."
 
-#: ../src/wxMaxima.cpp:2330
+#: ../src/wxMaxima.cpp:2336
 msgid "wxMaxima document"
 msgstr "Documento wxMaxima"
 
-#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2799
+#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2807
 msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 msgstr "Documento wxMaxima (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 
-#: ../src/wxMaxima.cpp:1455 ../src/wxMaxima.cpp:1469
+#: ../src/wxMaxima.cpp:1460 ../src/wxMaxima.cpp:1474
 msgid "wxMaxima encountered an error loading "
 msgstr "wxMaxima ha riscontrato un errore durante il caricamento "
 
-#: ../src/wxMaxima.cpp:4463
+#: ../src/wxMaxima.cpp:4475
 msgid "wxMaxima icon"
 msgstr "Icona wxMaxima"
 
-#: ../src/wxMaxima.cpp:4455
+#: ../src/wxMaxima.cpp:4467
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "MAXIMA based on wxWidgets."
@@ -5065,7 +5068,7 @@ msgstr ""
 "wxMaxima è un'interfaccia utente grafica basata sui wxWidgets per il sistema "
 "algebrico computerizzato Maxima."
 
-#: ../src/wxMaxima.cpp:4516
+#: ../src/wxMaxima.cpp:4528
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "Maxima based on wxWidgets."
@@ -5085,11 +5088,11 @@ msgstr ""
 msgid "x"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1346
+#: ../src/wxMaximaFrame.cpp:1345
 msgid "xi"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1643
+#: ../src/wxMaxima.cpp:1648
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
@@ -5098,11 +5101,11 @@ msgstr ""
 msgid "xor"
 msgstr "Esporta"
 
-#: ../src/wxMaxima.cpp:4522
+#: ../src/wxMaxima.cpp:4534
 msgid "yes"
 msgstr "sì"
 
-#: ../src/wxMaximaFrame.cpp:1338
+#: ../src/wxMaximaFrame.cpp:1337
 msgid "zeta"
 msgstr ""
 

--- a/locales/ja.po
+++ b/locales/ja.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxmaxima0.87\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-07 21:42+0200\n"
+"POT-Creation-Date: 2016-10-16 17:47+0900\n"
 "PO-Revision-Date: 2016-03-31 08:19+0200\n"
 "Last-Translator: matcha-zaq <Matcha_zaq@excite.co.jp>\n"
 "Language-Team: Japanese <maxima-discuss@lists.sourceforge.net>\n"
@@ -21,7 +21,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Lokalize 1.5\n"
 
-#: ../src/wxMaxima.cpp:4519
+#: ../src/wxMaxima.cpp:4531
 #, c-format
 msgid ""
 "\n"
@@ -34,7 +34,7 @@ msgstr ""
 "wxWidgets: %d.%d.%d\n"
 "Unicode support: %s"
 
-#: ../src/wxMaxima.cpp:4532
+#: ../src/wxMaxima.cpp:4544
 msgid ""
 "\n"
 "Lisp: "
@@ -42,7 +42,7 @@ msgstr ""
 "\n"
 "Lisp: "
 
-#: ../src/wxMaxima.cpp:4528
+#: ../src/wxMaxima.cpp:4540
 msgid ""
 "\n"
 "Maxima version: "
@@ -50,7 +50,7 @@ msgstr ""
 "\n"
 "Maxima version: "
 
-#: ../src/wxMaxima.cpp:5381
+#: ../src/wxMaxima.cpp:5397
 msgid ""
 "\n"
 "Not connected to Maxima!\n"
@@ -58,7 +58,7 @@ msgstr ""
 "\n"
 "Maximaと接続していません！\n"
 
-#: ../src/wxMaxima.cpp:4530
+#: ../src/wxMaxima.cpp:4542
 msgid ""
 "\n"
 "Not connected."
@@ -78,7 +78,7 @@ msgstr ""
 msgid " (Graphics) "
 msgstr ""
 
-#: ../src/EditorCell.cpp:3045 ../src/EditorCell.cpp:3227
+#: ../src/EditorCell.cpp:3088 ../src/EditorCell.cpp:3270
 #, c-format
 msgid " ... + %i hidden lines"
 msgstr ""
@@ -87,7 +87,7 @@ msgstr ""
 msgid " << Expression longer than allowed by the configuration setting! >>"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1673
+#: ../src/wxMaxima.cpp:1678
 msgid ""
 " was saved using a newer version of wxMaxima so it may not load correctly. "
 "Please update your wxMaxima."
@@ -95,7 +95,7 @@ msgstr ""
 " はより新しいバージョンのwxMaximaを用いて保存されたものなので、正しく読み込め"
 "ないかもしれません。 このwxMaximaををアップデートしてください。"
 
-#: ../src/wxMaxima.cpp:1665
+#: ../src/wxMaxima.cpp:1670
 msgid ""
 " was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr ""
@@ -110,64 +110,64 @@ msgstr ""
 msgid "\"implies\" symbol"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:101
+#: ../src/wxMaximaFrame.cpp:100
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:773
+#: ../src/wxMaximaFrame.cpp:772
 msgid "&Algebra"
 msgstr "代数(&A)"
 
-#: ../src/wxMaximaFrame.cpp:767
+#: ../src/wxMaximaFrame.cpp:766
 msgid "&Apply to List..."
 msgstr "リストにコマンドを適用(&A)"
 
-#: ../src/wxMaximaFrame.cpp:964
+#: ../src/wxMaximaFrame.cpp:963
 msgid "&Apropos..."
 msgstr "コマンドを探す(&A)"
 
-#: ../src/wxMaximaFrame.cpp:478
+#: ../src/wxMaximaFrame.cpp:477
 msgid "&Batch File...\tCtrl-B"
 msgstr "バッチファイル(&B)\tCtrl-B"
 
-#: ../src/wxMaximaFrame.cpp:724
+#: ../src/wxMaximaFrame.cpp:723
 msgid "&Boundary Value Problem..."
 msgstr "境界条件から特殊解を求める(&B)"
 
-#: ../src/wxMaximaFrame.cpp:975
+#: ../src/wxMaximaFrame.cpp:974
 msgid "&Bug Report"
 msgstr "バグの報告(&B)"
 
-#: ../src/wxMaximaFrame.cpp:825
+#: ../src/wxMaximaFrame.cpp:824
 msgid "&Calculus"
 msgstr "微積分(&C)"
 
-#: ../src/wxMaximaFrame.cpp:876
+#: ../src/wxMaximaFrame.cpp:875
 msgid "&Canonical Form"
 msgstr "三角関数式の整理(&C)"
 
-#: ../src/wxMaximaFrame.cpp:749
+#: ../src/wxMaximaFrame.cpp:748
 msgid "&Characteristic Polynomial..."
 msgstr "固有多項式(&C)"
 
-#: ../src/wxMaximaFrame.cpp:654
+#: ../src/wxMaximaFrame.cpp:653
 msgid "&Clear Memory"
 msgstr "メモリをクリア(&C)"
 
-#: ../src/wxMaximaFrame.cpp:859
+#: ../src/wxMaximaFrame.cpp:858
 msgid "&Combine Factorials"
 msgstr "係数の結合(&C)"
 
-#: ../src/wxMaximaFrame.cpp:902
+#: ../src/wxMaximaFrame.cpp:901
 msgid "&Complex Simplification"
 msgstr "複素関数への操作(&C)"
 
-#: ../src/wxMaximaFrame.cpp:822
+#: ../src/wxMaximaFrame.cpp:821
 msgid "&Continued Fraction"
 msgstr "連分数で表示(&C)"
 
-#: ../src/wxMaximaFrame.cpp:502
+#: ../src/wxMaximaFrame.cpp:501
 msgid "&Copy\tCtrl-C"
 msgstr "コピー(&C)\tCtrl-C"
 
@@ -175,108 +175,108 @@ msgstr "コピー(&C)\tCtrl-C"
 msgid "&Definite integration"
 msgstr "定積分(&D)"
 
-#: ../src/wxMaximaFrame.cpp:896
+#: ../src/wxMaximaFrame.cpp:895
 msgid "&Demoivre"
 msgstr "指数関数の変換(&D)"
 
-#: ../src/wxMaximaFrame.cpp:752
+#: ../src/wxMaximaFrame.cpp:751
 msgid "&Determinant"
 msgstr "行列式の計算(&D)"
 
-#: ../src/wxMaximaFrame.cpp:785
+#: ../src/wxMaximaFrame.cpp:784
 msgid "&Differentiate..."
 msgstr "微分(&D)"
 
-#: ../src/wxMaximaFrame.cpp:543
+#: ../src/wxMaximaFrame.cpp:542
 msgid "&Edit"
 msgstr "編集(&E)"
 
-#: ../src/wxMaximaFrame.cpp:709
+#: ../src/wxMaximaFrame.cpp:708
 msgid "&Eliminate Variable..."
 msgstr "方程式の数を減らす(&E)"
 
-#: ../src/wxMaximaFrame.cpp:744
+#: ../src/wxMaximaFrame.cpp:743
 msgid "&Enter Matrix..."
 msgstr "手入力による行列生成(&E)"
 
-#: ../src/wxMaximaFrame.cpp:961
+#: ../src/wxMaximaFrame.cpp:960
 msgid "&Example..."
 msgstr "コマンドの使用例(&E)"
 
-#: ../src/wxMaximaFrame.cpp:839
+#: ../src/wxMaximaFrame.cpp:838
 msgid "&Expand Expression"
 msgstr "展開(&E)"
 
-#: ../src/wxMaximaFrame.cpp:873
+#: ../src/wxMaximaFrame.cpp:872
 msgid "&Expand Trigonometric"
 msgstr "三角関数の展開(&E)"
 
-#: ../src/wxMaximaFrame.cpp:899
+#: ../src/wxMaximaFrame.cpp:898
 msgid "&Exponentialize"
 msgstr "三角関数の変換(&E)"
 
-#: ../src/wxMaximaFrame.cpp:480
+#: ../src/wxMaximaFrame.cpp:479
 msgid "&Export..."
 msgstr "エクスポート(&E)"
 
-#: ../src/wxMaximaFrame.cpp:834
+#: ../src/wxMaximaFrame.cpp:833
 msgid "&Factor Expression"
 msgstr "因数分解(&F)"
 
-#: ../src/wxMaximaFrame.cpp:489
+#: ../src/wxMaximaFrame.cpp:488
 msgid "&File"
 msgstr "ファイル(&F)"
 
-#: ../src/wxMaximaFrame.cpp:692
+#: ../src/wxMaximaFrame.cpp:691
 msgid "&Find Root..."
 msgstr "解を1つ探す(&F)"
 
-#: ../src/wxMaximaFrame.cpp:738
+#: ../src/wxMaximaFrame.cpp:737
 msgid "&Generate Matrix..."
 msgstr "文字のみの行列生成(&G)"
 
-#: ../src/wxMaximaFrame.cpp:809
+#: ../src/wxMaximaFrame.cpp:808
 msgid "&Greatest Common Divisor..."
 msgstr "最大公約数(&G)"
 
-#: ../src/wxMaximaFrame.cpp:994
+#: ../src/wxMaximaFrame.cpp:993
 msgid "&Help"
 msgstr "ヘルプ(&H)"
 
-#: ../src/wxMaximaFrame.cpp:777
+#: ../src/wxMaximaFrame.cpp:776
 msgid "&Integrate..."
 msgstr "積分(&I)"
 
-#: ../src/wxMaximaFrame.cpp:645
+#: ../src/wxMaximaFrame.cpp:644
 msgid "&Interrupt\tCtrl-."
 msgstr "処理を強制終了(&I)\tCtrl-"
 
-#: ../src/wxMaximaFrame.cpp:649
+#: ../src/wxMaximaFrame.cpp:648
 msgid "&Interrupt\tCtrl-G"
 msgstr "処理を強制終了(&I)\tCtrl-G"
 
-#: ../src/wxMaximaFrame.cpp:746
+#: ../src/wxMaximaFrame.cpp:745
 msgid "&Invert Matrix"
 msgstr "逆行列(&I)"
 
-#: ../src/wxMaximaFrame.cpp:476
+#: ../src/wxMaximaFrame.cpp:475
 msgid "&Load Package...\tCtrl-L"
 msgstr "パッケージ読込み(&L)\tCtrl-L"
 
-#: ../src/wxMaximaFrame.cpp:769
+#: ../src/wxMaximaFrame.cpp:768
 #, fuzzy
 msgid "&Map to List(s)..."
 msgstr "リストに関数を適用(&M)"
 
-#: ../src/wxMaximaFrame.cpp:684
+#: ../src/wxMaximaFrame.cpp:683
 msgid "&Maxima"
 msgstr "&Maxima"
 
-#: ../src/wxMaximaFrame.cpp:958
+#: ../src/wxMaximaFrame.cpp:957
 msgid "&Maxima help"
 msgstr "Maximaのヘルプ(&M)"
 
-#: ../src/wxMaximaFrame.cpp:917
+#: ../src/wxMaximaFrame.cpp:916
 msgid "&Modulus Computation..."
 msgstr "法を設定する(&M)"
 
@@ -284,7 +284,7 @@ msgstr "法を設定する(&M)"
 msgid "&New\tCtrl-N"
 msgstr "新規(&N)\tCtrl-N"
 
-#: ../src/wxMaximaFrame.cpp:947
+#: ../src/wxMaximaFrame.cpp:946
 msgid "&Numeric"
 msgstr "数値処理(&N)"
 
@@ -300,11 +300,11 @@ msgstr "数式で出力(&N)"
 msgid "&Open\tCtrl-O"
 msgstr "開く(&O)\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:463
+#: ../src/wxMaximaFrame.cpp:462
 msgid "&Open...\tCtrl-O"
 msgstr "開く(&O)\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:929
+#: ../src/wxMaximaFrame.cpp:928
 msgid "&Plot"
 msgstr "プロット(&P)"
 
@@ -312,7 +312,7 @@ msgstr "プロット(&P)"
 msgid "&Power series"
 msgstr "ベキ級数で表示(&P)"
 
-#: ../src/wxMaximaFrame.cpp:483
+#: ../src/wxMaximaFrame.cpp:482
 msgid "&Print...\tCtrl-P"
 msgstr "印刷(&P)\tCtrl-P"
 
@@ -320,39 +320,39 @@ msgstr "印刷(&P)\tCtrl-P"
 msgid "&Rational"
 msgstr "置換の代わりに代入を行う(&R)"
 
-#: ../src/wxMaximaFrame.cpp:870
+#: ../src/wxMaximaFrame.cpp:869
 msgid "&Reduce Trigonometric"
 msgstr "三角関数の結合(&R)"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "&Restart Maxima"
 msgstr "ラベル番号をリセット(&R)"
 
-#: ../src/wxMaximaFrame.cpp:700
+#: ../src/wxMaximaFrame.cpp:699
 msgid "&Roots of Polynomial (Real)"
 msgstr "実数解のみ求める(&R)"
 
-#: ../src/wxMaximaFrame.cpp:472
+#: ../src/wxMaximaFrame.cpp:471
 msgid "&Save\tCtrl-S"
 msgstr "上書き保存(&S)\tCtrl-S"
 
-#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:919
+#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:918
 msgid "&Simplify"
 msgstr "式の変形(&S)"
 
-#: ../src/wxMaximaFrame.cpp:829
+#: ../src/wxMaximaFrame.cpp:828
 msgid "&Simplify Expression"
 msgstr "式の整理(&S)"
 
-#: ../src/wxMaximaFrame.cpp:856
+#: ../src/wxMaximaFrame.cpp:855
 msgid "&Simplify Factorials"
 msgstr "階乗式の整理(&S)"
 
-#: ../src/wxMaximaFrame.cpp:867
+#: ../src/wxMaximaFrame.cpp:866
 msgid "&Simplify Trigonometric"
 msgstr "三角関数の変形(&S)"
 
-#: ../src/wxMaximaFrame.cpp:688
+#: ../src/wxMaximaFrame.cpp:687
 msgid "&Solve..."
 msgstr "方程式を解く(&S)"
 
@@ -364,11 +364,11 @@ msgstr "特殊プロット(&S)"
 msgid "&Taylor series"
 msgstr "テイラー展開を用いる(&T)"
 
-#: ../src/wxMaximaFrame.cpp:762
+#: ../src/wxMaximaFrame.cpp:761
 msgid "&Transpose Matrix"
 msgstr "転置行列(&T)"
 
-#: ../src/wxMaximaFrame.cpp:879
+#: ../src/wxMaximaFrame.cpp:878
 msgid "&Trigonometric Simplification"
 msgstr "三角関数への操作(&T)"
 
@@ -386,7 +386,7 @@ msgstr "（デフォルトの言語を使用）"
 msgid "- Infinity"
 msgstr "－∞"
 
-#: ../src/wxMaxima.cpp:351
+#: ../src/wxMaxima.cpp:356
 msgid ""
 "... [suppressed additional lines since the output is longer than allowed in "
 "the configuration] "
@@ -396,16 +396,16 @@ msgstr ""
 msgid "1/2"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:103
+#: ../src/wxMaximaFrame.cpp:102
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4601
+#: ../src/wxMaxima.cpp:4613
 msgid "<br>Lisp: "
 msgstr "<br>Lisp: "
 
-#: ../src/wxMaxima.cpp:5487
+#: ../src/wxMaxima.cpp:5503
 msgid ""
 "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
@@ -438,11 +438,11 @@ msgid ""
 "\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1472
+#: ../src/wxMaximaFrame.cpp:1495
 msgid "A symbol from the configuration dialogue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:731
+#: ../src/wxMaximaFrame.cpp:730
 msgid "A&t Value..."
 msgstr "初期条件の設定(&T)"
 
@@ -450,12 +450,12 @@ msgstr "初期条件の設定(&T)"
 msgid "Abort evaluation on error"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaxima.cpp:4603
+#: ../src/wxMaxima.cpp:4615 ../src/wxMaximaFrame.cpp:985
 msgid "About"
 msgstr "wxMaximaについて"
 
-#: ../src/wxMaximaFrame.cpp:987 ../src/wxMaximaFrame.cpp:990
-#: ../src/wxMaximaFrame.cpp:991
+#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaximaFrame.cpp:989
+#: ../src/wxMaximaFrame.cpp:990
 msgid "About wxMaxima"
 msgstr "wxMaximaについて"
 
@@ -463,23 +463,23 @@ msgstr "wxMaximaについて"
 msgid "Active cell bracket"
 msgstr "アクティブセル"
 
-#: ../src/wxMaximaFrame.cpp:760
+#: ../src/wxMaximaFrame.cpp:759
 msgid "Ad&joint Matrix"
 msgstr "余因子行列(&J)"
 
-#: ../src/wxMaximaFrame.cpp:914
+#: ../src/wxMaximaFrame.cpp:913
 msgid "Add Algebraic E&quality..."
 msgstr "整数環に多項式の解を追加(&Q)"
 
-#: ../src/wxMaximaFrame.cpp:657
+#: ../src/wxMaximaFrame.cpp:656
 msgid "Add a directory to search path"
 msgstr "Maximaパッケージを検索するディレクトリの追加"
 
-#: ../src/wxMaxima.cpp:3353
+#: ../src/wxMaxima.cpp:3365
 msgid "Add dir to path:"
 msgstr "検索するディレクトリの選択："
 
-#: ../src/wxMaximaFrame.cpp:915
+#: ../src/wxMaximaFrame.cpp:914
 msgid "Add equality to the rational simplifier"
 msgstr "代数的整数環に整数係数の多項式の解を追加"
 
@@ -487,7 +487,7 @@ msgstr "代数的整数環に整数係数の多項式の解を追加"
 msgid "Add the .wxmx file to the HTML export"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:656
+#: ../src/wxMaximaFrame.cpp:655
 msgid "Add to &Path..."
 msgstr "検索するディレクトリを追加(&P)"
 
@@ -529,27 +529,27 @@ msgstr "旧変数："
 msgid "All|*"
 msgstr "すべてのファイル (*.*)|*"
 
-#: ../src/wxMaximaFrame.cpp:1364
+#: ../src/wxMaximaFrame.cpp:1363
 msgid "Alpha"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3838
+#: ../src/wxMaxima.cpp:3850
 msgid "Apply"
 msgstr "リストにコマンドを適用"
 
-#: ../src/wxMaximaFrame.cpp:768
+#: ../src/wxMaximaFrame.cpp:767
 msgid "Apply function to a list"
 msgstr "リストにコマンドを適用（ダイアログの\"関数\"は\"コマンド\"のことです）"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Apropos"
 msgstr "コマンド検索"
 
-#: ../src/wxMaxima.cpp:3764
+#: ../src/wxMaxima.cpp:3776
 msgid "Array:"
 msgstr "文字："
 
-#: ../src/wxMaxima.cpp:4462
+#: ../src/wxMaxima.cpp:4474
 msgid "Artwork by"
 msgstr "アートワーク担当"
 
@@ -557,7 +557,7 @@ msgstr "アートワーク担当"
 msgid "Ask to save untitled documents"
 msgstr "タイトルがないドキュメントを保存するかどうか確認する"
 
-#: ../src/wxMaxima.cpp:3650
+#: ../src/wxMaxima.cpp:3662
 msgid "At value"
 msgstr "初期条件"
 
@@ -578,11 +578,11 @@ msgstr ""
 msgid "Autosave interval (minutes, 0 means: off):"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3557
+#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3569
 msgid "BC2"
 msgstr "境界条件"
 
-#: ../src/wxMaximaFrame.cpp:1272
+#: ../src/wxMaximaFrame.cpp:1271
 msgid "Barsplot..."
 msgstr "棒グラフ"
 
@@ -590,7 +590,7 @@ msgstr "棒グラフ"
 msgid "Bat files (*.bat)|*.bat|All|*"
 msgstr "BAT ファイル (*.bat)|*.bat|すべてのファイル (*.*)|*"
 
-#: ../src/wxMaxima.cpp:2943
+#: ../src/wxMaxima.cpp:2951
 msgid "Batch File"
 msgstr "バッチファイル"
 
@@ -603,7 +603,7 @@ msgid ""
 "cells."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1365
+#: ../src/wxMaximaFrame.cpp:1364
 msgid "Beta"
 msgstr ""
 
@@ -615,11 +615,11 @@ msgstr ""
 msgid "Bold"
 msgstr "太字"
 
-#: ../src/wxMaxima.cpp:2359
+#: ../src/wxMaxima.cpp:2366
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1274
+#: ../src/wxMaximaFrame.cpp:1273
 msgid "Boxplot..."
 msgstr "箱ひげ図"
 
@@ -631,15 +631,15 @@ msgstr "参照"
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2080
+#: ../src/MathCtrl.cpp:2127
 msgid "Bug: Cell left but not entered."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1178
+#: ../src/wxMaxima.cpp:1183
 msgid "Bug: Found a math end marker without any start marker."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1222
+#: ../src/wxMaxima.cpp:1227
 msgid "Bug: Found the end of autocompletion symbols but no beginning"
 msgstr ""
 
@@ -651,22 +651,22 @@ msgstr ""
 msgid "Bug: Fraction without enumerator"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2312
+#: ../src/MathCtrl.cpp:2359
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5839
+#: ../src/MathCtrl.cpp:5891
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of "
 "the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5913
+#: ../src/MathCtrl.cpp:5965
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5882
+#: ../src/MathCtrl.cpp:5934
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
@@ -676,49 +676,49 @@ msgstr ""
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
 msgstr ""
 
-#: ../src/GroupCell.cpp:780 ../src/GroupCell.cpp:951
+#: ../src/GroupCell.cpp:781 ../src/GroupCell.cpp:952
 msgid "Bug: No image counter to write to!"
 msgstr ""
 
-#: ../src/AbsCell.cpp:193
+#: ../src/AbsCell.cpp:199
 msgid "Bug: No last cell in an absCell!"
 msgstr ""
 
-#: ../src/ConjugateCell.cpp:185
+#: ../src/ConjugateCell.cpp:194
 msgid "Bug: No last cell in an conjugateCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:471
+#: ../src/FracCell.cpp:472
 msgid "Bug: No last cell in an denominator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:267
+#: ../src/ExptCell.cpp:270
 msgid "Bug: No last cell in an exponent of an exptCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:459
+#: ../src/FracCell.cpp:460
 msgid "Bug: No last cell in an numerator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:257
+#: ../src/ExptCell.cpp:260
 msgid "Bug: No last cell in the base of an exptCell!"
 msgstr ""
 
-#: ../src/ParenCell.cpp:534
+#: ../src/ParenCell.cpp:535
 msgid "Bug: No last cell inside a parenthesis!"
 msgstr ""
 
-#: ../src/SqrtCell.cpp:312
+#: ../src/SqrtCell.cpp:317
 msgid "Bug: No last cell inside a square root!"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2123
+#: ../src/MathCtrl.cpp:2170
 msgid ""
 "Bug: Start or end of merging of subsequent editing actions was requested two "
 "times in a row."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2090
+#: ../src/MathCtrl.cpp:2137
 msgid "Bug: Text changed, but no active cell."
 msgstr ""
 
@@ -726,39 +726,39 @@ msgstr ""
 msgid "Bug: Trying to append NULL to a group cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:555
+#: ../src/MathCtrl.cpp:600
 msgid "Bug: Trying to append maxima's output to a cell outside the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2014
+#: ../src/MathCtrl.cpp:2061
 msgid ""
 "Bug: Trying to merge individual cell adds to a region in the undo buffer but "
 "there are other cells between them."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6522
+#: ../src/MathCtrl.cpp:6577
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2092
+#: ../src/MathCtrl.cpp:2139
 msgid "Bug: Trying to record a cell contents change without a cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1495
+#: ../src/MathCtrl.cpp:1540
 msgid "Bug: Trying to select inside a cell without having a current cell"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5883
+#: ../src/MathCtrl.cpp:5935
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5844 ../src/MathCtrl.cpp:5918 ../src/MathCtrl.cpp:5952
+#: ../src/MathCtrl.cpp:5896 ../src/MathCtrl.cpp:5970 ../src/MathCtrl.cpp:6004
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:973
+#: ../src/wxMaximaFrame.cpp:972
 msgid "Build &Info"
 msgstr "ビルド情報(&I)"
 
@@ -774,51 +774,51 @@ msgstr ""
 "更するには，メニューバーの「編集」より「設定」ダイアログを開き，「Enterでセル"
 "を評価」にチェックを入れてください。"
 
-#: ../src/wxMaximaFrame.cpp:782
+#: ../src/wxMaximaFrame.cpp:781
 msgid "C&hange Variable..."
 msgstr "変数の置換(&H)"
 
-#: ../src/wxMaximaFrame.cpp:540
+#: ../src/wxMaximaFrame.cpp:539
 msgid "C&onfigure"
 msgstr "設定(&O)"
 
-#: ../src/wxMaximaFrame.cpp:801
+#: ../src/wxMaximaFrame.cpp:800
 msgid "Calculate &Product..."
 msgstr "数列の総乗(&P)"
 
-#: ../src/wxMaximaFrame.cpp:799
+#: ../src/wxMaximaFrame.cpp:798
 msgid "Calculate Su&m..."
 msgstr "数列の総和(&M)"
 
-#: ../src/wxMaximaFrame.cpp:939
+#: ../src/wxMaximaFrame.cpp:938
 msgid "Calculate bigfloat value of the last result"
 msgstr "浮動小数点で出力"
 
-#: ../src/wxMaximaFrame.cpp:936
+#: ../src/wxMaximaFrame.cpp:935
 msgid "Calculate float value of the last result"
 msgstr "小数点で出力"
 
-#: ../src/wxMaxima.cpp:3971
+#: ../src/wxMaxima.cpp:3983
 msgid "Calculate modulus:"
 msgstr "モジュラス（法）の設定:"
 
-#: ../src/wxMaximaFrame.cpp:942
+#: ../src/wxMaximaFrame.cpp:941
 msgid "Calculate numeric value of the last result"
 msgstr "最後の結果を小数点で出力"
 
-#: ../src/wxMaximaFrame.cpp:802
+#: ../src/wxMaximaFrame.cpp:801
 msgid "Calculate products"
 msgstr "総乗を計算"
 
-#: ../src/wxMaximaFrame.cpp:800
+#: ../src/wxMaximaFrame.cpp:799
 msgid "Calculate sums"
 msgstr "総和を計算"
 
-#: ../src/wxMaxima.cpp:5830
+#: ../src/wxMaxima.cpp:5845
 msgid "Can not connect to the web server."
 msgstr "Webサーバーに接続できません"
 
-#: ../src/wxMaxima.cpp:5881
+#: ../src/wxMaxima.cpp:5896
 msgid "Can not download version info."
 msgstr "バージョン情報をダウンロードできません"
 
@@ -834,15 +834,15 @@ msgstr "バージョン情報をダウンロードできません"
 #: ../src/PlotFormatWiz.cpp:48 ../src/SeriesWiz.cpp:49 ../src/SeriesWiz.cpp:51
 #: ../src/SubstituteWiz.cpp:41 ../src/SubstituteWiz.cpp:43 ../src/SumWiz.cpp:44
 #: ../src/SumWiz.cpp:46 ../src/SystemWiz.cpp:38 ../src/SystemWiz.cpp:40
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: ../src/wxMaximaFrame.cpp:126 ../src/wxMaxima.cpp:932
+#: ../src/wxMaxima.cpp:937 ../src/wxMaximaFrame.cpp:125
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1217
+#: ../src/wxMaximaFrame.cpp:1216
 msgid "Canonical (tr)"
 msgstr "整理 (tri)"
 
@@ -850,7 +850,7 @@ msgstr "整理 (tri)"
 msgid "Catalan"
 msgstr "カタロニア語"
 
-#: ../src/wxMaximaFrame.cpp:638
+#: ../src/wxMaximaFrame.cpp:637
 msgid "Ce&ll"
 msgstr "セル(L)"
 
@@ -858,39 +858,39 @@ msgstr "セル(L)"
 msgid "Cell bracket"
 msgstr "セル"
 
-#: ../src/wxMaxima.cpp:5261
+#: ../src/wxMaxima.cpp:5273
 msgid "Cell ends in a backslash"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:676
+#: ../src/wxMaximaFrame.cpp:675
 msgid "Change &2d Display"
 msgstr "出力の表示形式を変更(&2)"
 
-#: ../src/wxMaximaFrame.cpp:677
+#: ../src/wxMaximaFrame.cpp:676
 msgid "Change the 2d display algorithm used to display math output"
 msgstr "数式の出力形式を変更"
 
-#: ../src/wxMaxima.cpp:3995
+#: ../src/wxMaxima.cpp:4007
 msgid "Change variable"
 msgstr "変数の置換"
 
-#: ../src/wxMaximaFrame.cpp:783
+#: ../src/wxMaximaFrame.cpp:782
 msgid "Change variable in integral or sum"
 msgstr "未評価の積分，総和，総乗の変数を置換"
 
-#: ../src/wxMaxima.cpp:3751
+#: ../src/wxMaxima.cpp:3763
 msgid "Char poly"
 msgstr "固有多項式"
 
-#: ../src/wxMaximaFrame.cpp:978
+#: ../src/wxMaximaFrame.cpp:977
 msgid "Check for Updates"
 msgstr "更新の確認"
 
-#: ../src/wxMaximaFrame.cpp:979
+#: ../src/wxMaximaFrame.cpp:978
 msgid "Check if a newer version of wxMaxima/Maxima exist."
 msgstr "wxMaxima/Maxima の最新版がないか確認"
 
-#: ../src/wxMaximaFrame.cpp:1385
+#: ../src/wxMaximaFrame.cpp:1384
 msgid "Chi"
 msgstr ""
 
@@ -911,15 +911,15 @@ msgstr "フォントの選択"
 msgid "Choose new plot format:"
 msgstr "グラフ表示に使用する描画形式を選択："
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710
 msgid "Classes:"
 msgstr "区間の数："
 
-#: ../src/wxMaximaFrame.cpp:469
+#: ../src/wxMaximaFrame.cpp:468
 msgid "Close\tCtrl-W"
 msgstr "閉じる\tCtrl-W"
 
-#: ../src/wxMaximaFrame.cpp:470
+#: ../src/wxMaximaFrame.cpp:469
 msgid "Close window"
 msgstr "ウィンドウを閉じる"
 
@@ -951,19 +951,19 @@ msgstr ""
 msgid "Code highlighting: Variables"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4806
+#: ../src/wxMaxima.cpp:4818
 msgid "Col. names:"
 msgstr "文字変数："
 
-#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Columns:"
 msgstr "列数："
 
-#: ../src/wxMaximaFrame.cpp:860
+#: ../src/wxMaximaFrame.cpp:859
 msgid "Combine factorials in an expression"
 msgstr "与えられた階乗とその係数を結合して一つの階乗に変換"
 
-#: ../src/wxMaxima.cpp:5293
+#: ../src/wxMaxima.cpp:5305
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
@@ -975,24 +975,24 @@ msgstr "各x座標はカンマで区切ってください"
 msgid "Comma separated y coordinates"
 msgstr "各y座標はカンマで区切ってください"
 
-#: ../src/MathCtrl.cpp:1030
+#: ../src/MathCtrl.cpp:1072
 msgid "Comment Selection"
 msgstr "選択をコメント化"
 
-#: ../src/wxMaximaFrame.cpp:533
+#: ../src/wxMaximaFrame.cpp:532
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:532
+#: ../src/wxMaximaFrame.cpp:531
 #, fuzzy
 msgid "Comment selection\tCtrl-/"
 msgstr "選択をコメント化"
 
-#: ../src/wxMaximaFrame.cpp:601
+#: ../src/wxMaximaFrame.cpp:600
 msgid "Complete Word\tCtrl-K"
 msgstr "単語補完\tCtrl-K"
 
-#: ../src/wxMaximaFrame.cpp:602
+#: ../src/wxMaximaFrame.cpp:601
 msgid "Complete word"
 msgstr "単語補完"
 
@@ -1000,36 +1000,36 @@ msgstr "単語補完"
 msgid "Completely stop maxima and restart it"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:823
+#: ../src/wxMaximaFrame.cpp:822
 msgid "Compute continued fraction of a value"
 msgstr ""
 "連分数を求める（連分数の段数はコマンド \"cflength:＜段数＞\"で変更可能）"
 
-#: ../src/wxMaximaFrame.cpp:761
+#: ../src/wxMaximaFrame.cpp:760
 msgid "Compute the adjoint matrix"
 msgstr "余因子行列を求める"
 
-#: ../src/wxMaximaFrame.cpp:750
+#: ../src/wxMaximaFrame.cpp:749
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr "固有多項式を求めます"
 
-#: ../src/wxMaximaFrame.cpp:753
+#: ../src/wxMaximaFrame.cpp:752
 msgid "Compute the determinant of a matrix"
 msgstr "行列式の計算"
 
-#: ../src/wxMaximaFrame.cpp:810
+#: ../src/wxMaximaFrame.cpp:809
 msgid "Compute the greatest common divisor"
 msgstr "最大公約数を求める"
 
-#: ../src/wxMaximaFrame.cpp:747
+#: ../src/wxMaximaFrame.cpp:746
 msgid "Compute the inverse of a matrix"
 msgstr "逆行列を求める"
 
-#: ../src/wxMaximaFrame.cpp:813
+#: ../src/wxMaximaFrame.cpp:812
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr "最小公倍数を求める"
 
-#: ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4868
 msgid "Condition:"
 msgstr ""
 "抽出条件（複数指定可）：\n"
@@ -1044,8 +1044,8 @@ msgstr "設定ファイル (*.ini)|*.ini"
 msgid "Configuration warning"
 msgstr "設定変更の有効化"
 
-#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:538
-#: ../src/wxMaximaFrame.cpp:541
+#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:540
 msgid "Configure wxMaxima"
 msgstr "設定"
 
@@ -1054,132 +1054,134 @@ msgstr "設定"
 msgid "Constant"
 msgstr "定数"
 
-#: ../src/wxMaximaFrame.cpp:844
+#: ../src/wxMaximaFrame.cpp:843
 msgid "Contract Logarithms"
 msgstr "対数の結合"
 
-#: ../src/wxMaximaFrame.cpp:851
+#: ../src/wxMaximaFrame.cpp:850
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr "2項係数，ベータ関数およびガンマ関数を階乗に変換"
 
-#: ../src/wxMaximaFrame.cpp:854
+#: ../src/wxMaximaFrame.cpp:853
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr "2項係数，ベータ関数および階乗をガンマ関数に変換"
 
-#: ../src/wxMaximaFrame.cpp:888
+#: ../src/wxMaximaFrame.cpp:887
 msgid "Convert complex expression to polar form"
 msgstr "複素関数またはその展開形を極形式に変換（指数関数として出力されます）"
 
-#: ../src/wxMaximaFrame.cpp:885
+#: ../src/wxMaximaFrame.cpp:884
 msgid "Convert complex expression to rect form"
 msgstr "複素関数を実変数の関数と虚数iの積の形に変換"
 
-#: ../src/wxMaximaFrame.cpp:897
+#: ../src/wxMaximaFrame.cpp:896
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr "引数が複素数の指数関数を三角関数に変換"
 
-#: ../src/wxMaximaFrame.cpp:842
+#: ../src/wxMaximaFrame.cpp:841
 msgid "Convert logarithm of product to sum of logarithms"
 msgstr ""
 "対数の展開（自動的に展開したい場合はコマンド\"logexpand:super\"を入力）"
 
-#: ../src/wxMaximaFrame.cpp:845
+#: ../src/wxMaximaFrame.cpp:844
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "展開された状態の対数をまとめる"
 
-#: ../src/wxMaximaFrame.cpp:850
+#: ../src/wxMaximaFrame.cpp:849
 msgid "Convert to &Factorials"
 msgstr "階乗に変換(&F)"
 
-#: ../src/wxMaximaFrame.cpp:853
+#: ../src/wxMaximaFrame.cpp:852
 msgid "Convert to &Gamma"
 msgstr "ガンマ関数に変換(&G)"
 
-#: ../src/wxMaximaFrame.cpp:887
+#: ../src/wxMaximaFrame.cpp:886
 msgid "Convert to &Polarform"
 msgstr "複素関数の変換(&P)"
 
-#: ../src/wxMaximaFrame.cpp:884
+#: ../src/wxMaximaFrame.cpp:883
 msgid "Convert to &Rectform"
 msgstr "複素関数の展開(&R)"
 
-#: ../src/wxMaximaFrame.cpp:877
+#: ../src/wxMaximaFrame.cpp:876
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr ""
 "三角関数を含む有理式を整理（引数にｙπが含まれると余計に複雑になる事がありま"
 "す）"
 
-#: ../src/wxMaximaFrame.cpp:900
+#: ../src/wxMaximaFrame.cpp:899
 msgid "Convert trigonometric functions to exponential form"
 msgstr "三角関数および双曲線関数を指数関数に変換"
 
-#: ../src/ToolBar.cpp:140 ../src/MathCtrl.cpp:918 ../src/MathCtrl.cpp:931
-#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1024
+#: ../src/MathCtrl.cpp:960 ../src/MathCtrl.cpp:973 ../src/MathCtrl.cpp:1019
+#: ../src/MathCtrl.cpp:1066 ../src/ToolBar.cpp:140
 msgid "Copy"
 msgstr "コピー"
 
-#: ../src/wxMaximaFrame.cpp:597
+#: ../src/wxMaximaFrame.cpp:596
 msgid "Copy Previous Input\tCtrl-I"
 msgstr "直前の入力を再入力\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:599
+#: ../src/wxMaximaFrame.cpp:598
 msgid "Copy Previous Output\tCtrl-U"
 msgstr "直前の入力を再入力\tCtrl-U"
 
-#: ../src/wxMaximaFrame.cpp:514 ../src/MathCtrl.cpp:936 ../src/MathCtrl.cpp:982
+#: ../src/MathCtrl.cpp:978 ../src/MathCtrl.cpp:1024
+#: ../src/wxMaximaFrame.cpp:513
 msgid "Copy as Image"
 msgstr "画像としてコピー"
 
-#: ../src/wxMaximaFrame.cpp:507 ../src/MathCtrl.cpp:932 ../src/MathCtrl.cpp:978
+#: ../src/MathCtrl.cpp:974 ../src/MathCtrl.cpp:1020
+#: ../src/wxMaximaFrame.cpp:506
 msgid "Copy as LaTeX"
 msgstr "LaTeXとしてコピー"
 
-#: ../src/wxMaximaFrame.cpp:510
+#: ../src/wxMaximaFrame.cpp:509
 #, fuzzy
 msgid "Copy as MathML"
 msgstr "画像としてコピー"
 
-#: ../src/MathCtrl.cpp:935 ../src/MathCtrl.cpp:980
+#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1022
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:504
+#: ../src/wxMaximaFrame.cpp:503
 msgid "Copy as Text\tCtrl-Shift-C"
 msgstr "テキストとしてコピー\tCtrl-Shift-C"
 
-#: ../src/MathCtrl.cpp:933 ../src/MathCtrl.cpp:979
+#: ../src/MathCtrl.cpp:975 ../src/MathCtrl.cpp:1021
 #, fuzzy
 msgid "Copy as plain text"
 msgstr "画像としてコピー"
 
-#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:503
+#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:502
 msgid "Copy selection"
 msgstr "コピー"
 
-#: ../src/wxMaximaFrame.cpp:515
+#: ../src/wxMaximaFrame.cpp:514
 msgid "Copy selection from document as an image"
 msgstr "選択範囲を画像としてコピー"
 
-#: ../src/wxMaximaFrame.cpp:505
+#: ../src/wxMaximaFrame.cpp:504
 msgid "Copy selection from document as text"
 msgstr "選択範囲をテキストとしてコピー"
 
-#: ../src/wxMaximaFrame.cpp:508
+#: ../src/wxMaximaFrame.cpp:507
 msgid "Copy selection from document in LaTeX format"
 msgstr "選択範囲をLaTeXとしてコピー"
 
-#: ../src/wxMaximaFrame.cpp:511
+#: ../src/wxMaximaFrame.cpp:510
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:598
+#: ../src/wxMaximaFrame.cpp:597
 msgid "Create a new cell with previous input"
 msgstr "新しいセルに直前の入力を再入力"
 
-#: ../src/wxMaximaFrame.cpp:600
+#: ../src/wxMaximaFrame.cpp:599
 msgid "Create a new cell with previous output"
 msgstr "直前の入力を再入力して新しいセルを挿入"
 
@@ -1187,15 +1189,15 @@ msgstr "直前の入力を再入力して新しいセルを挿入"
 msgid "Cursor"
 msgstr "カーソル"
 
-#: ../src/ToolBar.cpp:137 ../src/MathCtrl.cpp:1023
+#: ../src/MathCtrl.cpp:1065 ../src/ToolBar.cpp:137
 msgid "Cut"
 msgstr "切り取り"
 
-#: ../src/wxMaximaFrame.cpp:499
+#: ../src/wxMaximaFrame.cpp:498
 msgid "Cut\tCtrl-X"
 msgstr "切り取り\tCtrl-X"
 
-#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:500
+#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:499
 msgid "Cut selection"
 msgstr "切り取り"
 
@@ -1207,18 +1209,18 @@ msgstr "チェコ語"
 msgid "Danish"
 msgstr "デンマーク語"
 
-#: ../src/wxMaxima.cpp:4799 ../src/wxMaxima.cpp:4806 ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4811 ../src/wxMaxima.cpp:4818 ../src/wxMaxima.cpp:4868
 msgid "Data Matrix:"
 msgstr "データ（行列）："
 
-#: ../src/wxMaxima.cpp:4826
+#: ../src/wxMaxima.cpp:4838
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr "データファイル (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698 ../src/wxMaxima.cpp:4712
-#: ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726 ../src/wxMaxima.cpp:4734
-#: ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748 ../src/wxMaxima.cpp:4755
-#: ../src/wxMaxima.cpp:4791
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710 ../src/wxMaxima.cpp:4724
+#: ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738 ../src/wxMaxima.cpp:4746
+#: ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760 ../src/wxMaxima.cpp:4767
+#: ../src/wxMaxima.cpp:4803
 msgid "Data:"
 msgstr "リスト/ベクトル："
 
@@ -1226,7 +1228,7 @@ msgstr "リスト/ベクトル："
 msgid "Debug: watch maxima's stdout stream"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:820
+#: ../src/wxMaximaFrame.cpp:819
 msgid "Decompose rational function to partial fractions"
 msgstr "指定した変数に対して部分分数分解を実行"
 
@@ -1258,47 +1260,47 @@ msgstr ""
 "アニメーションを再生する際のデフォルトのスピード（一秒あたりのフレーム数）を"
 "定義。"
 
-#: ../src/wxMaxima.cpp:3403 ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3415 ../src/wxMaxima.cpp:3424
 msgid "Delete"
 msgstr "削除"
 
-#: ../src/wxMaximaFrame.cpp:667
+#: ../src/wxMaximaFrame.cpp:666
 msgid "Delete F&unction..."
 msgstr "ユーザー定義関数を削除(&U)"
 
-#: ../src/MathCtrl.cpp:939 ../src/MathCtrl.cpp:985
+#: ../src/MathCtrl.cpp:981 ../src/MathCtrl.cpp:1027
 msgid "Delete Selection"
 msgstr "選択を削除"
 
-#: ../src/wxMaximaFrame.cpp:669
+#: ../src/wxMaximaFrame.cpp:668
 msgid "Delete V&ariable..."
 msgstr "ユーザー定義変数を削除(&A)"
 
-#: ../src/wxMaximaFrame.cpp:668
+#: ../src/wxMaximaFrame.cpp:667
 msgid "Delete a function"
 msgstr "ユーザー定義関数を削除"
 
-#: ../src/wxMaximaFrame.cpp:670
+#: ../src/wxMaximaFrame.cpp:669
 msgid "Delete a variable"
 msgstr "ユーザー定義変数を削除"
 
-#: ../src/wxMaximaFrame.cpp:655
+#: ../src/wxMaximaFrame.cpp:654
 msgid "Delete all values from memory"
 msgstr "セルの内容は保持してMaximaを起動した直後の状態にリセット"
 
-#: ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3424
 msgid "Delete function(s):"
 msgstr "削除する関数名の入力："
 
-#: ../src/wxMaxima.cpp:3403
+#: ../src/wxMaxima.cpp:3415
 msgid "Delete variable(s):"
 msgstr "削除する変数の入力："
 
-#: ../src/wxMaximaFrame.cpp:1367
+#: ../src/wxMaximaFrame.cpp:1366
 msgid "Delta"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4011
+#: ../src/wxMaxima.cpp:4023
 msgid "Denom. deg:"
 msgstr "分母の最高次数："
 
@@ -1306,35 +1308,35 @@ msgstr "分母の最高次数："
 msgid "Depth:"
 msgstr "次数の指定："
 
-#: ../src/wxMaxima.cpp:3541
+#: ../src/wxMaxima.cpp:3553
 msgid "Derivative:"
 msgstr "導関数の値："
 
-#: ../src/wxMaximaFrame.cpp:1258
+#: ../src/wxMaximaFrame.cpp:1257
 msgid "Deviation..."
 msgstr "標準偏差"
 
-#: ../src/wxMaximaFrame.cpp:816
+#: ../src/wxMaximaFrame.cpp:815
 msgid "Di&vide Polynomials..."
 msgstr "多項式の除算(&V)"
 
-#: ../src/wxMaximaFrame.cpp:1223
+#: ../src/wxMaximaFrame.cpp:1222
 msgid "Diff..."
 msgstr "微分"
 
-#: ../src/wxMaxima.cpp:4154 ../src/wxMaxima.cpp:5066
+#: ../src/wxMaxima.cpp:4166 ../src/wxMaxima.cpp:5078
 msgid "Differentiate"
 msgstr "微分"
 
-#: ../src/wxMaximaFrame.cpp:786
+#: ../src/wxMaximaFrame.cpp:785
 msgid "Differentiate expression"
 msgstr "微分"
 
-#: ../src/MathCtrl.cpp:1001
+#: ../src/MathCtrl.cpp:1043
 msgid "Differentiate..."
 msgstr "微分"
 
-#: ../src/LimitWiz.cpp:37 ../src/FindReplacePane.cpp:76
+#: ../src/FindReplacePane.cpp:76 ../src/LimitWiz.cpp:37
 msgid "Direction:"
 msgstr "近づき方："
 
@@ -1342,48 +1344,49 @@ msgstr "近づき方："
 msgid "Discrete plot"
 msgstr "座標データプロット"
 
-#: ../src/wxMaximaFrame.cpp:679
+#: ../src/wxMaximaFrame.cpp:678
 msgid "Display Te&X Form"
 msgstr "TeX形式で出力(&X)"
 
-#: ../src/wxMaxima.cpp:3320
+#: ../src/wxMaxima.cpp:3332
 msgid "Display algorithm"
 msgstr "表示形式"
 
-#: ../src/wxMaximaFrame.cpp:680
+#: ../src/wxMaximaFrame.cpp:679
 msgid "Display last result in TeX form"
 msgstr "一番新しい出力をTeX形式で出力"
 
-#: ../src/wxMaximaFrame.cpp:674
+#: ../src/wxMaximaFrame.cpp:673
 msgid "Display time used for evaluation"
 msgstr "計算に要した時間を表示"
 
-#: ../src/wxMaxima.cpp:4061
+#: ../src/wxMaxima.cpp:4073
 msgid "Divide"
 msgstr "除算"
 
-#: ../src/MathCtrl.cpp:1032
+#: ../src/MathCtrl.cpp:1074
 msgid "Divide Cell"
 msgstr "セルの分割"
 
-#: ../src/wxMaximaFrame.cpp:635
+#: ../src/wxMaximaFrame.cpp:634
 #, fuzzy
 msgid "Divide Cell\tCtrl-D"
 msgstr "セルの分割"
 
-#: ../src/wxMaximaFrame.cpp:817
+#: ../src/wxMaximaFrame.cpp:816
 msgid "Divide numbers or polynomials"
 msgstr "[商]および[余り]を出力"
 
-#: ../src/wxMaximaFrame.cpp:636
+#: ../src/wxMaximaFrame.cpp:635
 msgid "Divide this input cell into two cells"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5917
-msgid "Do you want to save the changes you made in the document \""
+#: ../src/wxMaxima.cpp:5932
+#, fuzzy, c-format
+msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr "ドキュメント内での変更を保存しますか"
 
-#: ../src/wxMaxima.cpp:1664 ../src/wxMaxima.cpp:1672
+#: ../src/wxMaxima.cpp:1669 ../src/wxMaxima.cpp:1677
 msgid "Document "
 msgstr "ドキュメント "
 
@@ -1404,7 +1407,7 @@ msgstr ""
 "Maximaの入力テキストを圧縮せず、画像を個別に圧縮します。 これはgitやsvnのよう"
 "なバージョン管理システムが効率的に差異を見つけ出すことを可能にします。"
 
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Don't save"
 msgstr "保存しない"
 
@@ -1412,27 +1415,27 @@ msgstr "保存しない"
 msgid "Down"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:734
+#: ../src/wxMaximaFrame.cpp:733
 msgid "E&quations"
 msgstr "方程式(&Q)"
 
-#: ../src/wxMaximaFrame.cpp:487
+#: ../src/wxMaximaFrame.cpp:486
 msgid "E&xit\tCtrl-Q"
 msgstr "終了(&X)\tCtrl-Q"
 
-#: ../src/wxMaximaFrame.cpp:757
+#: ../src/wxMaximaFrame.cpp:756
 msgid "Eige&nvectors"
 msgstr "固有ベクトル(&N)"
 
-#: ../src/wxMaximaFrame.cpp:755
+#: ../src/wxMaximaFrame.cpp:754
 msgid "Eigen&values"
 msgstr "固有値(&V)"
 
-#: ../src/wxMaxima.cpp:3572
+#: ../src/wxMaxima.cpp:3584
 msgid "Eliminate"
 msgstr "消去"
 
-#: ../src/wxMaximaFrame.cpp:710
+#: ../src/wxMaximaFrame.cpp:709
 msgid "Eliminate a variable from a system of equations"
 msgstr "連立方程式から指定した変数を消去（方程式に代入）"
 
@@ -1444,21 +1447,21 @@ msgstr ""
 msgid "English"
 msgstr "英語"
 
-#: ../src/wxMaxima.cpp:4712 ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726
-#: ../src/wxMaxima.cpp:4734 ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748
-#: ../src/wxMaxima.cpp:4755 ../src/wxMaxima.cpp:4791 ../src/wxMaxima.cpp:4799
+#: ../src/wxMaxima.cpp:4724 ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738
+#: ../src/wxMaxima.cpp:4746 ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760
+#: ../src/wxMaxima.cpp:4767 ../src/wxMaxima.cpp:4803 ../src/wxMaxima.cpp:4811
 msgid "Enter Data"
 msgstr "行列の各成分に任意の値を入力"
 
-#: ../src/wxMaximaFrame.cpp:1279
+#: ../src/wxMaximaFrame.cpp:1278
 msgid "Enter Matrix..."
 msgstr "行列を手入力"
 
-#: ../src/wxMaximaFrame.cpp:745
+#: ../src/wxMaximaFrame.cpp:744
 msgid "Enter a matrix"
 msgstr "行列の各成分に任意の値を入力"
 
-#: ../src/wxMaxima.cpp:3962
+#: ../src/wxMaxima.cpp:3974
 msgid "Enter an equation for rational simplification:"
 msgstr "整数環に解を追加するための整数係数の多項式:"
 
@@ -1470,11 +1473,11 @@ msgstr "変数はカンマで区切ります（例：x,y,…）"
 msgid "Enter evaluates cells"
 msgstr "Enterでセルを評価（改行はShift+Enterに変更されます）"
 
-#: ../src/wxMaxima.cpp:3734
+#: ../src/wxMaxima.cpp:3746
 msgid "Enter matrix"
 msgstr "行列の入力"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 #, fuzzy
 msgid "Enter new precision for bigfloats:"
 msgstr "表示桁数の設定："
@@ -1483,12 +1486,12 @@ msgstr "表示桁数の設定："
 msgid "Enter the path to the Maxima executable."
 msgstr "Maximaの実行ファイルのパスを入力"
 
-#: ../src/wxMaximaFrame.cpp:1368
+#: ../src/wxMaximaFrame.cpp:1367
 #, fuzzy
 msgid "Epsilon"
 msgstr "許容誤差："
 
-#: ../src/wxMaxima.cpp:4208
+#: ../src/wxMaxima.cpp:4220
 msgid "Epsilon:"
 msgstr "許容誤差："
 
@@ -1497,13 +1500,13 @@ msgstr "許容誤差："
 msgid "Equation %d:"
 msgstr "方程式 %d:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:3633
-#: ../src/wxMaxima.cpp:5019
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:3645
+#: ../src/wxMaxima.cpp:5031
 msgid "Equation(s):"
 msgstr "方程式："
 
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3993
-#: ../src/wxMaxima.cpp:4807 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:4005
+#: ../src/wxMaxima.cpp:4819 ../src/wxMaxima.cpp:5045
 msgid "Equation:"
 msgstr "方程式："
 
@@ -1514,77 +1517,77 @@ msgid ""
 "be introduced one into another. Also they are always printed out as 2D maths."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3570
+#: ../src/wxMaxima.cpp:3582
 msgid "Equations:"
 msgstr "方程式："
 
-#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1455
-#: ../src/wxMaxima.cpp:1469 ../src/wxMaxima.cpp:1620 ../src/wxMaxima.cpp:1633
-#: ../src/wxMaxima.cpp:1643 ../src/wxMaxima.cpp:1666 ../src/wxMaxima.cpp:2034
-#: ../src/wxMaxima.cpp:2206 ../src/wxMaxima.cpp:5381 ../src/wxMaxima.cpp:5830
-#: ../src/wxMaxima.cpp:5881
+#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1460
+#: ../src/wxMaxima.cpp:1474 ../src/wxMaxima.cpp:1625 ../src/wxMaxima.cpp:1638
+#: ../src/wxMaxima.cpp:1648 ../src/wxMaxima.cpp:1671 ../src/wxMaxima.cpp:2039
+#: ../src/wxMaxima.cpp:2211 ../src/wxMaxima.cpp:5397 ../src/wxMaxima.cpp:5845
+#: ../src/wxMaxima.cpp:5896
 msgid "Error"
 msgstr "エラー"
 
-#: ../src/wxMaxima.cpp:2886 ../src/wxMaxima.cpp:2900 ../src/wxMaxima.cpp:2913
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617 ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:2894 ../src/wxMaxima.cpp:2908 ../src/wxMaxima.cpp:2921
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629 ../src/wxMaxima.cpp:3740
 msgid "Error!"
 msgstr "エラー"
 
-#: ../src/wxMaximaFrame.cpp:1370
+#: ../src/wxMaximaFrame.cpp:1369
 msgid "Eta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:909
+#: ../src/wxMaximaFrame.cpp:908
 msgid "Evaluate &Noun Forms"
 msgstr "未評価の式を評価(&N)"
 
-#: ../src/wxMaximaFrame.cpp:589
+#: ../src/wxMaximaFrame.cpp:588
 msgid "Evaluate All Cells\tCtrl-Shift-R"
 msgstr "全てのセルを評価\tCtrl-Shift-R"
 
-#: ../src/wxMaximaFrame.cpp:587
+#: ../src/wxMaximaFrame.cpp:586
 msgid "Evaluate All Visible Cells\tCtrl-R"
 msgstr "表示されている全てのセルを評価\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:585 ../src/MathCtrl.cpp:942
+#: ../src/MathCtrl.cpp:984 ../src/wxMaximaFrame.cpp:584
 msgid "Evaluate Cell(s)"
 msgstr "セルを評価"
 
-#: ../src/wxMaximaFrame.cpp:591
+#: ../src/wxMaximaFrame.cpp:590
 #, fuzzy
 msgid "Evaluate Cells Above\tCtrl-Shift-P"
 msgstr "全てのセルを評価\tCtrl-Shift-R"
 
-#: ../src/MathCtrl.cpp:956 ../src/MathCtrl.cpp:1051
+#: ../src/MathCtrl.cpp:998 ../src/MathCtrl.cpp:1093
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:961 ../src/MathCtrl.cpp:1053
+#: ../src/MathCtrl.cpp:1003 ../src/MathCtrl.cpp:1095
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:971 ../src/MathCtrl.cpp:1057
+#: ../src/MathCtrl.cpp:1013 ../src/MathCtrl.cpp:1099
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:966 ../src/MathCtrl.cpp:1055
+#: ../src/MathCtrl.cpp:1008 ../src/MathCtrl.cpp:1097
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:586
+#: ../src/wxMaximaFrame.cpp:585
 msgid "Evaluate active or selected cell(s)"
 msgstr "アクティブ/選択セルを評価"
 
-#: ../src/wxMaximaFrame.cpp:590
+#: ../src/wxMaximaFrame.cpp:589
 msgid "Evaluate all cells in the document"
 msgstr "全てのセルを評価"
 
-#: ../src/wxMaximaFrame.cpp:910
+#: ../src/wxMaximaFrame.cpp:909
 msgid "Evaluate all noun forms in expression"
 msgstr "'integrateのような未評価の式を評価"
 
-#: ../src/wxMaximaFrame.cpp:588
+#: ../src/wxMaximaFrame.cpp:587
 msgid "Evaluate all visible cells in the document"
 msgstr "ドキュメント内の全てのセルを評価"
 
@@ -1597,7 +1600,7 @@ msgstr ""
 msgid "Evaluate to point"
 msgstr "未評価の式を評価(&N)"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Example"
 msgstr "使用例"
 
@@ -1610,31 +1613,31 @@ msgstr "テキストの例"
 msgid "Examples:"
 msgstr "使用例"
 
-#: ../src/wxMaximaFrame.cpp:488
+#: ../src/wxMaximaFrame.cpp:487
 msgid "Exit wxMaxima"
 msgstr "wxMaximaを終了"
 
-#: ../src/wxMaximaFrame.cpp:1214
+#: ../src/wxMaximaFrame.cpp:1213
 msgid "Expand"
 msgstr "展開"
 
-#: ../src/wxMaximaFrame.cpp:1219
+#: ../src/wxMaximaFrame.cpp:1218
 msgid "Expand (tr)"
 msgstr "展開 (tri)"
 
-#: ../src/MathCtrl.cpp:997
+#: ../src/MathCtrl.cpp:1039
 msgid "Expand Expression"
 msgstr "展開"
 
-#: ../src/wxMaximaFrame.cpp:841
+#: ../src/wxMaximaFrame.cpp:840
 msgid "Expand Logarithms"
 msgstr "対数の展開"
 
-#: ../src/wxMaximaFrame.cpp:840
+#: ../src/wxMaximaFrame.cpp:839
 msgid "Expand an expression"
 msgstr "展開"
 
-#: ../src/wxMaximaFrame.cpp:874
+#: ../src/wxMaximaFrame.cpp:873
 msgid "Expand trigonometric expression"
 msgstr "三角関数および双曲線関数の展開"
 
@@ -1642,7 +1645,7 @@ msgstr "三角関数および双曲線関数の展開"
 msgid "Expected the icon files to be found at"
 msgstr ""
 
-#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2834
+#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2842
 msgid "Export"
 msgstr "エクスポート"
 
@@ -1653,33 +1656,33 @@ msgstr ""
 "TeXにアニメーションを出力(ただしPDF閲覧ソフトがこの機能をサポートしている場合"
 "のみ画像が動きます)"
 
-#: ../src/wxMaximaFrame.cpp:481
+#: ../src/wxMaximaFrame.cpp:480
 msgid "Export document to a HTML or pdfLaTeX file"
 msgstr "HTML/TeX形式でエクスポート"
 
-#: ../src/wxMaximaFrame.cpp:253
+#: ../src/wxMaximaFrame.cpp:252
 #, fuzzy
 msgid "Export failed."
 msgstr "エクスポートに失敗しました"
 
-#: ../src/wxMaximaFrame.cpp:239
+#: ../src/wxMaximaFrame.cpp:238
 msgid "Export successful."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2913
+#: ../src/wxMaxima.cpp:2921
 msgid "Exporting to HTML failed!"
 msgstr "エクスポートに失敗しました"
 
-#: ../src/wxMaxima.cpp:2886
+#: ../src/wxMaxima.cpp:2894
 msgid "Exporting to TeX failed!"
 msgstr "エクスポートに失敗しました"
 
-#: ../src/wxMaxima.cpp:2900
+#: ../src/wxMaxima.cpp:2908
 #, fuzzy
 msgid "Exporting to maxima batch file failed!"
 msgstr "エクスポートに失敗しました"
 
-#: ../src/wxMaximaFrame.cpp:229
+#: ../src/wxMaximaFrame.cpp:228
 #, fuzzy
 msgid "Exporting..."
 msgstr "エクスポート(&E)"
@@ -1693,42 +1696,42 @@ msgid "Expression(s):"
 msgstr "関数："
 
 #: ../src/IntegrateWiz.cpp:30 ../src/LimitWiz.cpp:27 ../src/SeriesWiz.cpp:33
-#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3648
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:4205 ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5064
+#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3660
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:4217 ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5076
 msgid "Expression:"
 msgstr "関数："
 
-#: ../src/wxMaximaFrame.cpp:1213
+#: ../src/wxMaximaFrame.cpp:1212
 msgid "Factor"
 msgstr "因数分解"
 
-#: ../src/wxMaximaFrame.cpp:836
+#: ../src/wxMaximaFrame.cpp:835
 msgid "Factor Complex"
 msgstr "複素数の範囲で因数分解"
 
-#: ../src/MathCtrl.cpp:996
+#: ../src/MathCtrl.cpp:1038
 msgid "Factor Expression"
 msgstr "因数分解"
 
-#: ../src/wxMaximaFrame.cpp:835
+#: ../src/wxMaximaFrame.cpp:834
 msgid "Factor an expression"
 msgstr "因数分解（素因数分解も可能）"
 
-#: ../src/wxMaximaFrame.cpp:837
+#: ../src/wxMaximaFrame.cpp:836
 msgid "Factor an expression in Gaussian numbers"
 msgstr "複素数の範囲で因数分解"
 
-#: ../src/wxMaximaFrame.cpp:862
+#: ../src/wxMaximaFrame.cpp:861
 msgid "Factorials and &Gamma"
 msgstr "階乗とガンマ関数(&G)"
 
-#: ../src/wxMaxima.cpp:285
+#: ../src/wxMaxima.cpp:286
 msgid "Fatal error"
 msgstr "致命的なエラー"
 
-#: ../src/GroupCell.cpp:1571
+#: ../src/GroupCell.cpp:1572
 #, c-format
 msgid "Figure %d:"
 msgstr "図 %d:"
@@ -1737,22 +1740,22 @@ msgstr "図 %d:"
 msgid "File"
 msgstr "ファイル"
 
-#: ../src/wxMaxima.cpp:1457 ../src/wxMaxima.cpp:1623 ../src/wxMaxima.cpp:1636
-#: ../src/wxMaxima.cpp:1646 ../src/wxMaxima.cpp:1668
+#: ../src/wxMaxima.cpp:1462 ../src/wxMaxima.cpp:1628 ../src/wxMaxima.cpp:1641
+#: ../src/wxMaxima.cpp:1651 ../src/wxMaxima.cpp:1673
 #, fuzzy
 msgid "File could not be opened"
 msgstr "ファイルが見つかりません"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File not found"
 msgstr "ファイルが見つかりません"
 
-#: ../src/wxMaxima.cpp:1511 ../src/wxMaxima.cpp:1729
+#: ../src/wxMaxima.cpp:1516 ../src/wxMaxima.cpp:1734
 #, fuzzy
 msgid "File opened"
 msgstr "ファイルが見つかりません"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File you tried to open does not exist."
 msgstr ""
 "開こうとしたファイルは\n"
@@ -1766,69 +1769,69 @@ msgstr "EPS形式で出力："
 msgid "Find"
 msgstr "検索"
 
-#: ../src/wxMaximaFrame.cpp:523
+#: ../src/wxMaximaFrame.cpp:522
 msgid "Find\tCtrl-F"
 msgstr "テキストを検索\tCtrl-F"
 
-#: ../src/wxMaximaFrame.cpp:787
+#: ../src/wxMaximaFrame.cpp:786
 msgid "Find &Limit..."
 msgstr "極限値(&L)"
 
-#: ../src/wxMaximaFrame.cpp:790
+#: ../src/wxMaximaFrame.cpp:789
 msgid "Find Minimum..."
 msgstr "極小値"
 
-#: ../src/MathCtrl.cpp:993
+#: ../src/MathCtrl.cpp:1035
 msgid "Find Root..."
 msgstr "解を1つ探す"
 
-#: ../src/wxMaximaFrame.cpp:791
+#: ../src/wxMaximaFrame.cpp:790
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr "正しい極小値を得るには開始位置の値を極小値の付近に設定してください"
 
-#: ../src/wxMaximaFrame.cpp:788
+#: ../src/wxMaximaFrame.cpp:787
 msgid "Find a limit of an expression"
 msgstr "極限値を求める"
 
-#: ../src/wxMaximaFrame.cpp:693
+#: ../src/wxMaximaFrame.cpp:692
 msgid "Find a root of an equation on an interval"
 msgstr "定義域内で解を1つ探す（定義域の両端の符号が同じ場合エラーを出します）"
 
-#: ../src/wxMaximaFrame.cpp:695
+#: ../src/wxMaximaFrame.cpp:694
 msgid "Find all roots of a polynomial"
 msgstr "方程式の解を小数で求める"
 
-#: ../src/wxMaximaFrame.cpp:698
+#: ../src/wxMaximaFrame.cpp:697
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr "方程式の解を浮動小数点で求める"
 
-#: ../src/wxMaxima.cpp:3220
+#: ../src/wxMaxima.cpp:3215
 msgid "Find and Replace"
 msgstr "検索と置換"
 
-#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:523
+#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:522
 msgid "Find and replace"
 msgstr "検索と置換"
 
-#: ../src/wxMaximaFrame.cpp:756
+#: ../src/wxMaximaFrame.cpp:755
 msgid "Find eigenvalues of a matrix"
 msgstr "固有値を求める（[固有値],[各固有値の重複]の順に表示）"
 
-#: ../src/wxMaximaFrame.cpp:758
+#: ../src/wxMaximaFrame.cpp:757
 msgid "Find eigenvectors of a matrix"
 msgstr ""
 "固有ベクトルを求める（[固有値],[各固有値の重複],[各固有値での固有ベクトル]の"
 "順に表示）"
 
-#: ../src/wxMaxima.cpp:4210
+#: ../src/wxMaxima.cpp:4222
 msgid "Find minimum"
 msgstr "極小値"
 
-#: ../src/wxMaximaFrame.cpp:701
+#: ../src/wxMaximaFrame.cpp:700
 msgid "Find real roots of a polynomial"
 msgstr "方程式の実数解を有理数で求める"
 
-#: ../src/wxMaxima.cpp:3493 ../src/wxMaxima.cpp:5036
+#: ../src/wxMaxima.cpp:3505 ../src/wxMaxima.cpp:5048
 msgid "Find root"
 msgstr "解を1つ探す"
 
@@ -1851,11 +1854,11 @@ msgstr "記録された参照インデックス（%i、%o）を保存前に固�
 msgid "Fixed font in text controls"
 msgstr "テキスト入力ボックスで固定幅フォントを使用"
 
-#: ../src/wxMaximaFrame.cpp:623
+#: ../src/wxMaximaFrame.cpp:622
 msgid "Fold All\tCtrl-Alt-["
 msgstr "全て折りたたむ\tCtrl-Alt-["
 
-#: ../src/wxMaximaFrame.cpp:624
+#: ../src/wxMaximaFrame.cpp:623
 msgid "Fold all sections"
 msgstr "すべてのセクションを折りたたむ"
 
@@ -1863,25 +1866,25 @@ msgstr "すべてのセクションを折りたたむ"
 msgid "Follow"
 msgstr ""
 
-#: ../src/ParenCell.cpp:319
+#: ../src/ParenCell.cpp:320
 msgid "Font issue: The Parenthesis sign is too small!"
 msgstr ""
 
-#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:381
+#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:382
 msgid ""
 "Font issue: The char height is too small! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:199
+#: ../src/SqrtCell.cpp:202
 msgid ""
 "Font issue: The sqrt() sign has the size 0! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:198
+#: ../src/SqrtCell.cpp:201
 msgid "Font issue? The contents of a sqrt() has the size 0."
 msgstr ""
 
@@ -1912,15 +1915,15 @@ msgstr "フランス語"
 
 #: ../src/IntegrateWiz.cpp:37 ../src/Plot2dWiz.cpp:37 ../src/Plot2dWiz.cpp:47
 #: ../src/Plot2dWiz.cpp:536 ../src/Plot3dWiz.cpp:36 ../src/Plot3dWiz.cpp:45
-#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4240
+#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4252
 msgid "From:"
 msgstr "下端："
 
-#: ../src/wxMaximaFrame.cpp:576
+#: ../src/wxMaximaFrame.cpp:575
 msgid "Full Screen\tAlt-Enter"
 msgstr "全画面表示\tAlt-Enter"
 
-#: ../src/wxMaxima.cpp:3342
+#: ../src/wxMaxima.cpp:3354
 msgid "Function"
 msgstr "表示"
 
@@ -1928,32 +1931,32 @@ msgstr "表示"
 msgid "Function names"
 msgstr "ユーザー定義関数名"
 
-#: ../src/wxMaxima.cpp:3633
+#: ../src/wxMaxima.cpp:3645
 msgid "Function(s):"
 msgstr "関数："
 
-#: ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3803
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3815
+#: ../src/wxMaxima.cpp:3848
 msgid "Function:"
 msgstr "関数："
 
-#: ../src/wxMaximaFrame.cpp:904
+#: ../src/wxMaximaFrame.cpp:903
 msgid "Functions for complex simplification"
 msgstr "複素関数をを単純化するための機能"
 
-#: ../src/wxMaximaFrame.cpp:864
+#: ../src/wxMaximaFrame.cpp:863
 msgid "Functions for simplifying factorials and gamma function"
 msgstr "階乗とガンマ関数を単純化するための機能"
 
-#: ../src/wxMaximaFrame.cpp:881
+#: ../src/wxMaximaFrame.cpp:880
 msgid "Functions for simplifying trigonometric expressions"
 msgstr "三角関数をを単純化するための機能"
 
-#: ../src/wxMaxima.cpp:4046
+#: ../src/wxMaxima.cpp:4058
 msgid "GCD"
 msgstr "最大公約数"
 
-#: ../src/wxMaxima.cpp:5152
+#: ../src/wxMaxima.cpp:5164
 msgid "GIF image (*.gif)|*.gif"
 msgstr "GIF ファイル (*.gif)|*.gif"
 
@@ -1961,31 +1964,31 @@ msgstr "GIF ファイル (*.gif)|*.gif"
 msgid "Galician"
 msgstr "ガリシア語"
 
-#: ../src/wxMaximaFrame.cpp:1366
+#: ../src/wxMaximaFrame.cpp:1365
 msgid "Gamma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:391
+#: ../src/wxMaximaFrame.cpp:390
 msgid "General Math"
 msgstr "数式処理"
 
-#: ../src/wxMaximaFrame.cpp:549
+#: ../src/wxMaximaFrame.cpp:548
 msgid "General Math\tAlt-Shift-M"
 msgstr "数式処理\tAlt-Shift-M"
 
-#: ../src/wxMaxima.cpp:3766 ../src/wxMaxima.cpp:3785
+#: ../src/wxMaxima.cpp:3778 ../src/wxMaxima.cpp:3797
 msgid "Generate Matrix"
 msgstr "行列生成"
 
-#: ../src/wxMaximaFrame.cpp:741
+#: ../src/wxMaximaFrame.cpp:740
 msgid "Generate Matrix from Expression..."
 msgstr "関数から行列生成"
 
-#: ../src/wxMaximaFrame.cpp:739
+#: ../src/wxMaximaFrame.cpp:738
 msgid "Generate a matrix from a 2-dimensional array"
 msgstr "文字のみの行列を生成"
 
-#: ../src/wxMaximaFrame.cpp:742
+#: ../src/wxMaximaFrame.cpp:741
 msgid "Generate a matrix from a lambda expression"
 msgstr "i行j列の成分に関数f(i,j)の値を代入"
 
@@ -1993,40 +1996,40 @@ msgstr "i行j列の成分に関数f(i,j)の値を代入"
 msgid "German"
 msgstr "ドイツ語"
 
-#: ../src/wxMaximaFrame.cpp:893
+#: ../src/wxMaximaFrame.cpp:892
 msgid "Get &Imaginary Part"
 msgstr "虚部を取り出す(&I)"
 
-#: ../src/wxMaximaFrame.cpp:793
+#: ../src/wxMaximaFrame.cpp:792
 msgid "Get &Series..."
 msgstr "テイラー展開(&S)"
 
-#: ../src/wxMaximaFrame.cpp:804
+#: ../src/wxMaximaFrame.cpp:803
 msgid "Get Laplace transformation of an expression"
 msgstr "ラプラス変換を求める"
 
-#: ../src/wxMaximaFrame.cpp:890
+#: ../src/wxMaximaFrame.cpp:889
 msgid "Get Real P&art"
 msgstr "実部を取り出す(&A)"
 
-#: ../src/wxMaximaFrame.cpp:807
+#: ../src/wxMaximaFrame.cpp:806
 msgid "Get inverse Laplace transformation of an expression"
 msgstr ""
 "ラプラス逆変換を求めます（分母の多項式は各次数が定まっている必要があります）"
 
-#: ../src/wxMaximaFrame.cpp:794
+#: ../src/wxMaximaFrame.cpp:793
 msgid "Get the Taylor or power series of expression"
 msgstr "テイラー級数またはそのベキ級数を求める"
 
-#: ../src/wxMaximaFrame.cpp:894
+#: ../src/wxMaximaFrame.cpp:893
 msgid "Get the imaginary part of complex expression"
 msgstr "複素関数から虚部を取り出す"
 
-#: ../src/wxMaximaFrame.cpp:891
+#: ../src/wxMaximaFrame.cpp:890
 msgid "Get the real part of complex expression"
 msgstr "複素関数から実部を取り出す"
 
-#: ../src/MathCtrl.cpp:5932
+#: ../src/MathCtrl.cpp:5984
 msgid ""
 "Got a request to undo an action that involves an delete which isn't possible "
 "at this moment."
@@ -2036,12 +2039,12 @@ msgstr ""
 msgid "Greek"
 msgstr "ギリシャ語"
 
-#: ../src/wxMaximaFrame.cpp:356
+#: ../src/wxMaximaFrame.cpp:355
 #, fuzzy
 msgid "Greek Letters"
 msgstr "ギリシャ文字"
 
-#: ../src/wxMaximaFrame.cpp:552
+#: ../src/wxMaximaFrame.cpp:551
 #, fuzzy
 msgid "Greek Letters\tAlt-Shift-G"
 msgstr "数式処理\tAlt-Shift-M"
@@ -2054,7 +2057,7 @@ msgstr "ギリシャ文字"
 msgid "Grid:"
 msgstr "グラフの滑らかさ（y）："
 
-#: ../src/wxMaxima.cpp:2836
+#: ../src/wxMaxima.cpp:2844
 #, fuzzy
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|pdfLaTeX file (*."
@@ -2071,12 +2074,12 @@ msgstr ""
 msgid "Help"
 msgstr "ヘルプ"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 #, fuzzy
 msgid "Hide All Toolbars\tAlt-Shift--"
 msgstr "全て隠す\tAlt-Shift--"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide all panes"
 msgstr "サイドバーのツールを全て隠す"
 
@@ -2084,19 +2087,19 @@ msgstr "サイドバーのツールを全て隠す"
 msgid "Highlight (dpart)"
 msgstr "強調コマンド(dpartなど)の出力"
 
-#: ../src/wxMaxima.cpp:4685
+#: ../src/wxMaxima.cpp:4697
 msgid "Histogram"
 msgstr "ヒストグラム"
 
-#: ../src/wxMaximaFrame.cpp:1270
+#: ../src/wxMaximaFrame.cpp:1269
 msgid "Histogram..."
 msgstr "ヒストグラム"
 
-#: ../src/wxMaximaFrame.cpp:309
+#: ../src/wxMaximaFrame.cpp:308
 msgid "History"
 msgstr "入力履歴"
 
-#: ../src/wxMaximaFrame.cpp:555
+#: ../src/wxMaximaFrame.cpp:554
 #, fuzzy
 msgid "History\tAlt-Shift-I"
 msgstr "入力履歴\tAlt-Shift-H"
@@ -2116,11 +2119,11 @@ msgstr ""
 msgid "Hungarian"
 msgstr "ハンガリー語"
 
-#: ../src/wxMaxima.cpp:3527
+#: ../src/wxMaxima.cpp:3539
 msgid "IC1"
 msgstr "特殊解"
 
-#: ../src/wxMaxima.cpp:3543
+#: ../src/wxMaxima.cpp:3555
 msgid "IC2"
 msgstr "特殊解"
 
@@ -2136,7 +2139,7 @@ msgid ""
 "same output cell."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:683
+#: ../src/wxMaximaFrame.cpp:682
 msgid ""
 "If maxima ever finishes evaluating without wxMaxima realizing this this menu "
 "item can force wxMaxima to try to send commands to maxima again."
@@ -2202,11 +2205,11 @@ msgstr ""
 "もし入力セルの評価に時間がかかるようであれば、メニューバーの「Maxima」より"
 "「処理を強制終了」または「ラベル番号をリセット」を実行して下さい。"
 
-#: ../src/wxMaximaFrame.cpp:1499
+#: ../src/wxMaximaFrame.cpp:1518
 msgid "Image"
 msgstr "画像"
 
-#: ../src/wxMaxima.cpp:5644
+#: ../src/wxMaxima.cpp:5659
 msgid "Image files (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 msgstr "画像ファイル (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 
@@ -2235,7 +2238,7 @@ msgstr ""
 "LaTeXへの出力において、指数を最後の下付き文字の上部ではなく、後方に配置。 い"
 "くつかのフォントや短い下付き文字の読みやすさを向上させる可能性があります。"
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Include columns:"
 msgstr "抽出列"
 
@@ -2254,19 +2257,19 @@ msgstr ""
 msgid "Infinity"
 msgstr "∞"
 
-#: ../src/wxMaximaFrame.cpp:974
+#: ../src/wxMaximaFrame.cpp:973
 msgid "Info about Maxima build"
 msgstr "ビルド情報の表示"
 
-#: ../src/wxMaxima.cpp:4207
+#: ../src/wxMaxima.cpp:4219
 msgid "Initial Estimates:"
 msgstr "開始位置："
 
-#: ../src/wxMaximaFrame.cpp:718
+#: ../src/wxMaximaFrame.cpp:717
 msgid "Initial Value Problem (&1)..."
 msgstr "特殊解を求める（&1階微分方程式）"
 
-#: ../src/wxMaximaFrame.cpp:721
+#: ../src/wxMaximaFrame.cpp:720
 msgid "Initial Value Problem (&2)..."
 msgstr "特殊解を求める（&2階微分方程式）"
 
@@ -2274,7 +2277,7 @@ msgstr "特殊解を求める（&2階微分方程式）"
 msgid "Input labels"
 msgstr "入力ラベル"
 
-#: ../src/wxMaximaFrame.cpp:403
+#: ../src/wxMaximaFrame.cpp:402
 msgid "Insert"
 msgstr "挿入"
 
@@ -2282,98 +2285,98 @@ msgstr "挿入"
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr "セルの最初で演算子の前に「%」を挿入"
 
-#: ../src/wxMaximaFrame.cpp:612
+#: ../src/wxMaximaFrame.cpp:611
 msgid "Insert &Section Cell\tCtrl-3"
 msgstr "セクションセルの挿入(&S)\tCtrl-3"
 
-#: ../src/wxMaximaFrame.cpp:608
+#: ../src/wxMaximaFrame.cpp:607
 msgid "Insert &Text Cell\tCtrl-1"
 msgstr "テキストセルの挿入(&T)\tCtrl-1"
 
-#: ../src/wxMaximaFrame.cpp:558
+#: ../src/wxMaximaFrame.cpp:557
 msgid "Insert Cell\tAlt-Shift-C"
 msgstr "セルの挿入\tAlt-Shift-C"
 
-#: ../src/wxMaxima.cpp:5642
+#: ../src/wxMaxima.cpp:5657
 msgid "Insert Image"
 msgstr "画像の挿入"
 
-#: ../src/wxMaximaFrame.cpp:620
+#: ../src/wxMaximaFrame.cpp:619
 msgid "Insert Image..."
 msgstr "画像の挿入"
 
-#: ../src/wxMaximaFrame.cpp:606
+#: ../src/wxMaximaFrame.cpp:605
 msgid "Insert Input &Cell"
 msgstr "入力セルの挿入(&C)"
 
-#: ../src/wxMaximaFrame.cpp:618
+#: ../src/wxMaximaFrame.cpp:617
 msgid "Insert Page Break"
 msgstr "改ページの挿入"
 
-#: ../src/wxMaximaFrame.cpp:614
+#: ../src/wxMaximaFrame.cpp:613
 msgid "Insert S&ubsection Cell\tCtrl-4"
 msgstr "サブセクションセルの挿入(&U)\tCtrl-4"
 
-#: ../src/wxMaximaFrame.cpp:616
+#: ../src/wxMaximaFrame.cpp:615
 #, fuzzy
 msgid "Insert S&ubsubsection Cell\tCtrl-5"
 msgstr "サブセクションセルの挿入(&U)\tCtrl-4"
 
-#: ../src/MathCtrl.cpp:1015
+#: ../src/MathCtrl.cpp:1057
 msgid "Insert Section Cell"
 msgstr "セクションセルの挿入"
 
-#: ../src/MathCtrl.cpp:1016
+#: ../src/MathCtrl.cpp:1058
 msgid "Insert Subsection Cell"
 msgstr "サブセクションセルの挿入"
 
-#: ../src/MathCtrl.cpp:1017
+#: ../src/MathCtrl.cpp:1059
 #, fuzzy
 msgid "Insert Subsubsection Cell"
 msgstr "サブセクションセルの挿入"
 
-#: ../src/wxMaximaFrame.cpp:610
+#: ../src/wxMaximaFrame.cpp:609
 msgid "Insert T&itle Cell\tCtrl-2"
 msgstr "タイトルセルの挿入(&I)\tCtrl-2"
 
-#: ../src/MathCtrl.cpp:1013
+#: ../src/MathCtrl.cpp:1055
 msgid "Insert Text Cell"
 msgstr "テキストセルの挿入"
 
-#: ../src/MathCtrl.cpp:1014
+#: ../src/MathCtrl.cpp:1056
 msgid "Insert Title Cell"
 msgstr "タイトルセルの挿入"
 
-#: ../src/wxMaximaFrame.cpp:607
+#: ../src/wxMaximaFrame.cpp:606
 msgid "Insert a new input cell"
 msgstr "入力セルを挿入"
 
-#: ../src/wxMaximaFrame.cpp:613
+#: ../src/wxMaximaFrame.cpp:612
 msgid "Insert a new section cell"
 msgstr "セクションセルを挿入"
 
-#: ../src/wxMaximaFrame.cpp:615
+#: ../src/wxMaximaFrame.cpp:614
 msgid "Insert a new subsection cell"
 msgstr "サブセクションセルを挿入"
 
-#: ../src/wxMaximaFrame.cpp:617
+#: ../src/wxMaximaFrame.cpp:616
 #, fuzzy
 msgid "Insert a new subsubsection cell"
 msgstr "サブセクションセルを挿入"
 
-#: ../src/wxMaximaFrame.cpp:609
+#: ../src/wxMaximaFrame.cpp:608
 msgid "Insert a new text cell"
 msgstr "テキストセルを挿入"
 
-#: ../src/wxMaximaFrame.cpp:611
+#: ../src/wxMaximaFrame.cpp:610
 msgid "Insert a new title cell"
 msgstr "タイトルセルを挿入"
 
-#: ../src/wxMaximaFrame.cpp:619
+#: ../src/wxMaximaFrame.cpp:618
 msgid "Insert a page break"
 msgstr "改ページを挿入"
 
-#: ../src/wxMaximaFrame.cpp:621
+#: ../src/wxMaximaFrame.cpp:620
 msgid "Insert image"
 msgstr "画像を挿入"
 
@@ -2386,27 +2389,27 @@ msgstr ""
 msgid "Integral sign"
 msgstr "積分"
 
-#: ../src/wxMaxima.cpp:3992
+#: ../src/wxMaxima.cpp:4004
 msgid "Integral/Sum:"
 msgstr "未評価の式："
 
-#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4105 ../src/wxMaxima.cpp:5051
+#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4117 ../src/wxMaxima.cpp:5063
 msgid "Integrate"
 msgstr "積分"
 
-#: ../src/wxMaxima.cpp:4091
+#: ../src/wxMaxima.cpp:4103
 msgid "Integrate (risch)"
 msgstr "Risch積分"
 
-#: ../src/wxMaximaFrame.cpp:778
+#: ../src/wxMaximaFrame.cpp:777
 msgid "Integrate expression"
 msgstr "積分"
 
-#: ../src/wxMaximaFrame.cpp:780
+#: ../src/wxMaximaFrame.cpp:779
 msgid "Integrate expression with Risch algorithm"
 msgstr "Rishのアルゴリズムによる積分"
 
-#: ../src/wxMaximaFrame.cpp:1224 ../src/MathCtrl.cpp:1000
+#: ../src/MathCtrl.cpp:1042 ../src/wxMaximaFrame.cpp:1223
 msgid "Integrate..."
 msgstr "積分"
 
@@ -2414,7 +2417,7 @@ msgstr "積分"
 msgid "Interrupt"
 msgstr "強制終了"
 
-#: ../src/wxMaximaFrame.cpp:646 ../src/wxMaximaFrame.cpp:650
+#: ../src/wxMaximaFrame.cpp:645 ../src/wxMaximaFrame.cpp:649
 msgid "Interrupt current computation"
 msgstr "処理を強制終了"
 
@@ -2434,15 +2437,15 @@ msgstr ""
 "\n"
 "Maximaプログラムへのパスを再度入力してください"
 
-#: ../src/wxMaxima.cpp:4137
+#: ../src/wxMaxima.cpp:4149
 msgid "Inverse Laplace"
 msgstr "ラプラス逆変換"
 
-#: ../src/wxMaximaFrame.cpp:806
+#: ../src/wxMaximaFrame.cpp:805
 msgid "Inverse Laplace T&ransform..."
 msgstr "ラプラス逆変換(&R)"
 
-#: ../src/wxMaximaFrame.cpp:1372
+#: ../src/wxMaximaFrame.cpp:1371
 msgid "Iota"
 msgstr ""
 
@@ -2476,7 +2479,7 @@ msgstr "日本語"
 msgid "Kabyle"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1373
+#: ../src/wxMaximaFrame.cpp:1372
 msgid "Kappa"
 msgstr ""
 
@@ -2485,7 +2488,7 @@ msgstr ""
 msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr "数学において特殊な記号の頭に%をつける（%e, %i のようになります）"
 
-#: ../src/wxMaxima.cpp:4031
+#: ../src/wxMaxima.cpp:4043
 msgid "LCM"
 msgstr "最小公倍数"
 
@@ -2501,7 +2504,7 @@ msgstr ""
 msgid "Label width:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1374
+#: ../src/wxMaximaFrame.cpp:1373
 msgid "Lambda"
 msgstr ""
 
@@ -2513,11 +2516,11 @@ msgstr "wxMaximaのGUIに使用される言語"
 msgid "Language:"
 msgstr "使用言語："
 
-#: ../src/wxMaxima.cpp:4120
+#: ../src/wxMaxima.cpp:4132
 msgid "Laplace"
 msgstr "ラプラス変換"
 
-#: ../src/wxMaximaFrame.cpp:803
+#: ../src/wxMaximaFrame.cpp:802
 msgid "Laplace &Transform..."
 msgstr "ラプラス変換(&T)"
 
@@ -2525,15 +2528,15 @@ msgstr "ラプラス変換(&T)"
 msgid "Leads to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:812
+#: ../src/wxMaximaFrame.cpp:811
 msgid "Least Common Multiple..."
 msgstr "最小公倍数"
 
-#: ../src/wxMaxima.cpp:4809
+#: ../src/wxMaxima.cpp:4821
 msgid "Least Squares Fit"
 msgstr "最小二乗法"
 
-#: ../src/wxMaximaFrame.cpp:1266
+#: ../src/wxMaximaFrame.cpp:1265
 msgid "Least Squares Fit..."
 msgstr "回帰式の係数と切片を求める"
 
@@ -2544,24 +2547,24 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4192
+#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4204
 msgid "Limit"
 msgstr "極限値"
 
-#: ../src/wxMaximaFrame.cpp:1225
+#: ../src/wxMaximaFrame.cpp:1224
 msgid "Limit..."
 msgstr "極限値"
 
-#: ../src/wxMaximaFrame.cpp:1265
+#: ../src/wxMaximaFrame.cpp:1264
 msgid "Linear Regression..."
 msgstr "単回帰分析"
 
-#: ../src/wxMaxima.cpp:3803
+#: ../src/wxMaxima.cpp:3815
 #, fuzzy
 msgid "List(s):"
 msgstr "リスト："
 
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3848
 msgid "List:"
 msgstr "リスト："
 
@@ -2569,15 +2572,15 @@ msgstr "リスト："
 msgid "Load"
 msgstr "設定の読込み"
 
-#: ../src/wxMaxima.cpp:2932
+#: ../src/wxMaxima.cpp:2940
 msgid "Load Package"
 msgstr "パッケージ読み込み"
 
-#: ../src/wxMaximaFrame.cpp:479
+#: ../src/wxMaximaFrame.cpp:478
 msgid "Load a Maxima file using the batch command"
 msgstr "バッチ処理に使うファイルの読み込み"
 
-#: ../src/wxMaximaFrame.cpp:477
+#: ../src/wxMaximaFrame.cpp:476
 msgid "Load a Maxima package file"
 msgstr "パッケージファイルの読み込み"
 
@@ -2589,49 +2592,49 @@ msgstr "スタイルの読み込み"
 msgid "Long Right arrow"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Lower bound:"
 msgstr "下限："
 
-#: ../src/wxMaximaFrame.cpp:771
+#: ../src/wxMaximaFrame.cpp:770
 msgid "Ma&p to Matrix..."
 msgstr "行列に関数を適用(&P)"
 
-#: ../src/wxMaximaFrame.cpp:547
+#: ../src/wxMaximaFrame.cpp:546
 #, fuzzy
 msgid "Main Toolbar\tAlt-Shift-B"
 msgstr "ツールバー\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:765
+#: ../src/wxMaximaFrame.cpp:764
 msgid "Make &List..."
 msgstr "リスト作成(&L)"
 
-#: ../src/wxMaxima.cpp:3821
+#: ../src/wxMaxima.cpp:3833
 msgid "Make list"
 msgstr "リスト作成"
 
-#: ../src/wxMaximaFrame.cpp:766
+#: ../src/wxMaximaFrame.cpp:765
 msgid "Make list from expression"
 msgstr "関数からリストを作成"
 
-#: ../src/wxMaximaFrame.cpp:907
+#: ../src/wxMaximaFrame.cpp:906
 msgid "Make substitution in expression"
 msgstr "式中の部分式を置換"
 
-#: ../src/wxMaximaFrame.cpp:682
+#: ../src/wxMaximaFrame.cpp:681
 #, fuzzy
 msgid "Manually Trigger Evaluation"
 msgstr "計算に要した時間を表示"
 
-#: ../src/wxMaxima.cpp:3805
+#: ../src/wxMaxima.cpp:3817
 msgid "Map"
 msgstr "リストに関数を適用"
 
-#: ../src/wxMaximaFrame.cpp:770
+#: ../src/wxMaximaFrame.cpp:769
 msgid "Map function to a list"
 msgstr "リストに関数を適用"
 
-#: ../src/wxMaximaFrame.cpp:772
+#: ../src/wxMaximaFrame.cpp:771
 msgid "Map function to a matrix"
 msgstr "行列に関数を適用"
 
@@ -2648,23 +2651,23 @@ msgstr "括弧の自動補完"
 msgid "Math font:"
 msgstr "出力用フォント"
 
-#: ../src/wxMaximaFrame.cpp:374
+#: ../src/wxMaximaFrame.cpp:373
 msgid "Mathematical Symbols"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3716
+#: ../src/wxMaxima.cpp:3728
 msgid "Matrix"
 msgstr "行列"
 
-#: ../src/wxMaxima.cpp:3702
+#: ../src/wxMaxima.cpp:3714
 msgid "Matrix map"
 msgstr "行列に関数を適用"
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Matrix name:"
 msgstr "変数名："
 
-#: ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3749
+#: ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3761
 msgid "Matrix:"
 msgstr "行列："
 
@@ -2672,7 +2675,7 @@ msgstr "行列："
 msgid "Maxima"
 msgstr "Maxima"
 
-#: ../src/wxMaximaFrame.cpp:137
+#: ../src/wxMaximaFrame.cpp:136
 #, fuzzy
 msgid "Maxima has a question"
 msgstr "条件不足時のMaximaの質問"
@@ -2681,26 +2684,26 @@ msgstr "条件不足時のMaximaの質問"
 msgid "Maxima input"
 msgstr "入力文字列"
 
-#: ../src/wxMaximaFrame.cpp:166
+#: ../src/wxMaximaFrame.cpp:165
 msgid "Maxima is calculating"
 msgstr "処理中"
 
-#: ../src/wxMaximaFrame.cpp:111
+#: ../src/wxMaximaFrame.cpp:110
 #, fuzzy
 msgid "Maxima is ready for input."
 msgstr "入力文字列"
 
-#: ../src/wxMaxima.cpp:2945
+#: ../src/wxMaxima.cpp:2953
 msgid "Maxima package (*.mac)|*.mac"
 msgstr "バッチファイル (*.bat, *.mac)|*.bat;*.mac"
 
-#: ../src/wxMaxima.cpp:2934
+#: ../src/wxMaxima.cpp:2942
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr ""
 "Maxima パッケージ (*.mac)|*.mac|Lisp パッケージ (*.lisp)|*.lisp|すべてのファ"
 "イル (*.*)|*"
 
-#: ../src/wxMaxima.cpp:1014
+#: ../src/wxMaxima.cpp:1019
 msgid "Maxima process terminated."
 msgstr "Maximaの処理は終了しました"
 
@@ -2712,7 +2715,7 @@ msgstr "Maxima本体のパス："
 msgid "Maxima questions"
 msgstr "条件不足時のMaximaの質問"
 
-#: ../src/wxMaxima.cpp:942
+#: ../src/wxMaxima.cpp:947
 msgid "Maxima started. Waiting for connection..."
 msgstr "Maximaと接続しています"
 
@@ -2740,7 +2743,7 @@ msgstr ""
 "・　xに3を代入する場合、\"x : 3;\"と入力\n"
 "・　f(x) にx^2を定義する場合、「f(x) := x^2;」 と入力"
 
-#: ../src/wxMaxima.cpp:4597
+#: ../src/wxMaxima.cpp:4609
 msgid "Maxima version: "
 msgstr "Maxima version: "
 
@@ -2777,40 +2780,40 @@ msgstr ""
 msgid "Maximum displayed number of digits:"
 msgstr "表示する最大の桁数:"
 
-#: ../src/wxMaximaFrame.cpp:1263
+#: ../src/wxMaximaFrame.cpp:1262
 msgid "Mean Difference Test..."
 msgstr "母平均の差の検定"
 
-#: ../src/wxMaximaFrame.cpp:1262
+#: ../src/wxMaximaFrame.cpp:1261
 msgid "Mean Test..."
 msgstr "母平均の検定"
 
-#: ../src/wxMaximaFrame.cpp:1255
+#: ../src/wxMaximaFrame.cpp:1254
 msgid "Mean..."
 msgstr "平均値"
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Mean:"
 msgstr "比較する値："
 
-#: ../src/wxMaximaFrame.cpp:1256
+#: ../src/wxMaximaFrame.cpp:1255
 msgid "Median..."
 msgstr "中央値"
 
-#: ../src/MathCtrl.cpp:945
+#: ../src/MathCtrl.cpp:987
 msgid "Merge Cells"
 msgstr "セルの結合"
 
-#: ../src/wxMaximaFrame.cpp:633
+#: ../src/wxMaximaFrame.cpp:632
 #, fuzzy
 msgid "Merge Cells\tCtrl-M"
 msgstr "セルの結合"
 
-#: ../src/wxMaximaFrame.cpp:634
+#: ../src/wxMaximaFrame.cpp:633
 msgid "Merge the text from two input cells into one"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2668
+#: ../src/wxMaxima.cpp:2676
 msgid "Message from the stdout of Maxima: "
 msgstr ""
 
@@ -2818,20 +2821,20 @@ msgstr ""
 msgid "Method:"
 msgstr "数値積分法："
 
-#: ../src/wxMaxima.cpp:5289
+#: ../src/wxMaxima.cpp:5301
 #, fuzzy
 msgid "Mismatched parenthesis"
 msgstr "括弧の自動補完"
 
-#: ../src/wxMaxima.cpp:3972
+#: ../src/wxMaxima.cpp:3984
 msgid "Modulus"
 msgstr "モジュラス"
 
-#: ../src/wxMaximaFrame.cpp:1375
+#: ../src/wxMaximaFrame.cpp:1374
 msgid "Mu"
 msgstr ""
 
-#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Name:"
 msgstr "変数名："
 
@@ -2839,7 +2842,7 @@ msgstr "変数名："
 msgid "New"
 msgstr "新規作成"
 
-#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
+#: ../src/wxMaximaFrame.cpp:456 ../src/wxMaximaFrame.cpp:459
 msgid "New\tCtrl-N"
 msgstr "新規作成\tCtrl-N"
 
@@ -2855,11 +2858,11 @@ msgstr ""
 msgid "New value:"
 msgstr "新部分式："
 
-#: ../src/wxMaxima.cpp:3993 ../src/wxMaxima.cpp:4119 ../src/wxMaxima.cpp:4136
+#: ../src/wxMaxima.cpp:4005 ../src/wxMaxima.cpp:4131 ../src/wxMaxima.cpp:4148
 msgid "New variable:"
 msgstr "新変数："
 
-#: ../src/wxMaximaFrame.cpp:630
+#: ../src/wxMaximaFrame.cpp:629
 msgid "Next Command\tAlt-Down"
 msgstr "履歴から入力（次）\tAlt-Down"
 
@@ -2867,15 +2870,15 @@ msgstr "履歴から入力（次）\tAlt-Down"
 msgid "No"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5362
+#: ../src/wxMaxima.cpp:5378
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3249 ../src/wxMaxima.cpp:3271
+#: ../src/wxMaxima.cpp:3260 ../src/wxMaxima.cpp:3283
 msgid "No matches found!"
 msgstr "一致する文字列がありません"
 
-#: ../src/wxMaximaFrame.cpp:1264
+#: ../src/wxMaximaFrame.cpp:1263
 msgid "Normality Test..."
 msgstr "正規性の検定"
 
@@ -2898,34 +2901,34 @@ msgstr ""
 msgid "Norwegian"
 msgstr "ノルウェー語"
 
-#: ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:3740
 msgid "Not a valid matrix dimension!"
 msgstr "有効な行列の次元ではありません！"
 
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629
 msgid "Not a valid number of equations!"
 msgstr "有効な方程式の数ではありません!"
 
-#: ../src/wxMaximaFrame.cpp:197
+#: ../src/wxMaximaFrame.cpp:196
 #, fuzzy
 msgid "Not connected to maxima"
 msgstr ""
 "\n"
 "Maximaと接続していません！\n"
 
-#: ../src/wxMaxima.cpp:4599
+#: ../src/wxMaxima.cpp:4611
 msgid "Not connected."
 msgstr "接続していません"
 
-#: ../src/wxMaximaFrame.cpp:1376
+#: ../src/wxMaximaFrame.cpp:1375
 msgid "Nu"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Num. deg:"
 msgstr "分子の最高次数："
 
-#: ../src/wxMaxima.cpp:3585 ../src/wxMaxima.cpp:3609
+#: ../src/wxMaxima.cpp:3597 ../src/wxMaxima.cpp:3621
 msgid "Number of equations:"
 msgstr "方程式の数："
 
@@ -2952,15 +2955,15 @@ msgstr "OK"
 msgid "Old value:"
 msgstr "旧部分式："
 
-#: ../src/wxMaxima.cpp:3992 ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135
+#: ../src/wxMaxima.cpp:4004 ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147
 msgid "Old variable:"
 msgstr "旧変数："
 
-#: ../src/wxMaximaFrame.cpp:1387
+#: ../src/wxMaximaFrame.cpp:1386
 msgid "Omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1378
+#: ../src/wxMaximaFrame.cpp:1377
 msgid "Omicron"
 msgstr ""
 
@@ -2974,20 +2977,20 @@ msgid ""
 "stream for messages."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4763
+#: ../src/wxMaxima.cpp:4775
 msgid "One sample t-test"
 msgstr "t検定"
 
-#: ../src/wxMaximaFrame.cpp:971
+#: ../src/wxMaximaFrame.cpp:970
 msgid "Online tutorials"
 msgstr "ブラウザでチュートリアルのページを開く"
 
 #: ../src/ConfigDialogue.cpp:656 ../src/main.cpp:347 ../src/ToolBar.cpp:119
-#: ../src/wxMaxima.cpp:2797
+#: ../src/wxMaxima.cpp:2805
 msgid "Open"
 msgstr "参照"
 
-#: ../src/wxMaximaFrame.cpp:466
+#: ../src/wxMaximaFrame.cpp:465
 msgid "Open Recent"
 msgstr "最近開いたファイル"
 
@@ -2995,11 +2998,11 @@ msgstr "最近開いたファイル"
 msgid "Open a cell when Maxima expects input"
 msgstr "Maximaが入力を待機しているときセルを開く"
 
-#: ../src/wxMaximaFrame.cpp:464
+#: ../src/wxMaximaFrame.cpp:463
 msgid "Open a document"
 msgstr "ドキュメントを開く"
 
-#: ../src/wxMaximaFrame.cpp:458 ../src/wxMaximaFrame.cpp:461
+#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
 msgid "Open a new window"
 msgstr "新しいウィンドウを開く"
 
@@ -3007,11 +3010,11 @@ msgstr "新しいウィンドウを開く"
 msgid "Open document"
 msgstr "開く"
 
-#: ../src/wxMaxima.cpp:4824
+#: ../src/wxMaxima.cpp:4836
 msgid "Open matrix"
 msgstr "ファイルを開く"
 
-#: ../src/wxMaxima.cpp:1446 ../src/wxMaxima.cpp:1518
+#: ../src/wxMaxima.cpp:1451 ../src/wxMaxima.cpp:1523
 msgid "Opening file"
 msgstr "ファイルを開く"
 
@@ -3035,11 +3038,11 @@ msgstr "再入力する前の出力"
 msgid "Output labels"
 msgstr "出力ラベル"
 
-#: ../src/wxMaximaFrame.cpp:796
+#: ../src/wxMaximaFrame.cpp:795
 msgid "P&ade Approximation..."
 msgstr "Pade近似(&A)"
 
-#: ../src/wxMaxima.cpp:3132 ../src/wxMaxima.cpp:5133
+#: ../src/wxMaxima.cpp:3141 ../src/wxMaxima.cpp:5145
 #, fuzzy
 msgid ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
@@ -3049,15 +3052,15 @@ msgstr ""
 "PNG ファイル (*.png)|*.png|JPEG ファイル (*.jpg)|*.jpg|ビットマップ ファイル "
 "(*.bmp)|*.bmp|XPM ファイル (*.xpm)|*.xpm"
 
-#: ../src/wxMaxima.cpp:4012
+#: ../src/wxMaxima.cpp:4024
 msgid "Pade approximation"
 msgstr "Pade近似"
 
-#: ../src/wxMaximaFrame.cpp:797
+#: ../src/wxMaximaFrame.cpp:796
 msgid "Pade approximation of a Taylor series"
 msgstr "テイラー級数を有理式で近似"
 
-#: ../src/wxMaximaFrame.cpp:1500
+#: ../src/wxMaximaFrame.cpp:1519
 msgid "Pagebreak"
 msgstr "改ページ"
 
@@ -3069,19 +3072,19 @@ msgstr ""
 msgid "Parametric plot"
 msgstr "媒介変数プロット"
 
-#: ../src/wxMaximaFrame.cpp:188
+#: ../src/wxMaximaFrame.cpp:187
 msgid "Parsing output"
 msgstr "出力しています"
 
-#: ../src/wxMaximaFrame.cpp:819
+#: ../src/wxMaximaFrame.cpp:818
 msgid "Partial &Fractions..."
 msgstr "部分分数分解(&F)"
 
-#: ../src/wxMaxima.cpp:4076
+#: ../src/wxMaxima.cpp:4088
 msgid "Partial fractions"
 msgstr "部分分数分解"
 
-#: ../src/wxMaxima.cpp:1769
+#: ../src/wxMaxima.cpp:1774
 msgid "Parts of the document will not be loaded correctly!"
 msgstr "ドキュメントの一部は正確に読み込まれないでしょう！"
 
@@ -3092,11 +3095,11 @@ msgid ""
 "Found unknown XML Tag name "
 msgstr "ドキュメントの一部は正確に読み込まれないでしょう！"
 
-#: ../src/ToolBar.cpp:143 ../src/MathCtrl.cpp:1010 ../src/MathCtrl.cpp:1025
+#: ../src/MathCtrl.cpp:1052 ../src/MathCtrl.cpp:1067 ../src/ToolBar.cpp:143
 msgid "Paste"
 msgstr "貼り付け"
 
-#: ../src/wxMaximaFrame.cpp:518
+#: ../src/wxMaximaFrame.cpp:517
 msgid "Paste\tCtrl-V"
 msgstr "貼り付け\tCtrl-V"
 
@@ -3104,7 +3107,7 @@ msgstr "貼り付け\tCtrl-V"
 msgid "Paste from clipboard"
 msgstr "貼り付け"
 
-#: ../src/wxMaximaFrame.cpp:519
+#: ../src/wxMaximaFrame.cpp:518
 msgid "Paste text from clipboard"
 msgstr "クリップボードから貼り付け"
 
@@ -3112,19 +3115,19 @@ msgstr "クリップボードから貼り付け"
 msgid "Perpendicular to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1384
+#: ../src/wxMaximaFrame.cpp:1383
 msgid "Phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1379
+#: ../src/wxMaximaFrame.cpp:1378
 msgid "Pi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1273
+#: ../src/wxMaximaFrame.cpp:1272
 msgid "Piechart..."
 msgstr "円グラフ"
 
-#: ../src/wxMaxima.cpp:1952
+#: ../src/wxMaxima.cpp:1957
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr ""
 "メニューバーの「編集」から「設定」ダイアログを開き、wxMaximaを設定してくださ"
@@ -3134,52 +3137,52 @@ msgstr ""
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr "変更を有効にするにはwxMaximaを再起動する必要があります"
 
-#: ../src/wxMaximaFrame.cpp:923
+#: ../src/wxMaximaFrame.cpp:922
 msgid "Plot &2d..."
 msgstr "2次元プロット(&2)"
 
-#: ../src/wxMaximaFrame.cpp:925
+#: ../src/wxMaximaFrame.cpp:924
 msgid "Plot &3d..."
 msgstr "3次元プロット(&3)"
 
-#: ../src/wxMaximaFrame.cpp:927
+#: ../src/wxMaximaFrame.cpp:926
 msgid "Plot &Format..."
 msgstr "プロットエンジンの変更(&F)"
 
 #: ../src/Plot2dWiz.cpp:104 ../src/Plot2dWiz.cpp:450 ../src/Plot2dWiz.cpp:464
-#: ../src/wxMaxima.cpp:4283 ../src/wxMaxima.cpp:5102
+#: ../src/wxMaxima.cpp:4295 ../src/wxMaxima.cpp:5114
 msgid "Plot 2D"
 msgstr "2次元プロット"
 
-#: ../src/wxMaximaFrame.cpp:1227
+#: ../src/wxMaximaFrame.cpp:1226
 msgid "Plot 2D..."
 msgstr "2次元プロット"
 
-#: ../src/MathCtrl.cpp:1003
+#: ../src/MathCtrl.cpp:1045
 msgid "Plot 2d..."
 msgstr "2次元プロット"
 
-#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4269 ../src/wxMaxima.cpp:5115
+#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4281 ../src/wxMaxima.cpp:5127
 msgid "Plot 3D"
 msgstr "3次元プロット"
 
-#: ../src/wxMaximaFrame.cpp:1228
+#: ../src/wxMaximaFrame.cpp:1227
 msgid "Plot 3D..."
 msgstr "3次元プロット"
 
-#: ../src/MathCtrl.cpp:1004
+#: ../src/MathCtrl.cpp:1046
 msgid "Plot 3d..."
 msgstr "3次元プロット"
 
-#: ../src/wxMaxima.cpp:4296
+#: ../src/wxMaxima.cpp:4308
 msgid "Plot format"
 msgstr "プロットエンジン"
 
-#: ../src/wxMaximaFrame.cpp:924
+#: ../src/wxMaximaFrame.cpp:923
 msgid "Plot in 2 dimensions"
 msgstr "2次元プロット（同時に複数の関数を表示可能）"
 
-#: ../src/wxMaximaFrame.cpp:926
+#: ../src/wxMaximaFrame.cpp:925
 msgid "Plot in 3 dimensions"
 msgstr "3次元プロット（同時に表示できる関数は１つまたは３つ）"
 
@@ -3188,8 +3191,8 @@ msgid "Plot to file:"
 msgstr "EPS形式で出力："
 
 #: ../src/BC2Wiz.cpp:30 ../src/BC2Wiz.cpp:36 ../src/LimitWiz.cpp:33
-#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
-#: ../src/wxMaxima.cpp:3648
+#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
+#: ../src/wxMaxima.cpp:3660
 msgid "Point:"
 msgstr "値の入力："
 
@@ -3197,11 +3200,11 @@ msgstr "値の入力："
 msgid "Polish"
 msgstr "ポーランド語"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 1:"
 msgstr "多項式 1："
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 2:"
 msgstr "多項式 2："
 
@@ -3213,11 +3216,11 @@ msgstr "ポルトガル語（ブラジル）"
 msgid "Postscript file (*.eps)|*.eps|All|*"
 msgstr "Postscript ファイル (*.eps)|*.eps|すべてのファイル (*.*)|*"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Precision"
 msgstr "表示桁数"
 
-#: ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:536
 msgid "Preferences...\tCtrl+,"
 msgstr "設定\tCtrl+,"
 
@@ -3229,7 +3232,7 @@ msgid ""
 "packages and from functions that are defined in the current file."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:628
+#: ../src/wxMaximaFrame.cpp:627
 msgid "Previous Command\tAlt-Up"
 msgstr "履歴から入力（前）\tAlt-Up"
 
@@ -3237,11 +3240,11 @@ msgstr "履歴から入力（前）\tAlt-Up"
 msgid "Print"
 msgstr "印刷"
 
-#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:484
+#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:483
 msgid "Print document"
 msgstr "印刷"
 
-#: ../src/wxMaxima.cpp:4242
+#: ../src/wxMaxima.cpp:4254
 msgid "Product"
 msgstr "総乗"
 
@@ -3250,35 +3253,35 @@ msgstr "総乗"
 msgid "Product sign"
 msgstr "総乗"
 
-#: ../src/wxMaximaFrame.cpp:1386
+#: ../src/wxMaximaFrame.cpp:1385
 msgid "Psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:331
+#: ../src/wxMaximaFrame.cpp:330
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:592
+#: ../src/wxMaximaFrame.cpp:591
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr "カーソルがあるセルより上にある全てのセルを再評価"
 
-#: ../src/wxMaximaFrame.cpp:1278
+#: ../src/wxMaximaFrame.cpp:1277
 msgid "Read Matrix..."
 msgstr "行列のファイル"
 
-#: ../src/wxMaximaFrame.cpp:177
+#: ../src/wxMaximaFrame.cpp:176
 msgid "Reading Maxima output"
 msgstr "処理が終了しました"
 
-#: ../src/wxMaximaFrame.cpp:153
+#: ../src/wxMaximaFrame.cpp:152
 msgid "Ready for user input"
 msgstr "入力可能"
 
-#: ../src/wxMaximaFrame.cpp:631
+#: ../src/wxMaximaFrame.cpp:630
 msgid "Recall next command from history"
 msgstr "入力履歴のコマンドを古いものから順に表示します"
 
-#: ../src/wxMaximaFrame.cpp:629
+#: ../src/wxMaximaFrame.cpp:628
 msgid "Recall previous command from history"
 msgstr "入力履歴のコマンドを新しいものから順に表示します"
 
@@ -3286,36 +3289,36 @@ msgstr "入力履歴のコマンドを新しいものから順に表示します
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1215
+#: ../src/wxMaximaFrame.cpp:1214
 msgid "Rectform"
 msgstr "複素関数展開"
 
-#: ../src/wxMaximaFrame.cpp:495
+#: ../src/wxMaximaFrame.cpp:494
 #, fuzzy
 msgid "Redo\tCtrl-Y"
 msgstr "元に戻す\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:496
+#: ../src/wxMaximaFrame.cpp:495
 msgid "Redo last change"
 msgstr "一番新しい入力をやり直す"
 
-#: ../src/wxMaximaFrame.cpp:1220
+#: ../src/wxMaximaFrame.cpp:1219
 msgid "Reduce (tr)"
 msgstr "結合 (tri)"
 
-#: ../src/wxMaximaFrame.cpp:871
+#: ../src/wxMaximaFrame.cpp:870
 msgid "Reduce trigonometric expression"
 msgstr "三角関数(sin,cos)，双曲線関数(sinh,cosh)の積を一つの関数にまとめる"
 
-#: ../src/wxMaxima.cpp:622 ../src/wxMaxima.cpp:5495
+#: ../src/wxMaxima.cpp:627 ../src/wxMaxima.cpp:5511
 msgid "Refusing to send cell to maxima: "
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:594
+#: ../src/wxMaximaFrame.cpp:593
 msgid "Remove All Output"
 msgstr "全ての出力をクリア"
 
-#: ../src/wxMaximaFrame.cpp:595
+#: ../src/wxMaximaFrame.cpp:594
 msgid "Remove output from input cells"
 msgstr "全ての出力をクリア"
 
@@ -3324,7 +3327,7 @@ msgstr "全ての出力をクリア"
 msgid "Replace All"
 msgstr "全て選択"
 
-#: ../src/wxMaxima.cpp:3282
+#: ../src/wxMaxima.cpp:3294
 #, c-format
 msgid "Replaced %d occurrences."
 msgstr "%d箇所を置換しました"
@@ -3333,11 +3336,11 @@ msgstr "%d箇所を置換しました"
 msgid "Replacement:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:976
+#: ../src/wxMaximaFrame.cpp:975
 msgid "Report bug"
 msgstr "バグの報告"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "Restart Maxima"
 msgstr "ラベル番号をリセット"
 
@@ -3346,7 +3349,7 @@ msgstr "ラベル番号をリセット"
 msgid "Restart maxima"
 msgstr "ラベル番号をリセット"
 
-#: ../src/MathCtrl.cpp:4442
+#: ../src/MathCtrl.cpp:4497
 msgid "Result"
 msgstr ""
 
@@ -3354,7 +3357,7 @@ msgstr ""
 msgid "Return to the cell that is currently being evaluated"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1380
+#: ../src/wxMaximaFrame.cpp:1379
 msgid "Rho"
 msgstr ""
 
@@ -3362,19 +3365,19 @@ msgstr ""
 msgid "Right arrow"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:779
+#: ../src/wxMaximaFrame.cpp:778
 msgid "Risch Integration..."
 msgstr "Risch積分"
 
-#: ../src/wxMaximaFrame.cpp:694
+#: ../src/wxMaximaFrame.cpp:693
 msgid "Roots of &Polynomial"
 msgstr "解を小数で求める(&P)"
 
-#: ../src/wxMaximaFrame.cpp:697
+#: ../src/wxMaximaFrame.cpp:696
 msgid "Roots of Polynomial (bfloat)"
 msgstr "解を浮動小数点で求める"
 
-#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Rows:"
 msgstr "行数："
 
@@ -3382,56 +3385,56 @@ msgstr "行数："
 msgid "Russian"
 msgstr "ロシア語"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 1:"
 msgstr "標本１（リスト/行ベクトル）："
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 2:"
 msgstr "標本２（リスト/行ベクトル）："
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Sample:"
 msgstr "標本（リスト/行ベクトル）："
 
 #: ../src/ConfigDialogue.cpp:781 ../src/ToolBar.cpp:122
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Save"
 msgstr "設定の保存"
 
-#: ../src/MathCtrl.cpp:921
+#: ../src/MathCtrl.cpp:963
 msgid "Save Animation..."
 msgstr "アニメーションを保存する"
 
-#: ../src/wxMaxima.cpp:2565
+#: ../src/wxMaxima.cpp:2572
 msgid "Save As"
 msgstr "名前をつけて保存"
 
-#: ../src/wxMaximaFrame.cpp:474
+#: ../src/wxMaximaFrame.cpp:473
 msgid "Save As...\tShift-Ctrl-S"
 msgstr "名前を付けて保存\tShift-Ctrl-S"
 
-#: ../src/MathCtrl.cpp:919
+#: ../src/MathCtrl.cpp:961
 msgid "Save Image..."
 msgstr "画像として保存"
 
-#: ../src/wxMaxima.cpp:3130
+#: ../src/wxMaxima.cpp:3139
 msgid "Save Selection to Image"
 msgstr "選択範囲を画像として保存"
 
-#: ../src/wxMaximaFrame.cpp:528
+#: ../src/wxMaximaFrame.cpp:527
 msgid "Save Selection to Image..."
 msgstr "選択範囲を画像として保存"
 
-#: ../src/wxMaxima.cpp:5150
+#: ../src/wxMaxima.cpp:5162
 msgid "Save animation to file"
 msgstr "アニメーションの開始"
 
-#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:473
+#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:472
 msgid "Save document"
 msgstr "上書き保存"
 
-#: ../src/wxMaximaFrame.cpp:475
+#: ../src/wxMaximaFrame.cpp:474
 msgid "Save document as"
 msgstr "名前を付けて保存"
 
@@ -3453,11 +3456,11 @@ msgstr "セッション間でサイドバーのレイアウトを保持"
 msgid "Save plot to file"
 msgstr "名前を付けて保存"
 
-#: ../src/wxMaximaFrame.cpp:529
+#: ../src/wxMaximaFrame.cpp:528
 msgid "Save selection from document to an image file"
 msgstr "選択範囲を画像として保存"
 
-#: ../src/wxMaxima.cpp:5131
+#: ../src/wxMaxima.cpp:5143
 msgid "Save selection to file"
 msgstr "画像として保存"
 
@@ -3473,28 +3476,28 @@ msgstr "前回のウインドウサイズと位置を保持"
 msgid "Save wxMaxima window size/position between sessions."
 msgstr "セッション間でウインドウサイズと位置を保持"
 
-#: ../src/wxMaximaFrame.cpp:246
+#: ../src/wxMaximaFrame.cpp:245
 #, fuzzy
 msgid "Saving failed."
 msgstr "サーバーを開始できませんでした"
 
-#: ../src/wxMaximaFrame.cpp:222
+#: ../src/wxMaximaFrame.cpp:221
 msgid "Saving successful."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:212
+#: ../src/wxMaximaFrame.cpp:211
 msgid "Saving..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4699
+#: ../src/wxMaxima.cpp:4711
 msgid "Scatterplot"
 msgstr "散布図"
 
-#: ../src/wxMaximaFrame.cpp:1271
+#: ../src/wxMaximaFrame.cpp:1270
 msgid "Scatterplot..."
 msgstr "散布図"
 
-#: ../src/wxMaximaFrame.cpp:1498
+#: ../src/wxMaximaFrame.cpp:1517
 msgid "Section"
 msgstr "セクション"
 
@@ -3502,26 +3505,26 @@ msgstr "セクション"
 msgid "Section cell"
 msgstr "セクションセル"
 
-#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:292 ../src/TextCell.cpp:306
-#: ../src/TextCell.cpp:322 ../src/TextCell.cpp:334
+#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:290 ../src/TextCell.cpp:304
+#: ../src/TextCell.cpp:320 ../src/TextCell.cpp:332
 msgid ""
 "Seems like something is broken with a font. Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/TextCell.cpp:139
+#: ../src/TextCell.cpp:137
 msgid ""
 "Seems like something is broken with the maths font. Installing http://www."
 "math.union.edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use "
 "JSmath fonts\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1011 ../src/MathCtrl.cpp:1027
+#: ../src/MathCtrl.cpp:1053 ../src/MathCtrl.cpp:1069
 msgid "Select All"
 msgstr "全て選択"
 
-#: ../src/wxMaximaFrame.cpp:525
+#: ../src/wxMaximaFrame.cpp:524
 msgid "Select All\tCtrl-A"
 msgstr "全て選択\tCtrl-A"
 
@@ -3529,7 +3532,7 @@ msgstr "全て選択\tCtrl-A"
 msgid "Select Maxima program"
 msgstr "Maximaプログラムの選択"
 
-#: ../src/wxMaxima.cpp:4860
+#: ../src/wxMaxima.cpp:4872
 msgid "Select Subsample"
 msgstr "標本抽出"
 
@@ -3538,11 +3541,11 @@ msgstr "標本抽出"
 msgid "Select a constant"
 msgstr "定数を選択してください"
 
-#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:526
+#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:525
 msgid "Select all"
 msgstr "全て選択"
 
-#: ../src/wxMaxima.cpp:3319
+#: ../src/wxMaxima.cpp:3331
 msgid "Select math display algorithm"
 msgstr "数式の出力形式を選択してください"
 
@@ -3559,23 +3562,23 @@ msgstr ""
 msgid "Selection"
 msgstr "選択範囲"
 
-#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4178
+#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4190
 msgid "Series"
 msgstr "テイラー展開"
 
-#: ../src/wxMaximaFrame.cpp:1226
+#: ../src/wxMaximaFrame.cpp:1225
 msgid "Series..."
 msgstr "テイラー展開"
 
-#: ../src/wxMaxima.cpp:863
+#: ../src/wxMaxima.cpp:868
 msgid "Server started"
 msgstr "サーバーが開始しました"
 
-#: ../src/wxMaximaFrame.cpp:575
+#: ../src/wxMaximaFrame.cpp:574
 msgid "Set Zoom"
 msgstr "指定倍率で表示"
 
-#: ../src/wxMaximaFrame.cpp:944
+#: ../src/wxMaximaFrame.cpp:943
 #, fuzzy
 msgid "Set bigfloat &Precision..."
 msgstr "浮動小数点で表示する桁数の設定"
@@ -3584,61 +3587,61 @@ msgstr "浮動小数点で表示する桁数の設定"
 msgid "Set fixed font in text controls."
 msgstr "テキスト入力ボックスで固定幅フォントを使用"
 
-#: ../src/wxMaximaFrame.cpp:928
+#: ../src/wxMaximaFrame.cpp:927
 msgid "Set plot format"
 msgstr "プロットに使うソフトの変更"
 
-#: ../src/wxMaximaFrame.cpp:945
+#: ../src/wxMaximaFrame.cpp:944
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can "
 "be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:569
+#: ../src/wxMaximaFrame.cpp:568
 msgid "Set zoom to 100%"
 msgstr "100%の倍率で表示"
 
-#: ../src/wxMaximaFrame.cpp:570
+#: ../src/wxMaximaFrame.cpp:569
 msgid "Set zoom to 120%"
 msgstr "120%の倍率で表示"
 
-#: ../src/wxMaximaFrame.cpp:571
+#: ../src/wxMaximaFrame.cpp:570
 msgid "Set zoom to 150%"
 msgstr "150%の倍率で表示"
 
-#: ../src/wxMaximaFrame.cpp:572
+#: ../src/wxMaximaFrame.cpp:571
 msgid "Set zoom to 200%"
 msgstr "200%の倍率で表示"
 
-#: ../src/wxMaximaFrame.cpp:573
+#: ../src/wxMaximaFrame.cpp:572
 msgid "Set zoom to 300%"
 msgstr "300%の倍率で表示"
 
-#: ../src/wxMaximaFrame.cpp:568
+#: ../src/wxMaximaFrame.cpp:567
 msgid "Set zoom to 80%"
 msgstr "80%の倍率で表示"
 
-#: ../src/wxMaximaFrame.cpp:732
+#: ../src/wxMaximaFrame.cpp:731
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr "連立微分方程式の特殊解を求める際の初期条件を設定"
 
-#: ../src/wxMaximaFrame.cpp:918
+#: ../src/wxMaximaFrame.cpp:917
 msgid "Setup modulus computation"
 msgstr "モジュラス（法）を設定します"
 
-#: ../src/wxMaximaFrame.cpp:662
+#: ../src/wxMaximaFrame.cpp:661
 msgid "Show &Definition..."
 msgstr "ユーザー定義関数を表示(&D)"
 
-#: ../src/wxMaximaFrame.cpp:660
+#: ../src/wxMaximaFrame.cpp:659
 msgid "Show &Functions"
 msgstr "ユーザー定義関数名をリスト表示(&F)"
 
-#: ../src/wxMaximaFrame.cpp:967
+#: ../src/wxMaximaFrame.cpp:966
 msgid "Show &Tips..."
 msgstr "ヒントを表示(&T)"
 
-#: ../src/wxMaximaFrame.cpp:665
+#: ../src/wxMaximaFrame.cpp:664
 msgid "Show &Variables"
 msgstr "ユーザー定義変数をリスト表示(&V)"
 
@@ -3646,43 +3649,43 @@ msgstr "ユーザー定義変数をリスト表示(&V)"
 msgid "Show Maxima help"
 msgstr "ヘルプ"
 
-#: ../src/wxMaximaFrame.cpp:603
+#: ../src/wxMaximaFrame.cpp:602
 msgid "Show Template\tCtrl-Shift-K"
 msgstr "コマンドの補完\tCtrl-Shift-K"
 
-#: ../src/wxMaximaFrame.cpp:968
+#: ../src/wxMaximaFrame.cpp:967
 msgid "Show a tip"
 msgstr "ヒントを表示"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Show all commands similar to:"
 msgstr "コマンド名に含まれる文字列："
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Show an example for the command:"
 msgstr "使用例を見たいコマンド名："
 
-#: ../src/wxMaximaFrame.cpp:962
+#: ../src/wxMaximaFrame.cpp:961
 msgid "Show an example of usage"
 msgstr "コマンドの使用例を表示"
 
-#: ../src/wxMaximaFrame.cpp:965
+#: ../src/wxMaximaFrame.cpp:964
 msgid "Show commands similar to"
 msgstr "コマンドを探す"
 
-#: ../src/wxMaximaFrame.cpp:661
+#: ../src/wxMaximaFrame.cpp:660
 msgid "Show defined functions"
 msgstr "ユーザー定義関数名をリスト表示"
 
-#: ../src/wxMaximaFrame.cpp:666
+#: ../src/wxMaximaFrame.cpp:665
 msgid "Show defined variables"
 msgstr "ユーザー定義変数をリスト表示"
 
-#: ../src/wxMaximaFrame.cpp:663
+#: ../src/wxMaximaFrame.cpp:662
 msgid "Show definition of a function"
 msgstr "関数名を指定してユーザー定義関数を表示"
 
-#: ../src/wxMaximaFrame.cpp:604
+#: ../src/wxMaximaFrame.cpp:603
 msgid "Show function template"
 msgstr "コマンドの補完"
 
@@ -3695,7 +3698,7 @@ msgstr "wxMaximaのドキュメントで出力に時間がかかる式も表示"
 msgid "Show long expressions:"
 msgstr "出力に時間がかかる式も表示"
 
-#: ../src/wxMaxima.cpp:3341
+#: ../src/wxMaxima.cpp:3353
 msgid "Show the definition of function:"
 msgstr "表示する関数名の入力"
 
@@ -3704,43 +3707,43 @@ msgstr "表示する関数名の入力"
 msgid "Show user-defined labels instead of (%oxx)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:953 ../src/wxMaximaFrame.cpp:956
+#: ../src/wxMaximaFrame.cpp:952 ../src/wxMaximaFrame.cpp:955
 msgid "Show wxMaxima help"
 msgstr "wxMaximaのヘルプを表示"
 
-#: ../src/wxMaximaFrame.cpp:1381
+#: ../src/wxMaximaFrame.cpp:1380
 msgid "Sigma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1211
+#: ../src/wxMaximaFrame.cpp:1210
 msgid "Simplify"
 msgstr "式の整理"
 
-#: ../src/wxMaximaFrame.cpp:831
+#: ../src/wxMaximaFrame.cpp:830
 msgid "Simplify &Radicals"
 msgstr "関数の整理(&R)"
 
-#: ../src/wxMaximaFrame.cpp:1212
+#: ../src/wxMaximaFrame.cpp:1211
 msgid "Simplify (r)"
 msgstr "関数の整理"
 
-#: ../src/wxMaximaFrame.cpp:1218
+#: ../src/wxMaximaFrame.cpp:1217
 msgid "Simplify (tr)"
 msgstr "変形 (tri)"
 
-#: ../src/MathCtrl.cpp:995
+#: ../src/MathCtrl.cpp:1037
 msgid "Simplify Expression"
 msgstr "式の整理"
 
-#: ../src/wxMaximaFrame.cpp:857
+#: ../src/wxMaximaFrame.cpp:856
 msgid "Simplify an expression containing factorials"
 msgstr "階乗を含む有理式を整理"
 
-#: ../src/wxMaximaFrame.cpp:832
+#: ../src/wxMaximaFrame.cpp:831
 msgid "Simplify expression containing radicals"
 msgstr "式中の関数も含めて整理（三角関数は文字定数として扱われます）"
 
-#: ../src/wxMaximaFrame.cpp:830
+#: ../src/wxMaximaFrame.cpp:829
 msgid "Simplify rational expression"
 msgstr "式および関数の引数を整理（式中の関数自体は文字定数として扱われます）"
 
@@ -3748,7 +3751,7 @@ msgstr "式および関数の引数を整理（式中の関数自体は文字定
 msgid "Simplify the sum"
 msgstr "数式を整理して出力"
 
-#: ../src/wxMaximaFrame.cpp:868
+#: ../src/wxMaximaFrame.cpp:867
 msgid "Simplify trigonometric expression"
 msgstr "三角関数をsinとcosの関数，双曲線関数をsinhとcoshの関数に変形"
 
@@ -3763,87 +3766,87 @@ msgstr ""
 "バーの「セル」より「画像の挿入」を選択してください。画像を挿入したドキュメン"
 "トを保存するときは「wxMaxima XML document」フォーマットを選択してください。"
 
-#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
+#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
 msgid "Solution:"
 msgstr "一般解："
 
-#: ../src/wxMaxima.cpp:3461 ../src/wxMaxima.cpp:3475 ../src/wxMaxima.cpp:5020
+#: ../src/wxMaxima.cpp:3473 ../src/wxMaxima.cpp:3487 ../src/wxMaxima.cpp:5032
 msgid "Solve"
 msgstr "方程式"
 
-#: ../src/wxMaximaFrame.cpp:706
+#: ../src/wxMaximaFrame.cpp:705
 msgid "Solve &Algebraic System..."
 msgstr "連立高次方程式の解を求める(&A)"
 
-#: ../src/wxMaximaFrame.cpp:703
+#: ../src/wxMaximaFrame.cpp:702
 msgid "Solve &Linear System..."
 msgstr "連立一次方程式を解く(&L)"
 
-#: ../src/wxMaximaFrame.cpp:714
+#: ../src/wxMaximaFrame.cpp:713
 msgid "Solve &ODE..."
 msgstr "微分方程式を解く(&O)"
 
-#: ../src/wxMaximaFrame.cpp:690
+#: ../src/wxMaximaFrame.cpp:689
 msgid "Solve (to_poly)..."
 msgstr "高次方程式の解を求める"
 
-#: ../src/wxMaxima.cpp:3511 ../src/wxMaxima.cpp:3635
+#: ../src/wxMaxima.cpp:3523 ../src/wxMaxima.cpp:3647
 msgid "Solve ODE"
 msgstr "微分方程式"
 
-#: ../src/wxMaximaFrame.cpp:728
+#: ../src/wxMaximaFrame.cpp:727
 msgid "Solve ODE with Lapla&ce..."
 msgstr "連立微分方程式を解く(&C)"
 
-#: ../src/wxMaximaFrame.cpp:1222
+#: ../src/wxMaximaFrame.cpp:1221
 msgid "Solve ODE..."
 msgstr "微分方程式"
 
-#: ../src/wxMaxima.cpp:3586 ../src/wxMaxima.cpp:3597
+#: ../src/wxMaxima.cpp:3598 ../src/wxMaxima.cpp:3609
 msgid "Solve algebraic system"
 msgstr "連立高次方程式"
 
-#: ../src/wxMaximaFrame.cpp:707
+#: ../src/wxMaximaFrame.cpp:706
 msgid "Solve algebraic system of equations"
 msgstr "連立高次方程式の近似解（可能であれば厳密解）を求める"
 
-#: ../src/wxMaximaFrame.cpp:725
+#: ../src/wxMaximaFrame.cpp:724
 msgid "Solve boundary value problem for second degree ODE"
 msgstr "2階微分方程式の一般解に境界条件を適用"
 
-#: ../src/wxMaximaFrame.cpp:689
+#: ../src/wxMaximaFrame.cpp:688
 msgid "Solve equation(s)"
 msgstr "解の公式から厳密解を求める"
 
-#: ../src/wxMaximaFrame.cpp:691
+#: ../src/wxMaximaFrame.cpp:690
 msgid "Solve equation(s) with to_poly_solve"
 msgstr "高次方程式の近似解を小数で求める"
 
-#: ../src/wxMaximaFrame.cpp:719
+#: ../src/wxMaximaFrame.cpp:718
 msgid "Solve initial value problem for first degree ODE"
 msgstr "1階微分方程式の一般解に初期条件を適用"
 
-#: ../src/wxMaximaFrame.cpp:722
+#: ../src/wxMaximaFrame.cpp:721
 msgid "Solve initial value problem for second degree ODE"
 msgstr "2階微分方程式の一般解に初期条件を適用"
 
-#: ../src/wxMaxima.cpp:3610 ../src/wxMaxima.cpp:3621
+#: ../src/wxMaxima.cpp:3622 ../src/wxMaxima.cpp:3633
 msgid "Solve linear system"
 msgstr "連立一次方程式"
 
-#: ../src/wxMaximaFrame.cpp:704
+#: ../src/wxMaximaFrame.cpp:703
 msgid "Solve linear system of equations"
 msgstr "連立一次方程式を解く"
 
-#: ../src/wxMaximaFrame.cpp:715
+#: ../src/wxMaximaFrame.cpp:714
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr "Maximaが対応しているのは2階常微分方程式までです"
 
-#: ../src/wxMaximaFrame.cpp:729
+#: ../src/wxMaximaFrame.cpp:728
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr "連立微分方程式を解く （関数は変数名を明示する必要があります 例：f(x)）"
 
-#: ../src/wxMaximaFrame.cpp:1221 ../src/MathCtrl.cpp:992
+#: ../src/MathCtrl.cpp:1034 ../src/wxMaximaFrame.cpp:1220
 msgid "Solve..."
 msgstr "方程式を解く"
 
@@ -3871,7 +3874,7 @@ msgstr "数学定数"
 msgid "Special constants"
 msgstr "数学定数（ギリシャ文字以外）"
 
-#: ../src/MathCtrl.cpp:922
+#: ../src/MathCtrl.cpp:964
 msgid "Start Animation"
 msgstr "アニメーションの開始"
 
@@ -3890,28 +3893,28 @@ msgstr ""
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:294
+#: ../src/wxMaxima.cpp:295
 msgid "Starting Maxima process failed"
 msgstr "Maximaプロセスを開始できませんでした"
 
-#: ../src/wxMaxima.cpp:928
+#: ../src/wxMaxima.cpp:933
 msgid "Starting Maxima..."
 msgstr "Maximaを起動しています"
 
-#: ../src/wxMaxima.cpp:292 ../src/wxMaxima.cpp:860
+#: ../src/wxMaxima.cpp:293 ../src/wxMaxima.cpp:865
 msgid "Starting server failed"
 msgstr "サーバーを開始できませんでした"
 
-#: ../src/wxMaxima.cpp:841
+#: ../src/wxMaxima.cpp:846
 #, c-format
 msgid "Starting server on port %d"
 msgstr "ポート%dにおいてサーバーが開始しました"
 
-#: ../src/wxMaximaFrame.cpp:342
+#: ../src/wxMaximaFrame.cpp:341
 msgid "Statistics"
 msgstr "統計処理"
 
-#: ../src/wxMaximaFrame.cpp:550
+#: ../src/wxMaximaFrame.cpp:549
 msgid "Statistics\tAlt-Shift-S"
 msgstr "統計処理\tAlt-Shift-S"
 
@@ -3927,11 +3930,11 @@ msgstr "スタイル"
 msgid "Styles"
 msgstr "スタイル"
 
-#: ../src/wxMaximaFrame.cpp:1283
+#: ../src/wxMaximaFrame.cpp:1282
 msgid "Subsample..."
 msgstr "標本（行ベクトル）抽出"
 
-#: ../src/wxMaximaFrame.cpp:1496
+#: ../src/wxMaximaFrame.cpp:1515
 msgid "Subsection"
 msgstr "サブセクション"
 
@@ -3939,20 +3942,20 @@ msgstr "サブセクション"
 msgid "Subsection cell"
 msgstr "サブセクションセル"
 
-#: ../src/wxMaximaFrame.cpp:1216
+#: ../src/wxMaximaFrame.cpp:1215
 msgid "Subst..."
 msgstr "部分式の置換"
 
-#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3423
-#: ../src/wxMaxima.cpp:5089
+#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3435
+#: ../src/wxMaxima.cpp:5101
 msgid "Substitute"
 msgstr "置換"
 
-#: ../src/wxMaximaFrame.cpp:906 ../src/MathCtrl.cpp:998
+#: ../src/MathCtrl.cpp:1040 ../src/wxMaximaFrame.cpp:905
 msgid "Substitute..."
 msgstr "式中の部分式を置換"
 
-#: ../src/wxMaximaFrame.cpp:1497
+#: ../src/wxMaximaFrame.cpp:1516
 #, fuzzy
 msgid "Subsubsection"
 msgstr "サブセクション"
@@ -3962,7 +3965,7 @@ msgstr "サブセクション"
 msgid "Subsubsection cell"
 msgstr "サブセクションセル"
 
-#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4226
+#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4238
 msgid "Sum"
 msgstr "総和"
 
@@ -3970,37 +3973,37 @@ msgstr "総和"
 msgid "Sum sign"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:553
+#: ../src/wxMaximaFrame.cpp:552
 #, fuzzy
 msgid "Symbols\tAlt-Shift-Y"
 msgstr "統計処理\tAlt-Shift-S"
 
-#: ../src/wxMaxima.cpp:4456
+#: ../src/wxMaxima.cpp:4468
 msgid "System info"
 msgstr "System info"
 
-#: ../src/wxMaximaFrame.cpp:320
+#: ../src/wxMaximaFrame.cpp:319
 msgid "Table of Contents"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:556
+#: ../src/wxMaximaFrame.cpp:555
 #, fuzzy
 msgid "Table of Contents\tAlt-Shift-T"
 msgstr "ツールバー\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:1382
+#: ../src/wxMaximaFrame.cpp:1381
 msgid "Tau"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Taylor series:"
 msgstr "テイラー級数："
 
-#: ../src/wxMaxima.cpp:3963
+#: ../src/wxMaxima.cpp:3975
 msgid "Tellrat"
 msgstr "Tellrat"
 
-#: ../src/wxMaximaFrame.cpp:1494
+#: ../src/wxMaximaFrame.cpp:1513
 msgid "Text"
 msgstr "テキスト"
 
@@ -4046,7 +4049,7 @@ msgstr ""
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr ""
 
-#: ../src/TextCell.cpp:136
+#: ../src/TextCell.cpp:134
 msgid ""
 "The letter \"X\" is of width zero. Installing http://www.math.union.edu/"
 "~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts\" in "
@@ -4063,7 +4066,7 @@ msgstr ""
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:959
+#: ../src/wxMaximaFrame.cpp:958
 msgid "The offline manual of maxima"
 msgstr "Maximaのオフラインマニュアルを開く"
 
@@ -4103,7 +4106,7 @@ msgstr ""
 "についてより多くの情報が必要であったり、チュートリアルをお探しならば、http://"
 "andrejv.github.com/wxmaxima/help.htmlを訪れてみて下さい。"
 
-#: ../src/SlideShowCell.cpp:332
+#: ../src/SlideShowCell.cpp:336
 msgid ""
 "There was an error during GIF export!\n"
 "\n"
@@ -4114,7 +4117,7 @@ msgstr ""
 "ImageMagickがインストールされ、wxMaximaが変換に使用するプログラムを見つけるこ"
 "とができることを確認してください。"
 
-#: ../src/wxMaxima.cpp:442
+#: ../src/wxMaxima.cpp:447
 msgid ""
 "There was an error in generated XML!\n"
 "\n"
@@ -4124,7 +4127,7 @@ msgstr ""
 "\n"
 "この事象をバグとして報告していただければ幸いです。"
 
-#: ../src/wxMaximaFrame.cpp:1371
+#: ../src/wxMaximaFrame.cpp:1370
 msgid "Theta"
 msgstr ""
 
@@ -4132,7 +4135,7 @@ msgstr ""
 msgid "Ticks:"
 msgstr "グラフの滑らかさ："
 
-#: ../src/wxMaxima.cpp:4153 ../src/wxMaxima.cpp:5065
+#: ../src/wxMaxima.cpp:4165 ../src/wxMaxima.cpp:5077
 msgid "Times:"
 msgstr "微分回数："
 
@@ -4140,7 +4143,7 @@ msgstr "微分回数："
 msgid "Tips not available, sorry!"
 msgstr "申し訳ないですが、Tipsは利用できません。"
 
-#: ../src/wxMaximaFrame.cpp:1495
+#: ../src/wxMaximaFrame.cpp:1514
 msgid "Title"
 msgstr "タイトル"
 
@@ -4159,19 +4162,19 @@ msgstr ""
 "リックすることで「隠す／展開」の切り替えができます。Shiftを押しながらクリック"
 "すると，下位のセル全体に対して「隠す／展開」を行います。"
 
-#: ../src/wxMaximaFrame.cpp:938
+#: ../src/wxMaximaFrame.cpp:937
 msgid "To &Bigfloat"
 msgstr "浮動小数点で出力(&B)"
 
-#: ../src/wxMaximaFrame.cpp:935
+#: ../src/wxMaximaFrame.cpp:934
 msgid "To &Float"
 msgstr "小数点で出力(&F)"
 
-#: ../src/MathCtrl.cpp:990
+#: ../src/MathCtrl.cpp:1032
 msgid "To Float"
 msgstr "小数点で出力"
 
-#: ../src/wxMaximaFrame.cpp:941
+#: ../src/wxMaximaFrame.cpp:940
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr "数値で出力(&C)\tCtrl+Shift+N"
 
@@ -4215,52 +4218,52 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:41 ../src/Plot2dWiz.cpp:40 ../src/Plot2dWiz.cpp:50
 #: ../src/Plot2dWiz.cpp:539 ../src/Plot3dWiz.cpp:39 ../src/Plot3dWiz.cpp:48
-#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4241
+#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4253
 msgid "To:"
 msgstr "上端："
 
-#: ../src/wxMaximaFrame.cpp:912
+#: ../src/wxMaximaFrame.cpp:911
 msgid "Toggle &Algebraic Flag"
 msgstr "代数的整数の整理の有効化(&A)"
 
-#: ../src/wxMaximaFrame.cpp:933
+#: ../src/wxMaximaFrame.cpp:932
 msgid "Toggle &Numeric Output"
 msgstr "自動的に数値で出力(&N)"
 
-#: ../src/wxMaximaFrame.cpp:673
+#: ../src/wxMaximaFrame.cpp:672
 msgid "Toggle &Time Display"
 msgstr "計算に要した時間を表示(&T)"
 
-#: ../src/wxMaximaFrame.cpp:913
+#: ../src/wxMaximaFrame.cpp:912
 msgid "Toggle algebraic flag"
 msgstr ""
 "式中の平方根や虚数といった代数的整数の整理を有効にします（デフォルトは無効）"
 
-#: ../src/wxMaximaFrame.cpp:577
+#: ../src/wxMaximaFrame.cpp:576
 msgid "Toggle full screen editing"
 msgstr "全画面表示の切り替え"
 
-#: ../src/wxMaximaFrame.cpp:934
+#: ../src/wxMaximaFrame.cpp:933
 msgid "Toggle numeric output"
 msgstr "平方根やπといった数を自動的に数値で出力"
 
-#: ../src/wxMaxima.cpp:4464
+#: ../src/wxMaxima.cpp:4476
 msgid "Toolbar icons"
 msgstr "ツールバーのアイコン"
 
-#: ../src/wxMaxima.cpp:4465
+#: ../src/wxMaxima.cpp:4477
 msgid "Translated by"
 msgstr "翻訳担当"
 
-#: ../src/wxMaximaFrame.cpp:763
+#: ../src/wxMaximaFrame.cpp:762
 msgid "Transpose a matrix"
 msgstr "転置行列を求める"
 
-#: ../src/MathCtrl.cpp:5834
+#: ../src/MathCtrl.cpp:5886
 msgid "Trying to undo an action without starting cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5901
+#: ../src/MathCtrl.cpp:5953
 msgid "Trying to undo something but the undo action is empty."
 msgstr ""
 
@@ -4268,11 +4271,11 @@ msgstr ""
 msgid "Turkish"
 msgstr "トルコ語"
 
-#: ../src/wxMaximaFrame.cpp:970
+#: ../src/wxMaximaFrame.cpp:969
 msgid "Tutorials"
 msgstr "チュートリアル"
 
-#: ../src/wxMaxima.cpp:4778
+#: ../src/wxMaxima.cpp:4790
 msgid "Two sample t-test"
 msgstr "t検定"
 
@@ -4284,15 +4287,15 @@ msgstr "タイプ："
 msgid "Ukrainian"
 msgstr "ウクライナ語"
 
-#: ../src/wxMaxima.cpp:5356
+#: ../src/wxMaxima.cpp:5372
 msgid "Un-closed parenthesis"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5323
+#: ../src/wxMaxima.cpp:5335
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5889
 msgid ""
 "Unable to interpret the version info I got from http://andrejv.github.io//"
 "wxmaxima/version.txt: "
@@ -4306,11 +4309,11 @@ msgstr "下線"
 msgid "Underscore converts to subscripts:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:492
+#: ../src/wxMaximaFrame.cpp:491
 msgid "Undo\tCtrl-Z"
 msgstr "元に戻す\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:493
+#: ../src/wxMaximaFrame.cpp:492
 msgid "Undo last change"
 msgstr "一番新しい入力をリセット"
 
@@ -4318,23 +4321,23 @@ msgstr "一番新しい入力をリセット"
 msgid "Undo limit (0 for none):"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:625
+#: ../src/wxMaximaFrame.cpp:624
 msgid "Unfold All\tCtrl-Alt-]"
 msgstr "全て展開する\tCtrl-Alt-]"
 
-#: ../src/wxMaximaFrame.cpp:626
+#: ../src/wxMaximaFrame.cpp:625
 msgid "Unfold all folded sections"
 msgstr "全ての折りたたまれたセクションを展開"
 
-#: ../src/wxMaxima.cpp:4458
+#: ../src/wxMaxima.cpp:4470
 msgid "Unicode Support"
 msgstr "Unicode Support"
 
-#: ../src/wxMaxima.cpp:5335
+#: ../src/wxMaxima.cpp:5347
 msgid "Unterminated comment."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5309
+#: ../src/wxMaxima.cpp:5321
 msgid "Unterminated string."
 msgstr ""
 
@@ -4342,15 +4345,15 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5859 ../src/wxMaxima.cpp:5866 ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5874 ../src/wxMaxima.cpp:5881 ../src/wxMaxima.cpp:5889
 msgid "Upgrade"
 msgstr "ソフトウェアの更新"
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Upper bound:"
 msgstr "上限："
 
-#: ../src/wxMaximaFrame.cpp:1383
+#: ../src/wxMaximaFrame.cpp:1382
 #, fuzzy
 msgid "Upsilon"
 msgstr "許容誤差："
@@ -4395,22 +4398,22 @@ msgstr ""
 msgid "User-defined labels"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3525
-#: ../src/wxMaxima.cpp:3541 ../src/wxMaxima.cpp:3649
+#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3537
+#: ../src/wxMaxima.cpp:3553 ../src/wxMaxima.cpp:3661
 msgid "Value:"
 msgstr "関数の値："
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:5019 ../src/wxMaxima.cpp:5064
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:5031 ../src/wxMaxima.cpp:5076
 msgid "Variable(s):"
 msgstr "変数："
 
 #: ../src/IntegrateWiz.cpp:33 ../src/LimitWiz.cpp:30 ../src/Plot2dWiz.cpp:34
 #: ../src/Plot2dWiz.cpp:44 ../src/Plot2dWiz.cpp:533 ../src/Plot3dWiz.cpp:33
 #: ../src/Plot3dWiz.cpp:42 ../src/SeriesWiz.cpp:36 ../src/SumWiz.cpp:30
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3749
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3761
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5045
 msgid "Variable:"
 msgstr "変数："
 
@@ -4418,25 +4421,25 @@ msgstr "変数："
 msgid "Variables"
 msgstr "変数"
 
-#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3571 ../src/wxMaxima.cpp:4206
-#: ../src/wxMaxima.cpp:4807
+#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3583 ../src/wxMaxima.cpp:4218
+#: ../src/wxMaxima.cpp:4819
 msgid "Variables:"
 msgstr "変数："
 
-#: ../src/wxMaximaFrame.cpp:1257
+#: ../src/wxMaximaFrame.cpp:1256
 msgid "Variance..."
 msgstr "標本分散"
 
-#: ../src/wxMaximaFrame.cpp:580
+#: ../src/wxMaximaFrame.cpp:579
 msgid "View"
 msgstr ""
 
-#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1674 ../src/wxMaxima.cpp:1769
-#: ../src/wxMaxima.cpp:1950
+#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1679 ../src/wxMaxima.cpp:1774
+#: ../src/wxMaxima.cpp:1955
 msgid "Warning"
 msgstr "Warning"
 
-#: ../src/wxMaximaFrame.cpp:109 ../src/wxMaximaFrame.cpp:295
+#: ../src/wxMaximaFrame.cpp:108 ../src/wxMaximaFrame.cpp:294
 msgid "Welcome to wxMaxima"
 msgstr "wxMaximaへようこそ"
 
@@ -4459,7 +4462,7 @@ msgid ""
 "introducing an empty line."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2567
+#: ../src/wxMaxima.cpp:2574
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) "
 "(*.wxm)|*.wxm"
@@ -4475,7 +4478,7 @@ msgid ""
 "as equation markers"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6798
+#: ../src/MathCtrl.cpp:6856
 msgid "Wrapped search"
 msgstr ""
 
@@ -4483,15 +4486,15 @@ msgstr ""
 msgid "Write matching parenthesis in text controls."
 msgstr "テキスト入力ボックスでの括弧の自動補完"
 
-#: ../src/wxMaxima.cpp:4461
+#: ../src/wxMaxima.cpp:4473
 msgid "Written by"
 msgstr "開発担当"
 
-#: ../src/wxMaximaFrame.cpp:557
+#: ../src/wxMaximaFrame.cpp:556
 msgid "XML Inspector"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1377
+#: ../src/wxMaximaFrame.cpp:1376
 msgid "Xi"
 msgstr ""
 
@@ -4562,7 +4565,7 @@ msgstr ""
 "ドラッグ、もしくはShiftキーを押しながら矢印キーで水平カーソルを動かしてくださ"
 "い。"
 
-#: ../src/wxMaxima.cpp:5856
+#: ../src/wxMaxima.cpp:5871
 #, c-format
 msgid ""
 "You have version %s. Current version is %s.\n"
@@ -4573,41 +4576,41 @@ msgstr ""
 "\n"
 "OKを選択してwxMaximaのウェブページを開いてください。"
 
-#: ../src/wxMaxima.cpp:5921
+#: ../src/wxMaxima.cpp:5936
 msgid "Your changes will be lost if you don't save them."
 msgstr "保存しなければ、変更は失われます"
 
-#: ../src/wxMaxima.cpp:5866
+#: ../src/wxMaxima.cpp:5881
 msgid "Your version of wxMaxima is up to date."
 msgstr "お使いのwxMaximaは最新版です"
 
-#: ../src/wxMaximaFrame.cpp:1369
+#: ../src/wxMaximaFrame.cpp:1368
 msgid "Zeta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:562
+#: ../src/wxMaximaFrame.cpp:561
 #, fuzzy
 msgid "Zoom &In\tCtrl-+"
 msgstr "拡大(&I)\tAlt-I"
 
-#: ../src/wxMaximaFrame.cpp:564
+#: ../src/wxMaximaFrame.cpp:563
 #, fuzzy
 msgid "Zoom Ou&t\tCtrl--"
 msgstr "縮小(&T)\tAlt-O"
 
-#: ../src/wxMaximaFrame.cpp:563
+#: ../src/wxMaximaFrame.cpp:562
 msgid "Zoom in 10%"
 msgstr "拡大率10%"
 
-#: ../src/wxMaximaFrame.cpp:565
+#: ../src/wxMaximaFrame.cpp:564
 msgid "Zoom out 10%"
 msgstr "縮小率10%"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaximaFrame.cpp:287
 msgid "[ unsaved ]"
 msgstr "[ 無題 ]"
 
-#: ../src/wxMaxima.cpp:5700
+#: ../src/wxMaxima.cpp:5715
 msgid "[ unsaved* ]"
 msgstr "[ 無題* ]"
 
@@ -4616,17 +4619,17 @@ msgstr "[ 無題* ]"
 msgid "[%i digits]"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4392
+#: ../src/MathCtrl.cpp:4447
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" style=\"max-width:90%%;\" >\n"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4517
+#: ../src/MathCtrl.cpp:4572
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" >"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1333
+#: ../src/wxMaximaFrame.cpp:1332
 msgid "alpha"
 msgstr ""
 
@@ -4639,7 +4642,7 @@ msgstr "展開"
 msgid "antisymmetric"
 msgstr "反対称行列"
 
-#: ../src/wxMaximaFrame.cpp:1334
+#: ../src/wxMaximaFrame.cpp:1333
 msgid "beta"
 msgstr ""
 
@@ -4683,7 +4686,7 @@ msgstr ""
 msgid "bug:Invalid sup tag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1354
+#: ../src/wxMaximaFrame.cpp:1353
 msgid "chi"
 msgstr ""
 
@@ -4696,7 +4699,7 @@ msgstr ""
 msgid "default"
 msgstr "ユーザ指定のプロットエンジン"
 
-#: ../src/wxMaximaFrame.cpp:1336
+#: ../src/wxMaximaFrame.cpp:1335
 msgid "delta"
 msgstr ""
 
@@ -4708,7 +4711,7 @@ msgstr "対角行列"
 msgid "empty"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1337
+#: ../src/wxMaximaFrame.cpp:1336
 #, fuzzy
 msgid "epsilon"
 msgstr "許容誤差："
@@ -4717,7 +4720,7 @@ msgstr "許容誤差："
 msgid "equivalent"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1339
+#: ../src/wxMaximaFrame.cpp:1338
 msgid "eta"
 msgstr ""
 
@@ -4733,7 +4736,7 @@ msgid ""
 "all=_ marks subscripts."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1335
+#: ../src/wxMaximaFrame.cpp:1334
 msgid "gamma"
 msgstr ""
 
@@ -4762,15 +4765,15 @@ msgstr "ドキュメント内で表示"
 msgid "intersection"
 msgstr "近づき方："
 
-#: ../src/wxMaximaFrame.cpp:1341
+#: ../src/wxMaximaFrame.cpp:1340
 msgid "iota"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1342
+#: ../src/wxMaximaFrame.cpp:1341
 msgid "kappa"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1343
+#: ../src/wxMaximaFrame.cpp:1342
 msgid "lambda"
 msgstr ""
 
@@ -4787,7 +4790,7 @@ msgstr "サブセクションセル"
 msgid "logscale"
 msgstr "対数目盛を使用"
 
-#: ../src/wxMaxima.cpp:3783
+#: ../src/wxMaxima.cpp:3795
 msgid "matrix[i,j]:"
 msgstr "関数f(i,j)="
 
@@ -4795,7 +4798,7 @@ msgstr "関数f(i,j)="
 msgid "maxima's pwd is path to document"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1344
+#: ../src/wxMaximaFrame.cpp:1343
 msgid "mu"
 msgstr ""
 
@@ -4812,7 +4815,7 @@ msgstr ""
 msgid "nand"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4524
+#: ../src/wxMaxima.cpp:4536
 msgid "no"
 msgstr "no"
 
@@ -4838,15 +4841,15 @@ msgstr ""
 msgid "not subset or equal"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1345
+#: ../src/wxMaximaFrame.cpp:1344
 msgid "nu"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1356
+#: ../src/wxMaximaFrame.cpp:1355
 msgid "omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1347
+#: ../src/wxMaximaFrame.cpp:1346
 msgid "omicron"
 msgstr ""
 
@@ -4859,11 +4862,11 @@ msgstr ""
 msgid "partial sign"
 msgstr "部分分数分解"
 
-#: ../src/wxMaximaFrame.cpp:1353
+#: ../src/wxMaximaFrame.cpp:1352
 msgid "phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1348
+#: ../src/wxMaximaFrame.cpp:1347
 msgid "pi"
 msgstr ""
 
@@ -4875,11 +4878,11 @@ msgstr ""
 msgid "proportional to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1355
+#: ../src/wxMaximaFrame.cpp:1354
 msgid "psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1349
+#: ../src/wxMaximaFrame.cpp:1348
 msgid "rho"
 msgstr ""
 
@@ -4887,7 +4890,7 @@ msgstr ""
 msgid "right"
 msgstr "右極限"
 
-#: ../src/wxMaximaFrame.cpp:1350
+#: ../src/wxMaximaFrame.cpp:1349
 msgid "sigma"
 msgstr ""
 
@@ -4909,7 +4912,7 @@ msgstr "サブセクションセル"
 msgid "symmetric"
 msgstr "対称行列"
 
-#: ../src/wxMaximaFrame.cpp:1351
+#: ../src/wxMaximaFrame.cpp:1350
 msgid "tau"
 msgstr ""
 
@@ -4921,7 +4924,7 @@ msgstr ""
 msgid "there is no"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1340
+#: ../src/wxMaximaFrame.cpp:1339
 msgid "theta"
 msgstr ""
 
@@ -4937,12 +4940,12 @@ msgstr ""
 msgid "union"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5903
+#: ../src/wxMaxima.cpp:5918
 msgid "unsaved"
 msgstr "[ 無題 ]"
 
-#: ../src/wxMaximaFrame.cpp:290 ../src/wxMaxima.cpp:2559
-#: ../src/wxMaxima.cpp:2826
+#: ../src/wxMaxima.cpp:2566 ../src/wxMaxima.cpp:2834
+#: ../src/wxMaximaFrame.cpp:289
 msgid "untitled"
 msgstr "無題"
 
@@ -4951,26 +4954,26 @@ msgstr "無題"
 msgid "untitled %d"
 msgstr "無題 %d"
 
-#: ../src/wxMaximaFrame.cpp:1352
+#: ../src/wxMaximaFrame.cpp:1351
 #, fuzzy
 msgid "upsilon"
 msgstr "許容誤差："
 
-#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4538
+#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4550
 msgid "wxMaxima"
 msgstr "wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
-#: ../src/wxMaxima.cpp:5700 ../src/wxMaxima.cpp:5709 ../src/wxMaxima.cpp:5712
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaxima.cpp:5715 ../src/wxMaxima.cpp:5724
+#: ../src/wxMaxima.cpp:5727 ../src/wxMaximaFrame.cpp:287
 #, c-format
 msgid "wxMaxima %s "
 msgstr "wxMaxima %s "
 
-#: ../src/wxMaximaFrame.cpp:952
+#: ../src/wxMaximaFrame.cpp:951
 msgid "wxMaxima &Help\tCtrl+?"
 msgstr "wxMaximaのヘルプ(&H)\tCtrl+?"
 
-#: ../src/wxMaximaFrame.cpp:955
+#: ../src/wxMaximaFrame.cpp:954
 msgid "wxMaxima &Help\tF1"
 msgstr "wxMaximaのヘルプ(&H)\tF1"
 
@@ -4981,11 +4984,11 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1619
+#: ../src/wxMaxima.cpp:1624
 msgid "wxMaxima cannot open content.xml in the .wxmx zip archive "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1633
+#: ../src/wxMaxima.cpp:1638
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
@@ -4993,7 +4996,7 @@ msgstr ""
 msgid "wxMaxima configuration"
 msgstr "設定"
 
-#: ../src/wxMaxima.cpp:1947
+#: ../src/wxMaxima.cpp:1952
 msgid ""
 "wxMaxima could not find Maxima!\n"
 "\n"
@@ -5006,7 +5009,7 @@ msgstr ""
 "い\n"
 "その後wxMaximaを再起動してください"
 
-#: ../src/wxMaxima.cpp:2204
+#: ../src/wxMaxima.cpp:2209
 msgid ""
 "wxMaxima could not find help files.\n"
 "\n"
@@ -5016,7 +5019,7 @@ msgstr ""
 "\n"
 "インストールが正常に行われたかどうか確かめてください"
 
-#: ../src/wxMaxima.cpp:2032
+#: ../src/wxMaxima.cpp:2037
 msgid ""
 "wxMaxima could not find tip files.\n"
 "\n"
@@ -5026,7 +5029,7 @@ msgstr ""
 "\n"
 "インストールが正常に行われたかどうか確かめてください"
 
-#: ../src/wxMaxima.cpp:282
+#: ../src/wxMaxima.cpp:283
 msgid ""
 "wxMaxima could not start the server.\n"
 "\n"
@@ -5046,23 +5049,23 @@ msgstr ""
 "に「％」（直前の出力結果を表す記号）があらかじめ入力されています。ただし、ド"
 "キュメント内に選択状態のものがある場合、「％」の代わりにそれが入力されます。"
 
-#: ../src/wxMaxima.cpp:2330
+#: ../src/wxMaxima.cpp:2336
 msgid "wxMaxima document"
 msgstr "wxMaxima document"
 
-#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2799
+#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2807
 msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 msgstr "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 
-#: ../src/wxMaxima.cpp:1455 ../src/wxMaxima.cpp:1469
+#: ../src/wxMaxima.cpp:1460 ../src/wxMaxima.cpp:1474
 msgid "wxMaxima encountered an error loading "
 msgstr "以下のファイルの読込みに失敗しました　"
 
-#: ../src/wxMaxima.cpp:4463
+#: ../src/wxMaxima.cpp:4475
 msgid "wxMaxima icon"
 msgstr "wxMaxima"
 
-#: ../src/wxMaxima.cpp:4455
+#: ../src/wxMaxima.cpp:4467
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "MAXIMA based on wxWidgets."
@@ -5070,7 +5073,7 @@ msgstr ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "MAXIMA based on wxWidgets."
 
-#: ../src/wxMaxima.cpp:4516
+#: ../src/wxMaxima.cpp:4528
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "Maxima based on wxWidgets."
@@ -5090,11 +5093,11 @@ msgstr ""
 msgid "x"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1346
+#: ../src/wxMaximaFrame.cpp:1345
 msgid "xi"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1643
+#: ../src/wxMaxima.cpp:1648
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
@@ -5103,11 +5106,11 @@ msgstr ""
 msgid "xor"
 msgstr "エクスポート"
 
-#: ../src/wxMaxima.cpp:4522
+#: ../src/wxMaxima.cpp:4534
 msgid "yes"
 msgstr "yes"
 
-#: ../src/wxMaximaFrame.cpp:1338
+#: ../src/wxMaximaFrame.cpp:1337
 msgid "zeta"
 msgstr ""
 

--- a/locales/kab.po
+++ b/locales/kab.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fr\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-07 21:42+0200\n"
+"POT-Creation-Date: 2016-10-16 17:47+0900\n"
 "PO-Revision-Date: 2016-07-10 20:53+0100\n"
 "Last-Translator: Belkacem Mohammed <belkacem77@gmail.com>\n"
 "Language-Team: kabyle <kab@li.org>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.8\n"
 
-#: ../src/wxMaxima.cpp:4519
+#: ../src/wxMaxima.cpp:4531
 #, c-format
 msgid ""
 "\n"
@@ -29,7 +29,7 @@ msgstr ""
 "wxWidgets: %d.%d.%d\n"
 "Support d'Unicode: %s"
 
-#: ../src/wxMaxima.cpp:4532
+#: ../src/wxMaxima.cpp:4544
 msgid ""
 "\n"
 "Lisp: "
@@ -37,7 +37,7 @@ msgstr ""
 "\n"
 "Lisp : "
 
-#: ../src/wxMaxima.cpp:4528
+#: ../src/wxMaxima.cpp:4540
 msgid ""
 "\n"
 "Maxima version: "
@@ -45,7 +45,7 @@ msgstr ""
 "\n"
 "Lqem n Maxima : "
 
-#: ../src/wxMaxima.cpp:5381
+#: ../src/wxMaxima.cpp:5397
 msgid ""
 "\n"
 "Not connected to Maxima!\n"
@@ -53,7 +53,7 @@ msgstr ""
 "\n"
 "Ur yeqqin ara ɣer  Maxima!\n"
 
-#: ../src/wxMaxima.cpp:4530
+#: ../src/wxMaxima.cpp:4542
 msgid ""
 "\n"
 "Not connected."
@@ -73,7 +73,7 @@ msgstr "      -l <name>"
 msgid " (Graphics) "
 msgstr " (Udlifen) "
 
-#: ../src/EditorCell.cpp:3045 ../src/EditorCell.cpp:3227
+#: ../src/EditorCell.cpp:3088 ../src/EditorCell.cpp:3270
 #, c-format
 msgid " ... + %i hidden lines"
 msgstr ""
@@ -82,7 +82,7 @@ msgstr ""
 msgid " << Expression longer than allowed by the configuration setting! >>"
 msgstr " << Teɣzi n tenfalit yettusirgen deg iɣewwaṛen n twila! >>"
 
-#: ../src/wxMaxima.cpp:1673
+#: ../src/wxMaxima.cpp:1678
 msgid ""
 " was saved using a newer version of wxMaxima so it may not load correctly. "
 "Please update your wxMaxima."
@@ -90,7 +90,7 @@ msgstr ""
 "yettwasekles s lqem aneggaru n ‎wxMaxima, ihi ur yezmir ara ad d-yali akken "
 "iwata. Ma ulac aɣilif leqqem wxMaxima."
 
-#: ../src/wxMaxima.cpp:1665
+#: ../src/wxMaxima.cpp:1670
 msgid ""
 " was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr ""
@@ -104,64 +104,64 @@ msgstr ""
 msgid "\"implies\" symbol"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:101
+#: ../src/wxMaximaFrame.cpp:100
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:773
+#: ../src/wxMaximaFrame.cpp:772
 msgid "&Algebra"
 msgstr "&Aljibṛ"
 
-#: ../src/wxMaximaFrame.cpp:767
+#: ../src/wxMaximaFrame.cpp:766
 msgid "&Apply to List..."
 msgstr "&Snes i tebdart…"
 
-#: ../src/wxMaximaFrame.cpp:964
+#: ../src/wxMaximaFrame.cpp:963
 msgid "&Apropos..."
 msgstr "&À propos…"
 
-#: ../src/wxMaximaFrame.cpp:478
+#: ../src/wxMaximaFrame.cpp:477
 msgid "&Batch File...\tCtrl-B"
 msgstr "Traiter un fichier\tCTRL-B"
 
-#: ../src/wxMaximaFrame.cpp:724
+#: ../src/wxMaximaFrame.cpp:723
 msgid "&Boundary Value Problem..."
 msgstr "Pro&blème aux limites…"
 
-#: ../src/wxMaximaFrame.cpp:975
+#: ../src/wxMaximaFrame.cpp:974
 msgid "&Bug Report"
 msgstr "Rapport de &bogue"
 
-#: ../src/wxMaximaFrame.cpp:825
+#: ../src/wxMaximaFrame.cpp:824
 msgid "&Calculus"
 msgstr "A&siḍen"
 
-#: ../src/wxMaximaFrame.cpp:876
+#: ../src/wxMaximaFrame.cpp:875
 msgid "&Canonical Form"
 msgstr "Tala  &tuqnint"
 
-#: ../src/wxMaximaFrame.cpp:749
+#: ../src/wxMaximaFrame.cpp:748
 msgid "&Characteristic Polynomial..."
 msgstr "Polynôme &caractéristique…"
 
-#: ../src/wxMaximaFrame.cpp:654
+#: ../src/wxMaximaFrame.cpp:653
 msgid "&Clear Memory"
 msgstr "Effa&cer la mémoire"
 
-#: ../src/wxMaximaFrame.cpp:859
+#: ../src/wxMaximaFrame.cpp:858
 msgid "&Combine Factorials"
 msgstr "&Combiner les factorielles"
 
-#: ../src/wxMaximaFrame.cpp:902
+#: ../src/wxMaximaFrame.cpp:901
 msgid "&Complex Simplification"
 msgstr "Simplification &complexe"
 
-#: ../src/wxMaximaFrame.cpp:822
+#: ../src/wxMaximaFrame.cpp:821
 msgid "&Continued Fraction"
 msgstr "Fraction &continue"
 
-#: ../src/wxMaximaFrame.cpp:502
+#: ../src/wxMaximaFrame.cpp:501
 msgid "&Copy\tCtrl-C"
 msgstr "&Copier\tCtrl-C"
 
@@ -169,107 +169,107 @@ msgstr "&Copier\tCtrl-C"
 msgid "&Definite integration"
 msgstr "Intégrale &définie"
 
-#: ../src/wxMaximaFrame.cpp:896
+#: ../src/wxMaximaFrame.cpp:895
 msgid "&Demoivre"
 msgstr "&Demoivre"
 
-#: ../src/wxMaximaFrame.cpp:752
+#: ../src/wxMaximaFrame.cpp:751
 msgid "&Determinant"
 msgstr "Améguccal"
 
-#: ../src/wxMaximaFrame.cpp:785
+#: ../src/wxMaximaFrame.cpp:784
 msgid "&Differentiate..."
 msgstr "&Zlem…"
 
-#: ../src/wxMaximaFrame.cpp:543
+#: ../src/wxMaximaFrame.cpp:542
 msgid "&Edit"
 msgstr "&Taẓrigt"
 
-#: ../src/wxMaximaFrame.cpp:709
+#: ../src/wxMaximaFrame.cpp:708
 msgid "&Eliminate Variable..."
 msgstr "&Éliminer une variable…"
 
-#: ../src/wxMaximaFrame.cpp:744
+#: ../src/wxMaximaFrame.cpp:743
 msgid "&Enter Matrix..."
 msgstr "&Sekcem isirew..."
 
-#: ../src/wxMaximaFrame.cpp:961
+#: ../src/wxMaximaFrame.cpp:960
 msgid "&Example..."
 msgstr "&Exemple"
 
-#: ../src/wxMaximaFrame.cpp:839
+#: ../src/wxMaximaFrame.cpp:838
 msgid "&Expand Expression"
 msgstr "Dév&elopper une expression"
 
-#: ../src/wxMaximaFrame.cpp:873
+#: ../src/wxMaximaFrame.cpp:872
 msgid "&Expand Trigonometric"
 msgstr "Dév&elopper une expression trigonométrique"
 
-#: ../src/wxMaximaFrame.cpp:899
+#: ../src/wxMaximaFrame.cpp:898
 msgid "&Exponentialize"
 msgstr "&Exposant"
 
-#: ../src/wxMaximaFrame.cpp:480
+#: ../src/wxMaximaFrame.cpp:479
 msgid "&Export..."
 msgstr "&Exporter"
 
-#: ../src/wxMaximaFrame.cpp:834
+#: ../src/wxMaximaFrame.cpp:833
 msgid "&Factor Expression"
 msgstr "&Factoriser une expression"
 
-#: ../src/wxMaximaFrame.cpp:489
+#: ../src/wxMaximaFrame.cpp:488
 msgid "&File"
 msgstr "A&faylu"
 
-#: ../src/wxMaximaFrame.cpp:692
+#: ../src/wxMaximaFrame.cpp:691
 msgid "&Find Root..."
 msgstr "A&f tifrat..."
 
-#: ../src/wxMaximaFrame.cpp:738
+#: ../src/wxMaximaFrame.cpp:737
 msgid "&Generate Matrix..."
 msgstr "&Générer une matrice…"
 
-#: ../src/wxMaximaFrame.cpp:809
+#: ../src/wxMaximaFrame.cpp:808
 msgid "&Greatest Common Divisor..."
 msgstr "Plus &grand diviseur commun…"
 
-#: ../src/wxMaximaFrame.cpp:994
+#: ../src/wxMaximaFrame.cpp:993
 msgid "&Help"
 msgstr "Ta&llalt"
 
-#: ../src/wxMaximaFrame.cpp:777
+#: ../src/wxMaximaFrame.cpp:776
 msgid "&Integrate..."
 msgstr "&Sidef…"
 
-#: ../src/wxMaximaFrame.cpp:645
+#: ../src/wxMaximaFrame.cpp:644
 msgid "&Interrupt\tCtrl-."
 msgstr "&Interrompre\tCtrl-."
 
-#: ../src/wxMaximaFrame.cpp:649
+#: ../src/wxMaximaFrame.cpp:648
 msgid "&Interrupt\tCtrl-G"
 msgstr "&Interrompre\tCtrl-G"
 
-#: ../src/wxMaximaFrame.cpp:746
+#: ../src/wxMaximaFrame.cpp:745
 msgid "&Invert Matrix"
 msgstr "&Inverser la matrice"
 
-#: ../src/wxMaximaFrame.cpp:476
+#: ../src/wxMaximaFrame.cpp:475
 msgid "&Load Package...\tCtrl-L"
 msgstr "Sali-d akemmus\tCtrl-L"
 
-#: ../src/wxMaximaFrame.cpp:769
+#: ../src/wxMaximaFrame.cpp:768
 msgid "&Map to List(s)..."
 msgstr "Sens ɣef teb&dart (tibdarin)…"
 
-#: ../src/wxMaximaFrame.cpp:684
+#: ../src/wxMaximaFrame.cpp:683
 msgid "&Maxima"
 msgstr "&Maxima"
 
-#: ../src/wxMaximaFrame.cpp:958
+#: ../src/wxMaximaFrame.cpp:957
 msgid "&Maxima help"
 msgstr "Sken tallalt n Maxima"
 
-#: ../src/wxMaximaFrame.cpp:917
+#: ../src/wxMaximaFrame.cpp:916
 msgid "&Modulus Computation..."
 msgstr "Calcul &modulaire…"
 
@@ -277,7 +277,7 @@ msgstr "Calcul &modulaire…"
 msgid "&New\tCtrl-N"
 msgstr "&Rni tiɣimit session\tCtrl-N"
 
-#: ../src/wxMaximaFrame.cpp:947
+#: ../src/wxMaximaFrame.cpp:946
 msgid "&Numeric"
 msgstr "&Umḍin"
 
@@ -293,11 +293,11 @@ msgstr "&Nusum"
 msgid "&Open\tCtrl-O"
 msgstr "&Ldi tiɣimit\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:463
+#: ../src/wxMaximaFrame.cpp:462
 msgid "&Open...\tCtrl-O"
 msgstr "&Ldi tiɣimit\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:929
+#: ../src/wxMaximaFrame.cpp:928
 msgid "&Plot"
 msgstr "Asuneɣ n tmaknayt"
 
@@ -305,7 +305,7 @@ msgstr "Asuneɣ n tmaknayt"
 msgid "&Power series"
 msgstr "Série entière"
 
-#: ../src/wxMaximaFrame.cpp:483
+#: ../src/wxMaximaFrame.cpp:482
 msgid "&Print...\tCtrl-P"
 msgstr "Im&primer\tCtrl-P"
 
@@ -313,39 +313,39 @@ msgstr "Im&primer\tCtrl-P"
 msgid "&Rational"
 msgstr "&Rationnel"
 
-#: ../src/wxMaximaFrame.cpp:870
+#: ../src/wxMaximaFrame.cpp:869
 msgid "&Reduce Trigonometric"
 msgstr "&Réduire une expression trigonométrique"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "&Restart Maxima"
 msgstr "S&enker tikelt nniḍen Maxima"
 
-#: ../src/wxMaximaFrame.cpp:700
+#: ../src/wxMaximaFrame.cpp:699
 msgid "&Roots of Polynomial (Real)"
 msgstr "&Racines d'un polynôme (réelles)"
 
-#: ../src/wxMaximaFrame.cpp:472
+#: ../src/wxMaximaFrame.cpp:471
 msgid "&Save\tCtrl-S"
 msgstr "&Sekles tiɣimit\tCtrl-S"
 
-#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:919
+#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:918
 msgid "&Simplify"
 msgstr "&Sefres"
 
-#: ../src/wxMaximaFrame.cpp:829
+#: ../src/wxMaximaFrame.cpp:828
 msgid "&Simplify Expression"
 msgstr "&Simplifier une expression"
 
-#: ../src/wxMaximaFrame.cpp:856
+#: ../src/wxMaximaFrame.cpp:855
 msgid "&Simplify Factorials"
 msgstr "&Simplifier des factorielles"
 
-#: ../src/wxMaximaFrame.cpp:867
+#: ../src/wxMaximaFrame.cpp:866
 msgid "&Simplify Trigonometric"
 msgstr "&Simplifier une expression trigonométrique"
 
-#: ../src/wxMaximaFrame.cpp:688
+#: ../src/wxMaximaFrame.cpp:687
 msgid "&Solve..."
 msgstr "&Fru…"
 
@@ -357,11 +357,11 @@ msgstr "&Imeẓli"
 msgid "&Taylor series"
 msgstr "Série de Taylor :"
 
-#: ../src/wxMaximaFrame.cpp:762
+#: ../src/wxMaximaFrame.cpp:761
 msgid "&Transpose Matrix"
 msgstr "&Transposer une matrice"
 
-#: ../src/wxMaximaFrame.cpp:879
+#: ../src/wxMaximaFrame.cpp:878
 msgid "&Trigonometric Simplification"
 msgstr "Simplification &trigonométrique"
 
@@ -379,7 +379,7 @@ msgstr "(Seqdec tutlayt tamezwert)"
 msgid "- Infinity"
 msgstr "- Infini"
 
-#: ../src/wxMaxima.cpp:351
+#: ../src/wxMaxima.cpp:356
 msgid ""
 "... [suppressed additional lines since the output is longer than allowed in "
 "the configuration] "
@@ -389,16 +389,16 @@ msgstr ""
 msgid "1/2"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:103
+#: ../src/wxMaximaFrame.cpp:102
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4601
+#: ../src/wxMaxima.cpp:4613
 msgid "<br>Lisp: "
 msgstr "<br>Lisp : "
 
-#: ../src/wxMaxima.cpp:5487
+#: ../src/wxMaxima.cpp:5503
 msgid ""
 "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
@@ -432,11 +432,11 @@ msgid ""
 "\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1472
+#: ../src/wxMaximaFrame.cpp:1495
 msgid "A symbol from the configuration dialogue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:731
+#: ../src/wxMaximaFrame.cpp:730
 msgid "A&t Value..."
 msgstr "À la valeur…"
 
@@ -444,12 +444,12 @@ msgstr "À la valeur…"
 msgid "Abort evaluation on error"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaxima.cpp:4603
+#: ../src/wxMaxima.cpp:4615 ../src/wxMaximaFrame.cpp:985
 msgid "About"
 msgstr "Talɣut ɣef"
 
-#: ../src/wxMaximaFrame.cpp:987 ../src/wxMaximaFrame.cpp:990
-#: ../src/wxMaximaFrame.cpp:991
+#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaximaFrame.cpp:989
+#: ../src/wxMaximaFrame.cpp:990
 msgid "About wxMaxima"
 msgstr "À propos de wxMaxima"
 
@@ -457,23 +457,23 @@ msgstr "À propos de wxMaxima"
 msgid "Active cell bracket"
 msgstr "Crochet de la cellule active"
 
-#: ../src/wxMaximaFrame.cpp:760
+#: ../src/wxMaximaFrame.cpp:759
 msgid "Ad&joint Matrix"
 msgstr "Matrice associée"
 
-#: ../src/wxMaximaFrame.cpp:914
+#: ../src/wxMaximaFrame.cpp:913
 msgid "Add Algebraic E&quality..."
 msgstr "Ajouter une égalité algébri&que"
 
-#: ../src/wxMaximaFrame.cpp:657
+#: ../src/wxMaximaFrame.cpp:656
 msgid "Add a directory to search path"
 msgstr "Ajouter un répertoire au chemin de recherche"
 
-#: ../src/wxMaxima.cpp:3353
+#: ../src/wxMaxima.cpp:3365
 msgid "Add dir to path:"
 msgstr "Ajouter le répertoire au chemin:"
 
-#: ../src/wxMaximaFrame.cpp:915
+#: ../src/wxMaximaFrame.cpp:914
 msgid "Add equality to the rational simplifier"
 msgstr "Ajouter une égalité au simplificateur rationnel"
 
@@ -481,7 +481,7 @@ msgstr "Ajouter une égalité au simplificateur rationnel"
 msgid "Add the .wxmx file to the HTML export"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:656
+#: ../src/wxMaximaFrame.cpp:655
 msgid "Add to &Path..."
 msgstr "Ajouter au &chemin"
 
@@ -522,27 +522,27 @@ msgstr "Ancienne variable :"
 msgid "All|*"
 msgstr "Akk|*"
 
-#: ../src/wxMaximaFrame.cpp:1364
+#: ../src/wxMaximaFrame.cpp:1363
 msgid "Alpha"
 msgstr "Alpha"
 
-#: ../src/wxMaxima.cpp:3838
+#: ../src/wxMaxima.cpp:3850
 msgid "Apply"
 msgstr "Snes"
 
-#: ../src/wxMaximaFrame.cpp:768
+#: ../src/wxMaximaFrame.cpp:767
 msgid "Apply function to a list"
 msgstr "Appliquer une fonction à une liste"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Apropos"
 msgstr "Talɣut ɣef"
 
-#: ../src/wxMaxima.cpp:3764
+#: ../src/wxMaxima.cpp:3776
 msgid "Array:"
 msgstr "Tableau :"
 
-#: ../src/wxMaxima.cpp:4462
+#: ../src/wxMaxima.cpp:4474
 msgid "Artwork by"
 msgstr "Graphisme de "
 
@@ -550,7 +550,7 @@ msgstr "Graphisme de "
 msgid "Ask to save untitled documents"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3650
+#: ../src/wxMaxima.cpp:3662
 msgid "At value"
 msgstr "Ɣer wazal :"
 
@@ -571,11 +571,11 @@ msgstr ""
 msgid "Autosave interval (minutes, 0 means: off):"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3557
+#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3569
 msgid "BC2"
 msgstr "BC2"
 
-#: ../src/wxMaximaFrame.cpp:1272
+#: ../src/wxMaximaFrame.cpp:1271
 msgid "Barsplot..."
 msgstr "Udlif s ifeggagen…"
 
@@ -583,7 +583,7 @@ msgstr "Udlif s ifeggagen…"
 msgid "Bat files (*.bat)|*.bat|All|*"
 msgstr "Fichiers bat  (*.bat)|*.bat|Tous|*"
 
-#: ../src/wxMaxima.cpp:2943
+#: ../src/wxMaxima.cpp:2951
 msgid "Batch File"
 msgstr "Fichier de commandes"
 
@@ -596,7 +596,7 @@ msgid ""
 "cells."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1365
+#: ../src/wxMaximaFrame.cpp:1364
 msgid "Beta"
 msgstr "Beta"
 
@@ -608,11 +608,11 @@ msgstr ""
 msgid "Bold"
 msgstr "Zur"
 
-#: ../src/wxMaxima.cpp:2359
+#: ../src/wxMaxima.cpp:2366
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1274
+#: ../src/wxMaximaFrame.cpp:1273
 msgid "Boxplot..."
 msgstr "Udlif n tnaka…"
 
@@ -624,15 +624,15 @@ msgstr "Snirem"
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2080
+#: ../src/MathCtrl.cpp:2127
 msgid "Bug: Cell left but not entered."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1178
+#: ../src/wxMaxima.cpp:1183
 msgid "Bug: Found a math end marker without any start marker."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1222
+#: ../src/wxMaxima.cpp:1227
 msgid "Bug: Found the end of autocompletion symbols but no beginning"
 msgstr ""
 
@@ -644,22 +644,22 @@ msgstr ""
 msgid "Bug: Fraction without enumerator"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2312
+#: ../src/MathCtrl.cpp:2359
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5839
+#: ../src/MathCtrl.cpp:5891
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of "
 "the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5913
+#: ../src/MathCtrl.cpp:5965
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5882
+#: ../src/MathCtrl.cpp:5934
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
@@ -669,49 +669,49 @@ msgstr ""
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
 msgstr ""
 
-#: ../src/GroupCell.cpp:780 ../src/GroupCell.cpp:951
+#: ../src/GroupCell.cpp:781 ../src/GroupCell.cpp:952
 msgid "Bug: No image counter to write to!"
 msgstr ""
 
-#: ../src/AbsCell.cpp:193
+#: ../src/AbsCell.cpp:199
 msgid "Bug: No last cell in an absCell!"
 msgstr ""
 
-#: ../src/ConjugateCell.cpp:185
+#: ../src/ConjugateCell.cpp:194
 msgid "Bug: No last cell in an conjugateCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:471
+#: ../src/FracCell.cpp:472
 msgid "Bug: No last cell in an denominator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:267
+#: ../src/ExptCell.cpp:270
 msgid "Bug: No last cell in an exponent of an exptCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:459
+#: ../src/FracCell.cpp:460
 msgid "Bug: No last cell in an numerator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:257
+#: ../src/ExptCell.cpp:260
 msgid "Bug: No last cell in the base of an exptCell!"
 msgstr ""
 
-#: ../src/ParenCell.cpp:534
+#: ../src/ParenCell.cpp:535
 msgid "Bug: No last cell inside a parenthesis!"
 msgstr ""
 
-#: ../src/SqrtCell.cpp:312
+#: ../src/SqrtCell.cpp:317
 msgid "Bug: No last cell inside a square root!"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2123
+#: ../src/MathCtrl.cpp:2170
 msgid ""
 "Bug: Start or end of merging of subsequent editing actions was requested two "
 "times in a row."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2090
+#: ../src/MathCtrl.cpp:2137
 msgid "Bug: Text changed, but no active cell."
 msgstr ""
 
@@ -719,39 +719,39 @@ msgstr ""
 msgid "Bug: Trying to append NULL to a group cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:555
+#: ../src/MathCtrl.cpp:600
 msgid "Bug: Trying to append maxima's output to a cell outside the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2014
+#: ../src/MathCtrl.cpp:2061
 msgid ""
 "Bug: Trying to merge individual cell adds to a region in the undo buffer but "
 "there are other cells between them."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6522
+#: ../src/MathCtrl.cpp:6577
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2092
+#: ../src/MathCtrl.cpp:2139
 msgid "Bug: Trying to record a cell contents change without a cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1495
+#: ../src/MathCtrl.cpp:1540
 msgid "Bug: Trying to select inside a cell without having a current cell"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5883
+#: ../src/MathCtrl.cpp:5935
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5844 ../src/MathCtrl.cpp:5918 ../src/MathCtrl.cpp:5952
+#: ../src/MathCtrl.cpp:5896 ../src/MathCtrl.cpp:5970 ../src/MathCtrl.cpp:6004
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:973
+#: ../src/wxMaximaFrame.cpp:972
 msgid "Build &Info"
 msgstr "Information &de compilation"
 
@@ -769,52 +769,52 @@ msgstr ""
 "avec la touche Entrée\". Cette option permute le rôle de ces deux "
 "combinaisons de touches."
 
-#: ../src/wxMaximaFrame.cpp:782
+#: ../src/wxMaximaFrame.cpp:781
 msgid "C&hange Variable..."
 msgstr "C&hanger de variable…"
 
-#: ../src/wxMaximaFrame.cpp:540
+#: ../src/wxMaximaFrame.cpp:539
 msgid "C&onfigure"
 msgstr "C&onfigurer"
 
-#: ../src/wxMaximaFrame.cpp:801
+#: ../src/wxMaximaFrame.cpp:800
 msgid "Calculate &Product..."
 msgstr "Calculer le &produit…"
 
-#: ../src/wxMaximaFrame.cpp:799
+#: ../src/wxMaximaFrame.cpp:798
 msgid "Calculate Su&m..."
 msgstr "Calculer la som&me…"
 
-#: ../src/wxMaximaFrame.cpp:939
+#: ../src/wxMaximaFrame.cpp:938
 msgid "Calculate bigfloat value of the last result"
 msgstr "Valeur approchée (bigfloat) d'une expression"
 
-#: ../src/wxMaximaFrame.cpp:936
+#: ../src/wxMaximaFrame.cpp:935
 msgid "Calculate float value of the last result"
 msgstr "Calculer une valeur approchée du dernier résultat"
 
-#: ../src/wxMaxima.cpp:3971
+#: ../src/wxMaxima.cpp:3983
 msgid "Calculate modulus:"
 msgstr "Calculer le module :"
 
-#: ../src/wxMaximaFrame.cpp:942
+#: ../src/wxMaximaFrame.cpp:941
 #, fuzzy
 msgid "Calculate numeric value of the last result"
 msgstr "Calculer une valeur approchée du dernier résultat"
 
-#: ../src/wxMaximaFrame.cpp:802
+#: ../src/wxMaximaFrame.cpp:801
 msgid "Calculate products"
 msgstr "Calculer les produits"
 
-#: ../src/wxMaximaFrame.cpp:800
+#: ../src/wxMaximaFrame.cpp:799
 msgid "Calculate sums"
 msgstr "Calculer les sommes"
 
-#: ../src/wxMaxima.cpp:5830
+#: ../src/wxMaxima.cpp:5845
 msgid "Can not connect to the web server."
 msgstr "Ur yezmir ara ad yeqqen ɣer uqeddac Web"
 
-#: ../src/wxMaxima.cpp:5881
+#: ../src/wxMaxima.cpp:5896
 msgid "Can not download version info."
 msgstr ""
 
@@ -830,15 +830,15 @@ msgstr ""
 #: ../src/PlotFormatWiz.cpp:48 ../src/SeriesWiz.cpp:49 ../src/SeriesWiz.cpp:51
 #: ../src/SubstituteWiz.cpp:41 ../src/SubstituteWiz.cpp:43 ../src/SumWiz.cpp:44
 #: ../src/SumWiz.cpp:46 ../src/SystemWiz.cpp:38 ../src/SystemWiz.cpp:40
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Cancel"
 msgstr "Sefsex"
 
-#: ../src/wxMaximaFrame.cpp:126 ../src/wxMaxima.cpp:932
+#: ../src/wxMaxima.cpp:937 ../src/wxMaximaFrame.cpp:125
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1217
+#: ../src/wxMaximaFrame.cpp:1216
 msgid "Canonical (tr)"
 msgstr "Uqnin(asektiɣmer)"
 
@@ -846,7 +846,7 @@ msgstr "Uqnin(asektiɣmer)"
 msgid "Catalan"
 msgstr "Takaṭalant"
 
-#: ../src/wxMaximaFrame.cpp:638
+#: ../src/wxMaximaFrame.cpp:637
 msgid "Ce&ll"
 msgstr "Tabni&qt"
 
@@ -854,39 +854,39 @@ msgstr "Tabni&qt"
 msgid "Cell bracket"
 msgstr "Crochet de la cellule"
 
-#: ../src/wxMaxima.cpp:5261
+#: ../src/wxMaxima.cpp:5273
 msgid "Cell ends in a backslash"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:676
+#: ../src/wxMaximaFrame.cpp:675
 msgid "Change &2d Display"
 msgstr "Basculer en affichage &2d"
 
-#: ../src/wxMaximaFrame.cpp:677
+#: ../src/wxMaximaFrame.cpp:676
 msgid "Change the 2d display algorithm used to display math output"
 msgstr "Modifier l'algorithme d'affichage 2d utilisé pour les mathématiques"
 
-#: ../src/wxMaxima.cpp:3995
+#: ../src/wxMaxima.cpp:4007
 msgid "Change variable"
 msgstr "Changer la variable"
 
-#: ../src/wxMaximaFrame.cpp:783
+#: ../src/wxMaximaFrame.cpp:782
 msgid "Change variable in integral or sum"
 msgstr "Change la variable dans l'intégrale ou la somme"
 
-#: ../src/wxMaxima.cpp:3751
+#: ../src/wxMaxima.cpp:3763
 msgid "Char poly"
 msgstr "Polynôme caractéristique"
 
-#: ../src/wxMaximaFrame.cpp:978
+#: ../src/wxMaximaFrame.cpp:977
 msgid "Check for Updates"
 msgstr "Rechercher des mises à jour"
 
-#: ../src/wxMaximaFrame.cpp:979
+#: ../src/wxMaximaFrame.cpp:978
 msgid "Check if a newer version of wxMaxima/Maxima exist."
 msgstr "Vérifier si une nouvelle version de wxMaxima éxiste"
 
-#: ../src/wxMaximaFrame.cpp:1385
+#: ../src/wxMaximaFrame.cpp:1384
 msgid "Chi"
 msgstr ""
 
@@ -908,15 +908,15 @@ msgstr "Choisir la police"
 msgid "Choose new plot format:"
 msgstr "Entrer un nouveau format de tracé :"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710
 msgid "Classes:"
 msgstr "Classes :"
 
-#: ../src/wxMaximaFrame.cpp:469
+#: ../src/wxMaximaFrame.cpp:468
 msgid "Close\tCtrl-W"
 msgstr "Fermer\tCtrl-W"
 
-#: ../src/wxMaximaFrame.cpp:470
+#: ../src/wxMaximaFrame.cpp:469
 msgid "Close window"
 msgstr "Fermer la fenêtre"
 
@@ -948,19 +948,19 @@ msgstr ""
 msgid "Code highlighting: Variables"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4806
+#: ../src/wxMaxima.cpp:4818
 msgid "Col. names:"
 msgstr "Noms des colonnes :"
 
-#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Columns:"
 msgstr "Colonnes :"
 
-#: ../src/wxMaximaFrame.cpp:860
+#: ../src/wxMaximaFrame.cpp:859
 msgid "Combine factorials in an expression"
 msgstr "Combiner les factorielles dans une expression"
 
-#: ../src/wxMaxima.cpp:5293
+#: ../src/wxMaxima.cpp:5305
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
@@ -972,24 +972,24 @@ msgstr "Liste x séparée par des virgules"
 msgid "Comma separated y coordinates"
 msgstr "Liste y séparée par des virgules"
 
-#: ../src/MathCtrl.cpp:1030
+#: ../src/MathCtrl.cpp:1072
 msgid "Comment Selection"
 msgstr "Commenter la sélection"
 
-#: ../src/wxMaximaFrame.cpp:533
+#: ../src/wxMaximaFrame.cpp:532
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:532
+#: ../src/wxMaximaFrame.cpp:531
 #, fuzzy
 msgid "Comment selection\tCtrl-/"
 msgstr "Commenter la sélection"
 
-#: ../src/wxMaximaFrame.cpp:601
+#: ../src/wxMaximaFrame.cpp:600
 msgid "Complete Word\tCtrl-K"
 msgstr "Compléter l'expression\tCtrl-K"
 
-#: ../src/wxMaximaFrame.cpp:602
+#: ../src/wxMaximaFrame.cpp:601
 msgid "Complete word"
 msgstr "Compléter le mot"
 
@@ -997,36 +997,36 @@ msgstr "Compléter le mot"
 msgid "Completely stop maxima and restart it"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:823
+#: ../src/wxMaximaFrame.cpp:822
 msgid "Compute continued fraction of a value"
 msgstr "Calculer la fraction continue d'une valeur"
 
-#: ../src/wxMaximaFrame.cpp:761
+#: ../src/wxMaximaFrame.cpp:760
 msgid "Compute the adjoint matrix"
 msgstr "Calculer la matrice adjointe"
 
-#: ../src/wxMaximaFrame.cpp:750
+#: ../src/wxMaximaFrame.cpp:749
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr "Calculer le polynôme caractéristique d'une matrice"
 
-#: ../src/wxMaximaFrame.cpp:753
+#: ../src/wxMaximaFrame.cpp:752
 msgid "Compute the determinant of a matrix"
 msgstr "Calculer le déterminant d'une matrice"
 
-#: ../src/wxMaximaFrame.cpp:810
+#: ../src/wxMaximaFrame.cpp:809
 msgid "Compute the greatest common divisor"
 msgstr "Calculer le plus grand diviseur commun"
 
-#: ../src/wxMaximaFrame.cpp:747
+#: ../src/wxMaximaFrame.cpp:746
 msgid "Compute the inverse of a matrix"
 msgstr "Calculer l'inverse d'une matrice"
 
-#: ../src/wxMaximaFrame.cpp:813
+#: ../src/wxMaximaFrame.cpp:812
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
 "Calculer le plus petit multiple commun (faire load(functs) avant utilisation)"
 
-#: ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4868
 msgid "Condition:"
 msgstr "Condition :"
 
@@ -1038,8 +1038,8 @@ msgstr "Fichier de configuration (*.ini)|*.ini"
 msgid "Configuration warning"
 msgstr "Alerte de configuration"
 
-#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:538
-#: ../src/wxMaximaFrame.cpp:541
+#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:540
 msgid "Configure wxMaxima"
 msgstr "Configurer wxMaxima"
 
@@ -1048,134 +1048,136 @@ msgstr "Configurer wxMaxima"
 msgid "Constant"
 msgstr "Constante"
 
-#: ../src/wxMaximaFrame.cpp:844
+#: ../src/wxMaximaFrame.cpp:843
 msgid "Contract Logarithms"
 msgstr "Regrouper les logarithmes"
 
-#: ../src/wxMaximaFrame.cpp:851
+#: ../src/wxMaximaFrame.cpp:850
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr "Convertir combinaisons, fonctions beta et gamma en factorielles"
 
-#: ../src/wxMaximaFrame.cpp:854
+#: ../src/wxMaximaFrame.cpp:853
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr ""
 "Convertir combinaisons, factorielles et fonctions beta en fonction gamma"
 
-#: ../src/wxMaximaFrame.cpp:888
+#: ../src/wxMaximaFrame.cpp:887
 msgid "Convert complex expression to polar form"
 msgstr "Mettre une expression complexe sous forme polaire"
 
-#: ../src/wxMaximaFrame.cpp:885
+#: ../src/wxMaximaFrame.cpp:884
 msgid "Convert complex expression to rect form"
 msgstr "Mettre une expression complexe sous forme cartésienne"
 
-#: ../src/wxMaximaFrame.cpp:897
+#: ../src/wxMaximaFrame.cpp:896
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
 "Convertir une fonction exponentielle d'argument imaginaire sous forme "
 "trigonométrique"
 
-#: ../src/wxMaximaFrame.cpp:842
+#: ../src/wxMaximaFrame.cpp:841
 msgid "Convert logarithm of product to sum of logarithms"
 msgstr "Convertir le logarithme d'un produit en une somme de logarithmes"
 
-#: ../src/wxMaximaFrame.cpp:845
+#: ../src/wxMaximaFrame.cpp:844
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "Convertir une somme de logarithmes en un logarithme d'un produit"
 
-#: ../src/wxMaximaFrame.cpp:850
+#: ../src/wxMaximaFrame.cpp:849
 msgid "Convert to &Factorials"
 msgstr "Convertir en &factorielles"
 
-#: ../src/wxMaximaFrame.cpp:853
+#: ../src/wxMaximaFrame.cpp:852
 msgid "Convert to &Gamma"
 msgstr "Convertir en &Gamma"
 
-#: ../src/wxMaximaFrame.cpp:887
+#: ../src/wxMaximaFrame.cpp:886
 msgid "Convert to &Polarform"
 msgstr "Mettre sous forme &polaire"
 
-#: ../src/wxMaximaFrame.cpp:884
+#: ../src/wxMaximaFrame.cpp:883
 msgid "Convert to &Rectform"
 msgstr "Mettre sous forme ca&rtésienne"
 
-#: ../src/wxMaximaFrame.cpp:877
+#: ../src/wxMaximaFrame.cpp:876
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr ""
 "Convertir une expression trigonométrique en forme quasi-linéaire canonique"
 
-#: ../src/wxMaximaFrame.cpp:900
+#: ../src/wxMaximaFrame.cpp:899
 msgid "Convert trigonometric functions to exponential form"
 msgstr "Convertir les fonctions trigonométriques en forme exponentielle"
 
-#: ../src/ToolBar.cpp:140 ../src/MathCtrl.cpp:918 ../src/MathCtrl.cpp:931
-#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1024
+#: ../src/MathCtrl.cpp:960 ../src/MathCtrl.cpp:973 ../src/MathCtrl.cpp:1019
+#: ../src/MathCtrl.cpp:1066 ../src/ToolBar.cpp:140
 msgid "Copy"
 msgstr "Copier"
 
-#: ../src/wxMaximaFrame.cpp:597
+#: ../src/wxMaximaFrame.cpp:596
 msgid "Copy Previous Input\tCtrl-I"
 msgstr "Copier l'entrée précédente\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:599
+#: ../src/wxMaximaFrame.cpp:598
 #, fuzzy
 msgid "Copy Previous Output\tCtrl-U"
 msgstr "Copier l'entrée précédente\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:514 ../src/MathCtrl.cpp:936 ../src/MathCtrl.cpp:982
+#: ../src/MathCtrl.cpp:978 ../src/MathCtrl.cpp:1024
+#: ../src/wxMaximaFrame.cpp:513
 msgid "Copy as Image"
 msgstr "Copier comme image"
 
-#: ../src/wxMaximaFrame.cpp:507 ../src/MathCtrl.cpp:932 ../src/MathCtrl.cpp:978
+#: ../src/MathCtrl.cpp:974 ../src/MathCtrl.cpp:1020
+#: ../src/wxMaximaFrame.cpp:506
 msgid "Copy as LaTeX"
 msgstr "Copier comme code LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:510
+#: ../src/wxMaximaFrame.cpp:509
 #, fuzzy
 msgid "Copy as MathML"
 msgstr "Copier comme image"
 
-#: ../src/MathCtrl.cpp:935 ../src/MathCtrl.cpp:980
+#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1022
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:504
+#: ../src/wxMaximaFrame.cpp:503
 msgid "Copy as Text\tCtrl-Shift-C"
 msgstr "&Copier comme texte\tCtrl-Maj-C"
 
-#: ../src/MathCtrl.cpp:933 ../src/MathCtrl.cpp:979
+#: ../src/MathCtrl.cpp:975 ../src/MathCtrl.cpp:1021
 #, fuzzy
 msgid "Copy as plain text"
 msgstr "Copier comme image"
 
-#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:503
+#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:502
 msgid "Copy selection"
 msgstr "Copier la sélection"
 
-#: ../src/wxMaximaFrame.cpp:515
+#: ../src/wxMaximaFrame.cpp:514
 msgid "Copy selection from document as an image"
 msgstr "Copier la sélection du document au format image"
 
-#: ../src/wxMaximaFrame.cpp:505
+#: ../src/wxMaximaFrame.cpp:504
 msgid "Copy selection from document as text"
 msgstr "Copier la sélection du document au format texte"
 
-#: ../src/wxMaximaFrame.cpp:508
+#: ../src/wxMaximaFrame.cpp:507
 msgid "Copy selection from document in LaTeX format"
 msgstr "Copier la sélection du document au format LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:511
+#: ../src/wxMaximaFrame.cpp:510
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:598
+#: ../src/wxMaximaFrame.cpp:597
 msgid "Create a new cell with previous input"
 msgstr "Créer une nouvelle cellule avec l'entrée précédente"
 
-#: ../src/wxMaximaFrame.cpp:600
+#: ../src/wxMaximaFrame.cpp:599
 #, fuzzy
 msgid "Create a new cell with previous output"
 msgstr "Créer une nouvelle cellule avec l'entrée précédente"
@@ -1184,15 +1186,15 @@ msgstr "Créer une nouvelle cellule avec l'entrée précédente"
 msgid "Cursor"
 msgstr "Curseur"
 
-#: ../src/ToolBar.cpp:137 ../src/MathCtrl.cpp:1023
+#: ../src/MathCtrl.cpp:1065 ../src/ToolBar.cpp:137
 msgid "Cut"
 msgstr "Couper"
 
-#: ../src/wxMaximaFrame.cpp:499
+#: ../src/wxMaximaFrame.cpp:498
 msgid "Cut\tCtrl-X"
 msgstr "&Couper\tCtrl-X"
 
-#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:500
+#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:499
 msgid "Cut selection"
 msgstr "Couper la sélection"
 
@@ -1204,18 +1206,18 @@ msgstr "Tchèque"
 msgid "Danish"
 msgstr "Danois"
 
-#: ../src/wxMaxima.cpp:4799 ../src/wxMaxima.cpp:4806 ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4811 ../src/wxMaxima.cpp:4818 ../src/wxMaxima.cpp:4868
 msgid "Data Matrix:"
 msgstr "Matrice des données :"
 
-#: ../src/wxMaxima.cpp:4826
+#: ../src/wxMaxima.cpp:4838
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr "Fichier de données (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698 ../src/wxMaxima.cpp:4712
-#: ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726 ../src/wxMaxima.cpp:4734
-#: ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748 ../src/wxMaxima.cpp:4755
-#: ../src/wxMaxima.cpp:4791
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710 ../src/wxMaxima.cpp:4724
+#: ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738 ../src/wxMaxima.cpp:4746
+#: ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760 ../src/wxMaxima.cpp:4767
+#: ../src/wxMaxima.cpp:4803
 msgid "Data:"
 msgstr "Isefka :"
 
@@ -1223,7 +1225,7 @@ msgstr "Isefka :"
 msgid "Debug: watch maxima's stdout stream"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:820
+#: ../src/wxMaximaFrame.cpp:819
 msgid "Decompose rational function to partial fractions"
 msgstr "Décomposer une fonction rationnelle en éléments simples"
 
@@ -1255,47 +1257,47 @@ msgid ""
 "with."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3403 ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3415 ../src/wxMaxima.cpp:3424
 msgid "Delete"
 msgstr "Kkes"
 
-#: ../src/wxMaximaFrame.cpp:667
+#: ../src/wxMaximaFrame.cpp:666
 msgid "Delete F&unction..."
 msgstr "Kkes tawuri"
 
-#: ../src/MathCtrl.cpp:939 ../src/MathCtrl.cpp:985
+#: ../src/MathCtrl.cpp:981 ../src/MathCtrl.cpp:1027
 msgid "Delete Selection"
 msgstr "Kkes tafrant"
 
-#: ../src/wxMaximaFrame.cpp:669
+#: ../src/wxMaximaFrame.cpp:668
 msgid "Delete V&ariable..."
 msgstr "Kkes a&mutti"
 
-#: ../src/wxMaximaFrame.cpp:668
+#: ../src/wxMaximaFrame.cpp:667
 msgid "Delete a function"
 msgstr "Kkes tawuri"
 
-#: ../src/wxMaximaFrame.cpp:670
+#: ../src/wxMaximaFrame.cpp:669
 msgid "Delete a variable"
 msgstr "Kkes amutti"
 
-#: ../src/wxMaximaFrame.cpp:655
+#: ../src/wxMaximaFrame.cpp:654
 msgid "Delete all values from memory"
 msgstr "Effacer toutes les valeurs de la mémoire"
 
-#: ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3424
 msgid "Delete function(s):"
 msgstr "Effacer la (les) fonction(s):"
 
-#: ../src/wxMaxima.cpp:3403
+#: ../src/wxMaxima.cpp:3415
 msgid "Delete variable(s):"
 msgstr "Kkes amutti(imuttiyen):"
 
-#: ../src/wxMaximaFrame.cpp:1367
+#: ../src/wxMaximaFrame.cpp:1366
 msgid "Delta"
 msgstr "Delta"
 
-#: ../src/wxMaxima.cpp:4011
+#: ../src/wxMaxima.cpp:4023
 msgid "Denom. deg:"
 msgstr "denom deg :"
 
@@ -1303,35 +1305,35 @@ msgstr "denom deg :"
 msgid "Depth:"
 msgstr "talqayt :"
 
-#: ../src/wxMaxima.cpp:3541
+#: ../src/wxMaxima.cpp:3553
 msgid "Derivative:"
 msgstr "la dérivée est :"
 
-#: ../src/wxMaximaFrame.cpp:1258
+#: ../src/wxMaximaFrame.cpp:1257
 msgid "Deviation..."
 msgstr "Azza..."
 
-#: ../src/wxMaximaFrame.cpp:816
+#: ../src/wxMaximaFrame.cpp:815
 msgid "Di&vide Polynomials..."
 msgstr "Di&vision de polynômes…"
 
-#: ../src/wxMaximaFrame.cpp:1223
+#: ../src/wxMaximaFrame.cpp:1222
 msgid "Diff..."
 msgstr "Zlem.."
 
-#: ../src/wxMaxima.cpp:4154 ../src/wxMaxima.cpp:5066
+#: ../src/wxMaxima.cpp:4166 ../src/wxMaxima.cpp:5078
 msgid "Differentiate"
 msgstr "Zlem"
 
-#: ../src/wxMaximaFrame.cpp:786
+#: ../src/wxMaximaFrame.cpp:785
 msgid "Differentiate expression"
 msgstr "Zlem tanfalit"
 
-#: ../src/MathCtrl.cpp:1001
+#: ../src/MathCtrl.cpp:1043
 msgid "Differentiate..."
 msgstr "Zlem…"
 
-#: ../src/LimitWiz.cpp:37 ../src/FindReplacePane.cpp:76
+#: ../src/FindReplacePane.cpp:76 ../src/LimitWiz.cpp:37
 msgid "Direction:"
 msgstr "Tanila:"
 
@@ -1339,48 +1341,49 @@ msgstr "Tanila:"
 msgid "Discrete plot"
 msgstr "Graphe discret"
 
-#: ../src/wxMaximaFrame.cpp:679
+#: ../src/wxMaximaFrame.cpp:678
 msgid "Display Te&X Form"
 msgstr "Afficher en Te&X"
 
-#: ../src/wxMaxima.cpp:3320
+#: ../src/wxMaxima.cpp:3332
 msgid "Display algorithm"
 msgstr "Afficher l'algorithme"
 
-#: ../src/wxMaximaFrame.cpp:680
+#: ../src/wxMaximaFrame.cpp:679
 msgid "Display last result in TeX form"
 msgstr "Afficher la dernière expression en TeX"
 
-#: ../src/wxMaximaFrame.cpp:674
+#: ../src/wxMaximaFrame.cpp:673
 msgid "Display time used for evaluation"
 msgstr "Afficher le temps d'exécution"
 
-#: ../src/wxMaxima.cpp:4061
+#: ../src/wxMaxima.cpp:4073
 msgid "Divide"
 msgstr "Division"
 
-#: ../src/MathCtrl.cpp:1032
+#: ../src/MathCtrl.cpp:1074
 msgid "Divide Cell"
 msgstr "Partager la cellule"
 
-#: ../src/wxMaximaFrame.cpp:635
+#: ../src/wxMaximaFrame.cpp:634
 #, fuzzy
 msgid "Divide Cell\tCtrl-D"
 msgstr "Partager la cellule"
 
-#: ../src/wxMaximaFrame.cpp:817
+#: ../src/wxMaximaFrame.cpp:816
 msgid "Divide numbers or polynomials"
 msgstr "Division de nombres ou de polynômes"
 
-#: ../src/wxMaximaFrame.cpp:636
+#: ../src/wxMaximaFrame.cpp:635
 msgid "Divide this input cell into two cells"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5917
-msgid "Do you want to save the changes you made in the document \""
+#: ../src/wxMaxima.cpp:5932
+#, fuzzy, c-format
+msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr "Sauvegarder les modifications apportées au document ?\""
 
-#: ../src/wxMaxima.cpp:1664 ../src/wxMaxima.cpp:1672
+#: ../src/wxMaxima.cpp:1669 ../src/wxMaxima.cpp:1677
 msgid "Document "
 msgstr "Document"
 
@@ -1399,7 +1402,7 @@ msgid ""
 "differences."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Don't save"
 msgstr "Ur seklas ara"
 
@@ -1407,27 +1410,27 @@ msgstr "Ur seklas ara"
 msgid "Down"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:734
+#: ../src/wxMaximaFrame.cpp:733
 msgid "E&quations"
 msgstr "Tiig&diwin"
 
-#: ../src/wxMaximaFrame.cpp:487
+#: ../src/wxMaximaFrame.cpp:486
 msgid "E&xit\tCtrl-Q"
 msgstr "&Quitter\tCtrl-Q"
 
-#: ../src/wxMaximaFrame.cpp:757
+#: ../src/wxMaximaFrame.cpp:756
 msgid "Eige&nvectors"
 msgstr "Vecteurs propres"
 
-#: ../src/wxMaximaFrame.cpp:755
+#: ../src/wxMaximaFrame.cpp:754
 msgid "Eigen&values"
 msgstr "&Valeurs propres"
 
-#: ../src/wxMaxima.cpp:3572
+#: ../src/wxMaxima.cpp:3584
 msgid "Eliminate"
 msgstr "Éliminer"
 
-#: ../src/wxMaximaFrame.cpp:710
+#: ../src/wxMaximaFrame.cpp:709
 msgid "Eliminate a variable from a system of equations"
 msgstr "Éliminer une variable dans un système d'équations"
 
@@ -1439,21 +1442,21 @@ msgstr ""
 msgid "English"
 msgstr "Taglizit"
 
-#: ../src/wxMaxima.cpp:4712 ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726
-#: ../src/wxMaxima.cpp:4734 ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748
-#: ../src/wxMaxima.cpp:4755 ../src/wxMaxima.cpp:4791 ../src/wxMaxima.cpp:4799
+#: ../src/wxMaxima.cpp:4724 ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738
+#: ../src/wxMaxima.cpp:4746 ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760
+#: ../src/wxMaxima.cpp:4767 ../src/wxMaxima.cpp:4803 ../src/wxMaxima.cpp:4811
 msgid "Enter Data"
 msgstr "Sekcem isefka"
 
-#: ../src/wxMaximaFrame.cpp:1279
+#: ../src/wxMaximaFrame.cpp:1278
 msgid "Enter Matrix..."
 msgstr "&Sekcem isirew..."
 
-#: ../src/wxMaximaFrame.cpp:745
+#: ../src/wxMaximaFrame.cpp:744
 msgid "Enter a matrix"
 msgstr "Sekcem isirew"
 
-#: ../src/wxMaxima.cpp:3962
+#: ../src/wxMaxima.cpp:3974
 msgid "Enter an equation for rational simplification:"
 msgstr "Entrer une équation pour la simplification rationnelle :"
 
@@ -1465,11 +1468,11 @@ msgstr "Entrer une liste de variables séparées par des virgules"
 msgid "Enter evaluates cells"
 msgstr "Évaluation des cellules avec la touche Entrée"
 
-#: ../src/wxMaxima.cpp:3734
+#: ../src/wxMaxima.cpp:3746
 msgid "Enter matrix"
 msgstr "Sekcem isirew"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 #, fuzzy
 msgid "Enter new precision for bigfloats:"
 msgstr "Entrer la nouvelle précision :"
@@ -1478,11 +1481,11 @@ msgstr "Entrer la nouvelle précision :"
 msgid "Enter the path to the Maxima executable."
 msgstr "Entrez le chemin vers l'exécutable de Maxima:"
 
-#: ../src/wxMaximaFrame.cpp:1368
+#: ../src/wxMaximaFrame.cpp:1367
 msgid "Epsilon"
 msgstr "Epsilon :"
 
-#: ../src/wxMaxima.cpp:4208
+#: ../src/wxMaxima.cpp:4220
 msgid "Epsilon:"
 msgstr "Epsilon :"
 
@@ -1491,13 +1494,13 @@ msgstr "Epsilon :"
 msgid "Equation %d:"
 msgstr "Tagda %d :"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:3633
-#: ../src/wxMaxima.cpp:5019
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:3645
+#: ../src/wxMaxima.cpp:5031
 msgid "Equation(s):"
 msgstr "Tagda(Ti-win):"
 
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3993
-#: ../src/wxMaxima.cpp:4807 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:4005
+#: ../src/wxMaxima.cpp:4819 ../src/wxMaxima.cpp:5045
 msgid "Equation:"
 msgstr "Tagda :"
 
@@ -1508,83 +1511,83 @@ msgid ""
 "be introduced one into another. Also they are always printed out as 2D maths."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3570
+#: ../src/wxMaxima.cpp:3582
 msgid "Equations:"
 msgstr "Tigdiwin:"
 
-#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1455
-#: ../src/wxMaxima.cpp:1469 ../src/wxMaxima.cpp:1620 ../src/wxMaxima.cpp:1633
-#: ../src/wxMaxima.cpp:1643 ../src/wxMaxima.cpp:1666 ../src/wxMaxima.cpp:2034
-#: ../src/wxMaxima.cpp:2206 ../src/wxMaxima.cpp:5381 ../src/wxMaxima.cpp:5830
-#: ../src/wxMaxima.cpp:5881
+#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1460
+#: ../src/wxMaxima.cpp:1474 ../src/wxMaxima.cpp:1625 ../src/wxMaxima.cpp:1638
+#: ../src/wxMaxima.cpp:1648 ../src/wxMaxima.cpp:1671 ../src/wxMaxima.cpp:2039
+#: ../src/wxMaxima.cpp:2211 ../src/wxMaxima.cpp:5397 ../src/wxMaxima.cpp:5845
+#: ../src/wxMaxima.cpp:5896
 msgid "Error"
 msgstr "Tuccḍa"
 
-#: ../src/wxMaxima.cpp:2886 ../src/wxMaxima.cpp:2900 ../src/wxMaxima.cpp:2913
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617 ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:2894 ../src/wxMaxima.cpp:2908 ../src/wxMaxima.cpp:2921
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629 ../src/wxMaxima.cpp:3740
 msgid "Error!"
 msgstr "Tuccḍa!"
 
-#: ../src/wxMaximaFrame.cpp:1370
+#: ../src/wxMaximaFrame.cpp:1369
 msgid "Eta"
 msgstr "Eta"
 
-#: ../src/wxMaximaFrame.cpp:909
+#: ../src/wxMaximaFrame.cpp:908
 msgid "Evaluate &Noun Forms"
 msgstr "Évaluer les formes &nommées"
 
-#: ../src/wxMaximaFrame.cpp:589
+#: ../src/wxMaximaFrame.cpp:588
 #, fuzzy
 msgid "Evaluate All Cells\tCtrl-Shift-R"
 msgstr "Évaluer toutes les cellules\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:587
+#: ../src/wxMaximaFrame.cpp:586
 #, fuzzy
 msgid "Evaluate All Visible Cells\tCtrl-R"
 msgstr "Évaluer toutes les cellules\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:585 ../src/MathCtrl.cpp:942
+#: ../src/MathCtrl.cpp:984 ../src/wxMaximaFrame.cpp:584
 msgid "Evaluate Cell(s)"
 msgstr "Évaluer la (les) cellule(s)"
 
-#: ../src/wxMaximaFrame.cpp:591
+#: ../src/wxMaximaFrame.cpp:590
 #, fuzzy
 msgid "Evaluate Cells Above\tCtrl-Shift-P"
 msgstr "Évaluer toutes les cellules\tCtrl-R"
 
-#: ../src/MathCtrl.cpp:956 ../src/MathCtrl.cpp:1051
+#: ../src/MathCtrl.cpp:998 ../src/MathCtrl.cpp:1093
 #, fuzzy
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr "&Évaluer la cellule\tMaj-Entrée"
 
-#: ../src/MathCtrl.cpp:961 ../src/MathCtrl.cpp:1053
+#: ../src/MathCtrl.cpp:1003 ../src/MathCtrl.cpp:1095
 #, fuzzy
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr "&Évaluer la cellule\tMaj-Entrée"
 
-#: ../src/MathCtrl.cpp:971 ../src/MathCtrl.cpp:1057
+#: ../src/MathCtrl.cpp:1013 ../src/MathCtrl.cpp:1099
 #, fuzzy
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr "&Évaluer la cellule\tMaj-Entrée"
 
-#: ../src/MathCtrl.cpp:966 ../src/MathCtrl.cpp:1055
+#: ../src/MathCtrl.cpp:1008 ../src/MathCtrl.cpp:1097
 #, fuzzy
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr "&Évaluer la cellule\tMaj-Entrée"
 
-#: ../src/wxMaximaFrame.cpp:586
+#: ../src/wxMaximaFrame.cpp:585
 msgid "Evaluate active or selected cell(s)"
 msgstr "Réévaluer la cellule sélectionnée"
 
-#: ../src/wxMaximaFrame.cpp:590
+#: ../src/wxMaximaFrame.cpp:589
 msgid "Evaluate all cells in the document"
 msgstr "Réévaluer toutes les cellules du document"
 
-#: ../src/wxMaximaFrame.cpp:910
+#: ../src/wxMaximaFrame.cpp:909
 msgid "Evaluate all noun forms in expression"
 msgstr "Evaluer toutes les formes nommées"
 
-#: ../src/wxMaximaFrame.cpp:588
+#: ../src/wxMaximaFrame.cpp:587
 #, fuzzy
 msgid "Evaluate all visible cells in the document"
 msgstr "Réévaluer toutes les cellules du document"
@@ -1598,7 +1601,7 @@ msgstr ""
 msgid "Evaluate to point"
 msgstr "Évaluer les formes &nommées"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Example"
 msgstr "Exemple"
 
@@ -1611,31 +1614,31 @@ msgstr "Texte exemple…"
 msgid "Examples:"
 msgstr "Exemple"
 
-#: ../src/wxMaximaFrame.cpp:488
+#: ../src/wxMaximaFrame.cpp:487
 msgid "Exit wxMaxima"
 msgstr "Quitter wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:1214
+#: ../src/wxMaximaFrame.cpp:1213
 msgid "Expand"
 msgstr "Snefli"
 
-#: ../src/wxMaximaFrame.cpp:1219
+#: ../src/wxMaximaFrame.cpp:1218
 msgid "Expand (tr)"
 msgstr "Snefli (tanf.tasektuɣmirt)"
 
-#: ../src/MathCtrl.cpp:997
+#: ../src/MathCtrl.cpp:1039
 msgid "Expand Expression"
 msgstr "Développer une expression"
 
-#: ../src/wxMaximaFrame.cpp:841
+#: ../src/wxMaximaFrame.cpp:840
 msgid "Expand Logarithms"
 msgstr "Développer des logarithmes"
 
-#: ../src/wxMaximaFrame.cpp:840
+#: ../src/wxMaximaFrame.cpp:839
 msgid "Expand an expression"
 msgstr "Développer une expression"
 
-#: ../src/wxMaximaFrame.cpp:874
+#: ../src/wxMaximaFrame.cpp:873
 msgid "Expand trigonometric expression"
 msgstr "Développer une expression trigonométrique"
 
@@ -1643,7 +1646,7 @@ msgstr "Développer une expression trigonométrique"
 msgid "Expected the icon files to be found at"
 msgstr ""
 
-#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2834
+#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2842
 msgid "Export"
 msgstr "&Exporter"
 
@@ -1652,33 +1655,33 @@ msgid ""
 "Export animations to TeX (Images only move if the PDF viewer supports this)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:481
+#: ../src/wxMaximaFrame.cpp:480
 msgid "Export document to a HTML or pdfLaTeX file"
 msgstr "Exporter le document en HTML ou en pdfLateX"
 
-#: ../src/wxMaximaFrame.cpp:253
+#: ../src/wxMaximaFrame.cpp:252
 #, fuzzy
 msgid "Export failed."
 msgstr "Échec de l'export en TeX !"
 
-#: ../src/wxMaximaFrame.cpp:239
+#: ../src/wxMaximaFrame.cpp:238
 msgid "Export successful."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2913
+#: ../src/wxMaxima.cpp:2921
 msgid "Exporting to HTML failed!"
 msgstr "Échec de l'export en HTML"
 
-#: ../src/wxMaxima.cpp:2886
+#: ../src/wxMaxima.cpp:2894
 msgid "Exporting to TeX failed!"
 msgstr "Échec de l'export en TeX !"
 
-#: ../src/wxMaxima.cpp:2900
+#: ../src/wxMaxima.cpp:2908
 #, fuzzy
 msgid "Exporting to maxima batch file failed!"
 msgstr "Échec de l'export en TeX !"
 
-#: ../src/wxMaximaFrame.cpp:229
+#: ../src/wxMaximaFrame.cpp:228
 #, fuzzy
 msgid "Exporting..."
 msgstr "&Exporter"
@@ -1692,42 +1695,42 @@ msgid "Expression(s):"
 msgstr "Expression(s) :"
 
 #: ../src/IntegrateWiz.cpp:30 ../src/LimitWiz.cpp:27 ../src/SeriesWiz.cpp:33
-#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3648
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:4205 ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5064
+#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3660
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:4217 ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5076
 msgid "Expression:"
 msgstr "Expression :"
 
-#: ../src/wxMaximaFrame.cpp:1213
+#: ../src/wxMaximaFrame.cpp:1212
 msgid "Factor"
 msgstr "Factoriser"
 
-#: ../src/wxMaximaFrame.cpp:836
+#: ../src/wxMaximaFrame.cpp:835
 msgid "Factor Complex"
 msgstr "Factorisation &complexe"
 
-#: ../src/MathCtrl.cpp:996
+#: ../src/MathCtrl.cpp:1038
 msgid "Factor Expression"
 msgstr "Factoriser une expression"
 
-#: ../src/wxMaximaFrame.cpp:835
+#: ../src/wxMaximaFrame.cpp:834
 msgid "Factor an expression"
 msgstr "Factoriser une expression"
 
-#: ../src/wxMaximaFrame.cpp:837
+#: ../src/wxMaximaFrame.cpp:836
 msgid "Factor an expression in Gaussian numbers"
 msgstr "Factoriser une expression en nombre gaussiens"
 
-#: ../src/wxMaximaFrame.cpp:862
+#: ../src/wxMaximaFrame.cpp:861
 msgid "Factorials and &Gamma"
 msgstr "Factorielles et &gamma"
 
-#: ../src/wxMaxima.cpp:285
+#: ../src/wxMaxima.cpp:286
 msgid "Fatal error"
 msgstr "Erreur fatale"
 
-#: ../src/GroupCell.cpp:1571
+#: ../src/GroupCell.cpp:1572
 #, c-format
 msgid "Figure %d:"
 msgstr "Figure %d:"
@@ -1736,22 +1739,22 @@ msgstr "Figure %d:"
 msgid "File"
 msgstr "A&faylu"
 
-#: ../src/wxMaxima.cpp:1457 ../src/wxMaxima.cpp:1623 ../src/wxMaxima.cpp:1636
-#: ../src/wxMaxima.cpp:1646 ../src/wxMaxima.cpp:1668
+#: ../src/wxMaxima.cpp:1462 ../src/wxMaxima.cpp:1628 ../src/wxMaxima.cpp:1641
+#: ../src/wxMaxima.cpp:1651 ../src/wxMaxima.cpp:1673
 #, fuzzy
 msgid "File could not be opened"
 msgstr "Fichier non trouvé"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File not found"
 msgstr "Fichier non trouvé"
 
-#: ../src/wxMaxima.cpp:1511 ../src/wxMaxima.cpp:1729
+#: ../src/wxMaxima.cpp:1516 ../src/wxMaxima.cpp:1734
 #, fuzzy
 msgid "File opened"
 msgstr "Fichier non trouvé"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File you tried to open does not exist."
 msgstr "Le fichier que vous tentez d'ouvrir n'existe pas."
 
@@ -1763,67 +1766,67 @@ msgstr "A&faylu:"
 msgid "Find"
 msgstr "Nadi"
 
-#: ../src/wxMaximaFrame.cpp:523
+#: ../src/wxMaximaFrame.cpp:522
 msgid "Find\tCtrl-F"
 msgstr "Nadi\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:787
+#: ../src/wxMaximaFrame.cpp:786
 msgid "Find &Limit..."
 msgstr "Trouver la &limite…"
 
-#: ../src/wxMaximaFrame.cpp:790
+#: ../src/wxMaximaFrame.cpp:789
 msgid "Find Minimum..."
 msgstr "Trouver le minimum…"
 
-#: ../src/MathCtrl.cpp:993
+#: ../src/MathCtrl.cpp:1035
 msgid "Find Root..."
 msgstr "Af aẓaṛ…"
 
-#: ../src/wxMaximaFrame.cpp:791
+#: ../src/wxMaximaFrame.cpp:790
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr "Trouver un minimum (sans contrainte) d'une expression"
 
-#: ../src/wxMaximaFrame.cpp:788
+#: ../src/wxMaximaFrame.cpp:787
 msgid "Find a limit of an expression"
 msgstr "Trouver la limite d'une expression"
 
-#: ../src/wxMaximaFrame.cpp:693
+#: ../src/wxMaximaFrame.cpp:692
 msgid "Find a root of an equation on an interval"
 msgstr "Trouver une racine d'un polynôme dans un intervalle"
 
-#: ../src/wxMaximaFrame.cpp:695
+#: ../src/wxMaximaFrame.cpp:694
 msgid "Find all roots of a polynomial"
 msgstr "Trouver toutes les racines d'un polynôme"
 
-#: ../src/wxMaximaFrame.cpp:698
+#: ../src/wxMaximaFrame.cpp:697
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr "Trouver toutes les racines d'un polynôme (bfloat)"
 
-#: ../src/wxMaxima.cpp:3220
+#: ../src/wxMaxima.cpp:3215
 msgid "Find and Replace"
 msgstr "Nadi & semselsi"
 
-#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:523
+#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:522
 msgid "Find and replace"
 msgstr "Nadi & semselsi"
 
-#: ../src/wxMaximaFrame.cpp:756
+#: ../src/wxMaximaFrame.cpp:755
 msgid "Find eigenvalues of a matrix"
 msgstr "Trouver les valeurs propres d'une matrice"
 
-#: ../src/wxMaximaFrame.cpp:758
+#: ../src/wxMaximaFrame.cpp:757
 msgid "Find eigenvectors of a matrix"
 msgstr "Trouver les vecteurs propres d'une matrice"
 
-#: ../src/wxMaxima.cpp:4210
+#: ../src/wxMaxima.cpp:4222
 msgid "Find minimum"
 msgstr "Trouver le minimum"
 
-#: ../src/wxMaximaFrame.cpp:701
+#: ../src/wxMaximaFrame.cpp:700
 msgid "Find real roots of a polynomial"
 msgstr "Trouver les racines réelles d'un polynôme"
 
-#: ../src/wxMaxima.cpp:3493 ../src/wxMaxima.cpp:5036
+#: ../src/wxMaxima.cpp:3505 ../src/wxMaxima.cpp:5048
 msgid "Find root"
 msgstr "Af tifrat"
 
@@ -1845,12 +1848,12 @@ msgstr ""
 msgid "Fixed font in text controls"
 msgstr "Police à chasse fixe dans les contrôles de texte"
 
-#: ../src/wxMaximaFrame.cpp:623
+#: ../src/wxMaximaFrame.cpp:622
 #, fuzzy
 msgid "Fold All\tCtrl-Alt-["
 msgstr "Tout sélectionner"
 
-#: ../src/wxMaximaFrame.cpp:624
+#: ../src/wxMaximaFrame.cpp:623
 msgid "Fold all sections"
 msgstr ""
 
@@ -1858,25 +1861,25 @@ msgstr ""
 msgid "Follow"
 msgstr "Awraɣ"
 
-#: ../src/ParenCell.cpp:319
+#: ../src/ParenCell.cpp:320
 msgid "Font issue: The Parenthesis sign is too small!"
 msgstr ""
 
-#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:381
+#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:382
 msgid ""
 "Font issue: The char height is too small! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:199
+#: ../src/SqrtCell.cpp:202
 msgid ""
 "Font issue: The sqrt() sign has the size 0! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:198
+#: ../src/SqrtCell.cpp:201
 msgid "Font issue? The contents of a sqrt() has the size 0."
 msgstr ""
 
@@ -1907,15 +1910,15 @@ msgstr "Tafṛansist"
 
 #: ../src/IntegrateWiz.cpp:37 ../src/Plot2dWiz.cpp:37 ../src/Plot2dWiz.cpp:47
 #: ../src/Plot2dWiz.cpp:536 ../src/Plot3dWiz.cpp:36 ../src/Plot3dWiz.cpp:45
-#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4240
+#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4252
 msgid "From:"
 msgstr "seg :"
 
-#: ../src/wxMaximaFrame.cpp:576
+#: ../src/wxMaximaFrame.cpp:575
 msgid "Full Screen\tAlt-Enter"
 msgstr "Agdil aččuṛan\tAlt-Entrée"
 
-#: ../src/wxMaxima.cpp:3342
+#: ../src/wxMaxima.cpp:3354
 msgid "Function"
 msgstr "Tawuri"
 
@@ -1923,32 +1926,32 @@ msgstr "Tawuri"
 msgid "Function names"
 msgstr "Ismawen n twuriwin"
 
-#: ../src/wxMaxima.cpp:3633
+#: ../src/wxMaxima.cpp:3645
 msgid "Function(s):"
 msgstr "Tawurin(t-in) :"
 
-#: ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3803
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3815
+#: ../src/wxMaxima.cpp:3848
 msgid "Function:"
 msgstr "Tawuri"
 
-#: ../src/wxMaximaFrame.cpp:904
+#: ../src/wxMaximaFrame.cpp:903
 msgid "Functions for complex simplification"
 msgstr "Fonctions pour simplification complexe"
 
-#: ../src/wxMaximaFrame.cpp:864
+#: ../src/wxMaximaFrame.cpp:863
 msgid "Functions for simplifying factorials and gamma function"
 msgstr "Fonctions pour simplifier les factorielles et fonction gamma"
 
-#: ../src/wxMaximaFrame.cpp:881
+#: ../src/wxMaximaFrame.cpp:880
 msgid "Functions for simplifying trigonometric expressions"
 msgstr "Fonctions pour simplifier les expressions trigonométriques"
 
-#: ../src/wxMaxima.cpp:4046
+#: ../src/wxMaxima.cpp:4058
 msgid "GCD"
 msgstr "PGCD"
 
-#: ../src/wxMaxima.cpp:5152
+#: ../src/wxMaxima.cpp:5164
 msgid "GIF image (*.gif)|*.gif"
 msgstr "image GIF (*.gif)|*.gif"
 
@@ -1956,31 +1959,31 @@ msgstr "image GIF (*.gif)|*.gif"
 msgid "Galician"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1366
+#: ../src/wxMaximaFrame.cpp:1365
 msgid "Gamma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:391
+#: ../src/wxMaximaFrame.cpp:390
 msgid "General Math"
 msgstr "Tusnakt tamatut"
 
-#: ../src/wxMaximaFrame.cpp:549
+#: ../src/wxMaximaFrame.cpp:548
 msgid "General Math\tAlt-Shift-M"
 msgstr "Tusnakt tamatut\tAlt-Maj-M"
 
-#: ../src/wxMaxima.cpp:3766 ../src/wxMaxima.cpp:3785
+#: ../src/wxMaxima.cpp:3778 ../src/wxMaxima.cpp:3797
 msgid "Generate Matrix"
 msgstr "Générer une matrice"
 
-#: ../src/wxMaximaFrame.cpp:741
+#: ../src/wxMaximaFrame.cpp:740
 msgid "Generate Matrix from Expression..."
 msgstr "&Générer une matrice à partir d'une expression…"
 
-#: ../src/wxMaximaFrame.cpp:739
+#: ../src/wxMaximaFrame.cpp:738
 msgid "Generate a matrix from a 2-dimensional array"
 msgstr "Générer une matrice à partir d'un tableau à 2 dimensions"
 
-#: ../src/wxMaximaFrame.cpp:742
+#: ../src/wxMaximaFrame.cpp:741
 msgid "Generate a matrix from a lambda expression"
 msgstr "Générer une matrice à partir d'une lambda-expression"
 
@@ -1988,39 +1991,39 @@ msgstr "Générer une matrice à partir d'une lambda-expression"
 msgid "German"
 msgstr "Talmanit"
 
-#: ../src/wxMaximaFrame.cpp:893
+#: ../src/wxMaximaFrame.cpp:892
 msgid "Get &Imaginary Part"
 msgstr "Awi-d amur asu&gnan"
 
-#: ../src/wxMaximaFrame.cpp:793
+#: ../src/wxMaximaFrame.cpp:792
 msgid "Get &Series..."
 msgstr "Obtenir une &série…"
 
-#: ../src/wxMaximaFrame.cpp:804
+#: ../src/wxMaximaFrame.cpp:803
 msgid "Get Laplace transformation of an expression"
 msgstr "Transformée de Laplace d'une expression"
 
-#: ../src/wxMaximaFrame.cpp:890
+#: ../src/wxMaximaFrame.cpp:889
 msgid "Get Real P&art"
 msgstr "Awi-d amur &ilaw"
 
-#: ../src/wxMaximaFrame.cpp:807
+#: ../src/wxMaximaFrame.cpp:806
 msgid "Get inverse Laplace transformation of an expression"
 msgstr "Obtenir la transformée de Laplace inverse  d'une expression"
 
-#: ../src/wxMaximaFrame.cpp:794
+#: ../src/wxMaximaFrame.cpp:793
 msgid "Get the Taylor or power series of expression"
 msgstr "Obtenir le développement en série entière ou en série limité (Taylor)"
 
-#: ../src/wxMaximaFrame.cpp:894
+#: ../src/wxMaximaFrame.cpp:893
 msgid "Get the imaginary part of complex expression"
 msgstr "Partie imaginaire d'une expression complexe"
 
-#: ../src/wxMaximaFrame.cpp:891
+#: ../src/wxMaximaFrame.cpp:890
 msgid "Get the real part of complex expression"
 msgstr "Partie réelle d'une expression complexe"
 
-#: ../src/MathCtrl.cpp:5932
+#: ../src/MathCtrl.cpp:5984
 msgid ""
 "Got a request to undo an action that involves an delete which isn't possible "
 "at this moment."
@@ -2030,12 +2033,12 @@ msgstr ""
 msgid "Greek"
 msgstr "Tagrigit"
 
-#: ../src/wxMaximaFrame.cpp:356
+#: ../src/wxMaximaFrame.cpp:355
 #, fuzzy
 msgid "Greek Letters"
 msgstr "Constantes grecques"
 
-#: ../src/wxMaximaFrame.cpp:552
+#: ../src/wxMaximaFrame.cpp:551
 msgid "Greek Letters\tAlt-Shift-G"
 msgstr "Tusnakt tamatut\tAlt-Maj-M"
 
@@ -2047,7 +2050,7 @@ msgstr "Constantes grecques"
 msgid "Grid:"
 msgstr "Iẓiki:"
 
-#: ../src/wxMaxima.cpp:2836
+#: ../src/wxMaxima.cpp:2844
 #, fuzzy
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|pdfLaTeX file (*."
@@ -2062,12 +2065,12 @@ msgstr ""
 msgid "Help"
 msgstr "Tallalt"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 #, fuzzy
 msgid "Hide All Toolbars\tAlt-Shift--"
 msgstr "Cacher tout\tAlt-Maj--"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide all panes"
 msgstr "Cacher tous les panneaux"
 
@@ -2075,19 +2078,19 @@ msgstr "Cacher tous les panneaux"
 msgid "Highlight (dpart)"
 msgstr "Asebṛuṛeq"
 
-#: ../src/wxMaxima.cpp:4685
+#: ../src/wxMaxima.cpp:4697
 msgid "Histogram"
 msgstr "Amazrudlif"
 
-#: ../src/wxMaximaFrame.cpp:1270
+#: ../src/wxMaximaFrame.cpp:1269
 msgid "Histogram..."
 msgstr "Amazrudlif…"
 
-#: ../src/wxMaximaFrame.cpp:309
+#: ../src/wxMaximaFrame.cpp:308
 msgid "History"
 msgstr "Amazray"
 
-#: ../src/wxMaximaFrame.cpp:555
+#: ../src/wxMaximaFrame.cpp:554
 #, fuzzy
 msgid "History\tAlt-Shift-I"
 msgstr "Historique\tAlt-Maj-H"
@@ -2109,11 +2112,11 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Tahungaṛit"
 
-#: ../src/wxMaxima.cpp:3527
+#: ../src/wxMaxima.cpp:3539
 msgid "IC1"
 msgstr "IC1"
 
-#: ../src/wxMaxima.cpp:3543
+#: ../src/wxMaxima.cpp:3555
 msgid "IC2"
 msgstr "IC2"
 
@@ -2129,7 +2132,7 @@ msgid ""
 "same output cell."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:683
+#: ../src/wxMaximaFrame.cpp:682
 msgid ""
 "If maxima ever finishes evaluating without wxMaxima realizing this this menu "
 "item can force wxMaxima to try to send commands to maxima again."
@@ -2191,11 +2194,11 @@ msgstr ""
 "Si votre calcul met trop de temps à être évalué, vous pouvez essayer "
 "\"Maxima->Interrompre\" puis \"Maxima->Redémarrer Maxima"
 
-#: ../src/wxMaximaFrame.cpp:1499
+#: ../src/wxMaximaFrame.cpp:1518
 msgid "Image"
 msgstr "Image"
 
-#: ../src/wxMaxima.cpp:5644
+#: ../src/wxMaxima.cpp:5659
 msgid "Image files (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 msgstr "Fichiers images (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 
@@ -2222,7 +2225,7 @@ msgid ""
 "above it. Might increase readability for some fonts and short subscripts."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Include columns:"
 msgstr "Inclure les colonnes :"
 
@@ -2241,19 +2244,19 @@ msgstr ""
 msgid "Infinity"
 msgstr "Imifeḍ"
 
-#: ../src/wxMaximaFrame.cpp:974
+#: ../src/wxMaximaFrame.cpp:973
 msgid "Info about Maxima build"
 msgstr "Infos sur la compilation de Maxima"
 
-#: ../src/wxMaxima.cpp:4207
+#: ../src/wxMaxima.cpp:4219
 msgid "Initial Estimates:"
 msgstr "Estimations initiales :"
 
-#: ../src/wxMaximaFrame.cpp:718
+#: ../src/wxMaximaFrame.cpp:717
 msgid "Initial Value Problem (&1)..."
 msgstr "Tawtilt n tazwara (&1)…"
 
-#: ../src/wxMaximaFrame.cpp:721
+#: ../src/wxMaximaFrame.cpp:720
 msgid "Initial Value Problem (&2)..."
 msgstr "Tawtilt n tazwara (&2)…"
 
@@ -2261,7 +2264,7 @@ msgstr "Tawtilt n tazwara (&2)…"
 msgid "Input labels"
 msgstr "Étiquettes d'entrée"
 
-#: ../src/wxMaximaFrame.cpp:403
+#: ../src/wxMaximaFrame.cpp:402
 msgid "Insert"
 msgstr "Ger"
 
@@ -2269,108 +2272,108 @@ msgstr "Ger"
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:612
+#: ../src/wxMaximaFrame.cpp:611
 #, fuzzy
 msgid "Insert &Section Cell\tCtrl-3"
 msgstr "Insérer une cellule de section\tF8"
 
-#: ../src/wxMaximaFrame.cpp:608
+#: ../src/wxMaximaFrame.cpp:607
 #, fuzzy
 msgid "Insert &Text Cell\tCtrl-1"
 msgstr "Insérer une cellule de texte \tF6"
 
-#: ../src/wxMaximaFrame.cpp:558
+#: ../src/wxMaximaFrame.cpp:557
 msgid "Insert Cell\tAlt-Shift-C"
 msgstr "Insérer la cellule\tAlt-Maj-C"
 
-#: ../src/wxMaxima.cpp:5642
+#: ../src/wxMaxima.cpp:5657
 msgid "Insert Image"
 msgstr "Ger tugna"
 
-#: ../src/wxMaximaFrame.cpp:620
+#: ../src/wxMaximaFrame.cpp:619
 msgid "Insert Image..."
 msgstr "Ger tugna..."
 
-#: ../src/wxMaximaFrame.cpp:606
+#: ../src/wxMaximaFrame.cpp:605
 #, fuzzy
 msgid "Insert Input &Cell"
 msgstr "Insérer une cellule d'entrée\tF5"
 
-#: ../src/wxMaximaFrame.cpp:618
+#: ../src/wxMaximaFrame.cpp:617
 #, fuzzy
 msgid "Insert Page Break"
 msgstr "Insérer un saut de page\tF10"
 
-#: ../src/wxMaximaFrame.cpp:614
+#: ../src/wxMaximaFrame.cpp:613
 #, fuzzy
 msgid "Insert S&ubsection Cell\tCtrl-4"
 msgstr "Insérer une cellule de sous-section\tF7"
 
-#: ../src/wxMaximaFrame.cpp:616
+#: ../src/wxMaximaFrame.cpp:615
 #, fuzzy
 msgid "Insert S&ubsubsection Cell\tCtrl-5"
 msgstr "Insérer une cellule de sous-section\tF7"
 
-#: ../src/MathCtrl.cpp:1015
+#: ../src/MathCtrl.cpp:1057
 #, fuzzy
 msgid "Insert Section Cell"
 msgstr "Insérer une cellule de section\tF8"
 
-#: ../src/MathCtrl.cpp:1016
+#: ../src/MathCtrl.cpp:1058
 #, fuzzy
 msgid "Insert Subsection Cell"
 msgstr "Insérer une cellule de sous-section\tF7"
 
-#: ../src/MathCtrl.cpp:1017
+#: ../src/MathCtrl.cpp:1059
 #, fuzzy
 msgid "Insert Subsubsection Cell"
 msgstr "Insérer une cellule de sous-section\tF7"
 
-#: ../src/wxMaximaFrame.cpp:610
+#: ../src/wxMaximaFrame.cpp:609
 #, fuzzy
 msgid "Insert T&itle Cell\tCtrl-2"
 msgstr "Insérer une cellule de titre\tF9"
 
-#: ../src/MathCtrl.cpp:1013
+#: ../src/MathCtrl.cpp:1055
 #, fuzzy
 msgid "Insert Text Cell"
 msgstr "Insérer une cellule de texte \tF6"
 
-#: ../src/MathCtrl.cpp:1014
+#: ../src/MathCtrl.cpp:1056
 #, fuzzy
 msgid "Insert Title Cell"
 msgstr "Insérer une cellule de titre\tF9"
 
-#: ../src/wxMaximaFrame.cpp:607
+#: ../src/wxMaximaFrame.cpp:606
 msgid "Insert a new input cell"
 msgstr "Insérer une nouvelle cellule d'entrée"
 
-#: ../src/wxMaximaFrame.cpp:613
+#: ../src/wxMaximaFrame.cpp:612
 msgid "Insert a new section cell"
 msgstr "Insérer une nouvelle cellule de section"
 
-#: ../src/wxMaximaFrame.cpp:615
+#: ../src/wxMaximaFrame.cpp:614
 msgid "Insert a new subsection cell"
 msgstr "Insérer une nouvelle cellule de sous-section"
 
-#: ../src/wxMaximaFrame.cpp:617
+#: ../src/wxMaximaFrame.cpp:616
 #, fuzzy
 msgid "Insert a new subsubsection cell"
 msgstr "Insérer une nouvelle cellule de sous-section"
 
-#: ../src/wxMaximaFrame.cpp:609
+#: ../src/wxMaximaFrame.cpp:608
 msgid "Insert a new text cell"
 msgstr "Insérer une nouvelle cellule de texte"
 
-#: ../src/wxMaximaFrame.cpp:611
+#: ../src/wxMaximaFrame.cpp:610
 msgid "Insert a new title cell"
 msgstr "Insérer une nouvelle cellule de titre"
 
-#: ../src/wxMaximaFrame.cpp:619
+#: ../src/wxMaximaFrame.cpp:618
 msgid "Insert a page break"
 msgstr "Insérer un saut de page"
 
-#: ../src/wxMaximaFrame.cpp:621
+#: ../src/wxMaximaFrame.cpp:620
 msgid "Insert image"
 msgstr "Ger tugna"
 
@@ -2383,27 +2386,27 @@ msgstr ""
 msgid "Integral sign"
 msgstr "Intégrer une expression"
 
-#: ../src/wxMaxima.cpp:3992
+#: ../src/wxMaxima.cpp:4004
 msgid "Integral/Sum:"
 msgstr "Intégrale/somme"
 
-#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4105 ../src/wxMaxima.cpp:5051
+#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4117 ../src/wxMaxima.cpp:5063
 msgid "Integrate"
 msgstr "Sidef"
 
-#: ../src/wxMaxima.cpp:4091
+#: ../src/wxMaxima.cpp:4103
 msgid "Integrate (risch)"
 msgstr "Sidef (Risch)"
 
-#: ../src/wxMaximaFrame.cpp:778
+#: ../src/wxMaximaFrame.cpp:777
 msgid "Integrate expression"
 msgstr "Intégrer une expression"
 
-#: ../src/wxMaximaFrame.cpp:780
+#: ../src/wxMaximaFrame.cpp:779
 msgid "Integrate expression with Risch algorithm"
 msgstr "Intégrer une expression avec l'algorithme de Risch"
 
-#: ../src/wxMaximaFrame.cpp:1224 ../src/MathCtrl.cpp:1000
+#: ../src/MathCtrl.cpp:1042 ../src/wxMaximaFrame.cpp:1223
 msgid "Integrate..."
 msgstr "Sidef"
 
@@ -2411,7 +2414,7 @@ msgstr "Sidef"
 msgid "Interrupt"
 msgstr "Interrompre"
 
-#: ../src/wxMaximaFrame.cpp:646 ../src/wxMaximaFrame.cpp:650
+#: ../src/wxMaximaFrame.cpp:645 ../src/wxMaximaFrame.cpp:649
 msgid "Interrupt current computation"
 msgstr "Interrompre le calcul en cours"
 
@@ -2431,15 +2434,15 @@ msgstr ""
 "\n"
 "Entrer à nouveau le chemin vers l'exécutable Maxima."
 
-#: ../src/wxMaxima.cpp:4137
+#: ../src/wxMaxima.cpp:4149
 msgid "Inverse Laplace"
 msgstr "Inverse Laplace"
 
-#: ../src/wxMaximaFrame.cpp:806
+#: ../src/wxMaximaFrame.cpp:805
 msgid "Inverse Laplace T&ransform..."
 msgstr "&Transformée de Laplace  inverse…"
 
-#: ../src/wxMaximaFrame.cpp:1372
+#: ../src/wxMaximaFrame.cpp:1371
 msgid "Iota"
 msgstr ""
 
@@ -2473,7 +2476,7 @@ msgstr "Tajapunit"
 msgid "Kabyle"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1373
+#: ../src/wxMaximaFrame.cpp:1372
 msgid "Kappa"
 msgstr "Kappa"
 
@@ -2483,7 +2486,7 @@ msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr ""
 "Conserver le signe pourcentage avec les symboles spéciaux: %e, %i, etc."
 
-#: ../src/wxMaxima.cpp:4031
+#: ../src/wxMaxima.cpp:4043
 msgid "LCM"
 msgstr "PPCM"
 
@@ -2499,7 +2502,7 @@ msgstr ""
 msgid "Label width:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1374
+#: ../src/wxMaximaFrame.cpp:1373
 msgid "Lambda"
 msgstr "Lambda"
 
@@ -2511,11 +2514,11 @@ msgstr "Langue utilisée pour l'interface de wxMaxima"
 msgid "Language:"
 msgstr "Tutlayt:"
 
-#: ../src/wxMaxima.cpp:4120
+#: ../src/wxMaxima.cpp:4132
 msgid "Laplace"
 msgstr "Laplace"
 
-#: ../src/wxMaximaFrame.cpp:803
+#: ../src/wxMaximaFrame.cpp:802
 msgid "Laplace &Transform..."
 msgstr "&Transformée de Laplace…"
 
@@ -2523,15 +2526,15 @@ msgstr "&Transformée de Laplace…"
 msgid "Leads to"
 msgstr "arama d :"
 
-#: ../src/wxMaximaFrame.cpp:812
+#: ../src/wxMaximaFrame.cpp:811
 msgid "Least Common Multiple..."
 msgstr "Plus petit commun multiple…"
 
-#: ../src/wxMaxima.cpp:4809
+#: ../src/wxMaxima.cpp:4821
 msgid "Least Squares Fit"
 msgstr "Aswati s tarrayt s usemẓi uzmir-sin"
 
-#: ../src/wxMaximaFrame.cpp:1266
+#: ../src/wxMaximaFrame.cpp:1265
 msgid "Least Squares Fit..."
 msgstr "Aswati s tarrayt s usemẓi uzmir-sin..."
 
@@ -2542,23 +2545,23 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4192
+#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4204
 msgid "Limit"
 msgstr "Talast"
 
-#: ../src/wxMaximaFrame.cpp:1225
+#: ../src/wxMaximaFrame.cpp:1224
 msgid "Limit..."
 msgstr "Talast..."
 
-#: ../src/wxMaximaFrame.cpp:1265
+#: ../src/wxMaximaFrame.cpp:1264
 msgid "Linear Regression..."
 msgstr "Talkeyt timziregt…"
 
-#: ../src/wxMaxima.cpp:3803
+#: ../src/wxMaxima.cpp:3815
 msgid "List(s):"
 msgstr "Tabdart (tibdarin):"
 
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3848
 msgid "List:"
 msgstr "Tabdart :"
 
@@ -2566,15 +2569,15 @@ msgstr "Tabdart :"
 msgid "Load"
 msgstr "Sali-d"
 
-#: ../src/wxMaxima.cpp:2932
+#: ../src/wxMaxima.cpp:2940
 msgid "Load Package"
 msgstr "Sali-d akemmus\tCtrl-L"
 
-#: ../src/wxMaximaFrame.cpp:479
+#: ../src/wxMaximaFrame.cpp:478
 msgid "Load a Maxima file using the batch command"
 msgstr "Sali-d afaylu Maxima s useqdec n tladna s uɛemmuṛ"
 
-#: ../src/wxMaximaFrame.cpp:477
+#: ../src/wxMaximaFrame.cpp:476
 msgid "Load a Maxima package file"
 msgstr "Sali-d afaylu akemmus n Maxima"
 
@@ -2586,48 +2589,48 @@ msgstr "Sali-d aɣanib seg ufaylu"
 msgid "Long Right arrow"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Lower bound:"
 msgstr "talast n wadda :"
 
-#: ../src/wxMaximaFrame.cpp:771
+#: ../src/wxMaximaFrame.cpp:770
 msgid "Ma&p to Matrix..."
 msgstr "A&ppliquer à une matrice…"
 
-#: ../src/wxMaximaFrame.cpp:547
+#: ../src/wxMaximaFrame.cpp:546
 msgid "Main Toolbar\tAlt-Shift-B"
 msgstr "Afeggag n ifeckatAlt-Maj-T"
 
-#: ../src/wxMaximaFrame.cpp:765
+#: ../src/wxMaximaFrame.cpp:764
 msgid "Make &List..."
 msgstr "Sirew &tabdart…"
 
-#: ../src/wxMaxima.cpp:3821
+#: ../src/wxMaxima.cpp:3833
 msgid "Make list"
 msgstr "Sirew tabdart"
 
-#: ../src/wxMaximaFrame.cpp:766
+#: ../src/wxMaximaFrame.cpp:765
 msgid "Make list from expression"
 msgstr "Sirew tabdart si tenfalit"
 
-#: ../src/wxMaximaFrame.cpp:907
+#: ../src/wxMaximaFrame.cpp:906
 msgid "Make substitution in expression"
 msgstr "Semselsi tanfalit"
 
-#: ../src/wxMaximaFrame.cpp:682
+#: ../src/wxMaximaFrame.cpp:681
 #, fuzzy
 msgid "Manually Trigger Evaluation"
 msgstr "Afficher le temps d'exécution"
 
-#: ../src/wxMaxima.cpp:3805
+#: ../src/wxMaxima.cpp:3817
 msgid "Map"
 msgstr "Snes"
 
-#: ../src/wxMaximaFrame.cpp:770
+#: ../src/wxMaximaFrame.cpp:769
 msgid "Map function to a list"
 msgstr "Snes tawuri ɣef tebdart"
 
-#: ../src/wxMaximaFrame.cpp:772
+#: ../src/wxMaximaFrame.cpp:771
 msgid "Map function to a matrix"
 msgstr "Snes tawuri ɣef isirew"
 
@@ -2644,23 +2647,23 @@ msgstr "Faire correspondre les parenthèses dans les entrées de texte."
 msgid "Math font:"
 msgstr "Police mathématique :"
 
-#: ../src/wxMaximaFrame.cpp:374
+#: ../src/wxMaximaFrame.cpp:373
 msgid "Mathematical Symbols"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3716
+#: ../src/wxMaxima.cpp:3728
 msgid "Matrix"
 msgstr "Isirew"
 
-#: ../src/wxMaxima.cpp:3702
+#: ../src/wxMaxima.cpp:3714
 msgid "Matrix map"
 msgstr "Snes isirew"
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Matrix name:"
 msgstr "Isem n isirew :"
 
-#: ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3749
+#: ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3761
 msgid "Matrix:"
 msgstr "Isirew :"
 
@@ -2668,7 +2671,7 @@ msgstr "Isirew :"
 msgid "Maxima"
 msgstr "&Maxima"
 
-#: ../src/wxMaximaFrame.cpp:137
+#: ../src/wxMaximaFrame.cpp:136
 #, fuzzy
 msgid "Maxima has a question"
 msgstr "Isteqsiyen ɣef Maxima"
@@ -2677,24 +2680,24 @@ msgstr "Isteqsiyen ɣef Maxima"
 msgid "Maxima input"
 msgstr "Anekcam Maxima"
 
-#: ../src/wxMaximaFrame.cpp:166
+#: ../src/wxMaximaFrame.cpp:165
 msgid "Maxima is calculating"
 msgstr "Maxima est en train de calculer"
 
-#: ../src/wxMaximaFrame.cpp:111
+#: ../src/wxMaximaFrame.cpp:110
 #, fuzzy
 msgid "Maxima is ready for input."
 msgstr "Anekcam Maxima"
 
-#: ../src/wxMaxima.cpp:2945
+#: ../src/wxMaxima.cpp:2953
 msgid "Maxima package (*.mac)|*.mac"
 msgstr "paquetage Maxima (*.mac)|*.mac|"
 
-#: ../src/wxMaxima.cpp:2934
+#: ../src/wxMaxima.cpp:2942
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr "Paquetage Maxima (*.mac)|*.mac|Paquetage Lisp (*.lisp)|*.lisp|Tous|*"
 
-#: ../src/wxMaxima.cpp:1014
+#: ../src/wxMaxima.cpp:1019
 msgid "Maxima process terminated."
 msgstr "Maxima s'est arrêté."
 
@@ -2706,7 +2709,7 @@ msgstr "Ahil  Maxima :"
 msgid "Maxima questions"
 msgstr "Isteqsiyen ɣef Maxima"
 
-#: ../src/wxMaxima.cpp:942
+#: ../src/wxMaxima.cpp:947
 msgid "Maxima started. Waiting for connection..."
 msgstr "Maxima  a démarré. Attente de la connection…"
 
@@ -2730,7 +2733,7 @@ msgstr ""
 "Maxima utilise ':' pour affecter une valeur à une variable ('a : 3;') et ':"
 "=' pour définir une fonction ('f(x) := x^2;')."
 
-#: ../src/wxMaxima.cpp:4597
+#: ../src/wxMaxima.cpp:4609
 msgid "Maxima version: "
 msgstr "lqem n Maxima :"
 
@@ -2767,40 +2770,40 @@ msgstr ""
 msgid "Maximum displayed number of digits:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1263
+#: ../src/wxMaximaFrame.cpp:1262
 msgid "Mean Difference Test..."
 msgstr "Akayad n umgired n tlemmassin…"
 
-#: ../src/wxMaximaFrame.cpp:1262
+#: ../src/wxMaximaFrame.cpp:1261
 msgid "Mean Test..."
 msgstr "Akayad n tlemmast…"
 
-#: ../src/wxMaximaFrame.cpp:1255
+#: ../src/wxMaximaFrame.cpp:1254
 msgid "Mean..."
 msgstr "Talemmast…"
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Mean:"
 msgstr "Talemmast :"
 
-#: ../src/wxMaximaFrame.cpp:1256
+#: ../src/wxMaximaFrame.cpp:1255
 msgid "Median..."
 msgstr "Tanammast…"
 
-#: ../src/MathCtrl.cpp:945
+#: ../src/MathCtrl.cpp:987
 msgid "Merge Cells"
 msgstr "Smezdi tibniqin"
 
-#: ../src/wxMaximaFrame.cpp:633
+#: ../src/wxMaximaFrame.cpp:632
 #, fuzzy
 msgid "Merge Cells\tCtrl-M"
 msgstr "Smezdi tibniqin"
 
-#: ../src/wxMaximaFrame.cpp:634
+#: ../src/wxMaximaFrame.cpp:633
 msgid "Merge the text from two input cells into one"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2668
+#: ../src/wxMaxima.cpp:2676
 msgid "Message from the stdout of Maxima: "
 msgstr ""
 
@@ -2808,20 +2811,20 @@ msgstr ""
 msgid "Method:"
 msgstr "Tarrayt :"
 
-#: ../src/wxMaxima.cpp:5289
+#: ../src/wxMaxima.cpp:5301
 #, fuzzy
 msgid "Mismatched parenthesis"
 msgstr "Faire correspondre les parenthèses dans les entrées de texte."
 
-#: ../src/wxMaxima.cpp:3972
+#: ../src/wxMaxima.cpp:3984
 msgid "Modulus"
 msgstr "Azegrir"
 
-#: ../src/wxMaximaFrame.cpp:1375
+#: ../src/wxMaximaFrame.cpp:1374
 msgid "Mu"
 msgstr ""
 
-#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Name:"
 msgstr "Isem :"
 
@@ -2829,7 +2832,7 @@ msgstr "Isem :"
 msgid "New"
 msgstr "Rnu"
 
-#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
+#: ../src/wxMaximaFrame.cpp:456 ../src/wxMaximaFrame.cpp:459
 msgid "New\tCtrl-N"
 msgstr "&Rnu tiɣimit\tCtrl-N"
 
@@ -2845,11 +2848,11 @@ msgstr "Rnu izirigen: Ngez ɣer uḍris"
 msgid "New value:"
 msgstr "Rnu azal"
 
-#: ../src/wxMaxima.cpp:3993 ../src/wxMaxima.cpp:4119 ../src/wxMaxima.cpp:4136
+#: ../src/wxMaxima.cpp:4005 ../src/wxMaxima.cpp:4131 ../src/wxMaxima.cpp:4148
 msgid "New variable:"
 msgstr "Rnu amutti :"
 
-#: ../src/wxMaximaFrame.cpp:630
+#: ../src/wxMaximaFrame.cpp:629
 msgid "Next Command\tAlt-Down"
 msgstr "Commande suivante\tAlt-Down"
 
@@ -2857,15 +2860,15 @@ msgstr "Commande suivante\tAlt-Down"
 msgid "No"
 msgstr "Ala"
 
-#: ../src/wxMaxima.cpp:5362
+#: ../src/wxMaxima.cpp:5378
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3249 ../src/wxMaxima.cpp:3271
+#: ../src/wxMaxima.cpp:3260 ../src/wxMaxima.cpp:3283
 msgid "No matches found!"
 msgstr "Recherche infructueuse !"
 
-#: ../src/wxMaximaFrame.cpp:1264
+#: ../src/wxMaximaFrame.cpp:1263
 msgid "Normality Test..."
 msgstr "Akayad n tmugna…"
 
@@ -2888,34 +2891,34 @@ msgstr ""
 msgid "Norwegian"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:3740
 msgid "Not a valid matrix dimension!"
 msgstr "Dimension de matrice incorrecte !"
 
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629
 msgid "Not a valid number of equations!"
 msgstr "Nombre d'équations incorrect !"
 
-#: ../src/wxMaximaFrame.cpp:197
+#: ../src/wxMaximaFrame.cpp:196
 #, fuzzy
 msgid "Not connected to maxima"
 msgstr ""
 "\n"
 "Non connecté à Maxima!\n"
 
-#: ../src/wxMaxima.cpp:4599
+#: ../src/wxMaxima.cpp:4611
 msgid "Not connected."
 msgstr "Non connecté"
 
-#: ../src/wxMaximaFrame.cpp:1376
+#: ../src/wxMaximaFrame.cpp:1375
 msgid "Nu"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Num. deg:"
 msgstr "num deg :"
 
-#: ../src/wxMaxima.cpp:3585 ../src/wxMaxima.cpp:3609
+#: ../src/wxMaxima.cpp:3597 ../src/wxMaxima.cpp:3621
 msgid "Number of equations:"
 msgstr "Amḍan n tegdiwin :"
 
@@ -2942,15 +2945,15 @@ msgstr "Ih"
 msgid "Old value:"
 msgstr "Ancienne valeur :"
 
-#: ../src/wxMaxima.cpp:3992 ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135
+#: ../src/wxMaxima.cpp:4004 ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147
 msgid "Old variable:"
 msgstr "Ancienne variable :"
 
-#: ../src/wxMaximaFrame.cpp:1387
+#: ../src/wxMaximaFrame.cpp:1386
 msgid "Omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1378
+#: ../src/wxMaximaFrame.cpp:1377
 msgid "Omicron"
 msgstr ""
 
@@ -2964,20 +2967,20 @@ msgid ""
 "stream for messages."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4763
+#: ../src/wxMaxima.cpp:4775
 msgid "One sample t-test"
 msgstr "Test de Student (t-test) à 1 échantillon…"
 
-#: ../src/wxMaximaFrame.cpp:971
+#: ../src/wxMaximaFrame.cpp:970
 msgid "Online tutorials"
 msgstr "Tutoriels en ligne"
 
 #: ../src/ConfigDialogue.cpp:656 ../src/main.cpp:347 ../src/ToolBar.cpp:119
-#: ../src/wxMaxima.cpp:2797
+#: ../src/wxMaxima.cpp:2805
 msgid "Open"
 msgstr "Ldi"
 
-#: ../src/wxMaximaFrame.cpp:466
+#: ../src/wxMaximaFrame.cpp:465
 msgid "Open Recent"
 msgstr "Ldi afaylu n meli kan"
 
@@ -2985,11 +2988,11 @@ msgstr "Ldi afaylu n meli kan"
 msgid "Open a cell when Maxima expects input"
 msgstr "Ldi-d tabniqt ticki Maxima yettṛaǧu anekcam"
 
-#: ../src/wxMaximaFrame.cpp:464
+#: ../src/wxMaximaFrame.cpp:463
 msgid "Open a document"
 msgstr "Ldi isemli"
 
-#: ../src/wxMaximaFrame.cpp:458 ../src/wxMaximaFrame.cpp:461
+#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
 msgid "Open a new window"
 msgstr "Ldi asfaylu amaynut"
 
@@ -2997,11 +3000,11 @@ msgstr "Ldi asfaylu amaynut"
 msgid "Open document"
 msgstr "Ldi isemli"
 
-#: ../src/wxMaxima.cpp:4824
+#: ../src/wxMaxima.cpp:4836
 msgid "Open matrix"
 msgstr "Sekcem isirew"
 
-#: ../src/wxMaxima.cpp:1446 ../src/wxMaxima.cpp:1518
+#: ../src/wxMaxima.cpp:1451 ../src/wxMaxima.cpp:1523
 msgid "Opening file"
 msgstr "Tulya n ufaylu"
 
@@ -3025,11 +3028,11 @@ msgstr "Cellules inactualisées"
 msgid "Output labels"
 msgstr "Étiquettes de sorties"
 
-#: ../src/wxMaximaFrame.cpp:796
+#: ../src/wxMaximaFrame.cpp:795
 msgid "P&ade Approximation..."
 msgstr "Approximant de &Padé…"
 
-#: ../src/wxMaxima.cpp:3132 ../src/wxMaxima.cpp:5133
+#: ../src/wxMaxima.cpp:3141 ../src/wxMaxima.cpp:5145
 #, fuzzy
 msgid ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
@@ -3039,15 +3042,15 @@ msgstr ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
 "bmp|X pixmap (*.xpm)|*.xpm"
 
-#: ../src/wxMaxima.cpp:4012
+#: ../src/wxMaxima.cpp:4024
 msgid "Pade approximation"
 msgstr "Approximant de Padé"
 
-#: ../src/wxMaximaFrame.cpp:797
+#: ../src/wxMaximaFrame.cpp:796
 msgid "Pade approximation of a Taylor series"
 msgstr "Approximant de Padé d'un développement en série de Taylor"
 
-#: ../src/wxMaximaFrame.cpp:1500
+#: ../src/wxMaximaFrame.cpp:1519
 msgid "Pagebreak"
 msgstr "Saut de page"
 
@@ -3059,19 +3062,19 @@ msgstr ""
 msgid "Parametric plot"
 msgstr "Courbe paramétrée"
 
-#: ../src/wxMaximaFrame.cpp:188
+#: ../src/wxMaximaFrame.cpp:187
 msgid "Parsing output"
 msgstr "Analyse du résultat"
 
-#: ../src/wxMaximaFrame.cpp:819
+#: ../src/wxMaximaFrame.cpp:818
 msgid "Partial &Fractions..."
 msgstr "Éléments simples…"
 
-#: ../src/wxMaxima.cpp:4076
+#: ../src/wxMaxima.cpp:4088
 msgid "Partial fractions"
 msgstr "Éléments simples"
 
-#: ../src/wxMaxima.cpp:1769
+#: ../src/wxMaxima.cpp:1774
 msgid "Parts of the document will not be loaded correctly!"
 msgstr "Des parties du document ne seront pas chargées correctement !"
 
@@ -3082,11 +3085,11 @@ msgid ""
 "Found unknown XML Tag name "
 msgstr "Des parties du document ne seront pas chargées correctement !"
 
-#: ../src/ToolBar.cpp:143 ../src/MathCtrl.cpp:1010 ../src/MathCtrl.cpp:1025
+#: ../src/MathCtrl.cpp:1052 ../src/MathCtrl.cpp:1067 ../src/ToolBar.cpp:143
 msgid "Paste"
 msgstr "Senṭeḍ"
 
-#: ../src/wxMaximaFrame.cpp:518
+#: ../src/wxMaximaFrame.cpp:517
 msgid "Paste\tCtrl-V"
 msgstr "&Coller\tCtrl-V"
 
@@ -3094,7 +3097,7 @@ msgstr "&Coller\tCtrl-V"
 msgid "Paste from clipboard"
 msgstr "Coller le texte du presse-papier"
 
-#: ../src/wxMaximaFrame.cpp:519
+#: ../src/wxMaximaFrame.cpp:518
 msgid "Paste text from clipboard"
 msgstr "Coller le texte du presse-papier"
 
@@ -3102,19 +3105,19 @@ msgstr "Coller le texte du presse-papier"
 msgid "Perpendicular to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1384
+#: ../src/wxMaximaFrame.cpp:1383
 msgid "Phi"
 msgstr "Phi"
 
-#: ../src/wxMaximaFrame.cpp:1379
+#: ../src/wxMaximaFrame.cpp:1378
 msgid "Pi"
 msgstr "Pi"
 
-#: ../src/wxMaximaFrame.cpp:1273
+#: ../src/wxMaximaFrame.cpp:1272
 msgid "Piechart..."
 msgstr "Udlif uwnis…"
 
-#: ../src/wxMaxima.cpp:1952
+#: ../src/wxMaxima.cpp:1957
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr "Configurer wxMaxima avec 'Édition->Configurer'."
 
@@ -3122,52 +3125,52 @@ msgstr "Configurer wxMaxima avec 'Édition->Configurer'."
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr "Redémarrer wxMaxima pour que les changements prennent effet."
 
-#: ../src/wxMaximaFrame.cpp:923
+#: ../src/wxMaximaFrame.cpp:922
 msgid "Plot &2d..."
 msgstr "Tamaknayt &2d…"
 
-#: ../src/wxMaximaFrame.cpp:925
+#: ../src/wxMaximaFrame.cpp:924
 msgid "Plot &3d..."
 msgstr "Tamaknayt &3d…"
 
-#: ../src/wxMaximaFrame.cpp:927
+#: ../src/wxMaximaFrame.cpp:926
 msgid "Plot &Format..."
 msgstr "&Format de la courbe…"
 
 #: ../src/Plot2dWiz.cpp:104 ../src/Plot2dWiz.cpp:450 ../src/Plot2dWiz.cpp:464
-#: ../src/wxMaxima.cpp:4283 ../src/wxMaxima.cpp:5102
+#: ../src/wxMaxima.cpp:4295 ../src/wxMaxima.cpp:5114
 msgid "Plot 2D"
 msgstr "Tamaknayt 2D"
 
-#: ../src/wxMaximaFrame.cpp:1227
+#: ../src/wxMaximaFrame.cpp:1226
 msgid "Plot 2D..."
 msgstr "Tamaknayt 2D..."
 
-#: ../src/MathCtrl.cpp:1003
+#: ../src/MathCtrl.cpp:1045
 msgid "Plot 2d..."
 msgstr "Tamaknayt 2d…"
 
-#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4269 ../src/wxMaxima.cpp:5115
+#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4281 ../src/wxMaxima.cpp:5127
 msgid "Plot 3D"
 msgstr "Tamaknayt 3D"
 
-#: ../src/wxMaximaFrame.cpp:1228
+#: ../src/wxMaximaFrame.cpp:1227
 msgid "Plot 3D..."
 msgstr "Tamaknayt 3D"
 
-#: ../src/MathCtrl.cpp:1004
+#: ../src/MathCtrl.cpp:1046
 msgid "Plot 3d..."
 msgstr "Tamaknayt 3d…"
 
-#: ../src/wxMaxima.cpp:4296
+#: ../src/wxMaxima.cpp:4308
 msgid "Plot format"
 msgstr "Format de la courbe"
 
-#: ../src/wxMaximaFrame.cpp:924
+#: ../src/wxMaximaFrame.cpp:923
 msgid "Plot in 2 dimensions"
 msgstr "Courbe en 2 dimensions"
 
-#: ../src/wxMaximaFrame.cpp:926
+#: ../src/wxMaximaFrame.cpp:925
 msgid "Plot in 3 dimensions"
 msgstr "Courbe en 3 dimensions"
 
@@ -3176,8 +3179,8 @@ msgid "Plot to file:"
 msgstr "Tracer dans un fichier :"
 
 #: ../src/BC2Wiz.cpp:30 ../src/BC2Wiz.cpp:36 ../src/LimitWiz.cpp:33
-#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
-#: ../src/wxMaxima.cpp:3648
+#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
+#: ../src/wxMaxima.cpp:3660
 msgid "Point:"
 msgstr "Agaz :"
 
@@ -3185,11 +3188,11 @@ msgstr "Agaz :"
 msgid "Polish"
 msgstr "Tapolunit"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 1:"
 msgstr "Polynôme 1 :"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 2:"
 msgstr "Polynôme 2 :"
 
@@ -3201,11 +3204,11 @@ msgstr "Portugais (Brésil)"
 msgid "Postscript file (*.eps)|*.eps|All|*"
 msgstr "Fichier postscript (*.eps)|*.eps|Tous|*"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Precision"
 msgstr "Précision"
 
-#: ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:536
 msgid "Preferences...\tCtrl+,"
 msgstr ""
 
@@ -3217,7 +3220,7 @@ msgid ""
 "packages and from functions that are defined in the current file."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:628
+#: ../src/wxMaximaFrame.cpp:627
 msgid "Previous Command\tAlt-Up"
 msgstr "Commande précédente\tAlt-Up"
 
@@ -3225,11 +3228,11 @@ msgstr "Commande précédente\tAlt-Up"
 msgid "Print"
 msgstr "Imprimer"
 
-#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:484
+#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:483
 msgid "Print document"
 msgstr "Imprimer le document"
 
-#: ../src/wxMaxima.cpp:4242
+#: ../src/wxMaxima.cpp:4254
 msgid "Product"
 msgstr "Produit"
 
@@ -3238,36 +3241,36 @@ msgstr "Produit"
 msgid "Product sign"
 msgstr "Produit"
 
-#: ../src/wxMaximaFrame.cpp:1386
+#: ../src/wxMaximaFrame.cpp:1385
 msgid "Psi"
 msgstr "Psi"
 
-#: ../src/wxMaximaFrame.cpp:331
+#: ../src/wxMaximaFrame.cpp:330
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:592
+#: ../src/wxMaximaFrame.cpp:591
 #, fuzzy
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr "Réévaluer toutes les cellules du document"
 
-#: ../src/wxMaximaFrame.cpp:1278
+#: ../src/wxMaximaFrame.cpp:1277
 msgid "Read Matrix..."
 msgstr "&Ɣar isirew…"
 
-#: ../src/wxMaximaFrame.cpp:177
+#: ../src/wxMaximaFrame.cpp:176
 msgid "Reading Maxima output"
 msgstr "Lecture des résultats de Maxima"
 
-#: ../src/wxMaximaFrame.cpp:153
+#: ../src/wxMaximaFrame.cpp:152
 msgid "Ready for user input"
 msgstr "Prêt pour une entrée utilisateur"
 
-#: ../src/wxMaximaFrame.cpp:631
+#: ../src/wxMaximaFrame.cpp:630
 msgid "Recall next command from history"
 msgstr "Rappeler la commande suivante dans l'historique"
 
-#: ../src/wxMaximaFrame.cpp:629
+#: ../src/wxMaximaFrame.cpp:628
 msgid "Recall previous command from history"
 msgstr "Rappeler la commande précédent dans l'historique"
 
@@ -3275,35 +3278,35 @@ msgstr "Rappeler la commande précédent dans l'historique"
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1215
+#: ../src/wxMaximaFrame.cpp:1214
 msgid "Rectform"
 msgstr "Talɣa takaṛtizyant"
 
-#: ../src/wxMaximaFrame.cpp:495
+#: ../src/wxMaximaFrame.cpp:494
 msgid "Redo\tCtrl-Y"
 msgstr "&Sefsex\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:496
+#: ../src/wxMaximaFrame.cpp:495
 msgid "Redo last change"
 msgstr "Sefsex asnifel aneggaru"
 
-#: ../src/wxMaximaFrame.cpp:1220
+#: ../src/wxMaximaFrame.cpp:1219
 msgid "Reduce (tr)"
 msgstr "Fneẓ (tanfalit asektuɣmir)"
 
-#: ../src/wxMaximaFrame.cpp:871
+#: ../src/wxMaximaFrame.cpp:870
 msgid "Reduce trigonometric expression"
 msgstr "Réduire une expression trigonométrique"
 
-#: ../src/wxMaxima.cpp:622 ../src/wxMaxima.cpp:5495
+#: ../src/wxMaxima.cpp:627 ../src/wxMaxima.cpp:5511
 msgid "Refusing to send cell to maxima: "
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:594
+#: ../src/wxMaximaFrame.cpp:593
 msgid "Remove All Output"
 msgstr "Supprimer tous les résultats"
 
-#: ../src/wxMaximaFrame.cpp:595
+#: ../src/wxMaximaFrame.cpp:594
 msgid "Remove output from input cells"
 msgstr "Supprimer les résultats des cellules"
 
@@ -3312,7 +3315,7 @@ msgstr "Supprimer les résultats des cellules"
 msgid "Replace All"
 msgstr "Tout sélectionner"
 
-#: ../src/wxMaxima.cpp:3282
+#: ../src/wxMaxima.cpp:3294
 #, fuzzy, c-format
 msgid "Replaced %d occurrences."
 msgstr "%d occurrences remplacées"
@@ -3321,11 +3324,11 @@ msgstr "%d occurrences remplacées"
 msgid "Replacement:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:976
+#: ../src/wxMaximaFrame.cpp:975
 msgid "Report bug"
 msgstr "Rapport de bogue"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "Restart Maxima"
 msgstr "Senker tikelt nniḍen maxima"
 
@@ -3333,7 +3336,7 @@ msgstr "Senker tikelt nniḍen maxima"
 msgid "Restart maxima"
 msgstr "Senker tikelt nniḍen maxima"
 
-#: ../src/MathCtrl.cpp:4442
+#: ../src/MathCtrl.cpp:4497
 msgid "Result"
 msgstr "Agmuḍ"
 
@@ -3341,7 +3344,7 @@ msgstr "Agmuḍ"
 msgid "Return to the cell that is currently being evaluated"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1380
+#: ../src/wxMaximaFrame.cpp:1379
 msgid "Rho"
 msgstr "Rho"
 
@@ -3349,19 +3352,19 @@ msgstr "Rho"
 msgid "Right arrow"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:779
+#: ../src/wxMaximaFrame.cpp:778
 msgid "Risch Integration..."
 msgstr "Intégration de Risch…"
 
-#: ../src/wxMaximaFrame.cpp:694
+#: ../src/wxMaximaFrame.cpp:693
 msgid "Roots of &Polynomial"
 msgstr "Racines d'un &polynôme"
 
-#: ../src/wxMaximaFrame.cpp:697
+#: ../src/wxMaximaFrame.cpp:696
 msgid "Roots of Polynomial (bfloat)"
 msgstr "&Racines d'un polynôme (bigfloat)"
 
-#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Rows:"
 msgstr "Lignes :"
 
@@ -3369,56 +3372,56 @@ msgstr "Lignes :"
 msgid "Russian"
 msgstr "Russe"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 1:"
 msgstr "Échantillon 1 :"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 2:"
 msgstr "Échantillon 2 :"
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Sample:"
 msgstr "Échantillon"
 
 #: ../src/ConfigDialogue.cpp:781 ../src/ToolBar.cpp:122
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Save"
 msgstr "Sekles"
 
-#: ../src/MathCtrl.cpp:921
+#: ../src/MathCtrl.cpp:963
 msgid "Save Animation..."
 msgstr "Sekles amray…"
 
-#: ../src/wxMaxima.cpp:2565
+#: ../src/wxMaxima.cpp:2572
 msgid "Save As"
 msgstr "Sekles s yisem"
 
-#: ../src/wxMaximaFrame.cpp:474
+#: ../src/wxMaximaFrame.cpp:473
 msgid "Save As...\tShift-Ctrl-S"
 msgstr "&Sekles tiɣimit s yisem…\tMaj-Ctrl-S"
 
-#: ../src/MathCtrl.cpp:919
+#: ../src/MathCtrl.cpp:961
 msgid "Save Image..."
 msgstr "Sekles tugna…"
 
-#: ../src/wxMaxima.cpp:3130
+#: ../src/wxMaxima.cpp:3139
 msgid "Save Selection to Image"
 msgstr "Sauvegarder la sélection comme image"
 
-#: ../src/wxMaximaFrame.cpp:528
+#: ../src/wxMaximaFrame.cpp:527
 msgid "Save Selection to Image..."
 msgstr "Sauvegarder la sélection comme image…"
 
-#: ../src/wxMaxima.cpp:5150
+#: ../src/wxMaxima.cpp:5162
 msgid "Save animation to file"
 msgstr "Sekles amray ɣer ufaylu"
 
-#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:473
+#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:472
 msgid "Save document"
 msgstr "Sekles isemli"
 
-#: ../src/wxMaximaFrame.cpp:475
+#: ../src/wxMaximaFrame.cpp:474
 msgid "Save document as"
 msgstr "Sekles isemli s yisem"
 
@@ -3442,11 +3445,11 @@ msgstr ""
 msgid "Save plot to file"
 msgstr "Enregistrer le tracé dans un fichier "
 
-#: ../src/wxMaximaFrame.cpp:529
+#: ../src/wxMaximaFrame.cpp:528
 msgid "Save selection from document to an image file"
 msgstr "Sauvegarder la sélection du document dans un fichier image "
 
-#: ../src/wxMaxima.cpp:5131
+#: ../src/wxMaxima.cpp:5143
 msgid "Save selection to file"
 msgstr "Enregistrer la sélection dans un fichier"
 
@@ -3464,28 +3467,28 @@ msgstr ""
 "Enregistrer la taille/position de la fenêtre de wxMaxima d'une session à "
 "l'autre"
 
-#: ../src/wxMaximaFrame.cpp:246
+#: ../src/wxMaximaFrame.cpp:245
 #, fuzzy
 msgid "Saving failed."
 msgstr "Échec du démarrage du serveur"
 
-#: ../src/wxMaximaFrame.cpp:222
+#: ../src/wxMaximaFrame.cpp:221
 msgid "Saving successful."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:212
+#: ../src/wxMaximaFrame.cpp:211
 msgid "Saving..."
 msgstr "Asekles"
 
-#: ../src/wxMaxima.cpp:4699
+#: ../src/wxMaxima.cpp:4711
 msgid "Scatterplot"
 msgstr "Asigna n wagazen"
 
-#: ../src/wxMaximaFrame.cpp:1271
+#: ../src/wxMaximaFrame.cpp:1270
 msgid "Scatterplot..."
 msgstr "Asigna n wagazen..."
 
-#: ../src/wxMaximaFrame.cpp:1498
+#: ../src/wxMaximaFrame.cpp:1517
 msgid "Section"
 msgstr "Tigezmi"
 
@@ -3493,26 +3496,26 @@ msgstr "Tigezmi"
 msgid "Section cell"
 msgstr "Tabniqt n tgezmi"
 
-#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:292 ../src/TextCell.cpp:306
-#: ../src/TextCell.cpp:322 ../src/TextCell.cpp:334
+#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:290 ../src/TextCell.cpp:304
+#: ../src/TextCell.cpp:320 ../src/TextCell.cpp:332
 msgid ""
 "Seems like something is broken with a font. Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/TextCell.cpp:139
+#: ../src/TextCell.cpp:137
 msgid ""
 "Seems like something is broken with the maths font. Installing http://www."
 "math.union.edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use "
 "JSmath fonts\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1011 ../src/MathCtrl.cpp:1027
+#: ../src/MathCtrl.cpp:1053 ../src/MathCtrl.cpp:1069
 msgid "Select All"
 msgstr "Tout sélectionner"
 
-#: ../src/wxMaximaFrame.cpp:525
+#: ../src/wxMaximaFrame.cpp:524
 msgid "Select All\tCtrl-A"
 msgstr "Tout sélectionner"
 
@@ -3520,7 +3523,7 @@ msgstr "Tout sélectionner"
 msgid "Select Maxima program"
 msgstr "Choisir le programme Maxima"
 
-#: ../src/wxMaxima.cpp:4860
+#: ../src/wxMaxima.cpp:4872
 msgid "Select Subsample"
 msgstr "Choisir un sous-échantillon"
 
@@ -3529,11 +3532,11 @@ msgstr "Choisir un sous-échantillon"
 msgid "Select a constant"
 msgstr "Choisir une constante"
 
-#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:526
+#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:525
 msgid "Select all"
 msgstr "Fen imeṛṛa"
 
-#: ../src/wxMaxima.cpp:3319
+#: ../src/wxMaxima.cpp:3331
 msgid "Select math display algorithm"
 msgstr "Choisir l'algorithme d'affichage mathématique"
 
@@ -3550,23 +3553,23 @@ msgstr ""
 msgid "Selection"
 msgstr "Tafrant"
 
-#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4178
+#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4190
 msgid "Series"
 msgstr "Imazraren"
 
-#: ../src/wxMaximaFrame.cpp:1226
+#: ../src/wxMaximaFrame.cpp:1225
 msgid "Series..."
 msgstr "Imazraren…"
 
-#: ../src/wxMaxima.cpp:863
+#: ../src/wxMaxima.cpp:868
 msgid "Server started"
 msgstr "Aqeddac yekker"
 
-#: ../src/wxMaximaFrame.cpp:575
+#: ../src/wxMaximaFrame.cpp:574
 msgid "Set Zoom"
 msgstr "Sbadu zoom"
 
-#: ../src/wxMaximaFrame.cpp:944
+#: ../src/wxMaximaFrame.cpp:943
 #, fuzzy
 msgid "Set bigfloat &Precision..."
 msgstr "Régler la précision de la virgule flottante"
@@ -3575,63 +3578,63 @@ msgstr "Régler la précision de la virgule flottante"
 msgid "Set fixed font in text controls."
 msgstr "Sélectionner une police à chasse fixe dans les entrées de texte."
 
-#: ../src/wxMaximaFrame.cpp:928
+#: ../src/wxMaximaFrame.cpp:927
 msgid "Set plot format"
 msgstr "Régler le format de courbe"
 
-#: ../src/wxMaximaFrame.cpp:945
+#: ../src/wxMaximaFrame.cpp:944
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can "
 "be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:569
+#: ../src/wxMaximaFrame.cpp:568
 msgid "Set zoom to 100%"
 msgstr "Régler le zoom à 100%"
 
-#: ../src/wxMaximaFrame.cpp:570
+#: ../src/wxMaximaFrame.cpp:569
 msgid "Set zoom to 120%"
 msgstr "Régler le zoom à 120%"
 
-#: ../src/wxMaximaFrame.cpp:571
+#: ../src/wxMaximaFrame.cpp:570
 msgid "Set zoom to 150%"
 msgstr "Régler le zoom à 150%"
 
-#: ../src/wxMaximaFrame.cpp:572
+#: ../src/wxMaximaFrame.cpp:571
 msgid "Set zoom to 200%"
 msgstr "Régler le zoom à 200%"
 
-#: ../src/wxMaximaFrame.cpp:573
+#: ../src/wxMaximaFrame.cpp:572
 msgid "Set zoom to 300%"
 msgstr "Régler le zoom à 300%"
 
-#: ../src/wxMaximaFrame.cpp:568
+#: ../src/wxMaximaFrame.cpp:567
 msgid "Set zoom to 80%"
 msgstr "Régler le zoom à 80%"
 
-#: ../src/wxMaximaFrame.cpp:732
+#: ../src/wxMaximaFrame.cpp:731
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
 "Choisir 'à la valeur' pour la résolution d'une é.d.o. avec la transformée de "
 "Laplace"
 
-#: ../src/wxMaximaFrame.cpp:918
+#: ../src/wxMaximaFrame.cpp:917
 msgid "Setup modulus computation"
 msgstr "Calculer le module"
 
-#: ../src/wxMaximaFrame.cpp:662
+#: ../src/wxMaximaFrame.cpp:661
 msgid "Show &Definition..."
 msgstr "Montrer les &définitions"
 
-#: ../src/wxMaximaFrame.cpp:660
+#: ../src/wxMaximaFrame.cpp:659
 msgid "Show &Functions"
 msgstr "Montrer les &fonctions"
 
-#: ../src/wxMaximaFrame.cpp:967
+#: ../src/wxMaximaFrame.cpp:966
 msgid "Show &Tips..."
 msgstr "Montrer les as&tuces"
 
-#: ../src/wxMaximaFrame.cpp:665
+#: ../src/wxMaximaFrame.cpp:664
 msgid "Show &Variables"
 msgstr "Montrer les &variables"
 
@@ -3639,43 +3642,43 @@ msgstr "Montrer les &variables"
 msgid "Show Maxima help"
 msgstr "Sken tallalt n Maxima"
 
-#: ../src/wxMaximaFrame.cpp:603
+#: ../src/wxMaximaFrame.cpp:602
 msgid "Show Template\tCtrl-Shift-K"
 msgstr "Montrer le modèle\tCtrl-Maj-K"
 
-#: ../src/wxMaximaFrame.cpp:968
+#: ../src/wxMaximaFrame.cpp:967
 msgid "Show a tip"
 msgstr "Montrer une astuce"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Show all commands similar to:"
 msgstr "Montrer toutes les commandes analogues à :"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Show an example for the command:"
 msgstr "Montrer un exemple pour la commande :"
 
-#: ../src/wxMaximaFrame.cpp:962
+#: ../src/wxMaximaFrame.cpp:961
 msgid "Show an example of usage"
 msgstr "Montrer un exemple d'utilisation"
 
-#: ../src/wxMaximaFrame.cpp:965
+#: ../src/wxMaximaFrame.cpp:964
 msgid "Show commands similar to"
 msgstr "Montrer les commandes analogues à"
 
-#: ../src/wxMaximaFrame.cpp:661
+#: ../src/wxMaximaFrame.cpp:660
 msgid "Show defined functions"
 msgstr "Montrer les fonctions définies"
 
-#: ../src/wxMaximaFrame.cpp:666
+#: ../src/wxMaximaFrame.cpp:665
 msgid "Show defined variables"
 msgstr "Montrer les variables déclarées"
 
-#: ../src/wxMaximaFrame.cpp:663
+#: ../src/wxMaximaFrame.cpp:662
 msgid "Show definition of a function"
 msgstr "Montrer la définition d'une fonction"
 
-#: ../src/wxMaximaFrame.cpp:604
+#: ../src/wxMaximaFrame.cpp:603
 msgid "Show function template"
 msgstr "Montrer le modèle de la fonction"
 
@@ -3688,7 +3691,7 @@ msgstr "Montrer les expressions longues dans la console de wxMaxima"
 msgid "Show long expressions:"
 msgstr "Montrer les expressions longues"
 
-#: ../src/wxMaxima.cpp:3341
+#: ../src/wxMaxima.cpp:3353
 msgid "Show the definition of function:"
 msgstr "Montrer la définition de la fonction :"
 
@@ -3697,43 +3700,43 @@ msgstr "Montrer la définition de la fonction :"
 msgid "Show user-defined labels instead of (%oxx)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:953 ../src/wxMaximaFrame.cpp:956
+#: ../src/wxMaximaFrame.cpp:952 ../src/wxMaximaFrame.cpp:955
 msgid "Show wxMaxima help"
 msgstr "Sken tallalt n Maxima"
 
-#: ../src/wxMaximaFrame.cpp:1381
+#: ../src/wxMaximaFrame.cpp:1380
 msgid "Sigma"
 msgstr "Sigma"
 
-#: ../src/wxMaximaFrame.cpp:1211
+#: ../src/wxMaximaFrame.cpp:1210
 msgid "Simplify"
 msgstr "Sefres"
 
-#: ../src/wxMaximaFrame.cpp:831
+#: ../src/wxMaximaFrame.cpp:830
 msgid "Simplify &Radicals"
 msgstr "Simplifier des &radicaux"
 
-#: ../src/wxMaximaFrame.cpp:1212
+#: ../src/wxMaximaFrame.cpp:1211
 msgid "Simplify (r)"
 msgstr "Sefres (r)"
 
-#: ../src/wxMaximaFrame.cpp:1218
+#: ../src/wxMaximaFrame.cpp:1217
 msgid "Simplify (tr)"
 msgstr "Sefres (tanfalit. trig.)"
 
-#: ../src/MathCtrl.cpp:995
+#: ../src/MathCtrl.cpp:1037
 msgid "Simplify Expression"
 msgstr "Simplifier une expression"
 
-#: ../src/wxMaximaFrame.cpp:857
+#: ../src/wxMaximaFrame.cpp:856
 msgid "Simplify an expression containing factorials"
 msgstr "Simplifier une expression contenant des factorielles"
 
-#: ../src/wxMaximaFrame.cpp:832
+#: ../src/wxMaximaFrame.cpp:831
 msgid "Simplify expression containing radicals"
 msgstr "Simplifier une expression contenant des radicaux"
 
-#: ../src/wxMaximaFrame.cpp:830
+#: ../src/wxMaximaFrame.cpp:829
 msgid "Simplify rational expression"
 msgstr "Simplifier une expression rationnelle"
 
@@ -3741,7 +3744,7 @@ msgstr "Simplifier une expression rationnelle"
 msgid "Simplify the sum"
 msgstr "Simplifier la somme"
 
-#: ../src/wxMaximaFrame.cpp:868
+#: ../src/wxMaximaFrame.cpp:867
 msgid "Simplify trigonometric expression"
 msgstr "Simplifier une expression trigonométrique"
 
@@ -3757,88 +3760,88 @@ msgstr ""
 "vous voulez que les images soient sauvegardées dans vos documents, vous "
 "devez utiliser le format \"Document xml wxMaxima\"."
 
-#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
+#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
 msgid "Solution:"
 msgstr "Tifrat :"
 
-#: ../src/wxMaxima.cpp:3461 ../src/wxMaxima.cpp:3475 ../src/wxMaxima.cpp:5020
+#: ../src/wxMaxima.cpp:3473 ../src/wxMaxima.cpp:3487 ../src/wxMaxima.cpp:5032
 msgid "Solve"
 msgstr "Fru"
 
-#: ../src/wxMaximaFrame.cpp:706
+#: ../src/wxMaximaFrame.cpp:705
 msgid "Solve &Algebraic System..."
 msgstr "Fru a&nagraw aljibṛan..."
 
-#: ../src/wxMaximaFrame.cpp:703
+#: ../src/wxMaximaFrame.cpp:702
 msgid "Solve &Linear System..."
 msgstr "Résoudre un système &linéaire…"
 
-#: ../src/wxMaximaFrame.cpp:714
+#: ../src/wxMaximaFrame.cpp:713
 msgid "Solve &ODE..."
 msgstr "Fru tagda ta&meẓlayt…"
 
-#: ../src/wxMaximaFrame.cpp:690
+#: ../src/wxMaximaFrame.cpp:689
 msgid "Solve (to_poly)..."
 msgstr "Fru (to_poly)…"
 
-#: ../src/wxMaxima.cpp:3511 ../src/wxMaxima.cpp:3635
+#: ../src/wxMaxima.cpp:3523 ../src/wxMaxima.cpp:3647
 msgid "Solve ODE"
 msgstr "Fru tagda tameẓlayt"
 
-#: ../src/wxMaximaFrame.cpp:728
+#: ../src/wxMaximaFrame.cpp:727
 msgid "Solve ODE with Lapla&ce..."
 msgstr "Fru tagda tameẓlayt s Lapla&ce…"
 
-#: ../src/wxMaximaFrame.cpp:1222
+#: ../src/wxMaximaFrame.cpp:1221
 msgid "Solve ODE..."
 msgstr "Fru ta&gda tameẓlayt…"
 
-#: ../src/wxMaxima.cpp:3586 ../src/wxMaxima.cpp:3597
+#: ../src/wxMaxima.cpp:3598 ../src/wxMaxima.cpp:3609
 msgid "Solve algebraic system"
 msgstr "Fru anagraw aljibṛan"
 
-#: ../src/wxMaximaFrame.cpp:707
+#: ../src/wxMaximaFrame.cpp:706
 msgid "Solve algebraic system of equations"
 msgstr "Fru anagraw n tegdiwin tiljibṛanin"
 
-#: ../src/wxMaximaFrame.cpp:725
+#: ../src/wxMaximaFrame.cpp:724
 msgid "Solve boundary value problem for second degree ODE"
 msgstr "Résoudre un problème aux limites pour une é.d.o. du second ordre"
 
-#: ../src/wxMaximaFrame.cpp:689
+#: ../src/wxMaximaFrame.cpp:688
 msgid "Solve equation(s)"
 msgstr "Fru tagda (tagdiwin)"
 
-#: ../src/wxMaximaFrame.cpp:691
+#: ../src/wxMaximaFrame.cpp:690
 msgid "Solve equation(s) with to_poly_solve"
 msgstr "Résoudre une (des) équation(s) avec to_poly_solve"
 
-#: ../src/wxMaximaFrame.cpp:719
+#: ../src/wxMaximaFrame.cpp:718
 msgid "Solve initial value problem for first degree ODE"
 msgstr "Résoudre une é.d.o. du premier ordre avec condition initiale"
 
-#: ../src/wxMaximaFrame.cpp:722
+#: ../src/wxMaximaFrame.cpp:721
 msgid "Solve initial value problem for second degree ODE"
 msgstr "Résoudre une é.d.o. du second ordre avec conditions initiales"
 
-#: ../src/wxMaxima.cpp:3610 ../src/wxMaxima.cpp:3621
+#: ../src/wxMaxima.cpp:3622 ../src/wxMaxima.cpp:3633
 msgid "Solve linear system"
 msgstr "Résoudre un système &linéaire"
 
-#: ../src/wxMaximaFrame.cpp:704
+#: ../src/wxMaximaFrame.cpp:703
 msgid "Solve linear system of equations"
 msgstr "Résoudre un système d'équations linéaires"
 
-#: ../src/wxMaximaFrame.cpp:715
+#: ../src/wxMaximaFrame.cpp:714
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr "Résoudre une équation différentielle ordinaire de degré au plus 2"
 
-#: ../src/wxMaximaFrame.cpp:729
+#: ../src/wxMaximaFrame.cpp:728
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
 "Résoudre une équation différentielle ordinaire avec la transformée de Laplace"
 
-#: ../src/wxMaximaFrame.cpp:1221 ../src/MathCtrl.cpp:992
+#: ../src/MathCtrl.cpp:1034 ../src/wxMaximaFrame.cpp:1220
 msgid "Solve..."
 msgstr "Fru…"
 
@@ -3862,7 +3865,7 @@ msgstr "Ameẓli"
 msgid "Special constants"
 msgstr "Constantes spéciales"
 
-#: ../src/MathCtrl.cpp:922
+#: ../src/MathCtrl.cpp:964
 msgid "Start Animation"
 msgstr "Démarrer l'animation"
 
@@ -3881,28 +3884,28 @@ msgstr ""
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:294
+#: ../src/wxMaxima.cpp:295
 msgid "Starting Maxima process failed"
 msgstr "Le démarrage de Maxima a échoué"
 
-#: ../src/wxMaxima.cpp:928
+#: ../src/wxMaxima.cpp:933
 msgid "Starting Maxima..."
 msgstr "Démarrage de Maxima…"
 
-#: ../src/wxMaxima.cpp:292 ../src/wxMaxima.cpp:860
+#: ../src/wxMaxima.cpp:293 ../src/wxMaxima.cpp:865
 msgid "Starting server failed"
 msgstr "Échec du démarrage du serveur"
 
-#: ../src/wxMaxima.cpp:841
+#: ../src/wxMaxima.cpp:846
 #, c-format
 msgid "Starting server on port %d"
 msgstr "Asenker n uqeddac ɣef tebburt %d"
 
-#: ../src/wxMaximaFrame.cpp:342
+#: ../src/wxMaximaFrame.cpp:341
 msgid "Statistics"
 msgstr "Tiddadanin"
 
-#: ../src/wxMaximaFrame.cpp:550
+#: ../src/wxMaximaFrame.cpp:549
 msgid "Statistics\tAlt-Shift-S"
 msgstr "Tiddadanin\tAlt-Maj-S"
 
@@ -3918,11 +3921,11 @@ msgstr "Aɣanib"
 msgid "Styles"
 msgstr "Iɣunab"
 
-#: ../src/wxMaximaFrame.cpp:1283
+#: ../src/wxMaximaFrame.cpp:1282
 msgid "Subsample..."
 msgstr "Adtukkist..."
 
-#: ../src/wxMaximaFrame.cpp:1496
+#: ../src/wxMaximaFrame.cpp:1515
 msgid "Subsection"
 msgstr "Sous-section"
 
@@ -3930,20 +3933,20 @@ msgstr "Sous-section"
 msgid "Subsection cell"
 msgstr "Cellule de sous-section"
 
-#: ../src/wxMaximaFrame.cpp:1216
+#: ../src/wxMaximaFrame.cpp:1215
 msgid "Subst..."
 msgstr "Semselsi…"
 
-#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3423
-#: ../src/wxMaxima.cpp:5089
+#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3435
+#: ../src/wxMaxima.cpp:5101
 msgid "Substitute"
 msgstr "Semselsi"
 
-#: ../src/wxMaximaFrame.cpp:906 ../src/MathCtrl.cpp:998
+#: ../src/MathCtrl.cpp:1040 ../src/wxMaximaFrame.cpp:905
 msgid "Substitute..."
 msgstr "Semselsi..."
 
-#: ../src/wxMaximaFrame.cpp:1497
+#: ../src/wxMaximaFrame.cpp:1516
 #, fuzzy
 msgid "Subsubsection"
 msgstr "Sous-section"
@@ -3953,7 +3956,7 @@ msgstr "Sous-section"
 msgid "Subsubsection cell"
 msgstr "Cellule de sous-section"
 
-#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4226
+#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4238
 msgid "Sum"
 msgstr "Somme"
 
@@ -3961,36 +3964,36 @@ msgstr "Somme"
 msgid "Sum sign"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:553
+#: ../src/wxMaximaFrame.cpp:552
 msgid "Symbols\tAlt-Shift-Y"
 msgstr "Tiddadanin\tAlt-Maj-S"
 
-#: ../src/wxMaxima.cpp:4456
+#: ../src/wxMaxima.cpp:4468
 msgid "System info"
 msgstr "Info système"
 
-#: ../src/wxMaximaFrame.cpp:320
+#: ../src/wxMaximaFrame.cpp:319
 msgid "Table of Contents"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:556
+#: ../src/wxMaximaFrame.cpp:555
 #, fuzzy
 msgid "Table of Contents\tAlt-Shift-T"
 msgstr "Barre d'outils\tAlt-Maj-T"
 
-#: ../src/wxMaximaFrame.cpp:1382
+#: ../src/wxMaximaFrame.cpp:1381
 msgid "Tau"
 msgstr "Tau"
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Taylor series:"
 msgstr "Séries de Taylor :"
 
-#: ../src/wxMaxima.cpp:3963
+#: ../src/wxMaxima.cpp:3975
 msgid "Tellrat"
 msgstr "Tellrat"
 
-#: ../src/wxMaximaFrame.cpp:1494
+#: ../src/wxMaximaFrame.cpp:1513
 msgid "Text"
 msgstr "Aḍris"
 
@@ -4036,7 +4039,7 @@ msgstr ""
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr ""
 
-#: ../src/TextCell.cpp:136
+#: ../src/TextCell.cpp:134
 msgid ""
 "The letter \"X\" is of width zero. Installing http://www.math.union.edu/"
 "~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts\" in "
@@ -4053,7 +4056,7 @@ msgstr ""
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:959
+#: ../src/wxMaximaFrame.cpp:958
 msgid "The offline manual of maxima"
 msgstr ""
 
@@ -4091,7 +4094,7 @@ msgstr ""
 "http://wxmaxima.sourceforge.net/wiki/index.php/Tutorials pour obtenir plus "
 "d'information sur l'utilisation de wxMaxima et Maxima."
 
-#: ../src/SlideShowCell.cpp:332
+#: ../src/SlideShowCell.cpp:336
 #, fuzzy
 msgid ""
 "There was an error during GIF export!\n"
@@ -4103,7 +4106,7 @@ msgstr ""
 " Vérifiez que ImageMagick est installé et que wxMaxima trouve le programme "
 "de conversion."
 
-#: ../src/wxMaxima.cpp:442
+#: ../src/wxMaxima.cpp:447
 msgid ""
 "There was an error in generated XML!\n"
 "\n"
@@ -4113,7 +4116,7 @@ msgstr ""
 "\n"
 "Merci de faire un rapport de bogue."
 
-#: ../src/wxMaximaFrame.cpp:1371
+#: ../src/wxMaximaFrame.cpp:1370
 msgid "Theta"
 msgstr "Theta"
 
@@ -4121,7 +4124,7 @@ msgstr "Theta"
 msgid "Ticks:"
 msgstr "Graduations :"
 
-#: ../src/wxMaxima.cpp:4153 ../src/wxMaxima.cpp:5065
+#: ../src/wxMaxima.cpp:4165 ../src/wxMaxima.cpp:5077
 msgid "Times:"
 msgstr "fois :"
 
@@ -4129,7 +4132,7 @@ msgstr "fois :"
 msgid "Tips not available, sorry!"
 msgstr "Les astuces ne sont pas disponibles !"
 
-#: ../src/wxMaximaFrame.cpp:1495
+#: ../src/wxMaximaFrame.cpp:1514
 msgid "Title"
 msgstr "Titre"
 
@@ -4148,19 +4151,19 @@ msgstr ""
 "triangle à côté de la cellule. Si vous cliquez en enfonçant  la touche Maj, "
 "tous les sous-niveaux de cette cellule seront aussi repliés ou dépliés."
 
-#: ../src/wxMaximaFrame.cpp:938
+#: ../src/wxMaximaFrame.cpp:937
 msgid "To &Bigfloat"
 msgstr "Valeur approchée (bfloat)"
 
-#: ../src/wxMaximaFrame.cpp:935
+#: ../src/wxMaximaFrame.cpp:934
 msgid "To &Float"
 msgstr "En virgule flottante"
 
-#: ../src/MathCtrl.cpp:990
+#: ../src/MathCtrl.cpp:1032
 msgid "To Float"
 msgstr "En virgule &flottante"
 
-#: ../src/wxMaximaFrame.cpp:941
+#: ../src/wxMaximaFrame.cpp:940
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr ""
 
@@ -4203,51 +4206,51 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:41 ../src/Plot2dWiz.cpp:40 ../src/Plot2dWiz.cpp:50
 #: ../src/Plot2dWiz.cpp:539 ../src/Plot3dWiz.cpp:39 ../src/Plot3dWiz.cpp:48
-#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4241
+#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4253
 msgid "To:"
 msgstr "ɣer :"
 
-#: ../src/wxMaximaFrame.cpp:912
+#: ../src/wxMaximaFrame.cpp:911
 msgid "Toggle &Algebraic Flag"
 msgstr "Basculer le mode &algébrique"
 
-#: ../src/wxMaximaFrame.cpp:933
+#: ../src/wxMaximaFrame.cpp:932
 msgid "Toggle &Numeric Output"
 msgstr "Basculer l'affichage numérique"
 
-#: ../src/wxMaximaFrame.cpp:673
+#: ../src/wxMaximaFrame.cpp:672
 msgid "Toggle &Time Display"
 msgstr "Affichage du &temps"
 
-#: ../src/wxMaximaFrame.cpp:913
+#: ../src/wxMaximaFrame.cpp:912
 msgid "Toggle algebraic flag"
 msgstr "Basculer le mode algébrique"
 
-#: ../src/wxMaximaFrame.cpp:577
+#: ../src/wxMaximaFrame.cpp:576
 msgid "Toggle full screen editing"
 msgstr "Basculer en plein écran d'édition"
 
-#: ../src/wxMaximaFrame.cpp:934
+#: ../src/wxMaximaFrame.cpp:933
 msgid "Toggle numeric output"
 msgstr "Basculer l'affichage numérique entre valeur exacte et valeur approchée"
 
-#: ../src/wxMaxima.cpp:4464
+#: ../src/wxMaxima.cpp:4476
 msgid "Toolbar icons"
 msgstr "Icônes de la barre d'outils"
 
-#: ../src/wxMaxima.cpp:4465
+#: ../src/wxMaxima.cpp:4477
 msgid "Translated by"
 msgstr "Traduit par "
 
-#: ../src/wxMaximaFrame.cpp:763
+#: ../src/wxMaximaFrame.cpp:762
 msgid "Transpose a matrix"
 msgstr "Transposer une matrice"
 
-#: ../src/MathCtrl.cpp:5834
+#: ../src/MathCtrl.cpp:5886
 msgid "Trying to undo an action without starting cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5901
+#: ../src/MathCtrl.cpp:5953
 msgid "Trying to undo something but the undo action is empty."
 msgstr ""
 
@@ -4255,11 +4258,11 @@ msgstr ""
 msgid "Turkish"
 msgstr "Taṭiṛkit"
 
-#: ../src/wxMaximaFrame.cpp:970
+#: ../src/wxMaximaFrame.cpp:969
 msgid "Tutorials"
 msgstr "Tutoriels"
 
-#: ../src/wxMaxima.cpp:4778
+#: ../src/wxMaxima.cpp:4790
 msgid "Two sample t-test"
 msgstr "Test de Student (t-test) à 2 échantillons…"
 
@@ -4271,15 +4274,15 @@ msgstr "Tawsit :"
 msgid "Ukrainian"
 msgstr "Takrinit"
 
-#: ../src/wxMaxima.cpp:5356
+#: ../src/wxMaxima.cpp:5372
 msgid "Un-closed parenthesis"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5323
+#: ../src/wxMaxima.cpp:5335
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5889
 msgid ""
 "Unable to interpret the version info I got from http://andrejv.github.io//"
 "wxmaxima/version.txt: "
@@ -4293,11 +4296,11 @@ msgstr "Souligné"
 msgid "Underscore converts to subscripts:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:492
+#: ../src/wxMaximaFrame.cpp:491
 msgid "Undo\tCtrl-Z"
 msgstr "&Sefsex\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:493
+#: ../src/wxMaximaFrame.cpp:492
 msgid "Undo last change"
 msgstr "Sefsex asnifel aneggaru"
 
@@ -4305,26 +4308,26 @@ msgstr "Sefsex asnifel aneggaru"
 msgid "Undo limit (0 for none):"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:625
+#: ../src/wxMaximaFrame.cpp:624
 #, fuzzy
 msgid "Unfold All\tCtrl-Alt-]"
 msgstr "Tout sélectionner"
 
-#: ../src/wxMaximaFrame.cpp:626
+#: ../src/wxMaximaFrame.cpp:625
 #, fuzzy
 msgid "Unfold all folded sections"
 msgstr "Déplier tous les groupes"
 
-#: ../src/wxMaxima.cpp:4458
+#: ../src/wxMaxima.cpp:4470
 msgid "Unicode Support"
 msgstr "Support Unicode"
 
-#: ../src/wxMaxima.cpp:5335
+#: ../src/wxMaxima.cpp:5347
 #, fuzzy
 msgid "Unterminated comment."
 msgstr "Décommenter"
 
-#: ../src/wxMaxima.cpp:5309
+#: ../src/wxMaxima.cpp:5321
 msgid "Unterminated string."
 msgstr ""
 
@@ -4332,15 +4335,15 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5859 ../src/wxMaxima.cpp:5866 ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5874 ../src/wxMaxima.cpp:5881 ../src/wxMaxima.cpp:5889
 msgid "Upgrade"
 msgstr "Mettre à jour"
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Upper bound:"
 msgstr "borne supérieure :"
 
-#: ../src/wxMaximaFrame.cpp:1383
+#: ../src/wxMaximaFrame.cpp:1382
 #, fuzzy
 msgid "Upsilon"
 msgstr "Epsilon :"
@@ -4385,22 +4388,22 @@ msgstr ""
 msgid "User-defined labels"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3525
-#: ../src/wxMaxima.cpp:3541 ../src/wxMaxima.cpp:3649
+#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3537
+#: ../src/wxMaxima.cpp:3553 ../src/wxMaxima.cpp:3661
 msgid "Value:"
 msgstr "Azal:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:5019 ../src/wxMaxima.cpp:5064
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:5031 ../src/wxMaxima.cpp:5076
 msgid "Variable(s):"
 msgstr "Amutti (i-en) :"
 
 #: ../src/IntegrateWiz.cpp:33 ../src/LimitWiz.cpp:30 ../src/Plot2dWiz.cpp:34
 #: ../src/Plot2dWiz.cpp:44 ../src/Plot2dWiz.cpp:533 ../src/Plot3dWiz.cpp:33
 #: ../src/Plot3dWiz.cpp:42 ../src/SeriesWiz.cpp:36 ../src/SumWiz.cpp:30
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3749
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3761
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5045
 msgid "Variable:"
 msgstr "Amutti:"
 
@@ -4408,25 +4411,25 @@ msgstr "Amutti:"
 msgid "Variables"
 msgstr "Imuttiyen"
 
-#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3571 ../src/wxMaxima.cpp:4206
-#: ../src/wxMaxima.cpp:4807
+#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3583 ../src/wxMaxima.cpp:4218
+#: ../src/wxMaxima.cpp:4819
 msgid "Variables:"
 msgstr "Imuttiyen:"
 
-#: ../src/wxMaximaFrame.cpp:1257
+#: ../src/wxMaximaFrame.cpp:1256
 msgid "Variance..."
 msgstr "Awliwel…"
 
-#: ../src/wxMaximaFrame.cpp:580
+#: ../src/wxMaximaFrame.cpp:579
 msgid "View"
 msgstr "Timeẓriwt"
 
-#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1674 ../src/wxMaxima.cpp:1769
-#: ../src/wxMaxima.cpp:1950
+#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1679 ../src/wxMaxima.cpp:1774
+#: ../src/wxMaxima.cpp:1955
 msgid "Warning"
 msgstr "Alerte"
 
-#: ../src/wxMaximaFrame.cpp:109 ../src/wxMaximaFrame.cpp:295
+#: ../src/wxMaximaFrame.cpp:108 ../src/wxMaximaFrame.cpp:294
 msgid "Welcome to wxMaxima"
 msgstr "Bienvenue dans wxMaxima"
 
@@ -4450,7 +4453,7 @@ msgid ""
 "introducing an empty line."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2567
+#: ../src/wxMaxima.cpp:2574
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) "
 "(*.wxm)|*.wxm"
@@ -4466,7 +4469,7 @@ msgid ""
 "as equation markers"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6798
+#: ../src/MathCtrl.cpp:6856
 msgid "Wrapped search"
 msgstr ""
 
@@ -4474,15 +4477,15 @@ msgstr ""
 msgid "Write matching parenthesis in text controls."
 msgstr "Faire correspondre les parenthèses dans les entrées de texte."
 
-#: ../src/wxMaxima.cpp:4461
+#: ../src/wxMaxima.cpp:4473
 msgid "Written by"
 msgstr "Yura sɣur"
 
-#: ../src/wxMaximaFrame.cpp:557
+#: ../src/wxMaximaFrame.cpp:556
 msgid "XML Inspector"
 msgstr "Amaswaḍ"
 
-#: ../src/wxMaximaFrame.cpp:1377
+#: ../src/wxMaximaFrame.cpp:1376
 msgid "Xi"
 msgstr "Xi"
 
@@ -4556,7 +4559,7 @@ msgstr ""
 "horizontal. Ensuite, opérez sur la sélection. Utile pour supprimer ou "
 "évaluer plusieurs cellules."
 
-#: ../src/wxMaxima.cpp:5856
+#: ../src/wxMaxima.cpp:5871
 #, c-format
 msgid ""
 "You have version %s. Current version is %s.\n"
@@ -4567,39 +4570,39 @@ msgstr ""
 "\n"
 "Appuyez sur OK pour visiter le site de wxMaxima."
 
-#: ../src/wxMaxima.cpp:5921
+#: ../src/wxMaxima.cpp:5936
 msgid "Your changes will be lost if you don't save them."
 msgstr "Les changements seront perdus si vous ne les enregistrez pas"
 
-#: ../src/wxMaxima.cpp:5866
+#: ../src/wxMaxima.cpp:5881
 msgid "Your version of wxMaxima is up to date."
 msgstr "Lqem inek n wxMaximar d aneggaru."
 
-#: ../src/wxMaximaFrame.cpp:1369
+#: ../src/wxMaximaFrame.cpp:1368
 msgid "Zeta"
 msgstr "Zeta"
 
-#: ../src/wxMaximaFrame.cpp:562
+#: ../src/wxMaximaFrame.cpp:561
 msgid "Zoom &In\tCtrl-+"
 msgstr "Zoom ɣer zdat\tAlt-I"
 
-#: ../src/wxMaximaFrame.cpp:564
+#: ../src/wxMaximaFrame.cpp:563
 msgid "Zoom Ou&t\tCtrl--"
 msgstr "Zoom ɣer deffir\tAlt-O"
 
-#: ../src/wxMaximaFrame.cpp:563
+#: ../src/wxMaximaFrame.cpp:562
 msgid "Zoom in 10%"
 msgstr "Zoom ɣer zdat s 10%"
 
-#: ../src/wxMaximaFrame.cpp:565
+#: ../src/wxMaximaFrame.cpp:564
 msgid "Zoom out 10%"
 msgstr "Zoom ɣer deffir s 10%"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaximaFrame.cpp:287
 msgid "[ unsaved ]"
 msgstr "[ ur yettwasekles ara ]"
 
-#: ../src/wxMaxima.cpp:5700
+#: ../src/wxMaxima.cpp:5715
 msgid "[ unsaved* ]"
 msgstr "[ ur yettwasekles ara ]"
 
@@ -4608,17 +4611,17 @@ msgstr "[ ur yettwasekles ara ]"
 msgid "[%i digits]"
 msgstr "[%i izwilen]"
 
-#: ../src/MathCtrl.cpp:4392
+#: ../src/MathCtrl.cpp:4447
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" style=\"max-width:90%%;\" >\n"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4517
+#: ../src/MathCtrl.cpp:4572
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" >"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1333
+#: ../src/wxMaximaFrame.cpp:1332
 msgid "alpha"
 msgstr "alpha"
 
@@ -4630,7 +4633,7 @@ msgstr "akked"
 msgid "antisymmetric"
 msgstr "antisymétrique"
 
-#: ../src/wxMaximaFrame.cpp:1334
+#: ../src/wxMaximaFrame.cpp:1333
 msgid "beta"
 msgstr "beta"
 
@@ -4674,7 +4677,7 @@ msgstr ""
 msgid "bug:Invalid sup tag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1354
+#: ../src/wxMaximaFrame.cpp:1353
 #, fuzzy
 msgid "chi"
 msgstr "orchidée"
@@ -4688,7 +4691,7 @@ msgstr ""
 msgid "default"
 msgstr "par défaut"
 
-#: ../src/wxMaximaFrame.cpp:1336
+#: ../src/wxMaximaFrame.cpp:1335
 msgid "delta"
 msgstr "delta"
 
@@ -4700,7 +4703,7 @@ msgstr "diagonale"
 msgid "empty"
 msgstr "ilem"
 
-#: ../src/wxMaximaFrame.cpp:1337
+#: ../src/wxMaximaFrame.cpp:1336
 msgid "epsilon"
 msgstr "epsilon :"
 
@@ -4708,7 +4711,7 @@ msgstr "epsilon :"
 msgid "equivalent"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1339
+#: ../src/wxMaximaFrame.cpp:1338
 msgid "eta"
 msgstr "eta"
 
@@ -4724,7 +4727,7 @@ msgid ""
 "all=_ marks subscripts."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1335
+#: ../src/wxMaximaFrame.cpp:1334
 msgid "gamma"
 msgstr ""
 
@@ -4753,15 +4756,15 @@ msgstr "en ligne"
 msgid "intersection"
 msgstr "selon la direction"
 
-#: ../src/wxMaximaFrame.cpp:1341
+#: ../src/wxMaximaFrame.cpp:1340
 msgid "iota"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1342
+#: ../src/wxMaximaFrame.cpp:1341
 msgid "kappa"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1343
+#: ../src/wxMaximaFrame.cpp:1342
 msgid "lambda"
 msgstr ""
 
@@ -4778,7 +4781,7 @@ msgstr "Cellule de sous-section"
 msgid "logscale"
 msgstr "sellum alugaritman"
 
-#: ../src/wxMaxima.cpp:3783
+#: ../src/wxMaxima.cpp:3795
 msgid "matrix[i,j]:"
 msgstr "amektar[i,j] : "
 
@@ -4786,7 +4789,7 @@ msgstr "amektar[i,j] : "
 msgid "maxima's pwd is path to document"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1344
+#: ../src/wxMaximaFrame.cpp:1343
 msgid "mu"
 msgstr ""
 
@@ -4803,7 +4806,7 @@ msgstr ""
 msgid "nand"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4524
+#: ../src/wxMaxima.cpp:4536
 msgid "no"
 msgstr "ala"
 
@@ -4828,15 +4831,15 @@ msgstr ""
 msgid "not subset or equal"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1345
+#: ../src/wxMaximaFrame.cpp:1344
 msgid "nu"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1356
+#: ../src/wxMaximaFrame.cpp:1355
 msgid "omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1347
+#: ../src/wxMaximaFrame.cpp:1346
 msgid "omicron"
 msgstr ""
 
@@ -4849,11 +4852,11 @@ msgstr "neɣ"
 msgid "partial sign"
 msgstr "Éléments simples"
 
-#: ../src/wxMaximaFrame.cpp:1353
+#: ../src/wxMaximaFrame.cpp:1352
 msgid "phi"
 msgstr "phi"
 
-#: ../src/wxMaximaFrame.cpp:1348
+#: ../src/wxMaximaFrame.cpp:1347
 #, fuzzy
 msgid "pi"
 msgstr "rose"
@@ -4866,11 +4869,11 @@ msgstr ""
 msgid "proportional to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1355
+#: ../src/wxMaximaFrame.cpp:1354
 msgid "psi"
 msgstr "psi"
 
-#: ../src/wxMaximaFrame.cpp:1349
+#: ../src/wxMaximaFrame.cpp:1348
 msgid "rho"
 msgstr "rho"
 
@@ -4878,7 +4881,7 @@ msgstr "rho"
 msgid "right"
 msgstr "s ayeffus"
 
-#: ../src/wxMaximaFrame.cpp:1350
+#: ../src/wxMaximaFrame.cpp:1349
 msgid "sigma"
 msgstr ""
 
@@ -4900,7 +4903,7 @@ msgstr "Cellule de sous-section"
 msgid "symmetric"
 msgstr "symétrique"
 
-#: ../src/wxMaximaFrame.cpp:1351
+#: ../src/wxMaximaFrame.cpp:1350
 msgid "tau"
 msgstr "tau"
 
@@ -4912,7 +4915,7 @@ msgstr ""
 msgid "there is no"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1340
+#: ../src/wxMaximaFrame.cpp:1339
 msgid "theta"
 msgstr "theta"
 
@@ -4928,12 +4931,12 @@ msgstr ""
 msgid "union"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5903
+#: ../src/wxMaxima.cpp:5918
 msgid "unsaved"
 msgstr "non sauvegardé"
 
-#: ../src/wxMaximaFrame.cpp:290 ../src/wxMaxima.cpp:2559
-#: ../src/wxMaxima.cpp:2826
+#: ../src/wxMaxima.cpp:2566 ../src/wxMaxima.cpp:2834
+#: ../src/wxMaximaFrame.cpp:289
 msgid "untitled"
 msgstr "sans nom"
 
@@ -4942,26 +4945,26 @@ msgstr "sans nom"
 msgid "untitled %d"
 msgstr "sans nom %d"
 
-#: ../src/wxMaximaFrame.cpp:1352
+#: ../src/wxMaximaFrame.cpp:1351
 #, fuzzy
 msgid "upsilon"
 msgstr "Epsilon :"
 
-#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4538
+#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4550
 msgid "wxMaxima"
 msgstr "wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
-#: ../src/wxMaxima.cpp:5700 ../src/wxMaxima.cpp:5709 ../src/wxMaxima.cpp:5712
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaxima.cpp:5715 ../src/wxMaxima.cpp:5724
+#: ../src/wxMaxima.cpp:5727 ../src/wxMaximaFrame.cpp:287
 #, c-format
 msgid "wxMaxima %s "
 msgstr "wxMaxima %s"
 
-#: ../src/wxMaximaFrame.cpp:952
+#: ../src/wxMaximaFrame.cpp:951
 msgid "wxMaxima &Help\tCtrl+?"
 msgstr "Tallalt n  Maxima\tF1"
 
-#: ../src/wxMaximaFrame.cpp:955
+#: ../src/wxMaximaFrame.cpp:954
 msgid "wxMaxima &Help\tF1"
 msgstr "Tallalt n  Maxima\tF1"
 
@@ -4972,11 +4975,11 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1619
+#: ../src/wxMaxima.cpp:1624
 msgid "wxMaxima cannot open content.xml in the .wxmx zip archive "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1633
+#: ../src/wxMaxima.cpp:1638
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
@@ -4984,7 +4987,7 @@ msgstr ""
 msgid "wxMaxima configuration"
 msgstr "Aswel n  wxMaxima "
 
-#: ../src/wxMaxima.cpp:1947
+#: ../src/wxMaxima.cpp:1952
 msgid ""
 "wxMaxima could not find Maxima!\n"
 "\n"
@@ -4996,7 +4999,7 @@ msgstr ""
 "Configurez wxMaxima avec 'Édition->Configurer'.\n"
 "Puis redémarrez Maxima avec 'Maxima->Redémarrer Maxima'."
 
-#: ../src/wxMaxima.cpp:2204
+#: ../src/wxMaxima.cpp:2209
 msgid ""
 "wxMaxima could not find help files.\n"
 "\n"
@@ -5006,7 +5009,7 @@ msgstr ""
 "\n"
 "Vérifiez votre installation."
 
-#: ../src/wxMaxima.cpp:2032
+#: ../src/wxMaxima.cpp:2037
 msgid ""
 "wxMaxima could not find tip files.\n"
 "\n"
@@ -5016,7 +5019,7 @@ msgstr ""
 "\n"
 "Vérifiez votre installation."
 
-#: ../src/wxMaxima.cpp:282
+#: ../src/wxMaxima.cpp:283
 msgid ""
 "wxMaxima could not start the server.\n"
 "\n"
@@ -5038,23 +5041,23 @@ msgstr ""
 "dialogue, l'une d'entre elles étant '%'. Si vous avez opéré une sélection "
 "dans votre document, cette sélection sera utilisée au lieu de '%'."
 
-#: ../src/wxMaxima.cpp:2330
+#: ../src/wxMaxima.cpp:2336
 msgid "wxMaxima document"
 msgstr "Isemli wxMaxima "
 
-#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2799
+#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2807
 msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 msgstr "isemli wxMaxima (*.wxm)|*.wxm"
 
-#: ../src/wxMaxima.cpp:1455 ../src/wxMaxima.cpp:1469
+#: ../src/wxMaxima.cpp:1460 ../src/wxMaxima.cpp:1474
 msgid "wxMaxima encountered an error loading "
 msgstr "Erreur de wxMaxima au chargement"
 
-#: ../src/wxMaxima.cpp:4463
+#: ../src/wxMaxima.cpp:4475
 msgid "wxMaxima icon"
 msgstr "Tignit wxMaxima"
 
-#: ../src/wxMaxima.cpp:4455
+#: ../src/wxMaxima.cpp:4467
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "MAXIMA based on wxWidgets."
@@ -5062,7 +5065,7 @@ msgstr ""
 "wxMaxima est une interface graphique pour le logiciel de calcul formel "
 "MAXIMA basée sur wxWidgets."
 
-#: ../src/wxMaxima.cpp:4516
+#: ../src/wxMaxima.cpp:4528
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "Maxima based on wxWidgets."
@@ -5082,11 +5085,11 @@ msgstr ""
 msgid "x"
 msgstr "x"
 
-#: ../src/wxMaximaFrame.cpp:1346
+#: ../src/wxMaximaFrame.cpp:1345
 msgid "xi"
 msgstr "xi"
 
-#: ../src/wxMaxima.cpp:1643
+#: ../src/wxMaxima.cpp:1648
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
@@ -5094,11 +5097,11 @@ msgstr ""
 msgid "xor"
 msgstr "neɣ.tukksa"
 
-#: ../src/wxMaxima.cpp:4522
+#: ../src/wxMaxima.cpp:4534
 msgid "yes"
 msgstr "ih"
 
-#: ../src/wxMaximaFrame.cpp:1338
+#: ../src/wxMaximaFrame.cpp:1337
 msgid "zeta"
 msgstr "zeta"
 

--- a/locales/nb.po
+++ b/locales/nb.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: nb\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-07 21:42+0200\n"
+"POT-Creation-Date: 2016-10-16 17:47+0900\n"
 "PO-Revision-Date: 2015-01-11 07:47+0100\n"
 "Last-Translator: Asbjørn Apeland <asap openmailbox org>\n"
 "Language-Team: norwegian\n"
@@ -20,7 +20,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.7.1\n"
 
-#: ../src/wxMaxima.cpp:4519
+#: ../src/wxMaxima.cpp:4531
 #, c-format
 msgid ""
 "\n"
@@ -33,7 +33,7 @@ msgstr ""
 "wxWidgets: %d.%d.%d\n"
 "Unicode-støtte: %s"
 
-#: ../src/wxMaxima.cpp:4532
+#: ../src/wxMaxima.cpp:4544
 msgid ""
 "\n"
 "Lisp: "
@@ -41,7 +41,7 @@ msgstr ""
 "\n"
 "Lisp: "
 
-#: ../src/wxMaxima.cpp:4528
+#: ../src/wxMaxima.cpp:4540
 msgid ""
 "\n"
 "Maxima version: "
@@ -49,7 +49,7 @@ msgstr ""
 "\n"
 "Maxima-versjon: "
 
-#: ../src/wxMaxima.cpp:5381
+#: ../src/wxMaxima.cpp:5397
 msgid ""
 "\n"
 "Not connected to Maxima!\n"
@@ -57,7 +57,7 @@ msgstr ""
 "\n"
 "Ikke tilkoblet Maxima!\n"
 
-#: ../src/wxMaxima.cpp:4530
+#: ../src/wxMaxima.cpp:4542
 msgid ""
 "\n"
 "Not connected."
@@ -77,7 +77,7 @@ msgstr ""
 msgid " (Graphics) "
 msgstr ""
 
-#: ../src/EditorCell.cpp:3045 ../src/EditorCell.cpp:3227
+#: ../src/EditorCell.cpp:3088 ../src/EditorCell.cpp:3270
 #, c-format
 msgid " ... + %i hidden lines"
 msgstr ""
@@ -86,7 +86,7 @@ msgstr ""
 msgid " << Expression longer than allowed by the configuration setting! >>"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1673
+#: ../src/wxMaxima.cpp:1678
 msgid ""
 " was saved using a newer version of wxMaxima so it may not load correctly. "
 "Please update your wxMaxima."
@@ -94,7 +94,7 @@ msgstr ""
 " ble lagret med en nyere versjon av wxMaxima, så den lastes kanskje ikke "
 "korrekt. Vennligst oppdater wxMaxima'n din."
 
-#: ../src/wxMaxima.cpp:1665
+#: ../src/wxMaxima.cpp:1670
 msgid ""
 " was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr ""
@@ -109,64 +109,64 @@ msgstr ""
 msgid "\"implies\" symbol"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:101
+#: ../src/wxMaximaFrame.cpp:100
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:773
+#: ../src/wxMaximaFrame.cpp:772
 msgid "&Algebra"
 msgstr "&Algebra"
 
-#: ../src/wxMaximaFrame.cpp:767
+#: ../src/wxMaximaFrame.cpp:766
 msgid "&Apply to List..."
 msgstr "&Anvend på Liste..."
 
-#: ../src/wxMaximaFrame.cpp:964
+#: ../src/wxMaximaFrame.cpp:963
 msgid "&Apropos..."
 msgstr "&Apropos..."
 
-#: ../src/wxMaximaFrame.cpp:478
+#: ../src/wxMaximaFrame.cpp:477
 msgid "&Batch File...\tCtrl-B"
 msgstr "&Batchfil...\tCtrl-B"
 
-#: ../src/wxMaximaFrame.cpp:724
+#: ../src/wxMaximaFrame.cpp:723
 msgid "&Boundary Value Problem..."
 msgstr "&Grenseverdiproblem..."
 
-#: ../src/wxMaximaFrame.cpp:975
+#: ../src/wxMaximaFrame.cpp:974
 msgid "&Bug Report"
 msgstr "&Feilrapportering"
 
-#: ../src/wxMaximaFrame.cpp:825
+#: ../src/wxMaximaFrame.cpp:824
 msgid "&Calculus"
 msgstr "&Kalkulus"
 
-#: ../src/wxMaximaFrame.cpp:876
+#: ../src/wxMaximaFrame.cpp:875
 msgid "&Canonical Form"
 msgstr "&Kanonisk Form"
 
-#: ../src/wxMaximaFrame.cpp:749
+#: ../src/wxMaximaFrame.cpp:748
 msgid "&Characteristic Polynomial..."
 msgstr "&Karakteristisk Polynom..."
 
-#: ../src/wxMaximaFrame.cpp:654
+#: ../src/wxMaximaFrame.cpp:653
 msgid "&Clear Memory"
 msgstr "Tøm &Minnet"
 
-#: ../src/wxMaximaFrame.cpp:859
+#: ../src/wxMaximaFrame.cpp:858
 msgid "&Combine Factorials"
 msgstr "Trekk &Sammen Fakulteter"
 
-#: ../src/wxMaximaFrame.cpp:902
+#: ../src/wxMaximaFrame.cpp:901
 msgid "&Complex Simplification"
 msgstr "&Kompleks Forenkling"
 
-#: ../src/wxMaximaFrame.cpp:822
+#: ../src/wxMaximaFrame.cpp:821
 msgid "&Continued Fraction"
 msgstr "K&jedebrøk"
 
-#: ../src/wxMaximaFrame.cpp:502
+#: ../src/wxMaximaFrame.cpp:501
 msgid "&Copy\tCtrl-C"
 msgstr "Kopier\tCtrl-C"
 
@@ -174,108 +174,108 @@ msgstr "Kopier\tCtrl-C"
 msgid "&Definite integration"
 msgstr "&Bestemt Integrasjon"
 
-#: ../src/wxMaximaFrame.cpp:896
+#: ../src/wxMaximaFrame.cpp:895
 msgid "&Demoivre"
 msgstr "&Demoivre"
 
-#: ../src/wxMaximaFrame.cpp:752
+#: ../src/wxMaximaFrame.cpp:751
 msgid "&Determinant"
 msgstr "&Determinant"
 
-#: ../src/wxMaximaFrame.cpp:785
+#: ../src/wxMaximaFrame.cpp:784
 msgid "&Differentiate..."
 msgstr "&Deriver..."
 
-#: ../src/wxMaximaFrame.cpp:543
+#: ../src/wxMaximaFrame.cpp:542
 msgid "&Edit"
 msgstr "&Endre"
 
-#: ../src/wxMaximaFrame.cpp:709
+#: ../src/wxMaximaFrame.cpp:708
 msgid "&Eliminate Variable..."
 msgstr "&Eliminer Variabel..."
 
-#: ../src/wxMaximaFrame.cpp:744
+#: ../src/wxMaximaFrame.cpp:743
 msgid "&Enter Matrix..."
 msgstr "&Oppgi Matrise..."
 
-#: ../src/wxMaximaFrame.cpp:961
+#: ../src/wxMaximaFrame.cpp:960
 msgid "&Example..."
 msgstr "&Eksempel..."
 
-#: ../src/wxMaximaFrame.cpp:839
+#: ../src/wxMaximaFrame.cpp:838
 msgid "&Expand Expression"
 msgstr "&Utvid Uttrykk"
 
-#: ../src/wxMaximaFrame.cpp:873
+#: ../src/wxMaximaFrame.cpp:872
 msgid "&Expand Trigonometric"
 msgstr "&Utvid Trigonometrisk uttrykk"
 
-#: ../src/wxMaximaFrame.cpp:899
+#: ../src/wxMaximaFrame.cpp:898
 msgid "&Exponentialize"
 msgstr "&Eksponentialiser"
 
-#: ../src/wxMaximaFrame.cpp:480
+#: ../src/wxMaximaFrame.cpp:479
 msgid "&Export..."
 msgstr "&Eksporter..."
 
-#: ../src/wxMaximaFrame.cpp:834
+#: ../src/wxMaximaFrame.cpp:833
 msgid "&Factor Expression"
 msgstr "Faktoriser Uttr&ykk"
 
-#: ../src/wxMaximaFrame.cpp:489
+#: ../src/wxMaximaFrame.cpp:488
 msgid "&File"
 msgstr "&Fil"
 
-#: ../src/wxMaximaFrame.cpp:692
+#: ../src/wxMaximaFrame.cpp:691
 msgid "&Find Root..."
 msgstr "Finn Ro&t..."
 
-#: ../src/wxMaximaFrame.cpp:738
+#: ../src/wxMaximaFrame.cpp:737
 msgid "&Generate Matrix..."
 msgstr "&Generer Matrise..."
 
-#: ../src/wxMaximaFrame.cpp:809
+#: ../src/wxMaximaFrame.cpp:808
 msgid "&Greatest Common Divisor..."
 msgstr "&Største Felles Divisor..."
 
-#: ../src/wxMaximaFrame.cpp:994
+#: ../src/wxMaximaFrame.cpp:993
 msgid "&Help"
 msgstr "&Hjelp"
 
-#: ../src/wxMaximaFrame.cpp:777
+#: ../src/wxMaximaFrame.cpp:776
 msgid "&Integrate..."
 msgstr "&Integrer..."
 
-#: ../src/wxMaximaFrame.cpp:645
+#: ../src/wxMaximaFrame.cpp:644
 msgid "&Interrupt\tCtrl-."
 msgstr "&Avbryt\tCtrl-."
 
-#: ../src/wxMaximaFrame.cpp:649
+#: ../src/wxMaximaFrame.cpp:648
 msgid "&Interrupt\tCtrl-G"
 msgstr "&Avbryt\tCtrl-G"
 
-#: ../src/wxMaximaFrame.cpp:746
+#: ../src/wxMaximaFrame.cpp:745
 msgid "&Invert Matrix"
 msgstr "&Inverter Matrise"
 
-#: ../src/wxMaximaFrame.cpp:476
+#: ../src/wxMaximaFrame.cpp:475
 msgid "&Load Package...\tCtrl-L"
 msgstr "Last &Pakke...\tCtrl-L"
 
-#: ../src/wxMaximaFrame.cpp:769
+#: ../src/wxMaximaFrame.cpp:768
 #, fuzzy
 msgid "&Map to List(s)..."
 msgstr "Av&bild Liste..."
 
-#: ../src/wxMaximaFrame.cpp:684
+#: ../src/wxMaximaFrame.cpp:683
 msgid "&Maxima"
 msgstr "&Maxima"
 
-#: ../src/wxMaximaFrame.cpp:958
+#: ../src/wxMaximaFrame.cpp:957
 msgid "&Maxima help"
 msgstr "&Maxima-Hjelp"
 
-#: ../src/wxMaximaFrame.cpp:917
+#: ../src/wxMaximaFrame.cpp:916
 msgid "&Modulus Computation..."
 msgstr "&Moduloregning..."
 
@@ -283,7 +283,7 @@ msgstr "&Moduloregning..."
 msgid "&New\tCtrl-N"
 msgstr "&Ny\tCtrl-N"
 
-#: ../src/wxMaximaFrame.cpp:947
+#: ../src/wxMaximaFrame.cpp:946
 msgid "&Numeric"
 msgstr "&Numerisk"
 
@@ -299,11 +299,11 @@ msgstr "&Nusum"
 msgid "&Open\tCtrl-O"
 msgstr "&Åpne\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:463
+#: ../src/wxMaximaFrame.cpp:462
 msgid "&Open...\tCtrl-O"
 msgstr "&Åpne...\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:929
+#: ../src/wxMaximaFrame.cpp:928
 msgid "&Plot"
 msgstr "&Plott"
 
@@ -311,7 +311,7 @@ msgstr "&Plott"
 msgid "&Power series"
 msgstr "&Potensrekke"
 
-#: ../src/wxMaximaFrame.cpp:483
+#: ../src/wxMaximaFrame.cpp:482
 msgid "&Print...\tCtrl-P"
 msgstr "&Skriv Ut...\tCtrl-P"
 
@@ -319,39 +319,39 @@ msgstr "&Skriv Ut...\tCtrl-P"
 msgid "&Rational"
 msgstr "&Rasjonell"
 
-#: ../src/wxMaximaFrame.cpp:870
+#: ../src/wxMaximaFrame.cpp:869
 msgid "&Reduce Trigonometric"
 msgstr "&Reduser Trigonometrisk Uttrykk"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "&Restart Maxima"
 msgstr "&Restart Maxima"
 
-#: ../src/wxMaximaFrame.cpp:700
+#: ../src/wxMaximaFrame.cpp:699
 msgid "&Roots of Polynomial (Real)"
 msgstr "&Røtter til Polynom (Reelle)"
 
-#: ../src/wxMaximaFrame.cpp:472
+#: ../src/wxMaximaFrame.cpp:471
 msgid "&Save\tCtrl-S"
 msgstr "&Lagre\tCtrl-S"
 
-#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:919
+#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:918
 msgid "&Simplify"
 msgstr "F&orenkle"
 
-#: ../src/wxMaximaFrame.cpp:829
+#: ../src/wxMaximaFrame.cpp:828
 msgid "&Simplify Expression"
 msgstr "&Forenkle Uttrykk"
 
-#: ../src/wxMaximaFrame.cpp:856
+#: ../src/wxMaximaFrame.cpp:855
 msgid "&Simplify Factorials"
 msgstr "&Forenkle Fakulteter"
 
-#: ../src/wxMaximaFrame.cpp:867
+#: ../src/wxMaximaFrame.cpp:866
 msgid "&Simplify Trigonometric"
 msgstr "&Forenkle Trigonometrisk Uttrykk"
 
-#: ../src/wxMaximaFrame.cpp:688
+#: ../src/wxMaximaFrame.cpp:687
 msgid "&Solve..."
 msgstr "&Løs..."
 
@@ -363,11 +363,11 @@ msgstr "&Spesiell"
 msgid "&Taylor series"
 msgstr "&Taylorrekke"
 
-#: ../src/wxMaximaFrame.cpp:762
+#: ../src/wxMaximaFrame.cpp:761
 msgid "&Transpose Matrix"
 msgstr "&Transponer Matrise"
 
-#: ../src/wxMaximaFrame.cpp:879
+#: ../src/wxMaximaFrame.cpp:878
 msgid "&Trigonometric Simplification"
 msgstr "&Trigonometrisk Uttrykk"
 
@@ -385,7 +385,7 @@ msgstr "(Bruk forhåndsvalgt språk)"
 msgid "- Infinity"
 msgstr "- Uendelig"
 
-#: ../src/wxMaxima.cpp:351
+#: ../src/wxMaxima.cpp:356
 msgid ""
 "... [suppressed additional lines since the output is longer than allowed in "
 "the configuration] "
@@ -395,16 +395,16 @@ msgstr ""
 msgid "1/2"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:103
+#: ../src/wxMaximaFrame.cpp:102
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4601
+#: ../src/wxMaxima.cpp:4613
 msgid "<br>Lisp: "
 msgstr "<br>Lisp: "
 
-#: ../src/wxMaxima.cpp:5487
+#: ../src/wxMaxima.cpp:5503
 msgid ""
 "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
@@ -436,11 +436,11 @@ msgid ""
 "\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1472
+#: ../src/wxMaximaFrame.cpp:1495
 msgid "A symbol from the configuration dialogue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:731
+#: ../src/wxMaximaFrame.cpp:730
 msgid "A&t Value..."
 msgstr "Ved &Verdi..."
 
@@ -448,12 +448,12 @@ msgstr "Ved &Verdi..."
 msgid "Abort evaluation on error"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaxima.cpp:4603
+#: ../src/wxMaxima.cpp:4615 ../src/wxMaximaFrame.cpp:985
 msgid "About"
 msgstr "&Om"
 
-#: ../src/wxMaximaFrame.cpp:987 ../src/wxMaximaFrame.cpp:990
-#: ../src/wxMaximaFrame.cpp:991
+#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaximaFrame.cpp:989
+#: ../src/wxMaximaFrame.cpp:990
 msgid "About wxMaxima"
 msgstr "Om wxMaxima"
 
@@ -461,23 +461,23 @@ msgstr "Om wxMaxima"
 msgid "Active cell bracket"
 msgstr "Klammer rundt aktiv celle"
 
-#: ../src/wxMaximaFrame.cpp:760
+#: ../src/wxMaximaFrame.cpp:759
 msgid "Ad&joint Matrix"
 msgstr "Kon&jugert-Transponer Matrise"
 
-#: ../src/wxMaximaFrame.cpp:914
+#: ../src/wxMaximaFrame.cpp:913
 msgid "Add Algebraic E&quality..."
 msgstr "Legg til Algebraisk Ek&vivalens..."
 
-#: ../src/wxMaximaFrame.cpp:657
+#: ../src/wxMaximaFrame.cpp:656
 msgid "Add a directory to search path"
 msgstr "Legg en mappe til søkebane"
 
-#: ../src/wxMaxima.cpp:3353
+#: ../src/wxMaxima.cpp:3365
 msgid "Add dir to path:"
 msgstr "Legg mappe til bane:"
 
-#: ../src/wxMaximaFrame.cpp:915
+#: ../src/wxMaximaFrame.cpp:914
 msgid "Add equality to the rational simplifier"
 msgstr "Legg ekvivalens til den rasjonelle forenkleren"
 
@@ -485,7 +485,7 @@ msgstr "Legg ekvivalens til den rasjonelle forenkleren"
 msgid "Add the .wxmx file to the HTML export"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:656
+#: ../src/wxMaximaFrame.cpp:655
 msgid "Add to &Path..."
 msgstr "Legg til &Bane..."
 
@@ -526,27 +526,27 @@ msgstr "Forrige variabel:"
 msgid "All|*"
 msgstr "Alle|*"
 
-#: ../src/wxMaximaFrame.cpp:1364
+#: ../src/wxMaximaFrame.cpp:1363
 msgid "Alpha"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3838
+#: ../src/wxMaxima.cpp:3850
 msgid "Apply"
 msgstr "Anvend"
 
-#: ../src/wxMaximaFrame.cpp:768
+#: ../src/wxMaximaFrame.cpp:767
 msgid "Apply function to a list"
 msgstr "Anvend funksjon på liste"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Apropos"
 msgstr "Apropos"
 
-#: ../src/wxMaxima.cpp:3764
+#: ../src/wxMaxima.cpp:3776
 msgid "Array:"
 msgstr "Array:"
 
-#: ../src/wxMaxima.cpp:4462
+#: ../src/wxMaxima.cpp:4474
 msgid "Artwork by"
 msgstr "Grafikk av"
 
@@ -554,7 +554,7 @@ msgstr "Grafikk av"
 msgid "Ask to save untitled documents"
 msgstr "Spør om å lagre ulagrede dokument"
 
-#: ../src/wxMaxima.cpp:3650
+#: ../src/wxMaxima.cpp:3662
 msgid "At value"
 msgstr "Ved verdi"
 
@@ -575,11 +575,11 @@ msgstr ""
 msgid "Autosave interval (minutes, 0 means: off):"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3557
+#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3569
 msgid "BC2"
 msgstr "BC2"
 
-#: ../src/wxMaximaFrame.cpp:1272
+#: ../src/wxMaximaFrame.cpp:1271
 msgid "Barsplot..."
 msgstr "Søylediagram..."
 
@@ -587,7 +587,7 @@ msgstr "Søylediagram..."
 msgid "Bat files (*.bat)|*.bat|All|*"
 msgstr "Batchfiler (*.bat)|*.bat|Alle|*"
 
-#: ../src/wxMaxima.cpp:2943
+#: ../src/wxMaxima.cpp:2951
 msgid "Batch File"
 msgstr "Batchfil"
 
@@ -600,7 +600,7 @@ msgid ""
 "cells."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1365
+#: ../src/wxMaximaFrame.cpp:1364
 msgid "Beta"
 msgstr ""
 
@@ -612,11 +612,11 @@ msgstr ""
 msgid "Bold"
 msgstr "Fet"
 
-#: ../src/wxMaxima.cpp:2359
+#: ../src/wxMaxima.cpp:2366
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1274
+#: ../src/wxMaximaFrame.cpp:1273
 msgid "Boxplot..."
 msgstr "Boksdiagram..."
 
@@ -628,15 +628,15 @@ msgstr "Utforsk"
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2080
+#: ../src/MathCtrl.cpp:2127
 msgid "Bug: Cell left but not entered."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1178
+#: ../src/wxMaxima.cpp:1183
 msgid "Bug: Found a math end marker without any start marker."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1222
+#: ../src/wxMaxima.cpp:1227
 msgid "Bug: Found the end of autocompletion symbols but no beginning"
 msgstr ""
 
@@ -648,22 +648,22 @@ msgstr ""
 msgid "Bug: Fraction without enumerator"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2312
+#: ../src/MathCtrl.cpp:2359
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5839
+#: ../src/MathCtrl.cpp:5891
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of "
 "the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5913
+#: ../src/MathCtrl.cpp:5965
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5882
+#: ../src/MathCtrl.cpp:5934
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
@@ -673,49 +673,49 @@ msgstr ""
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
 msgstr ""
 
-#: ../src/GroupCell.cpp:780 ../src/GroupCell.cpp:951
+#: ../src/GroupCell.cpp:781 ../src/GroupCell.cpp:952
 msgid "Bug: No image counter to write to!"
 msgstr ""
 
-#: ../src/AbsCell.cpp:193
+#: ../src/AbsCell.cpp:199
 msgid "Bug: No last cell in an absCell!"
 msgstr ""
 
-#: ../src/ConjugateCell.cpp:185
+#: ../src/ConjugateCell.cpp:194
 msgid "Bug: No last cell in an conjugateCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:471
+#: ../src/FracCell.cpp:472
 msgid "Bug: No last cell in an denominator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:267
+#: ../src/ExptCell.cpp:270
 msgid "Bug: No last cell in an exponent of an exptCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:459
+#: ../src/FracCell.cpp:460
 msgid "Bug: No last cell in an numerator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:257
+#: ../src/ExptCell.cpp:260
 msgid "Bug: No last cell in the base of an exptCell!"
 msgstr ""
 
-#: ../src/ParenCell.cpp:534
+#: ../src/ParenCell.cpp:535
 msgid "Bug: No last cell inside a parenthesis!"
 msgstr ""
 
-#: ../src/SqrtCell.cpp:312
+#: ../src/SqrtCell.cpp:317
 msgid "Bug: No last cell inside a square root!"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2123
+#: ../src/MathCtrl.cpp:2170
 msgid ""
 "Bug: Start or end of merging of subsequent editing actions was requested two "
 "times in a row."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2090
+#: ../src/MathCtrl.cpp:2137
 msgid "Bug: Text changed, but no active cell."
 msgstr ""
 
@@ -723,39 +723,39 @@ msgstr ""
 msgid "Bug: Trying to append NULL to a group cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:555
+#: ../src/MathCtrl.cpp:600
 msgid "Bug: Trying to append maxima's output to a cell outside the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2014
+#: ../src/MathCtrl.cpp:2061
 msgid ""
 "Bug: Trying to merge individual cell adds to a region in the undo buffer but "
 "there are other cells between them."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6522
+#: ../src/MathCtrl.cpp:6577
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2092
+#: ../src/MathCtrl.cpp:2139
 msgid "Bug: Trying to record a cell contents change without a cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1495
+#: ../src/MathCtrl.cpp:1540
 msgid "Bug: Trying to select inside a cell without having a current cell"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5883
+#: ../src/MathCtrl.cpp:5935
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5844 ../src/MathCtrl.cpp:5918 ../src/MathCtrl.cpp:5952
+#: ../src/MathCtrl.cpp:5896 ../src/MathCtrl.cpp:5970 ../src/MathCtrl.cpp:6004
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:973
+#: ../src/wxMaximaFrame.cpp:972
 msgid "Build &Info"
 msgstr "Build &Info"
 
@@ -771,51 +771,51 @@ msgstr ""
 "for ny linje. Dette kan endres i dialogen 'Endre->Konfigurer' ved å huke av "
 "'Enter utfører celler'. Dette bytter om disse to kommandoenes roller."
 
-#: ../src/wxMaximaFrame.cpp:782
+#: ../src/wxMaximaFrame.cpp:781
 msgid "C&hange Variable..."
 msgstr "Endre &Variabel..."
 
-#: ../src/wxMaximaFrame.cpp:540
+#: ../src/wxMaximaFrame.cpp:539
 msgid "C&onfigure"
 msgstr "&Konfigurer"
 
-#: ../src/wxMaximaFrame.cpp:801
+#: ../src/wxMaximaFrame.cpp:800
 msgid "Calculate &Product..."
 msgstr "Kalkuler &Produkt..."
 
-#: ../src/wxMaximaFrame.cpp:799
+#: ../src/wxMaximaFrame.cpp:798
 msgid "Calculate Su&m..."
 msgstr "Kalkuler &Sum..."
 
-#: ../src/wxMaximaFrame.cpp:939
+#: ../src/wxMaximaFrame.cpp:938
 msgid "Calculate bigfloat value of the last result"
 msgstr "Kalkuler desimalverdien av siste resultat med uendelig presisjon"
 
-#: ../src/wxMaximaFrame.cpp:936
+#: ../src/wxMaximaFrame.cpp:935
 msgid "Calculate float value of the last result"
 msgstr "Kalkuler desimalverdien av siste resultat"
 
-#: ../src/wxMaxima.cpp:3971
+#: ../src/wxMaxima.cpp:3983
 msgid "Calculate modulus:"
 msgstr "Kalkuler modulo:"
 
-#: ../src/wxMaximaFrame.cpp:942
+#: ../src/wxMaximaFrame.cpp:941
 msgid "Calculate numeric value of the last result"
 msgstr "Kalkuler numerisk verdi av siste resultat"
 
-#: ../src/wxMaximaFrame.cpp:802
+#: ../src/wxMaximaFrame.cpp:801
 msgid "Calculate products"
 msgstr "Kalkuler produkter"
 
-#: ../src/wxMaximaFrame.cpp:800
+#: ../src/wxMaximaFrame.cpp:799
 msgid "Calculate sums"
 msgstr "Kalkuler summer"
 
-#: ../src/wxMaxima.cpp:5830
+#: ../src/wxMaxima.cpp:5845
 msgid "Can not connect to the web server."
 msgstr "Kan ikke koble til web server."
 
-#: ../src/wxMaxima.cpp:5881
+#: ../src/wxMaxima.cpp:5896
 msgid "Can not download version info."
 msgstr "Kan ikke laste ned versjonsinformasjon."
 
@@ -831,15 +831,15 @@ msgstr "Kan ikke laste ned versjonsinformasjon."
 #: ../src/PlotFormatWiz.cpp:48 ../src/SeriesWiz.cpp:49 ../src/SeriesWiz.cpp:51
 #: ../src/SubstituteWiz.cpp:41 ../src/SubstituteWiz.cpp:43 ../src/SumWiz.cpp:44
 #: ../src/SumWiz.cpp:46 ../src/SystemWiz.cpp:38 ../src/SystemWiz.cpp:40
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: ../src/wxMaximaFrame.cpp:126 ../src/wxMaxima.cpp:932
+#: ../src/wxMaxima.cpp:937 ../src/wxMaximaFrame.cpp:125
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1217
+#: ../src/wxMaximaFrame.cpp:1216
 msgid "Canonical (tr)"
 msgstr "Kanonisk (tr)"
 
@@ -847,7 +847,7 @@ msgstr "Kanonisk (tr)"
 msgid "Catalan"
 msgstr "Katalan"
 
-#: ../src/wxMaximaFrame.cpp:638
+#: ../src/wxMaximaFrame.cpp:637
 msgid "Ce&ll"
 msgstr "&Celle"
 
@@ -855,39 +855,39 @@ msgstr "&Celle"
 msgid "Cell bracket"
 msgstr "Celleklamme"
 
-#: ../src/wxMaxima.cpp:5261
+#: ../src/wxMaxima.cpp:5273
 msgid "Cell ends in a backslash"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:676
+#: ../src/wxMaximaFrame.cpp:675
 msgid "Change &2d Display"
 msgstr "Endre &2D-Visning"
 
-#: ../src/wxMaximaFrame.cpp:677
+#: ../src/wxMaximaFrame.cpp:676
 msgid "Change the 2d display algorithm used to display math output"
 msgstr "Endre 2D-visningsalgoritme brukt til å vise matteutdata"
 
-#: ../src/wxMaxima.cpp:3995
+#: ../src/wxMaxima.cpp:4007
 msgid "Change variable"
 msgstr "Endre variabel"
 
-#: ../src/wxMaximaFrame.cpp:783
+#: ../src/wxMaximaFrame.cpp:782
 msgid "Change variable in integral or sum"
 msgstr "Endre variabel i integral eller sum"
 
-#: ../src/wxMaxima.cpp:3751
+#: ../src/wxMaxima.cpp:3763
 msgid "Char poly"
 msgstr "charpoly"
 
-#: ../src/wxMaximaFrame.cpp:978
+#: ../src/wxMaximaFrame.cpp:977
 msgid "Check for Updates"
 msgstr "Se etter O&ppdatering"
 
-#: ../src/wxMaximaFrame.cpp:979
+#: ../src/wxMaximaFrame.cpp:978
 msgid "Check if a newer version of wxMaxima/Maxima exist."
 msgstr "Sjekk om en nyere versjon av wxMaxima/Maxima finnes."
 
-#: ../src/wxMaximaFrame.cpp:1385
+#: ../src/wxMaximaFrame.cpp:1384
 msgid "Chi"
 msgstr ""
 
@@ -908,15 +908,15 @@ msgstr "Velg font"
 msgid "Choose new plot format:"
 msgstr "Velg nytt plot-format:"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710
 msgid "Classes:"
 msgstr "Klasser:"
 
-#: ../src/wxMaximaFrame.cpp:469
+#: ../src/wxMaximaFrame.cpp:468
 msgid "Close\tCtrl-W"
 msgstr "Lukk\tCtrl-W"
 
-#: ../src/wxMaximaFrame.cpp:470
+#: ../src/wxMaximaFrame.cpp:469
 msgid "Close window"
 msgstr "Lukk vindu"
 
@@ -948,19 +948,19 @@ msgstr ""
 msgid "Code highlighting: Variables"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4806
+#: ../src/wxMaxima.cpp:4818
 msgid "Col. names:"
 msgstr "Kol. navn:"
 
-#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Columns:"
 msgstr "Kolonner:"
 
-#: ../src/wxMaximaFrame.cpp:860
+#: ../src/wxMaximaFrame.cpp:859
 msgid "Combine factorials in an expression"
 msgstr "Trekk sammen fakulteter i et uttrykk"
 
-#: ../src/wxMaxima.cpp:5293
+#: ../src/wxMaxima.cpp:5305
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
@@ -972,24 +972,24 @@ msgstr "Kommaseparerte x-koordinater"
 msgid "Comma separated y coordinates"
 msgstr "Kommaseparerte y-koordinater"
 
-#: ../src/MathCtrl.cpp:1030
+#: ../src/MathCtrl.cpp:1072
 msgid "Comment Selection"
 msgstr "Kommenter Utvalg"
 
-#: ../src/wxMaximaFrame.cpp:533
+#: ../src/wxMaximaFrame.cpp:532
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:532
+#: ../src/wxMaximaFrame.cpp:531
 #, fuzzy
 msgid "Comment selection\tCtrl-/"
 msgstr "Kommenter Utvalg"
 
-#: ../src/wxMaximaFrame.cpp:601
+#: ../src/wxMaximaFrame.cpp:600
 msgid "Complete Word\tCtrl-K"
 msgstr "Fullfør Ord\tCtrl-K"
 
-#: ../src/wxMaximaFrame.cpp:602
+#: ../src/wxMaximaFrame.cpp:601
 msgid "Complete word"
 msgstr "Fullfør ord"
 
@@ -997,36 +997,36 @@ msgstr "Fullfør ord"
 msgid "Completely stop maxima and restart it"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:823
+#: ../src/wxMaximaFrame.cpp:822
 msgid "Compute continued fraction of a value"
 msgstr "Utarbeid kjedebrøk av en verdi"
 
 # jeg har ikke jobbet med disse, endre til et bedre uttrykk om du vet bedre :)
-#: ../src/wxMaximaFrame.cpp:761
+#: ../src/wxMaximaFrame.cpp:760
 msgid "Compute the adjoint matrix"
 msgstr "Utarbeid konjugert-transponert matrise"
 
-#: ../src/wxMaximaFrame.cpp:750
+#: ../src/wxMaximaFrame.cpp:749
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr "Utarbeid det karakteristiske polynomet til en matrise"
 
-#: ../src/wxMaximaFrame.cpp:753
+#: ../src/wxMaximaFrame.cpp:752
 msgid "Compute the determinant of a matrix"
 msgstr "Utarbeid determinanten til en matrise"
 
-#: ../src/wxMaximaFrame.cpp:810
+#: ../src/wxMaximaFrame.cpp:809
 msgid "Compute the greatest common divisor"
 msgstr "Utarbeid største felles divisor"
 
-#: ../src/wxMaximaFrame.cpp:747
+#: ../src/wxMaximaFrame.cpp:746
 msgid "Compute the inverse of a matrix"
 msgstr "Utarbeid inversen til en matrise"
 
-#: ../src/wxMaximaFrame.cpp:813
+#: ../src/wxMaximaFrame.cpp:812
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr "Utarbeid minste felles multiplum (kjør load(functs) før bruk)"
 
-#: ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4868
 msgid "Condition:"
 msgstr "Betingelse:"
 
@@ -1038,8 +1038,8 @@ msgstr "Konfigurasjonsfil (*.ini)|*.ini"
 msgid "Configuration warning"
 msgstr "Konfigurasjonen har flunsa"
 
-#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:538
-#: ../src/wxMaximaFrame.cpp:541
+#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:540
 msgid "Configure wxMaxima"
 msgstr "Konfigurer wxMaxima"
 
@@ -1048,130 +1048,132 @@ msgstr "Konfigurer wxMaxima"
 msgid "Constant"
 msgstr "Konstant"
 
-#: ../src/wxMaximaFrame.cpp:844
+#: ../src/wxMaximaFrame.cpp:843
 msgid "Contract Logarithms"
 msgstr "Trekk &Sammen Logaritmer"
 
-#: ../src/wxMaximaFrame.cpp:851
+#: ../src/wxMaximaFrame.cpp:850
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr "Omgjør binomial, beta- og gammafunksjoner til fakulteter"
 
-#: ../src/wxMaximaFrame.cpp:854
+#: ../src/wxMaximaFrame.cpp:853
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr "Omgjør binomial, beta- og gammafunksjoner til gammafunksjon"
 
-#: ../src/wxMaximaFrame.cpp:888
+#: ../src/wxMaximaFrame.cpp:887
 msgid "Convert complex expression to polar form"
 msgstr "Omgjør komplekst uttrykk til polar form"
 
-#: ../src/wxMaximaFrame.cpp:885
+#: ../src/wxMaximaFrame.cpp:884
 msgid "Convert complex expression to rect form"
 msgstr "Omgjør komplekst uttrykk til rektangulær form"
 
-#: ../src/wxMaximaFrame.cpp:897
+#: ../src/wxMaximaFrame.cpp:896
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
 "Omgjør eksponentiell funksjon av imaginært argument til trigonometrisk form"
 
-#: ../src/wxMaximaFrame.cpp:842
+#: ../src/wxMaximaFrame.cpp:841
 msgid "Convert logarithm of product to sum of logarithms"
 msgstr "Omgjør logaritme av produkt til sum av logaritmer"
 
-#: ../src/wxMaximaFrame.cpp:845
+#: ../src/wxMaximaFrame.cpp:844
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "Omgjør sum av logaritmer til logaritme av produkt"
 
-#: ../src/wxMaximaFrame.cpp:850
+#: ../src/wxMaximaFrame.cpp:849
 msgid "Convert to &Factorials"
 msgstr "Omgjør til &Fakulteter"
 
-#: ../src/wxMaximaFrame.cpp:853
+#: ../src/wxMaximaFrame.cpp:852
 msgid "Convert to &Gamma"
 msgstr "Omgjør til &Gamma"
 
-#: ../src/wxMaximaFrame.cpp:887
+#: ../src/wxMaximaFrame.cpp:886
 msgid "Convert to &Polarform"
 msgstr "Omgjør til &Polar Form"
 
-#: ../src/wxMaximaFrame.cpp:884
+#: ../src/wxMaximaFrame.cpp:883
 msgid "Convert to &Rectform"
 msgstr "Omgjør til &Rektangulær Form"
 
-#: ../src/wxMaximaFrame.cpp:877
+#: ../src/wxMaximaFrame.cpp:876
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr "Omgjør trigonometrisk uttrykk til kanonisk kvasilineær form"
 
-#: ../src/wxMaximaFrame.cpp:900
+#: ../src/wxMaximaFrame.cpp:899
 msgid "Convert trigonometric functions to exponential form"
 msgstr "Omgjør trigonometrisk funksjon til eksponentiell form"
 
-#: ../src/ToolBar.cpp:140 ../src/MathCtrl.cpp:918 ../src/MathCtrl.cpp:931
-#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1024
+#: ../src/MathCtrl.cpp:960 ../src/MathCtrl.cpp:973 ../src/MathCtrl.cpp:1019
+#: ../src/MathCtrl.cpp:1066 ../src/ToolBar.cpp:140
 msgid "Copy"
 msgstr "Kopier"
 
-#: ../src/wxMaximaFrame.cpp:597
+#: ../src/wxMaximaFrame.cpp:596
 msgid "Copy Previous Input\tCtrl-I"
 msgstr "Kopier Forrige Inndata\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:599
+#: ../src/wxMaximaFrame.cpp:598
 msgid "Copy Previous Output\tCtrl-U"
 msgstr "Kopier Forrige Utdata\tCtrl-U"
 
-#: ../src/wxMaximaFrame.cpp:514 ../src/MathCtrl.cpp:936 ../src/MathCtrl.cpp:982
+#: ../src/MathCtrl.cpp:978 ../src/MathCtrl.cpp:1024
+#: ../src/wxMaximaFrame.cpp:513
 msgid "Copy as Image"
 msgstr "Kopier som Bilde"
 
-#: ../src/wxMaximaFrame.cpp:507 ../src/MathCtrl.cpp:932 ../src/MathCtrl.cpp:978
+#: ../src/MathCtrl.cpp:974 ../src/MathCtrl.cpp:1020
+#: ../src/wxMaximaFrame.cpp:506
 msgid "Copy as LaTeX"
 msgstr "Kopier som LaTe&X"
 
-#: ../src/wxMaximaFrame.cpp:510
+#: ../src/wxMaximaFrame.cpp:509
 #, fuzzy
 msgid "Copy as MathML"
 msgstr "Kopier som Bilde"
 
-#: ../src/MathCtrl.cpp:935 ../src/MathCtrl.cpp:980
+#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1022
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:504
+#: ../src/wxMaximaFrame.cpp:503
 msgid "Copy as Text\tCtrl-Shift-C"
 msgstr "Kopier som &Tekst\tCtrl-Shift-C"
 
-#: ../src/MathCtrl.cpp:933 ../src/MathCtrl.cpp:979
+#: ../src/MathCtrl.cpp:975 ../src/MathCtrl.cpp:1021
 #, fuzzy
 msgid "Copy as plain text"
 msgstr "Kopier som Bilde"
 
-#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:503
+#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:502
 msgid "Copy selection"
 msgstr "Kopier utvalg"
 
-#: ../src/wxMaximaFrame.cpp:515
+#: ../src/wxMaximaFrame.cpp:514
 msgid "Copy selection from document as an image"
 msgstr "Kopier utvalg fra dokument som et bilde"
 
-#: ../src/wxMaximaFrame.cpp:505
+#: ../src/wxMaximaFrame.cpp:504
 msgid "Copy selection from document as text"
 msgstr "Kopier utvalg fra dokument som tekst"
 
-#: ../src/wxMaximaFrame.cpp:508
+#: ../src/wxMaximaFrame.cpp:507
 msgid "Copy selection from document in LaTeX format"
 msgstr "Kopier utvalg fra dokument i LaTeX-format"
 
-#: ../src/wxMaximaFrame.cpp:511
+#: ../src/wxMaximaFrame.cpp:510
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:598
+#: ../src/wxMaximaFrame.cpp:597
 msgid "Create a new cell with previous input"
 msgstr "Lag en ny celle med forrige inndata"
 
-#: ../src/wxMaximaFrame.cpp:600
+#: ../src/wxMaximaFrame.cpp:599
 msgid "Create a new cell with previous output"
 msgstr "Lag en ny celle med forrige utdata"
 
@@ -1179,15 +1181,15 @@ msgstr "Lag en ny celle med forrige utdata"
 msgid "Cursor"
 msgstr "Peker"
 
-#: ../src/ToolBar.cpp:137 ../src/MathCtrl.cpp:1023
+#: ../src/MathCtrl.cpp:1065 ../src/ToolBar.cpp:137
 msgid "Cut"
 msgstr "Klipp Ut"
 
-#: ../src/wxMaximaFrame.cpp:499
+#: ../src/wxMaximaFrame.cpp:498
 msgid "Cut\tCtrl-X"
 msgstr "Klipp Ut\tCtrl-X"
 
-#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:500
+#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:499
 msgid "Cut selection"
 msgstr "Klipp Ut Utvalg"
 
@@ -1199,18 +1201,18 @@ msgstr "Tsjekkisk"
 msgid "Danish"
 msgstr "Dansk"
 
-#: ../src/wxMaxima.cpp:4799 ../src/wxMaxima.cpp:4806 ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4811 ../src/wxMaxima.cpp:4818 ../src/wxMaxima.cpp:4868
 msgid "Data Matrix:"
 msgstr "Datamatrise:"
 
-#: ../src/wxMaxima.cpp:4826
+#: ../src/wxMaxima.cpp:4838
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr "Datafil (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698 ../src/wxMaxima.cpp:4712
-#: ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726 ../src/wxMaxima.cpp:4734
-#: ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748 ../src/wxMaxima.cpp:4755
-#: ../src/wxMaxima.cpp:4791
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710 ../src/wxMaxima.cpp:4724
+#: ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738 ../src/wxMaxima.cpp:4746
+#: ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760 ../src/wxMaxima.cpp:4767
+#: ../src/wxMaxima.cpp:4803
 msgid "Data:"
 msgstr "Data:"
 
@@ -1218,7 +1220,7 @@ msgstr "Data:"
 msgid "Debug: watch maxima's stdout stream"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:820
+#: ../src/wxMaximaFrame.cpp:819
 msgid "Decompose rational function to partial fractions"
 msgstr "Utvid rasjonelle funksjoner til delvise brøker"
 
@@ -1249,47 +1251,47 @@ msgid ""
 "with."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3403 ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3415 ../src/wxMaxima.cpp:3424
 msgid "Delete"
 msgstr "Slett"
 
-#: ../src/wxMaximaFrame.cpp:667
+#: ../src/wxMaximaFrame.cpp:666
 msgid "Delete F&unction..."
 msgstr "&Slett Funksjon..."
 
-#: ../src/MathCtrl.cpp:939 ../src/MathCtrl.cpp:985
+#: ../src/MathCtrl.cpp:981 ../src/MathCtrl.cpp:1027
 msgid "Delete Selection"
 msgstr "Slett Utvalg"
 
-#: ../src/wxMaximaFrame.cpp:669
+#: ../src/wxMaximaFrame.cpp:668
 msgid "Delete V&ariable..."
 msgstr "&Slett Variabel..."
 
-#: ../src/wxMaximaFrame.cpp:668
+#: ../src/wxMaximaFrame.cpp:667
 msgid "Delete a function"
 msgstr "Slett en funksjon"
 
-#: ../src/wxMaximaFrame.cpp:670
+#: ../src/wxMaximaFrame.cpp:669
 msgid "Delete a variable"
 msgstr "Slett en variabel"
 
-#: ../src/wxMaximaFrame.cpp:655
+#: ../src/wxMaximaFrame.cpp:654
 msgid "Delete all values from memory"
 msgstr "Slett alle verdier fra minnet"
 
-#: ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3424
 msgid "Delete function(s):"
 msgstr "Slett funksjoner:"
 
-#: ../src/wxMaxima.cpp:3403
+#: ../src/wxMaxima.cpp:3415
 msgid "Delete variable(s):"
 msgstr "Slett variabler:"
 
-#: ../src/wxMaximaFrame.cpp:1367
+#: ../src/wxMaximaFrame.cpp:1366
 msgid "Delta"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4011
+#: ../src/wxMaxima.cpp:4023
 msgid "Denom. deg:"
 msgstr "Nevnergrad:"
 
@@ -1298,35 +1300,35 @@ msgid "Depth:"
 msgstr "Dybde:"
 
 # kontekst?
-#: ../src/wxMaxima.cpp:3541
+#: ../src/wxMaxima.cpp:3553
 msgid "Derivative:"
 msgstr "Derivert:"
 
-#: ../src/wxMaximaFrame.cpp:1258
+#: ../src/wxMaximaFrame.cpp:1257
 msgid "Deviation..."
 msgstr "Avvik..."
 
-#: ../src/wxMaximaFrame.cpp:816
+#: ../src/wxMaximaFrame.cpp:815
 msgid "Di&vide Polynomials..."
 msgstr "Di&vider Polynom..."
 
-#: ../src/wxMaximaFrame.cpp:1223
+#: ../src/wxMaximaFrame.cpp:1222
 msgid "Diff..."
 msgstr "Deriver..."
 
-#: ../src/wxMaxima.cpp:4154 ../src/wxMaxima.cpp:5066
+#: ../src/wxMaxima.cpp:4166 ../src/wxMaxima.cpp:5078
 msgid "Differentiate"
 msgstr "Deriver"
 
-#: ../src/wxMaximaFrame.cpp:786
+#: ../src/wxMaximaFrame.cpp:785
 msgid "Differentiate expression"
 msgstr "Deriver uttrykk"
 
-#: ../src/MathCtrl.cpp:1001
+#: ../src/MathCtrl.cpp:1043
 msgid "Differentiate..."
 msgstr "Deriver..."
 
-#: ../src/LimitWiz.cpp:37 ../src/FindReplacePane.cpp:76
+#: ../src/FindReplacePane.cpp:76 ../src/LimitWiz.cpp:37
 msgid "Direction:"
 msgstr "Retning:"
 
@@ -1334,48 +1336,49 @@ msgstr "Retning:"
 msgid "Discrete plot"
 msgstr "Diskret Plott"
 
-#: ../src/wxMaximaFrame.cpp:679
+#: ../src/wxMaximaFrame.cpp:678
 msgid "Display Te&X Form"
 msgstr "Vis Te&X-Form"
 
-#: ../src/wxMaxima.cpp:3320
+#: ../src/wxMaxima.cpp:3332
 msgid "Display algorithm"
 msgstr "Vis algoritme"
 
-#: ../src/wxMaximaFrame.cpp:680
+#: ../src/wxMaximaFrame.cpp:679
 msgid "Display last result in TeX form"
 msgstr "Vis siste resultat i TeX-form"
 
-#: ../src/wxMaximaFrame.cpp:674
+#: ../src/wxMaximaFrame.cpp:673
 msgid "Display time used for evaluation"
 msgstr "Vis brukt tid ved utførelse"
 
-#: ../src/wxMaxima.cpp:4061
+#: ../src/wxMaxima.cpp:4073
 msgid "Divide"
 msgstr "Divider"
 
-#: ../src/MathCtrl.cpp:1032
+#: ../src/MathCtrl.cpp:1074
 msgid "Divide Cell"
 msgstr "Divider Celle"
 
-#: ../src/wxMaximaFrame.cpp:635
+#: ../src/wxMaximaFrame.cpp:634
 #, fuzzy
 msgid "Divide Cell\tCtrl-D"
 msgstr "Divider Celle"
 
-#: ../src/wxMaximaFrame.cpp:817
+#: ../src/wxMaximaFrame.cpp:816
 msgid "Divide numbers or polynomials"
 msgstr "Divider tall eller polynomer"
 
-#: ../src/wxMaximaFrame.cpp:636
+#: ../src/wxMaximaFrame.cpp:635
 msgid "Divide this input cell into two cells"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5917
-msgid "Do you want to save the changes you made in the document \""
+#: ../src/wxMaxima.cpp:5932
+#, fuzzy, c-format
+msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr "Vil du lagre endringene i dokumentet \""
 
-#: ../src/wxMaxima.cpp:1664 ../src/wxMaxima.cpp:1672
+#: ../src/wxMaxima.cpp:1669 ../src/wxMaxima.cpp:1677
 msgid "Document "
 msgstr "Dokument "
 
@@ -1397,7 +1400,7 @@ msgstr ""
 "gjør versjonkontrollsystem som git og svn i stand til å effektivt oppdage "
 "forskjeller."
 
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Don't save"
 msgstr "Ikke lagre"
 
@@ -1405,27 +1408,27 @@ msgstr "Ikke lagre"
 msgid "Down"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:734
+#: ../src/wxMaximaFrame.cpp:733
 msgid "E&quations"
 msgstr "&Likninger"
 
-#: ../src/wxMaximaFrame.cpp:487
+#: ../src/wxMaximaFrame.cpp:486
 msgid "E&xit\tCtrl-Q"
 msgstr "&Avslutt\tCtrl-Q"
 
-#: ../src/wxMaximaFrame.cpp:757
+#: ../src/wxMaximaFrame.cpp:756
 msgid "Eige&nvectors"
 msgstr "&Egenvektorer"
 
-#: ../src/wxMaximaFrame.cpp:755
+#: ../src/wxMaximaFrame.cpp:754
 msgid "Eigen&values"
 msgstr "Egen&verdier"
 
-#: ../src/wxMaxima.cpp:3572
+#: ../src/wxMaxima.cpp:3584
 msgid "Eliminate"
 msgstr "Eliminer"
 
-#: ../src/wxMaximaFrame.cpp:710
+#: ../src/wxMaximaFrame.cpp:709
 msgid "Eliminate a variable from a system of equations"
 msgstr "Eliminer en variabel fra et likningssett"
 
@@ -1437,21 +1440,21 @@ msgstr ""
 msgid "English"
 msgstr "Engelsk"
 
-#: ../src/wxMaxima.cpp:4712 ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726
-#: ../src/wxMaxima.cpp:4734 ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748
-#: ../src/wxMaxima.cpp:4755 ../src/wxMaxima.cpp:4791 ../src/wxMaxima.cpp:4799
+#: ../src/wxMaxima.cpp:4724 ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738
+#: ../src/wxMaxima.cpp:4746 ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760
+#: ../src/wxMaxima.cpp:4767 ../src/wxMaxima.cpp:4803 ../src/wxMaxima.cpp:4811
 msgid "Enter Data"
 msgstr "Oppgi Data"
 
-#: ../src/wxMaximaFrame.cpp:1279
+#: ../src/wxMaximaFrame.cpp:1278
 msgid "Enter Matrix..."
 msgstr "Oppgi Matrise..."
 
-#: ../src/wxMaximaFrame.cpp:745
+#: ../src/wxMaximaFrame.cpp:744
 msgid "Enter a matrix"
 msgstr "Oppgi en matrise"
 
-#: ../src/wxMaxima.cpp:3962
+#: ../src/wxMaxima.cpp:3974
 msgid "Enter an equation for rational simplification:"
 msgstr "Oppgi en likning til rasjonell forenkling:"
 
@@ -1463,11 +1466,11 @@ msgstr "Oppgi kommaseparert liste av variabler."
 msgid "Enter evaluates cells"
 msgstr "Enter utfører celler"
 
-#: ../src/wxMaxima.cpp:3734
+#: ../src/wxMaxima.cpp:3746
 msgid "Enter matrix"
 msgstr "Oppgi matrise"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 #, fuzzy
 msgid "Enter new precision for bigfloats:"
 msgstr "Oppgi ny presisjon:"
@@ -1476,12 +1479,12 @@ msgstr "Oppgi ny presisjon:"
 msgid "Enter the path to the Maxima executable."
 msgstr "Oppgi banen til Maxima-programfilen."
 
-#: ../src/wxMaximaFrame.cpp:1368
+#: ../src/wxMaximaFrame.cpp:1367
 #, fuzzy
 msgid "Epsilon"
 msgstr "Epsilon:"
 
-#: ../src/wxMaxima.cpp:4208
+#: ../src/wxMaxima.cpp:4220
 msgid "Epsilon:"
 msgstr "Epsilon:"
 
@@ -1490,13 +1493,13 @@ msgstr "Epsilon:"
 msgid "Equation %d:"
 msgstr "Likning %d:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:3633
-#: ../src/wxMaxima.cpp:5019
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:3645
+#: ../src/wxMaxima.cpp:5031
 msgid "Equation(s):"
 msgstr "Likninger:"
 
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3993
-#: ../src/wxMaxima.cpp:4807 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:4005
+#: ../src/wxMaxima.cpp:4819 ../src/wxMaxima.cpp:5045
 msgid "Equation:"
 msgstr "Likning:"
 
@@ -1507,81 +1510,81 @@ msgid ""
 "be introduced one into another. Also they are always printed out as 2D maths."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3570
+#: ../src/wxMaxima.cpp:3582
 msgid "Equations:"
 msgstr "Likninger:"
 
-#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1455
-#: ../src/wxMaxima.cpp:1469 ../src/wxMaxima.cpp:1620 ../src/wxMaxima.cpp:1633
-#: ../src/wxMaxima.cpp:1643 ../src/wxMaxima.cpp:1666 ../src/wxMaxima.cpp:2034
-#: ../src/wxMaxima.cpp:2206 ../src/wxMaxima.cpp:5381 ../src/wxMaxima.cpp:5830
-#: ../src/wxMaxima.cpp:5881
+#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1460
+#: ../src/wxMaxima.cpp:1474 ../src/wxMaxima.cpp:1625 ../src/wxMaxima.cpp:1638
+#: ../src/wxMaxima.cpp:1648 ../src/wxMaxima.cpp:1671 ../src/wxMaxima.cpp:2039
+#: ../src/wxMaxima.cpp:2211 ../src/wxMaxima.cpp:5397 ../src/wxMaxima.cpp:5845
+#: ../src/wxMaxima.cpp:5896
 msgid "Error"
 msgstr "Feil"
 
-#: ../src/wxMaxima.cpp:2886 ../src/wxMaxima.cpp:2900 ../src/wxMaxima.cpp:2913
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617 ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:2894 ../src/wxMaxima.cpp:2908 ../src/wxMaxima.cpp:2921
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629 ../src/wxMaxima.cpp:3740
 msgid "Error!"
 msgstr "Feil!"
 
-#: ../src/wxMaximaFrame.cpp:1370
+#: ../src/wxMaximaFrame.cpp:1369
 msgid "Eta"
 msgstr ""
 
 # Jeg ved ikke hvad man skal oversætte noun til?
 # JT: Navn(eord) - det vil u.a.o. kun være for "kendere"?
-#: ../src/wxMaximaFrame.cpp:909
+#: ../src/wxMaximaFrame.cpp:908
 #, fuzzy
 msgid "Evaluate &Noun Forms"
 msgstr "Utfør &Navneformer"
 
-#: ../src/wxMaximaFrame.cpp:589
+#: ../src/wxMaximaFrame.cpp:588
 msgid "Evaluate All Cells\tCtrl-Shift-R"
 msgstr "Utfør Alle Celler\tCtrl-Shift-R"
 
-#: ../src/wxMaximaFrame.cpp:587
+#: ../src/wxMaximaFrame.cpp:586
 msgid "Evaluate All Visible Cells\tCtrl-R"
 msgstr "Utfør Alle Synlige Celler\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:585 ../src/MathCtrl.cpp:942
+#: ../src/MathCtrl.cpp:984 ../src/wxMaximaFrame.cpp:584
 msgid "Evaluate Cell(s)"
 msgstr "&Utfør Celler"
 
-#: ../src/wxMaximaFrame.cpp:591
+#: ../src/wxMaximaFrame.cpp:590
 #, fuzzy
 msgid "Evaluate Cells Above\tCtrl-Shift-P"
 msgstr "Utfør Alle Celler\tCtrl-Shift-R"
 
-#: ../src/MathCtrl.cpp:956 ../src/MathCtrl.cpp:1051
+#: ../src/MathCtrl.cpp:998 ../src/MathCtrl.cpp:1093
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:961 ../src/MathCtrl.cpp:1053
+#: ../src/MathCtrl.cpp:1003 ../src/MathCtrl.cpp:1095
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:971 ../src/MathCtrl.cpp:1057
+#: ../src/MathCtrl.cpp:1013 ../src/MathCtrl.cpp:1099
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:966 ../src/MathCtrl.cpp:1055
+#: ../src/MathCtrl.cpp:1008 ../src/MathCtrl.cpp:1097
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:586
+#: ../src/wxMaximaFrame.cpp:585
 msgid "Evaluate active or selected cell(s)"
 msgstr "Utfør aktive eller valgte celler"
 
-#: ../src/wxMaximaFrame.cpp:590
+#: ../src/wxMaximaFrame.cpp:589
 msgid "Evaluate all cells in the document"
 msgstr "Utfør alle celler i dokument"
 
 # Nouns in Verbs umwandeln und auswerten
-#: ../src/wxMaximaFrame.cpp:910
+#: ../src/wxMaximaFrame.cpp:909
 msgid "Evaluate all noun forms in expression"
 msgstr "Utfør alle navneformer i uttrykk"
 
-#: ../src/wxMaximaFrame.cpp:588
+#: ../src/wxMaximaFrame.cpp:587
 msgid "Evaluate all visible cells in the document"
 msgstr "Utfør alle synlige celler i dokument"
 
@@ -1596,7 +1599,7 @@ msgstr ""
 msgid "Evaluate to point"
 msgstr "Utfør &Navneformer"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Example"
 msgstr "Eksempel"
 
@@ -1609,31 +1612,31 @@ msgstr "Eksempeltekst"
 msgid "Examples:"
 msgstr "Eksempel"
 
-#: ../src/wxMaximaFrame.cpp:488
+#: ../src/wxMaximaFrame.cpp:487
 msgid "Exit wxMaxima"
 msgstr "Avslutt wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:1214
+#: ../src/wxMaximaFrame.cpp:1213
 msgid "Expand"
 msgstr "Utvid"
 
-#: ../src/wxMaximaFrame.cpp:1219
+#: ../src/wxMaximaFrame.cpp:1218
 msgid "Expand (tr)"
 msgstr "Utvid (tr)"
 
-#: ../src/MathCtrl.cpp:997
+#: ../src/MathCtrl.cpp:1039
 msgid "Expand Expression"
 msgstr "Utvid Uttrykk"
 
-#: ../src/wxMaximaFrame.cpp:841
+#: ../src/wxMaximaFrame.cpp:840
 msgid "Expand Logarithms"
 msgstr "Utvid &Logaritmer"
 
-#: ../src/wxMaximaFrame.cpp:840
+#: ../src/wxMaximaFrame.cpp:839
 msgid "Expand an expression"
 msgstr "Utvid et uttrykk"
 
-#: ../src/wxMaximaFrame.cpp:874
+#: ../src/wxMaximaFrame.cpp:873
 msgid "Expand trigonometric expression"
 msgstr "Utvid trigonometrisk uttrykk"
 
@@ -1641,7 +1644,7 @@ msgstr "Utvid trigonometrisk uttrykk"
 msgid "Expected the icon files to be found at"
 msgstr ""
 
-#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2834
+#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2842
 msgid "Export"
 msgstr "Eksporter"
 
@@ -1650,33 +1653,33 @@ msgid ""
 "Export animations to TeX (Images only move if the PDF viewer supports this)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:481
+#: ../src/wxMaximaFrame.cpp:480
 msgid "Export document to a HTML or pdfLaTeX file"
 msgstr "Eksporter dokument til en HTML- eller pdfLaTeX-fil"
 
-#: ../src/wxMaximaFrame.cpp:253
+#: ../src/wxMaximaFrame.cpp:252
 #, fuzzy
 msgid "Export failed."
 msgstr "Eksport til TeX feilet!"
 
-#: ../src/wxMaximaFrame.cpp:239
+#: ../src/wxMaximaFrame.cpp:238
 msgid "Export successful."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2913
+#: ../src/wxMaxima.cpp:2921
 msgid "Exporting to HTML failed!"
 msgstr "Eksport til HTML feilet!"
 
-#: ../src/wxMaxima.cpp:2886
+#: ../src/wxMaxima.cpp:2894
 msgid "Exporting to TeX failed!"
 msgstr "Eksport til TeX feilet!"
 
-#: ../src/wxMaxima.cpp:2900
+#: ../src/wxMaxima.cpp:2908
 #, fuzzy
 msgid "Exporting to maxima batch file failed!"
 msgstr "Eksport til TeX feilet!"
 
-#: ../src/wxMaximaFrame.cpp:229
+#: ../src/wxMaximaFrame.cpp:228
 #, fuzzy
 msgid "Exporting..."
 msgstr "&Eksporter..."
@@ -1690,42 +1693,42 @@ msgid "Expression(s):"
 msgstr "Uttrykk:"
 
 #: ../src/IntegrateWiz.cpp:30 ../src/LimitWiz.cpp:27 ../src/SeriesWiz.cpp:33
-#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3648
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:4205 ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5064
+#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3660
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:4217 ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5076
 msgid "Expression:"
 msgstr "Uttrykk:"
 
-#: ../src/wxMaximaFrame.cpp:1213
+#: ../src/wxMaximaFrame.cpp:1212
 msgid "Factor"
 msgstr "Faktoriser"
 
-#: ../src/wxMaximaFrame.cpp:836
+#: ../src/wxMaximaFrame.cpp:835
 msgid "Factor Complex"
 msgstr "Faktoriser K&omplekst"
 
-#: ../src/MathCtrl.cpp:996
+#: ../src/MathCtrl.cpp:1038
 msgid "Factor Expression"
 msgstr "Faktoriser Uttrykk"
 
-#: ../src/wxMaximaFrame.cpp:835
+#: ../src/wxMaximaFrame.cpp:834
 msgid "Factor an expression"
 msgstr "Faktoriser et uttrykk"
 
-#: ../src/wxMaximaFrame.cpp:837
+#: ../src/wxMaximaFrame.cpp:836
 msgid "Factor an expression in Gaussian numbers"
 msgstr "Faktoriser et uttrykk i gaussiske heltall"
 
-#: ../src/wxMaximaFrame.cpp:862
+#: ../src/wxMaximaFrame.cpp:861
 msgid "Factorials and &Gamma"
 msgstr "Fakultet og &Gamma"
 
-#: ../src/wxMaxima.cpp:285
+#: ../src/wxMaxima.cpp:286
 msgid "Fatal error"
 msgstr "Fatal feil"
 
-#: ../src/GroupCell.cpp:1571
+#: ../src/GroupCell.cpp:1572
 #, c-format
 msgid "Figure %d:"
 msgstr "Figur %d:"
@@ -1734,22 +1737,22 @@ msgstr "Figur %d:"
 msgid "File"
 msgstr "Fil"
 
-#: ../src/wxMaxima.cpp:1457 ../src/wxMaxima.cpp:1623 ../src/wxMaxima.cpp:1636
-#: ../src/wxMaxima.cpp:1646 ../src/wxMaxima.cpp:1668
+#: ../src/wxMaxima.cpp:1462 ../src/wxMaxima.cpp:1628 ../src/wxMaxima.cpp:1641
+#: ../src/wxMaxima.cpp:1651 ../src/wxMaxima.cpp:1673
 #, fuzzy
 msgid "File could not be opened"
 msgstr "Fant ikke fil"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File not found"
 msgstr "Fant ikke fil"
 
-#: ../src/wxMaxima.cpp:1511 ../src/wxMaxima.cpp:1729
+#: ../src/wxMaxima.cpp:1516 ../src/wxMaxima.cpp:1734
 #, fuzzy
 msgid "File opened"
 msgstr "Fant ikke fil"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File you tried to open does not exist."
 msgstr "Filen du forsøkte å åpne finnes ikke."
 
@@ -1761,67 +1764,67 @@ msgstr "Fil:"
 msgid "Find"
 msgstr "Finn"
 
-#: ../src/wxMaximaFrame.cpp:523
+#: ../src/wxMaximaFrame.cpp:522
 msgid "Find\tCtrl-F"
 msgstr "&Finn\tCtrl-F"
 
-#: ../src/wxMaximaFrame.cpp:787
+#: ../src/wxMaximaFrame.cpp:786
 msgid "Find &Limit..."
 msgstr "Finn &Grenseverdi..."
 
-#: ../src/wxMaximaFrame.cpp:790
+#: ../src/wxMaximaFrame.cpp:789
 msgid "Find Minimum..."
 msgstr "Finn Minim&um..."
 
-#: ../src/MathCtrl.cpp:993
+#: ../src/MathCtrl.cpp:1035
 msgid "Find Root..."
 msgstr "Finn Rot..."
 
-#: ../src/wxMaximaFrame.cpp:791
+#: ../src/wxMaximaFrame.cpp:790
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr "Finn et (ubegrenset) minimum til et uttrykk"
 
-#: ../src/wxMaximaFrame.cpp:788
+#: ../src/wxMaximaFrame.cpp:787
 msgid "Find a limit of an expression"
 msgstr "Finn grenseverdi til et uttrykk"
 
-#: ../src/wxMaximaFrame.cpp:693
+#: ../src/wxMaximaFrame.cpp:692
 msgid "Find a root of an equation on an interval"
 msgstr "Finn en rot til en likning i et intervall"
 
-#: ../src/wxMaximaFrame.cpp:695
+#: ../src/wxMaximaFrame.cpp:694
 msgid "Find all roots of a polynomial"
 msgstr "Finn alle røttene til et polynom"
 
-#: ../src/wxMaximaFrame.cpp:698
+#: ../src/wxMaximaFrame.cpp:697
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr "Finn alle røttene til et polynom (bigfloat)"
 
-#: ../src/wxMaxima.cpp:3220
+#: ../src/wxMaxima.cpp:3215
 msgid "Find and Replace"
 msgstr "Finn og Erstatt"
 
-#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:523
+#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:522
 msgid "Find and replace"
 msgstr "Finn og erstatt"
 
-#: ../src/wxMaximaFrame.cpp:756
+#: ../src/wxMaximaFrame.cpp:755
 msgid "Find eigenvalues of a matrix"
 msgstr "Finn egenverdier til en matrise"
 
-#: ../src/wxMaximaFrame.cpp:758
+#: ../src/wxMaximaFrame.cpp:757
 msgid "Find eigenvectors of a matrix"
 msgstr "Finn egenvektorer til en matrise"
 
-#: ../src/wxMaxima.cpp:4210
+#: ../src/wxMaxima.cpp:4222
 msgid "Find minimum"
 msgstr "Finn minimum"
 
-#: ../src/wxMaximaFrame.cpp:701
+#: ../src/wxMaximaFrame.cpp:700
 msgid "Find real roots of a polynomial"
 msgstr "Finn reelle røtter til et polynom"
 
-#: ../src/wxMaxima.cpp:3493 ../src/wxMaxima.cpp:5036
+#: ../src/wxMaxima.cpp:3505 ../src/wxMaxima.cpp:5048
 msgid "Find root"
 msgstr "Finn røtter"
 
@@ -1844,11 +1847,11 @@ msgstr "Fiks omstokkede referanseindekser (av %i, %o) før lagring"
 msgid "Fixed font in text controls"
 msgstr "Fast font i tekstkontroller"
 
-#: ../src/wxMaximaFrame.cpp:623
+#: ../src/wxMaximaFrame.cpp:622
 msgid "Fold All\tCtrl-Alt-["
 msgstr "F&old Alle\tCtrl-A-["
 
-#: ../src/wxMaximaFrame.cpp:624
+#: ../src/wxMaximaFrame.cpp:623
 msgid "Fold all sections"
 msgstr "Fold alle seksjoner"
 
@@ -1856,25 +1859,25 @@ msgstr "Fold alle seksjoner"
 msgid "Follow"
 msgstr ""
 
-#: ../src/ParenCell.cpp:319
+#: ../src/ParenCell.cpp:320
 msgid "Font issue: The Parenthesis sign is too small!"
 msgstr ""
 
-#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:381
+#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:382
 msgid ""
 "Font issue: The char height is too small! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:199
+#: ../src/SqrtCell.cpp:202
 msgid ""
 "Font issue: The sqrt() sign has the size 0! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:198
+#: ../src/SqrtCell.cpp:201
 msgid "Font issue? The contents of a sqrt() has the size 0."
 msgstr ""
 
@@ -1905,15 +1908,15 @@ msgstr "Fransk"
 
 #: ../src/IntegrateWiz.cpp:37 ../src/Plot2dWiz.cpp:37 ../src/Plot2dWiz.cpp:47
 #: ../src/Plot2dWiz.cpp:536 ../src/Plot3dWiz.cpp:36 ../src/Plot3dWiz.cpp:45
-#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4240
+#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4252
 msgid "From:"
 msgstr "Fra:"
 
-#: ../src/wxMaximaFrame.cpp:576
+#: ../src/wxMaximaFrame.cpp:575
 msgid "Full Screen\tAlt-Enter"
 msgstr "F&ullskjerm\tAlt-Enter"
 
-#: ../src/wxMaxima.cpp:3342
+#: ../src/wxMaxima.cpp:3354
 msgid "Function"
 msgstr "Funksjon"
 
@@ -1921,32 +1924,32 @@ msgstr "Funksjon"
 msgid "Function names"
 msgstr "Funksjonnavn"
 
-#: ../src/wxMaxima.cpp:3633
+#: ../src/wxMaxima.cpp:3645
 msgid "Function(s):"
 msgstr "Funksjoner:"
 
-#: ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3803
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3815
+#: ../src/wxMaxima.cpp:3848
 msgid "Function:"
 msgstr "Funksjon:"
 
-#: ../src/wxMaximaFrame.cpp:904
+#: ../src/wxMaximaFrame.cpp:903
 msgid "Functions for complex simplification"
 msgstr "Funksjoner til kompleks forenkling"
 
-#: ../src/wxMaximaFrame.cpp:864
+#: ../src/wxMaximaFrame.cpp:863
 msgid "Functions for simplifying factorials and gamma function"
 msgstr "Funksjon til forenkling av fakulteter og gammafunksjoner"
 
-#: ../src/wxMaximaFrame.cpp:881
+#: ../src/wxMaximaFrame.cpp:880
 msgid "Functions for simplifying trigonometric expressions"
 msgstr "Funksjoner til forenkling av trigonometriske uttrykk"
 
-#: ../src/wxMaxima.cpp:4046
+#: ../src/wxMaxima.cpp:4058
 msgid "GCD"
 msgstr "SFD"
 
-#: ../src/wxMaxima.cpp:5152
+#: ../src/wxMaxima.cpp:5164
 msgid "GIF image (*.gif)|*.gif"
 msgstr "GIF-bilde (*.gif)|*.gif"
 
@@ -1954,31 +1957,31 @@ msgstr "GIF-bilde (*.gif)|*.gif"
 msgid "Galician"
 msgstr "Galisisk"
 
-#: ../src/wxMaximaFrame.cpp:1366
+#: ../src/wxMaximaFrame.cpp:1365
 msgid "Gamma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:391
+#: ../src/wxMaximaFrame.cpp:390
 msgid "General Math"
 msgstr "Generell Matte"
 
-#: ../src/wxMaximaFrame.cpp:549
+#: ../src/wxMaximaFrame.cpp:548
 msgid "General Math\tAlt-Shift-M"
 msgstr "Generell Matte\tAlt-Shift-M"
 
-#: ../src/wxMaxima.cpp:3766 ../src/wxMaxima.cpp:3785
+#: ../src/wxMaxima.cpp:3778 ../src/wxMaxima.cpp:3797
 msgid "Generate Matrix"
 msgstr "Generer Matrise"
 
-#: ../src/wxMaximaFrame.cpp:741
+#: ../src/wxMaximaFrame.cpp:740
 msgid "Generate Matrix from Expression..."
 msgstr "Generer Matrise fra &Uttrykk..."
 
-#: ../src/wxMaximaFrame.cpp:739
+#: ../src/wxMaximaFrame.cpp:738
 msgid "Generate a matrix from a 2-dimensional array"
 msgstr "Generer en matrise fra et 2-dimensjonalt array"
 
-#: ../src/wxMaximaFrame.cpp:742
+#: ../src/wxMaximaFrame.cpp:741
 msgid "Generate a matrix from a lambda expression"
 msgstr "Generer en matrise fra et lambdauttrykk"
 
@@ -1987,39 +1990,39 @@ msgid "German"
 msgstr "Tysk"
 
 # s/Finn/Bestem|Skaff|Trekk ut ?
-#: ../src/wxMaximaFrame.cpp:893
+#: ../src/wxMaximaFrame.cpp:892
 msgid "Get &Imaginary Part"
 msgstr "Finn &Imaginær Del"
 
-#: ../src/wxMaximaFrame.cpp:793
+#: ../src/wxMaximaFrame.cpp:792
 msgid "Get &Series..."
 msgstr "Finn Re&kke..."
 
-#: ../src/wxMaximaFrame.cpp:804
+#: ../src/wxMaximaFrame.cpp:803
 msgid "Get Laplace transformation of an expression"
 msgstr "Finn laplacetransformasjon av et uttrykk"
 
-#: ../src/wxMaximaFrame.cpp:890
+#: ../src/wxMaximaFrame.cpp:889
 msgid "Get Real P&art"
 msgstr "Finn &Reell Del"
 
-#: ../src/wxMaximaFrame.cpp:807
+#: ../src/wxMaximaFrame.cpp:806
 msgid "Get inverse Laplace transformation of an expression"
 msgstr "Finn invers laplacetransformasjon av et uttrykk"
 
-#: ../src/wxMaximaFrame.cpp:794
+#: ../src/wxMaximaFrame.cpp:793
 msgid "Get the Taylor or power series of expression"
 msgstr "Finn taylor- eller potensrekke fra uttrykk"
 
-#: ../src/wxMaximaFrame.cpp:894
+#: ../src/wxMaximaFrame.cpp:893
 msgid "Get the imaginary part of complex expression"
 msgstr "Finn imaginær del av et komplekst uttrykk"
 
-#: ../src/wxMaximaFrame.cpp:891
+#: ../src/wxMaximaFrame.cpp:890
 msgid "Get the real part of complex expression"
 msgstr "Finn reell del av et komplekst uttrykk"
 
-#: ../src/MathCtrl.cpp:5932
+#: ../src/MathCtrl.cpp:5984
 msgid ""
 "Got a request to undo an action that involves an delete which isn't possible "
 "at this moment."
@@ -2029,12 +2032,12 @@ msgstr ""
 msgid "Greek"
 msgstr "Gresk"
 
-#: ../src/wxMaximaFrame.cpp:356
+#: ../src/wxMaximaFrame.cpp:355
 #, fuzzy
 msgid "Greek Letters"
 msgstr "Greske konstanter"
 
-#: ../src/wxMaximaFrame.cpp:552
+#: ../src/wxMaximaFrame.cpp:551
 #, fuzzy
 msgid "Greek Letters\tAlt-Shift-G"
 msgstr "Generell Matte\tAlt-Shift-M"
@@ -2047,7 +2050,7 @@ msgstr "Greske konstanter"
 msgid "Grid:"
 msgstr "Rutenett:"
 
-#: ../src/wxMaxima.cpp:2836
+#: ../src/wxMaxima.cpp:2844
 #, fuzzy
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|pdfLaTeX file (*."
@@ -2062,12 +2065,12 @@ msgstr ""
 msgid "Help"
 msgstr "Hjelp"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 #, fuzzy
 msgid "Hide All Toolbars\tAlt-Shift--"
 msgstr "Gjem Alt\tAlt-Shift--"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide all panes"
 msgstr "Gjem alle inndelingsruter"
 
@@ -2075,19 +2078,19 @@ msgstr "Gjem alle inndelingsruter"
 msgid "Highlight (dpart)"
 msgstr "Fremhev (dpart)"
 
-#: ../src/wxMaxima.cpp:4685
+#: ../src/wxMaxima.cpp:4697
 msgid "Histogram"
 msgstr "Histogram"
 
-#: ../src/wxMaximaFrame.cpp:1270
+#: ../src/wxMaximaFrame.cpp:1269
 msgid "Histogram..."
 msgstr "Histogram..."
 
-#: ../src/wxMaximaFrame.cpp:309
+#: ../src/wxMaximaFrame.cpp:308
 msgid "History"
 msgstr "Historikk"
 
-#: ../src/wxMaximaFrame.cpp:555
+#: ../src/wxMaximaFrame.cpp:554
 #, fuzzy
 msgid "History\tAlt-Shift-I"
 msgstr "Historikk\tAlt-Shift-H"
@@ -2108,11 +2111,11 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Ungarsk"
 
-#: ../src/wxMaxima.cpp:3527
+#: ../src/wxMaxima.cpp:3539
 msgid "IC1"
 msgstr "IC1"
 
-#: ../src/wxMaxima.cpp:3543
+#: ../src/wxMaxima.cpp:3555
 msgid "IC2"
 msgstr "IC2"
 
@@ -2128,7 +2131,7 @@ msgid ""
 "same output cell."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:683
+#: ../src/wxMaximaFrame.cpp:682
 msgid ""
 "If maxima ever finishes evaluating without wxMaxima realizing this this menu "
 "item can force wxMaxima to try to send commands to maxima again."
@@ -2194,11 +2197,11 @@ msgstr ""
 "Om kalkulasjonen din tar for lang tid å utføre, kan du prøve 'Maxima-"
 ">Avbryt' eller 'Maxima->Restart Maxima' fra menyen."
 
-#: ../src/wxMaximaFrame.cpp:1499
+#: ../src/wxMaximaFrame.cpp:1518
 msgid "Image"
 msgstr "Bilde"
 
-#: ../src/wxMaxima.cpp:5644
+#: ../src/wxMaxima.cpp:5659
 msgid "Image files (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 msgstr "Bildefiler (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 
@@ -2225,7 +2228,7 @@ msgid ""
 "above it. Might increase readability for some fonts and short subscripts."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Include columns:"
 msgstr "Inkluder kolonner:"
 
@@ -2244,19 +2247,19 @@ msgstr ""
 msgid "Infinity"
 msgstr "Uendelig"
 
-#: ../src/wxMaximaFrame.cpp:974
+#: ../src/wxMaximaFrame.cpp:973
 msgid "Info about Maxima build"
 msgstr "Info om Maxima-build"
 
-#: ../src/wxMaxima.cpp:4207
+#: ../src/wxMaxima.cpp:4219
 msgid "Initial Estimates:"
 msgstr "Umiddelbare Estimat:"
 
-#: ../src/wxMaximaFrame.cpp:718
+#: ../src/wxMaximaFrame.cpp:717
 msgid "Initial Value Problem (&1)..."
 msgstr "Initialverdiproblem (&0)..."
 
-#: ../src/wxMaximaFrame.cpp:721
+#: ../src/wxMaximaFrame.cpp:720
 msgid "Initial Value Problem (&2)..."
 msgstr "Initialverdiproblem (&1)..."
 
@@ -2264,7 +2267,7 @@ msgstr "Initialverdiproblem (&1)..."
 msgid "Input labels"
 msgstr "Inndataetiketter"
 
-#: ../src/wxMaximaFrame.cpp:403
+#: ../src/wxMaximaFrame.cpp:402
 msgid "Insert"
 msgstr "Sett inn"
 
@@ -2272,98 +2275,98 @@ msgstr "Sett inn"
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr "Sett inn % før en operator ved begynnelsen av celler"
 
-#: ../src/wxMaximaFrame.cpp:612
+#: ../src/wxMaximaFrame.cpp:611
 msgid "Insert &Section Cell\tCtrl-3"
 msgstr "Sett Inn &Seksjoncelle\tCtrl-3"
 
-#: ../src/wxMaximaFrame.cpp:608
+#: ../src/wxMaximaFrame.cpp:607
 msgid "Insert &Text Cell\tCtrl-1"
 msgstr "Sett Inn &Tekstcelle\tCtrl-1"
 
-#: ../src/wxMaximaFrame.cpp:558
+#: ../src/wxMaximaFrame.cpp:557
 msgid "Insert Cell\tAlt-Shift-C"
 msgstr "Sett Inn Celle\tAlt-Shift-C"
 
-#: ../src/wxMaxima.cpp:5642
+#: ../src/wxMaxima.cpp:5657
 msgid "Insert Image"
 msgstr "Sett Inn Bilde"
 
-#: ../src/wxMaximaFrame.cpp:620
+#: ../src/wxMaximaFrame.cpp:619
 msgid "Insert Image..."
 msgstr "Sett Inn &Bilde..."
 
-#: ../src/wxMaximaFrame.cpp:606
+#: ../src/wxMaximaFrame.cpp:605
 msgid "Insert Input &Cell"
 msgstr "Sett Inn Inndata&celle"
 
-#: ../src/wxMaximaFrame.cpp:618
+#: ../src/wxMaximaFrame.cpp:617
 msgid "Insert Page Break"
 msgstr "Sett Inn S&ideskift"
 
-#: ../src/wxMaximaFrame.cpp:614
+#: ../src/wxMaximaFrame.cpp:613
 msgid "Insert S&ubsection Cell\tCtrl-4"
 msgstr "Sett Inn U&nderseksjoncelle\tCtrl-4"
 
-#: ../src/wxMaximaFrame.cpp:616
+#: ../src/wxMaximaFrame.cpp:615
 #, fuzzy
 msgid "Insert S&ubsubsection Cell\tCtrl-5"
 msgstr "Sett Inn U&nderseksjoncelle\tCtrl-4"
 
-#: ../src/MathCtrl.cpp:1015
+#: ../src/MathCtrl.cpp:1057
 msgid "Insert Section Cell"
 msgstr "Sett Inn Seksjoncelle"
 
-#: ../src/MathCtrl.cpp:1016
+#: ../src/MathCtrl.cpp:1058
 msgid "Insert Subsection Cell"
 msgstr "Sett Inn Underseksjoncelle"
 
-#: ../src/MathCtrl.cpp:1017
+#: ../src/MathCtrl.cpp:1059
 #, fuzzy
 msgid "Insert Subsubsection Cell"
 msgstr "Sett Inn Underseksjoncelle"
 
-#: ../src/wxMaximaFrame.cpp:610
+#: ../src/wxMaximaFrame.cpp:609
 msgid "Insert T&itle Cell\tCtrl-2"
 msgstr "Sett Inn &Tittelcelle\tCtrl-2"
 
-#: ../src/MathCtrl.cpp:1013
+#: ../src/MathCtrl.cpp:1055
 msgid "Insert Text Cell"
 msgstr "Sett Inn Tekstcelle"
 
-#: ../src/MathCtrl.cpp:1014
+#: ../src/MathCtrl.cpp:1056
 msgid "Insert Title Cell"
 msgstr "Sett Inn Tittelcelle"
 
-#: ../src/wxMaximaFrame.cpp:607
+#: ../src/wxMaximaFrame.cpp:606
 msgid "Insert a new input cell"
 msgstr "Sett inn ny inndatacelle"
 
-#: ../src/wxMaximaFrame.cpp:613
+#: ../src/wxMaximaFrame.cpp:612
 msgid "Insert a new section cell"
 msgstr "Sett inn ny seksjoncelle"
 
-#: ../src/wxMaximaFrame.cpp:615
+#: ../src/wxMaximaFrame.cpp:614
 msgid "Insert a new subsection cell"
 msgstr "Sett inn ny underseksjoncelle"
 
-#: ../src/wxMaximaFrame.cpp:617
+#: ../src/wxMaximaFrame.cpp:616
 #, fuzzy
 msgid "Insert a new subsubsection cell"
 msgstr "Sett inn ny underseksjoncelle"
 
-#: ../src/wxMaximaFrame.cpp:609
+#: ../src/wxMaximaFrame.cpp:608
 msgid "Insert a new text cell"
 msgstr "Sett inn ny tekstcelle"
 
-#: ../src/wxMaximaFrame.cpp:611
+#: ../src/wxMaximaFrame.cpp:610
 msgid "Insert a new title cell"
 msgstr "Sett inn ny tekstcelle"
 
-#: ../src/wxMaximaFrame.cpp:619
+#: ../src/wxMaximaFrame.cpp:618
 msgid "Insert a page break"
 msgstr "Sett inn et sideskift"
 
-#: ../src/wxMaximaFrame.cpp:621
+#: ../src/wxMaximaFrame.cpp:620
 msgid "Insert image"
 msgstr "Sett Inn Bilde"
 
@@ -2376,27 +2379,27 @@ msgstr ""
 msgid "Integral sign"
 msgstr "Integrer uttrykk"
 
-#: ../src/wxMaxima.cpp:3992
+#: ../src/wxMaxima.cpp:4004
 msgid "Integral/Sum:"
 msgstr "Integral/Sum:"
 
-#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4105 ../src/wxMaxima.cpp:5051
+#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4117 ../src/wxMaxima.cpp:5063
 msgid "Integrate"
 msgstr "Integrer"
 
-#: ../src/wxMaxima.cpp:4091
+#: ../src/wxMaxima.cpp:4103
 msgid "Integrate (risch)"
 msgstr "Integrer (risch)"
 
-#: ../src/wxMaximaFrame.cpp:778
+#: ../src/wxMaximaFrame.cpp:777
 msgid "Integrate expression"
 msgstr "Integrer uttrykk"
 
-#: ../src/wxMaximaFrame.cpp:780
+#: ../src/wxMaximaFrame.cpp:779
 msgid "Integrate expression with Risch algorithm"
 msgstr "Integrer uttrykk med Risch algoritme"
 
-#: ../src/wxMaximaFrame.cpp:1224 ../src/MathCtrl.cpp:1000
+#: ../src/MathCtrl.cpp:1042 ../src/wxMaximaFrame.cpp:1223
 msgid "Integrate..."
 msgstr "Integrer..."
 
@@ -2404,7 +2407,7 @@ msgstr "Integrer..."
 msgid "Interrupt"
 msgstr "Avbryt"
 
-#: ../src/wxMaximaFrame.cpp:646 ../src/wxMaximaFrame.cpp:650
+#: ../src/wxMaximaFrame.cpp:645 ../src/wxMaximaFrame.cpp:649
 msgid "Interrupt current computation"
 msgstr "Avbryt løpende kalkulasjon"
 
@@ -2424,15 +2427,15 @@ msgstr ""
 "\n"
 "Vennligst oppgi banen til Maxima-programmet igjen."
 
-#: ../src/wxMaxima.cpp:4137
+#: ../src/wxMaxima.cpp:4149
 msgid "Inverse Laplace"
 msgstr "Invers Laplace"
 
-#: ../src/wxMaximaFrame.cpp:806
+#: ../src/wxMaximaFrame.cpp:805
 msgid "Inverse Laplace T&ransform..."
 msgstr "I&nvers Laplacetransformasjon..."
 
-#: ../src/wxMaximaFrame.cpp:1372
+#: ../src/wxMaximaFrame.cpp:1371
 msgid "Iota"
 msgstr ""
 
@@ -2466,7 +2469,7 @@ msgstr "Japansk"
 msgid "Kabyle"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1373
+#: ../src/wxMaximaFrame.cpp:1372
 msgid "Kappa"
 msgstr ""
 
@@ -2475,7 +2478,7 @@ msgstr ""
 msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr "Behold prosenttegn ved spesielle symbol: %e, %i, etc."
 
-#: ../src/wxMaxima.cpp:4031
+#: ../src/wxMaxima.cpp:4043
 msgid "LCM"
 msgstr "MFM"
 
@@ -2491,7 +2494,7 @@ msgstr ""
 msgid "Label width:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1374
+#: ../src/wxMaximaFrame.cpp:1373
 msgid "Lambda"
 msgstr ""
 
@@ -2503,11 +2506,11 @@ msgstr "Språk brukt til wxMaxima GUI."
 msgid "Language:"
 msgstr "Språk:"
 
-#: ../src/wxMaxima.cpp:4120
+#: ../src/wxMaxima.cpp:4132
 msgid "Laplace"
 msgstr "Laplace"
 
-#: ../src/wxMaximaFrame.cpp:803
+#: ../src/wxMaximaFrame.cpp:802
 msgid "Laplace &Transform..."
 msgstr "Laplace&transformer..."
 
@@ -2515,15 +2518,15 @@ msgstr "Laplace&transformer..."
 msgid "Leads to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:812
+#: ../src/wxMaximaFrame.cpp:811
 msgid "Least Common Multiple..."
 msgstr "&Minste Felles Multiplum..."
 
-#: ../src/wxMaxima.cpp:4809
+#: ../src/wxMaxima.cpp:4821
 msgid "Least Squares Fit"
 msgstr "Minste Kvadraters Metode"
 
-#: ../src/wxMaximaFrame.cpp:1266
+#: ../src/wxMaximaFrame.cpp:1265
 msgid "Least Squares Fit..."
 msgstr "Minste Kvadraters Metode..."
 
@@ -2534,24 +2537,24 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4192
+#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4204
 msgid "Limit"
 msgstr "Grenseverdi"
 
-#: ../src/wxMaximaFrame.cpp:1225
+#: ../src/wxMaximaFrame.cpp:1224
 msgid "Limit..."
 msgstr "Grenseverdi..."
 
-#: ../src/wxMaximaFrame.cpp:1265
+#: ../src/wxMaximaFrame.cpp:1264
 msgid "Linear Regression..."
 msgstr "Lineær Regresjon..."
 
-#: ../src/wxMaxima.cpp:3803
+#: ../src/wxMaxima.cpp:3815
 #, fuzzy
 msgid "List(s):"
 msgstr "Liste:"
 
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3848
 msgid "List:"
 msgstr "Liste:"
 
@@ -2559,15 +2562,15 @@ msgstr "Liste:"
 msgid "Load"
 msgstr "Last"
 
-#: ../src/wxMaxima.cpp:2932
+#: ../src/wxMaxima.cpp:2940
 msgid "Load Package"
 msgstr "Last Pakke"
 
-#: ../src/wxMaximaFrame.cpp:479
+#: ../src/wxMaximaFrame.cpp:478
 msgid "Load a Maxima file using the batch command"
 msgstr "Last en Maxima-fil ved bruk av batch-kommandoen"
 
-#: ../src/wxMaximaFrame.cpp:477
+#: ../src/wxMaximaFrame.cpp:476
 msgid "Load a Maxima package file"
 msgstr "Last en Maxima-pakkefil"
 
@@ -2579,49 +2582,49 @@ msgstr "Last en stil fra fil"
 msgid "Long Right arrow"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Lower bound:"
 msgstr "Nedre grense:"
 
-#: ../src/wxMaximaFrame.cpp:771
+#: ../src/wxMaximaFrame.cpp:770
 msgid "Ma&p to Matrix..."
 msgstr "Av&bild Matrise..."
 
-#: ../src/wxMaximaFrame.cpp:547
+#: ../src/wxMaximaFrame.cpp:546
 #, fuzzy
 msgid "Main Toolbar\tAlt-Shift-B"
 msgstr "Verktøylinje\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:765
+#: ../src/wxMaximaFrame.cpp:764
 msgid "Make &List..."
 msgstr "Lag &Liste..."
 
-#: ../src/wxMaxima.cpp:3821
+#: ../src/wxMaxima.cpp:3833
 msgid "Make list"
 msgstr "Lag liste"
 
-#: ../src/wxMaximaFrame.cpp:766
+#: ../src/wxMaximaFrame.cpp:765
 msgid "Make list from expression"
 msgstr "Lag liste fra uttrykk"
 
-#: ../src/wxMaximaFrame.cpp:907
+#: ../src/wxMaximaFrame.cpp:906
 msgid "Make substitution in expression"
 msgstr "Gjør utbyttelse i uttrykk"
 
-#: ../src/wxMaximaFrame.cpp:682
+#: ../src/wxMaximaFrame.cpp:681
 #, fuzzy
 msgid "Manually Trigger Evaluation"
 msgstr "Vis brukt tid ved utførelse"
 
-#: ../src/wxMaxima.cpp:3805
+#: ../src/wxMaxima.cpp:3817
 msgid "Map"
 msgstr "Avbild"
 
-#: ../src/wxMaximaFrame.cpp:770
+#: ../src/wxMaximaFrame.cpp:769
 msgid "Map function to a list"
 msgstr "Anvend funksjon på en liste"
 
-#: ../src/wxMaximaFrame.cpp:772
+#: ../src/wxMaximaFrame.cpp:771
 msgid "Map function to a matrix"
 msgstr "Anvend funksjon på en matrise"
 
@@ -2638,23 +2641,23 @@ msgstr "Samsvar parenteser i tekstkontroller"
 msgid "Math font:"
 msgstr "Matematikkfont:"
 
-#: ../src/wxMaximaFrame.cpp:374
+#: ../src/wxMaximaFrame.cpp:373
 msgid "Mathematical Symbols"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3716
+#: ../src/wxMaxima.cpp:3728
 msgid "Matrix"
 msgstr "Matrise"
 
-#: ../src/wxMaxima.cpp:3702
+#: ../src/wxMaxima.cpp:3714
 msgid "Matrix map"
 msgstr "Matrisemapping"
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Matrix name:"
 msgstr "Matrisenavn:"
 
-#: ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3749
+#: ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3761
 msgid "Matrix:"
 msgstr "Matrise:"
 
@@ -2662,7 +2665,7 @@ msgstr "Matrise:"
 msgid "Maxima"
 msgstr "Maxima"
 
-#: ../src/wxMaximaFrame.cpp:137
+#: ../src/wxMaximaFrame.cpp:136
 #, fuzzy
 msgid "Maxima has a question"
 msgstr "Maxima-spørsmål"
@@ -2671,24 +2674,24 @@ msgstr "Maxima-spørsmål"
 msgid "Maxima input"
 msgstr "Maxima-inndata"
 
-#: ../src/wxMaximaFrame.cpp:166
+#: ../src/wxMaximaFrame.cpp:165
 msgid "Maxima is calculating"
 msgstr "Maxima kalkulerer"
 
-#: ../src/wxMaximaFrame.cpp:111
+#: ../src/wxMaximaFrame.cpp:110
 #, fuzzy
 msgid "Maxima is ready for input."
 msgstr "Maxima-inndata"
 
-#: ../src/wxMaxima.cpp:2945
+#: ../src/wxMaxima.cpp:2953
 msgid "Maxima package (*.mac)|*.mac"
 msgstr "Maxima-pakke (*.mac)|*.mac"
 
-#: ../src/wxMaxima.cpp:2934
+#: ../src/wxMaxima.cpp:2942
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr "Maxima-pakke (*.mac)|*.mac|Lisp-pakke (*.lisp)|*.lisp|Alle|*"
 
-#: ../src/wxMaxima.cpp:1014
+#: ../src/wxMaxima.cpp:1019
 msgid "Maxima process terminated."
 msgstr "Maxima-prosess avsluttet."
 
@@ -2700,7 +2703,7 @@ msgstr "Maxima-program:"
 msgid "Maxima questions"
 msgstr "Maxima-spørsmål"
 
-#: ../src/wxMaxima.cpp:942
+#: ../src/wxMaxima.cpp:947
 msgid "Maxima started. Waiting for connection..."
 msgstr "Maxima startet. Venter på tilkobling..."
 
@@ -2724,7 +2727,7 @@ msgstr ""
 "Maxima bruker ':' for å sette verdier ( 'a : 3;' ) og ':=' for å definere "
 "funksjoner ( 'f(x) := x^2;' )."
 
-#: ../src/wxMaxima.cpp:4597
+#: ../src/wxMaxima.cpp:4609
 msgid "Maxima version: "
 msgstr "Maxima-versjon:"
 
@@ -2762,42 +2765,42 @@ msgid "Maximum displayed number of digits:"
 msgstr ""
 
 # oversetter er ikke kjent med 'mean'-stuff. gi lyd om du vet bedre.
-#: ../src/wxMaximaFrame.cpp:1263
+#: ../src/wxMaximaFrame.cpp:1262
 msgid "Mean Difference Test..."
 msgstr "Mean Difference Test..."
 
-#: ../src/wxMaximaFrame.cpp:1262
+#: ../src/wxMaximaFrame.cpp:1261
 msgid "Mean Test..."
 msgstr "Mean Test..."
 
-#: ../src/wxMaximaFrame.cpp:1255
+#: ../src/wxMaximaFrame.cpp:1254
 #, fuzzy
 msgid "Mean..."
 msgstr "Gjennomsnitt..."
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 #, fuzzy
 msgid "Mean:"
 msgstr "Gjennomsnitt:"
 
-#: ../src/wxMaximaFrame.cpp:1256
+#: ../src/wxMaximaFrame.cpp:1255
 msgid "Median..."
 msgstr "Median..."
 
-#: ../src/MathCtrl.cpp:945
+#: ../src/MathCtrl.cpp:987
 msgid "Merge Cells"
 msgstr "Slå Sammen Celler"
 
-#: ../src/wxMaximaFrame.cpp:633
+#: ../src/wxMaximaFrame.cpp:632
 #, fuzzy
 msgid "Merge Cells\tCtrl-M"
 msgstr "Slå Sammen Celler"
 
-#: ../src/wxMaximaFrame.cpp:634
+#: ../src/wxMaximaFrame.cpp:633
 msgid "Merge the text from two input cells into one"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2668
+#: ../src/wxMaxima.cpp:2676
 msgid "Message from the stdout of Maxima: "
 msgstr ""
 
@@ -2805,20 +2808,20 @@ msgstr ""
 msgid "Method:"
 msgstr "Metode:"
 
-#: ../src/wxMaxima.cpp:5289
+#: ../src/wxMaxima.cpp:5301
 #, fuzzy
 msgid "Mismatched parenthesis"
 msgstr "Samsvar parenteser i tekstkontroller"
 
-#: ../src/wxMaxima.cpp:3972
+#: ../src/wxMaxima.cpp:3984
 msgid "Modulus"
 msgstr "Modulo"
 
-#: ../src/wxMaximaFrame.cpp:1375
+#: ../src/wxMaximaFrame.cpp:1374
 msgid "Mu"
 msgstr ""
 
-#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Name:"
 msgstr "Navn:"
 
@@ -2826,7 +2829,7 @@ msgstr "Navn:"
 msgid "New"
 msgstr "Ny"
 
-#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
+#: ../src/wxMaximaFrame.cpp:456 ../src/wxMaximaFrame.cpp:459
 msgid "New\tCtrl-N"
 msgstr "&Ny\tCtrl-N"
 
@@ -2842,11 +2845,11 @@ msgstr ""
 msgid "New value:"
 msgstr "Ny verdi:"
 
-#: ../src/wxMaxima.cpp:3993 ../src/wxMaxima.cpp:4119 ../src/wxMaxima.cpp:4136
+#: ../src/wxMaxima.cpp:4005 ../src/wxMaxima.cpp:4131 ../src/wxMaxima.cpp:4148
 msgid "New variable:"
 msgstr "Ny variabel:"
 
-#: ../src/wxMaximaFrame.cpp:630
+#: ../src/wxMaximaFrame.cpp:629
 msgid "Next Command\tAlt-Down"
 msgstr "Neste Kommando\tAlt-Down"
 
@@ -2854,15 +2857,15 @@ msgstr "Neste Kommando\tAlt-Down"
 msgid "No"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5362
+#: ../src/wxMaxima.cpp:5378
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3249 ../src/wxMaxima.cpp:3271
+#: ../src/wxMaxima.cpp:3260 ../src/wxMaxima.cpp:3283
 msgid "No matches found!"
 msgstr "Ingen treff funnet!"
 
-#: ../src/wxMaximaFrame.cpp:1264
+#: ../src/wxMaximaFrame.cpp:1263
 msgid "Normality Test..."
 msgstr "Normalitetstest..."
 
@@ -2885,34 +2888,34 @@ msgstr ""
 msgid "Norwegian"
 msgstr "Norsk"
 
-#: ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:3740
 msgid "Not a valid matrix dimension!"
 msgstr "Ikke en gyldig matrisedimensjon!"
 
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629
 msgid "Not a valid number of equations!"
 msgstr "Ikke et gyldig antall likninger!"
 
-#: ../src/wxMaximaFrame.cpp:197
+#: ../src/wxMaximaFrame.cpp:196
 #, fuzzy
 msgid "Not connected to maxima"
 msgstr ""
 "\n"
 "Ikke tilkoblet Maxima!\n"
 
-#: ../src/wxMaxima.cpp:4599
+#: ../src/wxMaxima.cpp:4611
 msgid "Not connected."
 msgstr "Ikke tilkoblet."
 
-#: ../src/wxMaximaFrame.cpp:1376
+#: ../src/wxMaximaFrame.cpp:1375
 msgid "Nu"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Num. deg:"
 msgstr "Tellergrad:"
 
-#: ../src/wxMaxima.cpp:3585 ../src/wxMaxima.cpp:3609
+#: ../src/wxMaxima.cpp:3597 ../src/wxMaxima.cpp:3621
 msgid "Number of equations:"
 msgstr "Antall likninger:"
 
@@ -2939,15 +2942,15 @@ msgstr "OK"
 msgid "Old value:"
 msgstr "Forrige verdi:"
 
-#: ../src/wxMaxima.cpp:3992 ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135
+#: ../src/wxMaxima.cpp:4004 ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147
 msgid "Old variable:"
 msgstr "Forrige variabel:"
 
-#: ../src/wxMaximaFrame.cpp:1387
+#: ../src/wxMaximaFrame.cpp:1386
 msgid "Omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1378
+#: ../src/wxMaximaFrame.cpp:1377
 msgid "Omicron"
 msgstr ""
 
@@ -2961,20 +2964,20 @@ msgid ""
 "stream for messages."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4763
+#: ../src/wxMaxima.cpp:4775
 msgid "One sample t-test"
 msgstr "Enmålings t-test"
 
-#: ../src/wxMaximaFrame.cpp:971
+#: ../src/wxMaximaFrame.cpp:970
 msgid "Online tutorials"
 msgstr "Internett holder åpen buffet på læreressurser :D"
 
 #: ../src/ConfigDialogue.cpp:656 ../src/main.cpp:347 ../src/ToolBar.cpp:119
-#: ../src/wxMaxima.cpp:2797
+#: ../src/wxMaxima.cpp:2805
 msgid "Open"
 msgstr "Åpne"
 
-#: ../src/wxMaximaFrame.cpp:466
+#: ../src/wxMaximaFrame.cpp:465
 msgid "Open Recent"
 msgstr "Åpne N&ylig"
 
@@ -2982,11 +2985,11 @@ msgstr "Åpne N&ylig"
 msgid "Open a cell when Maxima expects input"
 msgstr "Åpne en celle når Maxima forventer inndata"
 
-#: ../src/wxMaximaFrame.cpp:464
+#: ../src/wxMaximaFrame.cpp:463
 msgid "Open a document"
 msgstr "Åpne et dokument"
 
-#: ../src/wxMaximaFrame.cpp:458 ../src/wxMaximaFrame.cpp:461
+#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
 msgid "Open a new window"
 msgstr "Åpne et nytt vindu"
 
@@ -2994,11 +2997,11 @@ msgstr "Åpne et nytt vindu"
 msgid "Open document"
 msgstr "Åpne dokument"
 
-#: ../src/wxMaxima.cpp:4824
+#: ../src/wxMaxima.cpp:4836
 msgid "Open matrix"
 msgstr "Åpne matrise"
 
-#: ../src/wxMaxima.cpp:1446 ../src/wxMaxima.cpp:1518
+#: ../src/wxMaxima.cpp:1451 ../src/wxMaxima.cpp:1523
 msgid "Opening file"
 msgstr "Åpne fil"
 
@@ -3022,11 +3025,11 @@ msgstr "Utdaterte celler"
 msgid "Output labels"
 msgstr "Utdataetiketter"
 
-#: ../src/wxMaximaFrame.cpp:796
+#: ../src/wxMaximaFrame.cpp:795
 msgid "P&ade Approximation..."
 msgstr "&Padétilnærming..."
 
-#: ../src/wxMaxima.cpp:3132 ../src/wxMaxima.cpp:5133
+#: ../src/wxMaxima.cpp:3141 ../src/wxMaxima.cpp:5145
 #, fuzzy
 msgid ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
@@ -3036,15 +3039,15 @@ msgstr ""
 "PNG-bilde (*.png)|*.png|JPEG-bilde (*.jpg)|*.jpg|Windows-bitmap (*.bmp)|*."
 "bmp|X-pixmap (*.xpm)|*.xpm"
 
-#: ../src/wxMaxima.cpp:4012
+#: ../src/wxMaxima.cpp:4024
 msgid "Pade approximation"
 msgstr "Padétilnærming"
 
-#: ../src/wxMaximaFrame.cpp:797
+#: ../src/wxMaximaFrame.cpp:796
 msgid "Pade approximation of a Taylor series"
 msgstr "Padétilnærming av en taylorrekke"
 
-#: ../src/wxMaximaFrame.cpp:1500
+#: ../src/wxMaximaFrame.cpp:1519
 msgid "Pagebreak"
 msgstr "Sideskift"
 
@@ -3057,19 +3060,19 @@ msgid "Parametric plot"
 msgstr "Parametrisk Plott"
 
 # s/Kjemmer/Går igjennom, men ikke like gøy? :)
-#: ../src/wxMaximaFrame.cpp:188
+#: ../src/wxMaximaFrame.cpp:187
 msgid "Parsing output"
 msgstr "Kjemmer utdata"
 
-#: ../src/wxMaximaFrame.cpp:819
+#: ../src/wxMaximaFrame.cpp:818
 msgid "Partial &Fractions..."
 msgstr "D&elbrøker..."
 
-#: ../src/wxMaxima.cpp:4076
+#: ../src/wxMaxima.cpp:4088
 msgid "Partial fractions"
 msgstr "Delbrøker"
 
-#: ../src/wxMaxima.cpp:1769
+#: ../src/wxMaxima.cpp:1774
 msgid "Parts of the document will not be loaded correctly!"
 msgstr "Deler av dokumentet vil ikke bli lastet riktig!"
 
@@ -3080,11 +3083,11 @@ msgid ""
 "Found unknown XML Tag name "
 msgstr "Deler av dokumentet vil ikke bli lastet riktig!"
 
-#: ../src/ToolBar.cpp:143 ../src/MathCtrl.cpp:1010 ../src/MathCtrl.cpp:1025
+#: ../src/MathCtrl.cpp:1052 ../src/MathCtrl.cpp:1067 ../src/ToolBar.cpp:143
 msgid "Paste"
 msgstr "Lim inn"
 
-#: ../src/wxMaximaFrame.cpp:518
+#: ../src/wxMaximaFrame.cpp:517
 msgid "Paste\tCtrl-V"
 msgstr "Lim Inn\tCtrl-V"
 
@@ -3092,7 +3095,7 @@ msgstr "Lim Inn\tCtrl-V"
 msgid "Paste from clipboard"
 msgstr "Lim inn fra utklippstavle"
 
-#: ../src/wxMaximaFrame.cpp:519
+#: ../src/wxMaximaFrame.cpp:518
 msgid "Paste text from clipboard"
 msgstr "Lim inn tekst fra utklippstavle"
 
@@ -3100,19 +3103,19 @@ msgstr "Lim inn tekst fra utklippstavle"
 msgid "Perpendicular to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1384
+#: ../src/wxMaximaFrame.cpp:1383
 msgid "Phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1379
+#: ../src/wxMaximaFrame.cpp:1378
 msgid "Pi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1273
+#: ../src/wxMaximaFrame.cpp:1272
 msgid "Piechart..."
 msgstr "Kakediagram..."
 
-#: ../src/wxMaxima.cpp:1952
+#: ../src/wxMaxima.cpp:1957
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr "Vennligst konfigurer wxMaxima med 'Endre->Konfigurer'."
 
@@ -3120,52 +3123,52 @@ msgstr "Vennligst konfigurer wxMaxima med 'Endre->Konfigurer'."
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr "Vennligst restart wxMaxima for at endringene skal tre i kraft!"
 
-#: ../src/wxMaximaFrame.cpp:923
+#: ../src/wxMaximaFrame.cpp:922
 msgid "Plot &2d..."
 msgstr "Plott &2D..."
 
-#: ../src/wxMaximaFrame.cpp:925
+#: ../src/wxMaximaFrame.cpp:924
 msgid "Plot &3d..."
 msgstr "Plott &3D..."
 
-#: ../src/wxMaximaFrame.cpp:927
+#: ../src/wxMaximaFrame.cpp:926
 msgid "Plot &Format..."
 msgstr "Plott&format..."
 
 #: ../src/Plot2dWiz.cpp:104 ../src/Plot2dWiz.cpp:450 ../src/Plot2dWiz.cpp:464
-#: ../src/wxMaxima.cpp:4283 ../src/wxMaxima.cpp:5102
+#: ../src/wxMaxima.cpp:4295 ../src/wxMaxima.cpp:5114
 msgid "Plot 2D"
 msgstr "Plott 2D"
 
-#: ../src/wxMaximaFrame.cpp:1227
+#: ../src/wxMaximaFrame.cpp:1226
 msgid "Plot 2D..."
 msgstr "Plott 2D..."
 
-#: ../src/MathCtrl.cpp:1003
+#: ../src/MathCtrl.cpp:1045
 msgid "Plot 2d..."
 msgstr "Plott 2D..."
 
-#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4269 ../src/wxMaxima.cpp:5115
+#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4281 ../src/wxMaxima.cpp:5127
 msgid "Plot 3D"
 msgstr "Plott 3D"
 
-#: ../src/wxMaximaFrame.cpp:1228
+#: ../src/wxMaximaFrame.cpp:1227
 msgid "Plot 3D..."
 msgstr "Plott 3D..."
 
-#: ../src/MathCtrl.cpp:1004
+#: ../src/MathCtrl.cpp:1046
 msgid "Plot 3d..."
 msgstr "Plott 3D..."
 
-#: ../src/wxMaxima.cpp:4296
+#: ../src/wxMaxima.cpp:4308
 msgid "Plot format"
 msgstr "Plottformat"
 
-#: ../src/wxMaximaFrame.cpp:924
+#: ../src/wxMaximaFrame.cpp:923
 msgid "Plot in 2 dimensions"
 msgstr "Plott i 2 dimensjoner"
 
-#: ../src/wxMaximaFrame.cpp:926
+#: ../src/wxMaximaFrame.cpp:925
 msgid "Plot in 3 dimensions"
 msgstr "Plott i 3 dimensjoner"
 
@@ -3174,8 +3177,8 @@ msgid "Plot to file:"
 msgstr "Plott til fil:"
 
 #: ../src/BC2Wiz.cpp:30 ../src/BC2Wiz.cpp:36 ../src/LimitWiz.cpp:33
-#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
-#: ../src/wxMaxima.cpp:3648
+#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
+#: ../src/wxMaxima.cpp:3660
 msgid "Point:"
 msgstr "Punkt:"
 
@@ -3183,11 +3186,11 @@ msgstr "Punkt:"
 msgid "Polish"
 msgstr "Polsk"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 1:"
 msgstr "Polynom 0:"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 2:"
 msgstr "Polynom 1:"
 
@@ -3199,11 +3202,11 @@ msgstr "Portugisisk (brasiliansk)"
 msgid "Postscript file (*.eps)|*.eps|All|*"
 msgstr "Postscript-fil (*.eps)|*.eps|Alle|*"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Precision"
 msgstr "Presisjon"
 
-#: ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:536
 msgid "Preferences...\tCtrl+,"
 msgstr "Preferanser...\tCtrl+,"
 
@@ -3215,7 +3218,7 @@ msgid ""
 "packages and from functions that are defined in the current file."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:628
+#: ../src/wxMaximaFrame.cpp:627
 msgid "Previous Command\tAlt-Up"
 msgstr "Forrige Kommando\tAlt-Up"
 
@@ -3223,11 +3226,11 @@ msgstr "Forrige Kommando\tAlt-Up"
 msgid "Print"
 msgstr "Skriv ut"
 
-#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:484
+#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:483
 msgid "Print document"
 msgstr "Skriv ut dokument"
 
-#: ../src/wxMaxima.cpp:4242
+#: ../src/wxMaxima.cpp:4254
 msgid "Product"
 msgstr "Produkt"
 
@@ -3236,36 +3239,36 @@ msgstr "Produkt"
 msgid "Product sign"
 msgstr "Produkt"
 
-#: ../src/wxMaximaFrame.cpp:1386
+#: ../src/wxMaximaFrame.cpp:1385
 msgid "Psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:331
+#: ../src/wxMaximaFrame.cpp:330
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:592
+#: ../src/wxMaximaFrame.cpp:591
 #, fuzzy
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr "Utfør alle celler i dokument"
 
-#: ../src/wxMaximaFrame.cpp:1278
+#: ../src/wxMaximaFrame.cpp:1277
 msgid "Read Matrix..."
 msgstr "Les Matrise..."
 
-#: ../src/wxMaximaFrame.cpp:177
+#: ../src/wxMaximaFrame.cpp:176
 msgid "Reading Maxima output"
 msgstr "Leser Maxima-utdata"
 
-#: ../src/wxMaximaFrame.cpp:153
+#: ../src/wxMaximaFrame.cpp:152
 msgid "Ready for user input"
 msgstr "Klar for brukerinndata"
 
-#: ../src/wxMaximaFrame.cpp:631
+#: ../src/wxMaximaFrame.cpp:630
 msgid "Recall next command from history"
 msgstr "Hent frem neste kommando fra historikk"
 
-#: ../src/wxMaximaFrame.cpp:629
+#: ../src/wxMaximaFrame.cpp:628
 msgid "Recall previous command from history"
 msgstr "Hent frem forrige kommando fra historikk"
 
@@ -3273,36 +3276,36 @@ msgstr "Hent frem forrige kommando fra historikk"
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1215
+#: ../src/wxMaximaFrame.cpp:1214
 msgid "Rectform"
 msgstr "Rekt. form"
 
-#: ../src/wxMaximaFrame.cpp:495
+#: ../src/wxMaximaFrame.cpp:494
 #, fuzzy
 msgid "Redo\tCtrl-Y"
 msgstr "Angre\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:496
+#: ../src/wxMaximaFrame.cpp:495
 msgid "Redo last change"
 msgstr "Gjør om igjen den siste endringen du angret"
 
-#: ../src/wxMaximaFrame.cpp:1220
+#: ../src/wxMaximaFrame.cpp:1219
 msgid "Reduce (tr)"
 msgstr "Reduser (tr)"
 
-#: ../src/wxMaximaFrame.cpp:871
+#: ../src/wxMaximaFrame.cpp:870
 msgid "Reduce trigonometric expression"
 msgstr "Reduser trigonometrisk uttrykk"
 
-#: ../src/wxMaxima.cpp:622 ../src/wxMaxima.cpp:5495
+#: ../src/wxMaxima.cpp:627 ../src/wxMaxima.cpp:5511
 msgid "Refusing to send cell to maxima: "
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:594
+#: ../src/wxMaximaFrame.cpp:593
 msgid "Remove All Output"
 msgstr "&Fjern All Utdata"
 
-#: ../src/wxMaximaFrame.cpp:595
+#: ../src/wxMaximaFrame.cpp:594
 msgid "Remove output from input cells"
 msgstr "Fjern utdata fra inndataceller"
 
@@ -3311,7 +3314,7 @@ msgstr "Fjern utdata fra inndataceller"
 msgid "Replace All"
 msgstr "Velg Alle"
 
-#: ../src/wxMaxima.cpp:3282
+#: ../src/wxMaxima.cpp:3294
 #, c-format
 msgid "Replaced %d occurrences."
 msgstr "Erstattet %d forekomster."
@@ -3320,11 +3323,11 @@ msgstr "Erstattet %d forekomster."
 msgid "Replacement:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:976
+#: ../src/wxMaximaFrame.cpp:975
 msgid "Report bug"
 msgstr "Rapporter feil"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "Restart Maxima"
 msgstr "Restart Maxima"
 
@@ -3333,7 +3336,7 @@ msgstr "Restart Maxima"
 msgid "Restart maxima"
 msgstr "Restart Maxima"
 
-#: ../src/MathCtrl.cpp:4442
+#: ../src/MathCtrl.cpp:4497
 msgid "Result"
 msgstr ""
 
@@ -3341,7 +3344,7 @@ msgstr ""
 msgid "Return to the cell that is currently being evaluated"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1380
+#: ../src/wxMaximaFrame.cpp:1379
 msgid "Rho"
 msgstr ""
 
@@ -3349,19 +3352,19 @@ msgstr ""
 msgid "Right arrow"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:779
+#: ../src/wxMaximaFrame.cpp:778
 msgid "Risch Integration..."
 msgstr "&Rischintegrasjon..."
 
-#: ../src/wxMaximaFrame.cpp:694
+#: ../src/wxMaximaFrame.cpp:693
 msgid "Roots of &Polynomial"
 msgstr "&Røtter til Polynom"
 
-#: ../src/wxMaximaFrame.cpp:697
+#: ../src/wxMaximaFrame.cpp:696
 msgid "Roots of Polynomial (bfloat)"
 msgstr "&Røtter til Polynom (bigfloat)"
 
-#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Rows:"
 msgstr "Rader:"
 
@@ -3369,56 +3372,56 @@ msgstr "Rader:"
 msgid "Russian"
 msgstr "Russisk"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 1:"
 msgstr "Måling 0:"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 2:"
 msgstr "Måling 1:"
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Sample:"
 msgstr "Måling:"
 
 #: ../src/ConfigDialogue.cpp:781 ../src/ToolBar.cpp:122
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Save"
 msgstr "Lagre"
 
-#: ../src/MathCtrl.cpp:921
+#: ../src/MathCtrl.cpp:963
 msgid "Save Animation..."
 msgstr "Lagre Animasjon..."
 
-#: ../src/wxMaxima.cpp:2565
+#: ../src/wxMaxima.cpp:2572
 msgid "Save As"
 msgstr "Lagre Som"
 
-#: ../src/wxMaximaFrame.cpp:474
+#: ../src/wxMaximaFrame.cpp:473
 msgid "Save As...\tShift-Ctrl-S"
 msgstr "Lagre &Som...\tShift-Ctrl-S"
 
-#: ../src/MathCtrl.cpp:919
+#: ../src/MathCtrl.cpp:961
 msgid "Save Image..."
 msgstr "Lagre Bilde..."
 
-#: ../src/wxMaxima.cpp:3130
+#: ../src/wxMaxima.cpp:3139
 msgid "Save Selection to Image"
 msgstr "Lagre Utvalg til Bilde"
 
-#: ../src/wxMaximaFrame.cpp:528
+#: ../src/wxMaximaFrame.cpp:527
 msgid "Save Selection to Image..."
 msgstr "Lagre Utvalg til &Bilde..."
 
-#: ../src/wxMaxima.cpp:5150
+#: ../src/wxMaxima.cpp:5162
 msgid "Save animation to file"
 msgstr "Lagre animasjon til fil"
 
-#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:473
+#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:472
 msgid "Save document"
 msgstr "Lagre dokument"
 
-#: ../src/wxMaximaFrame.cpp:475
+#: ../src/wxMaximaFrame.cpp:474
 msgid "Save document as"
 msgstr "Lagre dokument som"
 
@@ -3440,11 +3443,11 @@ msgstr "Lagre inndelingsvindu-layout mellom økter."
 msgid "Save plot to file"
 msgstr "Lagre plott til fil"
 
-#: ../src/wxMaximaFrame.cpp:529
+#: ../src/wxMaximaFrame.cpp:528
 msgid "Save selection from document to an image file"
 msgstr "Lagre utvalg fra dokument til en bildefil"
 
-#: ../src/wxMaxima.cpp:5131
+#: ../src/wxMaxima.cpp:5143
 msgid "Save selection to file"
 msgstr "Lagre utvalg til fil"
 
@@ -3460,28 +3463,28 @@ msgstr "Lagre wxMaximas vindusstørrelse/-posisjon"
 msgid "Save wxMaxima window size/position between sessions."
 msgstr "Lagre wxMaximas vindusstørrelse/-posisjon mellom økter."
 
-#: ../src/wxMaximaFrame.cpp:246
+#: ../src/wxMaximaFrame.cpp:245
 #, fuzzy
 msgid "Saving failed."
 msgstr "Klarte ikke starte server"
 
-#: ../src/wxMaximaFrame.cpp:222
+#: ../src/wxMaximaFrame.cpp:221
 msgid "Saving successful."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:212
+#: ../src/wxMaximaFrame.cpp:211
 msgid "Saving..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4699
+#: ../src/wxMaxima.cpp:4711
 msgid "Scatterplot"
 msgstr "Spredningsplott"
 
-#: ../src/wxMaximaFrame.cpp:1271
+#: ../src/wxMaximaFrame.cpp:1270
 msgid "Scatterplot..."
 msgstr "Spredningsplott..."
 
-#: ../src/wxMaximaFrame.cpp:1498
+#: ../src/wxMaximaFrame.cpp:1517
 msgid "Section"
 msgstr "Seksjon"
 
@@ -3489,26 +3492,26 @@ msgstr "Seksjon"
 msgid "Section cell"
 msgstr "Seksjoncelle"
 
-#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:292 ../src/TextCell.cpp:306
-#: ../src/TextCell.cpp:322 ../src/TextCell.cpp:334
+#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:290 ../src/TextCell.cpp:304
+#: ../src/TextCell.cpp:320 ../src/TextCell.cpp:332
 msgid ""
 "Seems like something is broken with a font. Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/TextCell.cpp:139
+#: ../src/TextCell.cpp:137
 msgid ""
 "Seems like something is broken with the maths font. Installing http://www."
 "math.union.edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use "
 "JSmath fonts\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1011 ../src/MathCtrl.cpp:1027
+#: ../src/MathCtrl.cpp:1053 ../src/MathCtrl.cpp:1069
 msgid "Select All"
 msgstr "Velg Alle"
 
-#: ../src/wxMaximaFrame.cpp:525
+#: ../src/wxMaximaFrame.cpp:524
 msgid "Select All\tCtrl-A"
 msgstr "Velg Alle\tCtrl-A"
 
@@ -3516,7 +3519,7 @@ msgstr "Velg Alle\tCtrl-A"
 msgid "Select Maxima program"
 msgstr "Velg Maxima-program"
 
-#: ../src/wxMaxima.cpp:4860
+#: ../src/wxMaxima.cpp:4872
 msgid "Select Subsample"
 msgstr "Velg Undermåling"
 
@@ -3525,12 +3528,12 @@ msgstr "Velg Undermåling"
 msgid "Select a constant"
 msgstr "Velg en konstant"
 
-#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:526
+#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:525
 msgid "Select all"
 msgstr "Velg alle"
 
 # vi elsker sammensatte ord, gjør vi ikke?
-#: ../src/wxMaxima.cpp:3319
+#: ../src/wxMaxima.cpp:3331
 msgid "Select math display algorithm"
 msgstr "Velg matematikkvisningsalgoritme"
 
@@ -3547,23 +3550,23 @@ msgstr ""
 msgid "Selection"
 msgstr "Utvalg"
 
-#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4178
+#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4190
 msgid "Series"
 msgstr "Rekke"
 
-#: ../src/wxMaximaFrame.cpp:1226
+#: ../src/wxMaximaFrame.cpp:1225
 msgid "Series..."
 msgstr "Rekke..."
 
-#: ../src/wxMaxima.cpp:863
+#: ../src/wxMaxima.cpp:868
 msgid "Server started"
 msgstr "Server startet"
 
-#: ../src/wxMaximaFrame.cpp:575
+#: ../src/wxMaximaFrame.cpp:574
 msgid "Set Zoom"
 msgstr "Sett &Zoom"
 
-#: ../src/wxMaximaFrame.cpp:944
+#: ../src/wxMaximaFrame.cpp:943
 #, fuzzy
 msgid "Set bigfloat &Precision..."
 msgstr "Sett bigfloat-presisjon"
@@ -3572,63 +3575,63 @@ msgstr "Sett bigfloat-presisjon"
 msgid "Set fixed font in text controls."
 msgstr "Set fast font i tekstkontroller."
 
-#: ../src/wxMaximaFrame.cpp:928
+#: ../src/wxMaximaFrame.cpp:927
 msgid "Set plot format"
 msgstr "Sett plottformat"
 
-#: ../src/wxMaximaFrame.cpp:945
+#: ../src/wxMaximaFrame.cpp:944
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can "
 "be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:569
+#: ../src/wxMaximaFrame.cpp:568
 msgid "Set zoom to 100%"
 msgstr "Sett zoom til 100%"
 
-#: ../src/wxMaximaFrame.cpp:570
+#: ../src/wxMaximaFrame.cpp:569
 msgid "Set zoom to 120%"
 msgstr "Sett zoom til 120%"
 
-#: ../src/wxMaximaFrame.cpp:571
+#: ../src/wxMaximaFrame.cpp:570
 msgid "Set zoom to 150%"
 msgstr "Sett zoom til 150%"
 
-#: ../src/wxMaximaFrame.cpp:572
+#: ../src/wxMaximaFrame.cpp:571
 msgid "Set zoom to 200%"
 msgstr "Sett zoom til 200%"
 
-#: ../src/wxMaximaFrame.cpp:573
+#: ../src/wxMaximaFrame.cpp:572
 msgid "Set zoom to 300%"
 msgstr "Sett zoom til 300%"
 
-#: ../src/wxMaximaFrame.cpp:568
+#: ../src/wxMaximaFrame.cpp:567
 msgid "Set zoom to 80%"
 msgstr "Sett zoom til 80%"
 
 # send en mail om du vet hva en atvalue er på norsk
-#: ../src/wxMaximaFrame.cpp:732
+#: ../src/wxMaximaFrame.cpp:731
 #, fuzzy
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr "Sett opp vedverdier til å løse ODE med laplacetransformasjon"
 
-#: ../src/wxMaximaFrame.cpp:918
+#: ../src/wxMaximaFrame.cpp:917
 msgid "Setup modulus computation"
 msgstr "Sett opp moduloregning"
 
-#: ../src/wxMaximaFrame.cpp:662
+#: ../src/wxMaximaFrame.cpp:661
 msgid "Show &Definition..."
 msgstr "Vis &Definisjon..."
 
-#: ../src/wxMaximaFrame.cpp:660
+#: ../src/wxMaximaFrame.cpp:659
 msgid "Show &Functions"
 msgstr "Vis &Funksjoner"
 
-#: ../src/wxMaximaFrame.cpp:967
+#: ../src/wxMaximaFrame.cpp:966
 msgid "Show &Tips..."
 msgstr "Vis &Tips..."
 
-#: ../src/wxMaximaFrame.cpp:665
+#: ../src/wxMaximaFrame.cpp:664
 msgid "Show &Variables"
 msgstr "Vis &Variabler"
 
@@ -3636,43 +3639,43 @@ msgstr "Vis &Variabler"
 msgid "Show Maxima help"
 msgstr "Vis Maxima-hjelp"
 
-#: ../src/wxMaximaFrame.cpp:603
+#: ../src/wxMaximaFrame.cpp:602
 msgid "Show Template\tCtrl-Shift-K"
 msgstr "Vis Mal\tCtrl-Shift-K"
 
-#: ../src/wxMaximaFrame.cpp:968
+#: ../src/wxMaximaFrame.cpp:967
 msgid "Show a tip"
 msgstr "Vis et tips"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Show all commands similar to:"
 msgstr "Vis alle kommandoer som ligner:"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Show an example for the command:"
 msgstr "Vis et eksempel for kommandoen:"
 
-#: ../src/wxMaximaFrame.cpp:962
+#: ../src/wxMaximaFrame.cpp:961
 msgid "Show an example of usage"
 msgstr "Vis et eksempel av bruk"
 
-#: ../src/wxMaximaFrame.cpp:965
+#: ../src/wxMaximaFrame.cpp:964
 msgid "Show commands similar to"
 msgstr "Vis kommandoer som ligner"
 
-#: ../src/wxMaximaFrame.cpp:661
+#: ../src/wxMaximaFrame.cpp:660
 msgid "Show defined functions"
 msgstr "Vis definerte funksjoner"
 
-#: ../src/wxMaximaFrame.cpp:666
+#: ../src/wxMaximaFrame.cpp:665
 msgid "Show defined variables"
 msgstr "Vis definerte variabler"
 
-#: ../src/wxMaximaFrame.cpp:663
+#: ../src/wxMaximaFrame.cpp:662
 msgid "Show definition of a function"
 msgstr "Vis definisjon av en funksjon"
 
-#: ../src/wxMaximaFrame.cpp:604
+#: ../src/wxMaximaFrame.cpp:603
 msgid "Show function template"
 msgstr "Vis funksjonmal"
 
@@ -3685,7 +3688,7 @@ msgstr "Vis lange uttrykk i wxMaxima-dokument."
 msgid "Show long expressions:"
 msgstr "Vis lange uttrykk"
 
-#: ../src/wxMaxima.cpp:3341
+#: ../src/wxMaxima.cpp:3353
 msgid "Show the definition of function:"
 msgstr "Vis definisjonen av funksjon:"
 
@@ -3694,43 +3697,43 @@ msgstr "Vis definisjonen av funksjon:"
 msgid "Show user-defined labels instead of (%oxx)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:953 ../src/wxMaximaFrame.cpp:956
+#: ../src/wxMaximaFrame.cpp:952 ../src/wxMaximaFrame.cpp:955
 msgid "Show wxMaxima help"
 msgstr "Vis wxMaxima-hjelp"
 
-#: ../src/wxMaximaFrame.cpp:1381
+#: ../src/wxMaximaFrame.cpp:1380
 msgid "Sigma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1211
+#: ../src/wxMaximaFrame.cpp:1210
 msgid "Simplify"
 msgstr "Forenkle"
 
-#: ../src/wxMaximaFrame.cpp:831
+#: ../src/wxMaximaFrame.cpp:830
 msgid "Simplify &Radicals"
 msgstr "Forenkle &Radikaler"
 
-#: ../src/wxMaximaFrame.cpp:1212
+#: ../src/wxMaximaFrame.cpp:1211
 msgid "Simplify (r)"
 msgstr "Forenkle (r)"
 
-#: ../src/wxMaximaFrame.cpp:1218
+#: ../src/wxMaximaFrame.cpp:1217
 msgid "Simplify (tr)"
 msgstr "Forenkle (tr)"
 
-#: ../src/MathCtrl.cpp:995
+#: ../src/MathCtrl.cpp:1037
 msgid "Simplify Expression"
 msgstr "Forenkle Uttrykk"
 
-#: ../src/wxMaximaFrame.cpp:857
+#: ../src/wxMaximaFrame.cpp:856
 msgid "Simplify an expression containing factorials"
 msgstr "Forenkle et uttrykk med fakulteter"
 
-#: ../src/wxMaximaFrame.cpp:832
+#: ../src/wxMaximaFrame.cpp:831
 msgid "Simplify expression containing radicals"
 msgstr "Forenkle et uttrykk med radikaler"
 
-#: ../src/wxMaximaFrame.cpp:830
+#: ../src/wxMaximaFrame.cpp:829
 msgid "Simplify rational expression"
 msgstr "Forenkle rasjonelt uttrykk"
 
@@ -3738,7 +3741,7 @@ msgstr "Forenkle rasjonelt uttrykk"
 msgid "Simplify the sum"
 msgstr "Forenkle summen"
 
-#: ../src/wxMaximaFrame.cpp:868
+#: ../src/wxMaximaFrame.cpp:867
 msgid "Simplify trigonometric expression"
 msgstr "Forenkle trigonometrisk uttrykk"
 
@@ -3754,87 +3757,87 @@ msgstr ""
 "dokumentet i formatet 'wxMaxima XML-dokument' om du vil at bilder skal "
 "lagres i tillegg til dokumentet."
 
-#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
+#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
 msgid "Solution:"
 msgstr "Løsning:"
 
-#: ../src/wxMaxima.cpp:3461 ../src/wxMaxima.cpp:3475 ../src/wxMaxima.cpp:5020
+#: ../src/wxMaxima.cpp:3473 ../src/wxMaxima.cpp:3487 ../src/wxMaxima.cpp:5032
 msgid "Solve"
 msgstr "Løs"
 
-#: ../src/wxMaximaFrame.cpp:706
+#: ../src/wxMaximaFrame.cpp:705
 msgid "Solve &Algebraic System..."
 msgstr "Løs &Algebraisk System..."
 
-#: ../src/wxMaximaFrame.cpp:703
+#: ../src/wxMaximaFrame.cpp:702
 msgid "Solve &Linear System..."
 msgstr "Løs L&ineært System..."
 
-#: ../src/wxMaximaFrame.cpp:714
+#: ../src/wxMaximaFrame.cpp:713
 msgid "Solve &ODE..."
 msgstr "Løs &ODE..."
 
-#: ../src/wxMaximaFrame.cpp:690
+#: ../src/wxMaximaFrame.cpp:689
 msgid "Solve (to_poly)..."
 msgstr "&Løs (to_poly)..."
 
-#: ../src/wxMaxima.cpp:3511 ../src/wxMaxima.cpp:3635
+#: ../src/wxMaxima.cpp:3523 ../src/wxMaxima.cpp:3647
 msgid "Solve ODE"
 msgstr "Løs ODE"
 
-#: ../src/wxMaximaFrame.cpp:728
+#: ../src/wxMaximaFrame.cpp:727
 msgid "Solve ODE with Lapla&ce..."
 msgstr "Løs ODE med Lapla&ce..."
 
-#: ../src/wxMaximaFrame.cpp:1222
+#: ../src/wxMaximaFrame.cpp:1221
 msgid "Solve ODE..."
 msgstr "Løs ODE..."
 
-#: ../src/wxMaxima.cpp:3586 ../src/wxMaxima.cpp:3597
+#: ../src/wxMaxima.cpp:3598 ../src/wxMaxima.cpp:3609
 msgid "Solve algebraic system"
 msgstr "Løs algebraisk system"
 
-#: ../src/wxMaximaFrame.cpp:707
+#: ../src/wxMaximaFrame.cpp:706
 msgid "Solve algebraic system of equations"
 msgstr "Løs algebraisk system av likninger"
 
-#: ../src/wxMaximaFrame.cpp:725
+#: ../src/wxMaximaFrame.cpp:724
 msgid "Solve boundary value problem for second degree ODE"
 msgstr "Løs randverdiproblem for andregrads ODE"
 
-#: ../src/wxMaximaFrame.cpp:689
+#: ../src/wxMaximaFrame.cpp:688
 msgid "Solve equation(s)"
 msgstr "Løs likninger"
 
-#: ../src/wxMaximaFrame.cpp:691
+#: ../src/wxMaximaFrame.cpp:690
 msgid "Solve equation(s) with to_poly_solve"
 msgstr "Løs likninger med to_poly_solve"
 
-#: ../src/wxMaximaFrame.cpp:719
+#: ../src/wxMaximaFrame.cpp:718
 msgid "Solve initial value problem for first degree ODE"
 msgstr "Løs initialverdiproblem for førstegrads ODE"
 
-#: ../src/wxMaximaFrame.cpp:722
+#: ../src/wxMaximaFrame.cpp:721
 msgid "Solve initial value problem for second degree ODE"
 msgstr "Løs initialverdiproblem for andregrads ODE"
 
-#: ../src/wxMaxima.cpp:3610 ../src/wxMaxima.cpp:3621
+#: ../src/wxMaxima.cpp:3622 ../src/wxMaxima.cpp:3633
 msgid "Solve linear system"
 msgstr "Løs lineært system"
 
-#: ../src/wxMaximaFrame.cpp:704
+#: ../src/wxMaximaFrame.cpp:703
 msgid "Solve linear system of equations"
 msgstr "Løs lineært system av likninger"
 
-#: ../src/wxMaximaFrame.cpp:715
+#: ../src/wxMaximaFrame.cpp:714
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr "Løs Ordinary Differential Equation-er av maksimum 2. grad"
 
-#: ../src/wxMaximaFrame.cpp:729
+#: ../src/wxMaximaFrame.cpp:728
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr "Løs Ordinary Differential Equation-er med laplacetransformasjon"
 
-#: ../src/wxMaximaFrame.cpp:1221 ../src/MathCtrl.cpp:992
+#: ../src/MathCtrl.cpp:1034 ../src/wxMaximaFrame.cpp:1220
 msgid "Solve..."
 msgstr "Løs..."
 
@@ -3858,7 +3861,7 @@ msgstr "Spesiell"
 msgid "Special constants"
 msgstr "Spesielle konstanter"
 
-#: ../src/MathCtrl.cpp:922
+#: ../src/MathCtrl.cpp:964
 msgid "Start Animation"
 msgstr "Start Animasjon"
 
@@ -3877,28 +3880,28 @@ msgstr ""
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:294
+#: ../src/wxMaxima.cpp:295
 msgid "Starting Maxima process failed"
 msgstr "Klarte ikke starte Maxima-prosess"
 
-#: ../src/wxMaxima.cpp:928
+#: ../src/wxMaxima.cpp:933
 msgid "Starting Maxima..."
 msgstr "Starter Maxima..."
 
-#: ../src/wxMaxima.cpp:292 ../src/wxMaxima.cpp:860
+#: ../src/wxMaxima.cpp:293 ../src/wxMaxima.cpp:865
 msgid "Starting server failed"
 msgstr "Klarte ikke starte server"
 
-#: ../src/wxMaxima.cpp:841
+#: ../src/wxMaxima.cpp:846
 #, c-format
 msgid "Starting server on port %d"
 msgstr "Klarte ikke starte server på port %d"
 
-#: ../src/wxMaximaFrame.cpp:342
+#: ../src/wxMaximaFrame.cpp:341
 msgid "Statistics"
 msgstr "Statistikk"
 
-#: ../src/wxMaximaFrame.cpp:550
+#: ../src/wxMaximaFrame.cpp:549
 msgid "Statistics\tAlt-Shift-S"
 msgstr "Statistikk\tAlt-Shift-S"
 
@@ -3914,11 +3917,11 @@ msgstr "Stil"
 msgid "Styles"
 msgstr "Stiler"
 
-#: ../src/wxMaximaFrame.cpp:1283
+#: ../src/wxMaximaFrame.cpp:1282
 msgid "Subsample..."
 msgstr "Undermåling..."
 
-#: ../src/wxMaximaFrame.cpp:1496
+#: ../src/wxMaximaFrame.cpp:1515
 msgid "Subsection"
 msgstr "Underseksjon"
 
@@ -3926,20 +3929,20 @@ msgstr "Underseksjon"
 msgid "Subsection cell"
 msgstr "Underseksjoncelle"
 
-#: ../src/wxMaximaFrame.cpp:1216
+#: ../src/wxMaximaFrame.cpp:1215
 msgid "Subst..."
 msgstr "Erstatt..."
 
-#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3423
-#: ../src/wxMaxima.cpp:5089
+#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3435
+#: ../src/wxMaxima.cpp:5101
 msgid "Substitute"
 msgstr "Erstatt"
 
-#: ../src/wxMaximaFrame.cpp:906 ../src/MathCtrl.cpp:998
+#: ../src/MathCtrl.cpp:1040 ../src/wxMaximaFrame.cpp:905
 msgid "Substitute..."
 msgstr "&Erstatt..."
 
-#: ../src/wxMaximaFrame.cpp:1497
+#: ../src/wxMaximaFrame.cpp:1516
 #, fuzzy
 msgid "Subsubsection"
 msgstr "Underseksjon"
@@ -3949,7 +3952,7 @@ msgstr "Underseksjon"
 msgid "Subsubsection cell"
 msgstr "Underseksjoncelle"
 
-#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4226
+#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4238
 msgid "Sum"
 msgstr "Sum"
 
@@ -3957,37 +3960,37 @@ msgstr "Sum"
 msgid "Sum sign"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:553
+#: ../src/wxMaximaFrame.cpp:552
 #, fuzzy
 msgid "Symbols\tAlt-Shift-Y"
 msgstr "Statistikk\tAlt-Shift-S"
 
-#: ../src/wxMaxima.cpp:4456
+#: ../src/wxMaxima.cpp:4468
 msgid "System info"
 msgstr "Systeminfo"
 
-#: ../src/wxMaximaFrame.cpp:320
+#: ../src/wxMaximaFrame.cpp:319
 msgid "Table of Contents"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:556
+#: ../src/wxMaximaFrame.cpp:555
 #, fuzzy
 msgid "Table of Contents\tAlt-Shift-T"
 msgstr "Verktøylinje\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:1382
+#: ../src/wxMaximaFrame.cpp:1381
 msgid "Tau"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Taylor series:"
 msgstr "Taylorrekke:"
 
-#: ../src/wxMaxima.cpp:3963
+#: ../src/wxMaxima.cpp:3975
 msgid "Tellrat"
 msgstr "tellrat"
 
-#: ../src/wxMaximaFrame.cpp:1494
+#: ../src/wxMaximaFrame.cpp:1513
 msgid "Text"
 msgstr "Tekst"
 
@@ -4033,7 +4036,7 @@ msgstr ""
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr ""
 
-#: ../src/TextCell.cpp:136
+#: ../src/TextCell.cpp:134
 msgid ""
 "The letter \"X\" is of width zero. Installing http://www.math.union.edu/"
 "~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts\" in "
@@ -4050,7 +4053,7 @@ msgstr ""
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:959
+#: ../src/wxMaximaFrame.cpp:958
 msgid "The offline manual of maxima"
 msgstr "Offline-manualen til Maxima"
 
@@ -4087,7 +4090,7 @@ msgstr ""
 "frem engelskkunnskapene og besøk bl.a. https://andrejv.github.com/wxmaxima/"
 "help.html for å finne mer informasjon om bruk av Maxima og wxMaxima."
 
-#: ../src/SlideShowCell.cpp:332
+#: ../src/SlideShowCell.cpp:336
 msgid ""
 "There was an error during GIF export!\n"
 "\n"
@@ -4098,7 +4101,7 @@ msgstr ""
 "Sørg for at ImageMagick er installert og at wxMaxima kan finne dette "
 "konverteringsprogrammet."
 
-#: ../src/wxMaxima.cpp:442
+#: ../src/wxMaxima.cpp:447
 msgid ""
 "There was an error in generated XML!\n"
 "\n"
@@ -4108,7 +4111,7 @@ msgstr ""
 "\n"
 "Vær grei og feilrapporter dette."
 
-#: ../src/wxMaximaFrame.cpp:1371
+#: ../src/wxMaximaFrame.cpp:1370
 msgid "Theta"
 msgstr ""
 
@@ -4119,7 +4122,7 @@ msgid "Ticks:"
 msgstr "Haker:"
 
 # hvilken kontekst?
-#: ../src/wxMaxima.cpp:4153 ../src/wxMaxima.cpp:5065
+#: ../src/wxMaxima.cpp:4165 ../src/wxMaxima.cpp:5077
 msgid "Times:"
 msgstr "Antall:"
 
@@ -4127,7 +4130,7 @@ msgstr "Antall:"
 msgid "Tips not available, sorry!"
 msgstr "Tips ikke tilgjengelig, beklager!"
 
-#: ../src/wxMaximaFrame.cpp:1495
+#: ../src/wxMaximaFrame.cpp:1514
 msgid "Title"
 msgstr "Tittel"
 
@@ -4145,19 +4148,19 @@ msgstr ""
 "innhold. For å folde eller utfolde, klikk i firkanten ved cellen. Hvis du "
 "Shift-klikker, vil alle undernivå av cellen også foldes/utfoldes."
 
-#: ../src/wxMaximaFrame.cpp:938
+#: ../src/wxMaximaFrame.cpp:937
 msgid "To &Bigfloat"
 msgstr "Til &Bigfloat"
 
-#: ../src/wxMaximaFrame.cpp:935
+#: ../src/wxMaximaFrame.cpp:934
 msgid "To &Float"
 msgstr "Til &Desimaltall"
 
-#: ../src/MathCtrl.cpp:990
+#: ../src/MathCtrl.cpp:1032
 msgid "To Float"
 msgstr "Til Desimaltall"
 
-#: ../src/wxMaximaFrame.cpp:941
+#: ../src/wxMaximaFrame.cpp:940
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr "Til &Numerisk\tCtrl+Shift+N"
 
@@ -4198,51 +4201,51 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:41 ../src/Plot2dWiz.cpp:40 ../src/Plot2dWiz.cpp:50
 #: ../src/Plot2dWiz.cpp:539 ../src/Plot3dWiz.cpp:39 ../src/Plot3dWiz.cpp:48
-#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4241
+#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4253
 msgid "To:"
 msgstr "Til:"
 
-#: ../src/wxMaximaFrame.cpp:912
+#: ../src/wxMaximaFrame.cpp:911
 msgid "Toggle &Algebraic Flag"
 msgstr "Veksle &Algebraisk Flagg"
 
-#: ../src/wxMaximaFrame.cpp:933
+#: ../src/wxMaximaFrame.cpp:932
 msgid "Toggle &Numeric Output"
 msgstr "&Veksle Numerisk Utdata"
 
-#: ../src/wxMaximaFrame.cpp:673
+#: ../src/wxMaximaFrame.cpp:672
 msgid "Toggle &Time Display"
 msgstr "Veksle &Tidsvisning"
 
-#: ../src/wxMaximaFrame.cpp:913
+#: ../src/wxMaximaFrame.cpp:912
 msgid "Toggle algebraic flag"
 msgstr "Veksle algebraisk flagg"
 
-#: ../src/wxMaximaFrame.cpp:577
+#: ../src/wxMaximaFrame.cpp:576
 msgid "Toggle full screen editing"
 msgstr "Veksle fullskjermredigering"
 
-#: ../src/wxMaximaFrame.cpp:934
+#: ../src/wxMaximaFrame.cpp:933
 msgid "Toggle numeric output"
 msgstr "Veksle numerisk utdata"
 
-#: ../src/wxMaxima.cpp:4464
+#: ../src/wxMaxima.cpp:4476
 msgid "Toolbar icons"
 msgstr "Verktøylinjeikon"
 
-#: ../src/wxMaxima.cpp:4465
+#: ../src/wxMaxima.cpp:4477
 msgid "Translated by"
 msgstr "Oversatt av"
 
-#: ../src/wxMaximaFrame.cpp:763
+#: ../src/wxMaximaFrame.cpp:762
 msgid "Transpose a matrix"
 msgstr "Transponer en matrise"
 
-#: ../src/MathCtrl.cpp:5834
+#: ../src/MathCtrl.cpp:5886
 msgid "Trying to undo an action without starting cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5901
+#: ../src/MathCtrl.cpp:5953
 msgid "Trying to undo something but the undo action is empty."
 msgstr ""
 
@@ -4250,11 +4253,11 @@ msgstr ""
 msgid "Turkish"
 msgstr "Tyrkisk"
 
-#: ../src/wxMaximaFrame.cpp:970
+#: ../src/wxMaximaFrame.cpp:969
 msgid "Tutorials"
 msgstr "&Læreressurser"
 
-#: ../src/wxMaxima.cpp:4778
+#: ../src/wxMaxima.cpp:4790
 msgid "Two sample t-test"
 msgstr "Tomålings t-test"
 
@@ -4266,15 +4269,15 @@ msgstr "Type:"
 msgid "Ukrainian"
 msgstr "Ukrainsk"
 
-#: ../src/wxMaxima.cpp:5356
+#: ../src/wxMaxima.cpp:5372
 msgid "Un-closed parenthesis"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5323
+#: ../src/wxMaxima.cpp:5335
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5889
 msgid ""
 "Unable to interpret the version info I got from http://andrejv.github.io//"
 "wxmaxima/version.txt: "
@@ -4289,11 +4292,11 @@ msgstr "Underlinjet"
 msgid "Underscore converts to subscripts:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:492
+#: ../src/wxMaximaFrame.cpp:491
 msgid "Undo\tCtrl-Z"
 msgstr "Angre\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:493
+#: ../src/wxMaximaFrame.cpp:492
 msgid "Undo last change"
 msgstr "Angre siste endring"
 
@@ -4301,23 +4304,23 @@ msgstr "Angre siste endring"
 msgid "Undo limit (0 for none):"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:625
+#: ../src/wxMaximaFrame.cpp:624
 msgid "Unfold All\tCtrl-Alt-]"
 msgstr "Fo&ld Ut Alle\tCtrl-A-]"
 
-#: ../src/wxMaximaFrame.cpp:626
+#: ../src/wxMaximaFrame.cpp:625
 msgid "Unfold all folded sections"
 msgstr "Fold ut alle foldede seksjoner"
 
-#: ../src/wxMaxima.cpp:4458
+#: ../src/wxMaxima.cpp:4470
 msgid "Unicode Support"
 msgstr "Unicode-støtte"
 
-#: ../src/wxMaxima.cpp:5335
+#: ../src/wxMaxima.cpp:5347
 msgid "Unterminated comment."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5309
+#: ../src/wxMaxima.cpp:5321
 msgid "Unterminated string."
 msgstr ""
 
@@ -4325,15 +4328,15 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5859 ../src/wxMaxima.cpp:5866 ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5874 ../src/wxMaxima.cpp:5881 ../src/wxMaxima.cpp:5889
 msgid "Upgrade"
 msgstr "Oppgrader"
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Upper bound:"
 msgstr "Øvre grense:"
 
-#: ../src/wxMaximaFrame.cpp:1383
+#: ../src/wxMaximaFrame.cpp:1382
 #, fuzzy
 msgid "Upsilon"
 msgstr "Epsilon:"
@@ -4378,22 +4381,22 @@ msgstr ""
 msgid "User-defined labels"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3525
-#: ../src/wxMaxima.cpp:3541 ../src/wxMaxima.cpp:3649
+#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3537
+#: ../src/wxMaxima.cpp:3553 ../src/wxMaxima.cpp:3661
 msgid "Value:"
 msgstr "Verdi:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:5019 ../src/wxMaxima.cpp:5064
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:5031 ../src/wxMaxima.cpp:5076
 msgid "Variable(s):"
 msgstr "Variabler:"
 
 #: ../src/IntegrateWiz.cpp:33 ../src/LimitWiz.cpp:30 ../src/Plot2dWiz.cpp:34
 #: ../src/Plot2dWiz.cpp:44 ../src/Plot2dWiz.cpp:533 ../src/Plot3dWiz.cpp:33
 #: ../src/Plot3dWiz.cpp:42 ../src/SeriesWiz.cpp:36 ../src/SumWiz.cpp:30
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3749
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3761
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5045
 msgid "Variable:"
 msgstr "Variabel:"
 
@@ -4401,25 +4404,25 @@ msgstr "Variabel:"
 msgid "Variables"
 msgstr "Variabler"
 
-#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3571 ../src/wxMaxima.cpp:4206
-#: ../src/wxMaxima.cpp:4807
+#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3583 ../src/wxMaxima.cpp:4218
+#: ../src/wxMaxima.cpp:4819
 msgid "Variables:"
 msgstr "Variabler:"
 
-#: ../src/wxMaximaFrame.cpp:1257
+#: ../src/wxMaximaFrame.cpp:1256
 msgid "Variance..."
 msgstr "Varians..."
 
-#: ../src/wxMaximaFrame.cpp:580
+#: ../src/wxMaximaFrame.cpp:579
 msgid "View"
 msgstr ""
 
-#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1674 ../src/wxMaxima.cpp:1769
-#: ../src/wxMaxima.cpp:1950
+#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1679 ../src/wxMaxima.cpp:1774
+#: ../src/wxMaxima.cpp:1955
 msgid "Warning"
 msgstr "Advarsel"
 
-#: ../src/wxMaximaFrame.cpp:109 ../src/wxMaximaFrame.cpp:295
+#: ../src/wxMaximaFrame.cpp:108 ../src/wxMaximaFrame.cpp:294
 msgid "Welcome to wxMaxima"
 msgstr "Velkommen til wxMaxima"
 
@@ -4443,7 +4446,7 @@ msgid ""
 "introducing an empty line."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2567
+#: ../src/wxMaxima.cpp:2574
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) "
 "(*.wxm)|*.wxm"
@@ -4459,7 +4462,7 @@ msgid ""
 "as equation markers"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6798
+#: ../src/MathCtrl.cpp:6856
 msgid "Wrapped search"
 msgstr ""
 
@@ -4467,15 +4470,15 @@ msgstr ""
 msgid "Write matching parenthesis in text controls."
 msgstr "Sett inn samsvarende parenteser i tekstkontroller."
 
-#: ../src/wxMaxima.cpp:4461
+#: ../src/wxMaxima.cpp:4473
 msgid "Written by"
 msgstr "Skrevet av"
 
-#: ../src/wxMaximaFrame.cpp:557
+#: ../src/wxMaximaFrame.cpp:556
 msgid "XML Inspector"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1377
+#: ../src/wxMaximaFrame.cpp:1376
 msgid "Xi"
 msgstr ""
 
@@ -4545,7 +4548,7 @@ msgstr ""
 "Shift mens du flytter den horisontale pekeren — og betjen deretter utvalget. "
 "Dette er hendig når du vil slette eller utføre flere celler."
 
-#: ../src/wxMaxima.cpp:5856
+#: ../src/wxMaxima.cpp:5871
 #, c-format
 msgid ""
 "You have version %s. Current version is %s.\n"
@@ -4556,41 +4559,41 @@ msgstr ""
 "\n"
 "Velg OK for å besøke wxMaxima-nettsiden."
 
-#: ../src/wxMaxima.cpp:5921
+#: ../src/wxMaxima.cpp:5936
 msgid "Your changes will be lost if you don't save them."
 msgstr "Endringene dine vil gå tapt om du ikke lagrer dem."
 
-#: ../src/wxMaxima.cpp:5866
+#: ../src/wxMaxima.cpp:5881
 msgid "Your version of wxMaxima is up to date."
 msgstr "Du har siste versjon av wxMaxima."
 
-#: ../src/wxMaximaFrame.cpp:1369
+#: ../src/wxMaximaFrame.cpp:1368
 msgid "Zeta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:562
+#: ../src/wxMaximaFrame.cpp:561
 #, fuzzy
 msgid "Zoom &In\tCtrl-+"
 msgstr "Zoom Inn\tAlt-I"
 
-#: ../src/wxMaximaFrame.cpp:564
+#: ../src/wxMaximaFrame.cpp:563
 #, fuzzy
 msgid "Zoom Ou&t\tCtrl--"
 msgstr "Zoom Ut\tAlt-O"
 
-#: ../src/wxMaximaFrame.cpp:563
+#: ../src/wxMaximaFrame.cpp:562
 msgid "Zoom in 10%"
 msgstr "Zoom inn 10%"
 
-#: ../src/wxMaximaFrame.cpp:565
+#: ../src/wxMaximaFrame.cpp:564
 msgid "Zoom out 10%"
 msgstr "Zoom ut 10%"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaximaFrame.cpp:287
 msgid "[ unsaved ]"
 msgstr "[ ulagret ]"
 
-#: ../src/wxMaxima.cpp:5700
+#: ../src/wxMaxima.cpp:5715
 msgid "[ unsaved* ]"
 msgstr "[ ulagret* ]"
 
@@ -4599,17 +4602,17 @@ msgstr "[ ulagret* ]"
 msgid "[%i digits]"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4392
+#: ../src/MathCtrl.cpp:4447
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" style=\"max-width:90%%;\" >\n"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4517
+#: ../src/MathCtrl.cpp:4572
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" >"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1333
+#: ../src/wxMaximaFrame.cpp:1332
 msgid "alpha"
 msgstr ""
 
@@ -4622,7 +4625,7 @@ msgstr "Utvid"
 msgid "antisymmetric"
 msgstr "antisymmetrisk"
 
-#: ../src/wxMaximaFrame.cpp:1334
+#: ../src/wxMaximaFrame.cpp:1333
 msgid "beta"
 msgstr ""
 
@@ -4666,7 +4669,7 @@ msgstr ""
 msgid "bug:Invalid sup tag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1354
+#: ../src/wxMaximaFrame.cpp:1353
 msgid "chi"
 msgstr ""
 
@@ -4679,7 +4682,7 @@ msgstr ""
 msgid "default"
 msgstr "forhåndsvalgt"
 
-#: ../src/wxMaximaFrame.cpp:1336
+#: ../src/wxMaximaFrame.cpp:1335
 msgid "delta"
 msgstr ""
 
@@ -4691,7 +4694,7 @@ msgstr "diagonalt"
 msgid "empty"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1337
+#: ../src/wxMaximaFrame.cpp:1336
 #, fuzzy
 msgid "epsilon"
 msgstr "Epsilon:"
@@ -4700,7 +4703,7 @@ msgstr "Epsilon:"
 msgid "equivalent"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1339
+#: ../src/wxMaximaFrame.cpp:1338
 msgid "eta"
 msgstr ""
 
@@ -4716,7 +4719,7 @@ msgid ""
 "all=_ marks subscripts."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1335
+#: ../src/wxMaximaFrame.cpp:1334
 msgid "gamma"
 msgstr ""
 
@@ -4746,15 +4749,15 @@ msgstr "inline"
 msgid "intersection"
 msgstr "Retning:"
 
-#: ../src/wxMaximaFrame.cpp:1341
+#: ../src/wxMaximaFrame.cpp:1340
 msgid "iota"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1342
+#: ../src/wxMaximaFrame.cpp:1341
 msgid "kappa"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1343
+#: ../src/wxMaximaFrame.cpp:1342
 msgid "lambda"
 msgstr ""
 
@@ -4771,7 +4774,7 @@ msgstr "Underseksjoncelle"
 msgid "logscale"
 msgstr "logscale"
 
-#: ../src/wxMaxima.cpp:3783
+#: ../src/wxMaxima.cpp:3795
 msgid "matrix[i,j]:"
 msgstr "matrise[i,j]:"
 
@@ -4779,7 +4782,7 @@ msgstr "matrise[i,j]:"
 msgid "maxima's pwd is path to document"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1344
+#: ../src/wxMaximaFrame.cpp:1343
 msgid "mu"
 msgstr ""
 
@@ -4796,7 +4799,7 @@ msgstr ""
 msgid "nand"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4524
+#: ../src/wxMaxima.cpp:4536
 msgid "no"
 msgstr "nei"
 
@@ -4822,15 +4825,15 @@ msgstr ""
 msgid "not subset or equal"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1345
+#: ../src/wxMaximaFrame.cpp:1344
 msgid "nu"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1356
+#: ../src/wxMaximaFrame.cpp:1355
 msgid "omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1347
+#: ../src/wxMaximaFrame.cpp:1346
 msgid "omicron"
 msgstr ""
 
@@ -4843,11 +4846,11 @@ msgstr ""
 msgid "partial sign"
 msgstr "Delbrøker"
 
-#: ../src/wxMaximaFrame.cpp:1353
+#: ../src/wxMaximaFrame.cpp:1352
 msgid "phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1348
+#: ../src/wxMaximaFrame.cpp:1347
 msgid "pi"
 msgstr ""
 
@@ -4859,11 +4862,11 @@ msgstr ""
 msgid "proportional to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1355
+#: ../src/wxMaximaFrame.cpp:1354
 msgid "psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1349
+#: ../src/wxMaximaFrame.cpp:1348
 msgid "rho"
 msgstr ""
 
@@ -4871,7 +4874,7 @@ msgstr ""
 msgid "right"
 msgstr "høyre"
 
-#: ../src/wxMaximaFrame.cpp:1350
+#: ../src/wxMaximaFrame.cpp:1349
 msgid "sigma"
 msgstr ""
 
@@ -4893,7 +4896,7 @@ msgstr "Underseksjoncelle"
 msgid "symmetric"
 msgstr "symmetrisk"
 
-#: ../src/wxMaximaFrame.cpp:1351
+#: ../src/wxMaximaFrame.cpp:1350
 msgid "tau"
 msgstr ""
 
@@ -4905,7 +4908,7 @@ msgstr ""
 msgid "there is no"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1340
+#: ../src/wxMaximaFrame.cpp:1339
 msgid "theta"
 msgstr ""
 
@@ -4921,12 +4924,12 @@ msgstr ""
 msgid "union"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5903
+#: ../src/wxMaxima.cpp:5918
 msgid "unsaved"
 msgstr "ulagret"
 
-#: ../src/wxMaximaFrame.cpp:290 ../src/wxMaxima.cpp:2559
-#: ../src/wxMaxima.cpp:2826
+#: ../src/wxMaxima.cpp:2566 ../src/wxMaxima.cpp:2834
+#: ../src/wxMaximaFrame.cpp:289
 msgid "untitled"
 msgstr "navnløs"
 
@@ -4935,26 +4938,26 @@ msgstr "navnløs"
 msgid "untitled %d"
 msgstr "navnløs %d"
 
-#: ../src/wxMaximaFrame.cpp:1352
+#: ../src/wxMaximaFrame.cpp:1351
 #, fuzzy
 msgid "upsilon"
 msgstr "Epsilon:"
 
-#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4538
+#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4550
 msgid "wxMaxima"
 msgstr "wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
-#: ../src/wxMaxima.cpp:5700 ../src/wxMaxima.cpp:5709 ../src/wxMaxima.cpp:5712
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaxima.cpp:5715 ../src/wxMaxima.cpp:5724
+#: ../src/wxMaxima.cpp:5727 ../src/wxMaximaFrame.cpp:287
 #, c-format
 msgid "wxMaxima %s "
 msgstr "wxMaxima %s "
 
-#: ../src/wxMaximaFrame.cpp:952
+#: ../src/wxMaximaFrame.cpp:951
 msgid "wxMaxima &Help\tCtrl+?"
 msgstr "wxMaxima-&Hjelp\tCtrl+?"
 
-#: ../src/wxMaximaFrame.cpp:955
+#: ../src/wxMaximaFrame.cpp:954
 msgid "wxMaxima &Help\tF1"
 msgstr "wxMaxima-&Hjelp\tF1"
 
@@ -4965,11 +4968,11 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1619
+#: ../src/wxMaxima.cpp:1624
 msgid "wxMaxima cannot open content.xml in the .wxmx zip archive "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1633
+#: ../src/wxMaxima.cpp:1638
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
@@ -4977,7 +4980,7 @@ msgstr ""
 msgid "wxMaxima configuration"
 msgstr "wxMaxima-konfigurasjon"
 
-#: ../src/wxMaxima.cpp:1947
+#: ../src/wxMaxima.cpp:1952
 msgid ""
 "wxMaxima could not find Maxima!\n"
 "\n"
@@ -4989,7 +4992,7 @@ msgstr ""
 "Vennligst konfigurer wxMaxima med 'Endre->Konfigurer'.\n"
 "Deretter, start Maxima med 'Maxima->Restart Maxima'."
 
-#: ../src/wxMaxima.cpp:2204
+#: ../src/wxMaxima.cpp:2209
 msgid ""
 "wxMaxima could not find help files.\n"
 "\n"
@@ -4999,7 +5002,7 @@ msgstr ""
 "\n"
 "Vennligst sjekk installasjonen din."
 
-#: ../src/wxMaxima.cpp:2032
+#: ../src/wxMaxima.cpp:2037
 msgid ""
 "wxMaxima could not find tip files.\n"
 "\n"
@@ -5009,7 +5012,7 @@ msgstr ""
 "\n"
 "Vennligst sjekk installasjonen din."
 
-#: ../src/wxMaxima.cpp:282
+#: ../src/wxMaxima.cpp:283
 msgid ""
 "wxMaxima could not start the server.\n"
 "\n"
@@ -5031,23 +5034,23 @@ msgstr ""
 "er '%'. Om du har gjordt et utvalg i dokumentet ditt, vil utvalget bli brukt "
 "i stedet for '%'."
 
-#: ../src/wxMaxima.cpp:2330
+#: ../src/wxMaxima.cpp:2336
 msgid "wxMaxima document"
 msgstr "wxMaxima-dokument"
 
-#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2799
+#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2807
 msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 msgstr "wxMaxima-dokument (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 
-#: ../src/wxMaxima.cpp:1455 ../src/wxMaxima.cpp:1469
+#: ../src/wxMaxima.cpp:1460 ../src/wxMaxima.cpp:1474
 msgid "wxMaxima encountered an error loading "
 msgstr "wxMaxima støtte på et problem under lasting"
 
-#: ../src/wxMaxima.cpp:4463
+#: ../src/wxMaxima.cpp:4475
 msgid "wxMaxima icon"
 msgstr "wxMaxima-ikon"
 
-#: ../src/wxMaxima.cpp:4455
+#: ../src/wxMaxima.cpp:4467
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "MAXIMA based on wxWidgets."
@@ -5055,7 +5058,7 @@ msgstr ""
 "wxMaxima er et grafisk brukergrensesnitt til Computer Algebra System-et "
 "MAXIMA basert på wxWidgets."
 
-#: ../src/wxMaxima.cpp:4516
+#: ../src/wxMaxima.cpp:4528
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "Maxima based on wxWidgets."
@@ -5075,11 +5078,11 @@ msgstr ""
 msgid "x"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1346
+#: ../src/wxMaximaFrame.cpp:1345
 msgid "xi"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1643
+#: ../src/wxMaxima.cpp:1648
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
@@ -5088,11 +5091,11 @@ msgstr ""
 msgid "xor"
 msgstr "Eksporter"
 
-#: ../src/wxMaxima.cpp:4522
+#: ../src/wxMaxima.cpp:4534
 msgid "yes"
 msgstr "ja"
 
-#: ../src/wxMaximaFrame.cpp:1338
+#: ../src/wxMaximaFrame.cpp:1337
 msgid "zeta"
 msgstr ""
 

--- a/locales/pl.po
+++ b/locales/pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pl\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-07 21:42+0200\n"
+"POT-Creation-Date: 2016-10-16 17:47+0900\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Ihor Rokach <rokach@tu.kielce.pl>\n"
 "Language-Team: \n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../src/wxMaxima.cpp:4519
+#: ../src/wxMaxima.cpp:4531
 #, c-format
 msgid ""
 "\n"
@@ -30,7 +30,7 @@ msgstr ""
 "wxWidgets: %d.%d.%d\n"
 "Wsparcie Unicode: %s"
 
-#: ../src/wxMaxima.cpp:4532
+#: ../src/wxMaxima.cpp:4544
 msgid ""
 "\n"
 "Lisp: "
@@ -38,7 +38,7 @@ msgstr ""
 "\n"
 " Lisp:"
 
-#: ../src/wxMaxima.cpp:4528
+#: ../src/wxMaxima.cpp:4540
 msgid ""
 "\n"
 "Maxima version: "
@@ -46,7 +46,7 @@ msgstr ""
 "\n"
 " Wersja Maximy:"
 
-#: ../src/wxMaxima.cpp:5381
+#: ../src/wxMaxima.cpp:5397
 msgid ""
 "\n"
 "Not connected to Maxima!\n"
@@ -54,7 +54,7 @@ msgstr ""
 "\n"
 "Nie połączono z Maxima!\n"
 
-#: ../src/wxMaxima.cpp:4530
+#: ../src/wxMaxima.cpp:4542
 msgid ""
 "\n"
 "Not connected."
@@ -74,7 +74,7 @@ msgstr ""
 msgid " (Graphics) "
 msgstr ""
 
-#: ../src/EditorCell.cpp:3045 ../src/EditorCell.cpp:3227
+#: ../src/EditorCell.cpp:3088 ../src/EditorCell.cpp:3270
 #, c-format
 msgid " ... + %i hidden lines"
 msgstr ""
@@ -83,7 +83,7 @@ msgstr ""
 msgid " << Expression longer than allowed by the configuration setting! >>"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1673
+#: ../src/wxMaxima.cpp:1678
 msgid ""
 " was saved using a newer version of wxMaxima so it may not load correctly. "
 "Please update your wxMaxima."
@@ -91,7 +91,7 @@ msgstr ""
 "został zapisany z użyciem nowszej wersji wxMaximy przez co może nie zostać "
 "wczytany poprawnie. Zaleca się aktualizację wxMaximy."
 
-#: ../src/wxMaxima.cpp:1665
+#: ../src/wxMaxima.cpp:1670
 msgid ""
 " was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr ""
@@ -106,64 +106,64 @@ msgstr ""
 msgid "\"implies\" symbol"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:101
+#: ../src/wxMaximaFrame.cpp:100
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:773
+#: ../src/wxMaximaFrame.cpp:772
 msgid "&Algebra"
 msgstr "&Algebra"
 
-#: ../src/wxMaximaFrame.cpp:767
+#: ../src/wxMaximaFrame.cpp:766
 msgid "&Apply to List..."
 msgstr "&Zastosuj do listy ..."
 
-#: ../src/wxMaximaFrame.cpp:964
+#: ../src/wxMaximaFrame.cpp:963
 msgid "&Apropos..."
 msgstr "&Apropos..."
 
-#: ../src/wxMaximaFrame.cpp:478
+#: ../src/wxMaximaFrame.cpp:477
 msgid "&Batch File...\tCtrl-B"
 msgstr "&Plik wsadowy...\tCtrl-B"
 
-#: ../src/wxMaximaFrame.cpp:724
+#: ../src/wxMaximaFrame.cpp:723
 msgid "&Boundary Value Problem..."
 msgstr "Warunek &brzegowy ..."
 
-#: ../src/wxMaximaFrame.cpp:975
+#: ../src/wxMaximaFrame.cpp:974
 msgid "&Bug Report"
 msgstr "Zgłoś &błąd"
 
-#: ../src/wxMaximaFrame.cpp:825
+#: ../src/wxMaximaFrame.cpp:824
 msgid "&Calculus"
 msgstr "A&naliza"
 
-#: ../src/wxMaximaFrame.cpp:876
+#: ../src/wxMaximaFrame.cpp:875
 msgid "&Canonical Form"
 msgstr "Postać &kanoniczna"
 
-#: ../src/wxMaximaFrame.cpp:749
+#: ../src/wxMaximaFrame.cpp:748
 msgid "&Characteristic Polynomial..."
 msgstr "Wielomian charakterystyczny ..."
 
-#: ../src/wxMaximaFrame.cpp:654
+#: ../src/wxMaximaFrame.cpp:653
 msgid "&Clear Memory"
 msgstr "&Wyczyść pamięć"
 
-#: ../src/wxMaximaFrame.cpp:859
+#: ../src/wxMaximaFrame.cpp:858
 msgid "&Combine Factorials"
 msgstr "&Połącz silnie "
 
-#: ../src/wxMaximaFrame.cpp:902
+#: ../src/wxMaximaFrame.cpp:901
 msgid "&Complex Simplification"
 msgstr "Uproszczenia &zespolone"
 
-#: ../src/wxMaximaFrame.cpp:822
+#: ../src/wxMaximaFrame.cpp:821
 msgid "&Continued Fraction"
 msgstr "Ułamek ł&ańcuchowy"
 
-#: ../src/wxMaximaFrame.cpp:502
+#: ../src/wxMaximaFrame.cpp:501
 msgid "&Copy\tCtrl-C"
 msgstr "&Kopiuj\tCtrl-C"
 
@@ -171,110 +171,110 @@ msgstr "&Kopiuj\tCtrl-C"
 msgid "&Definite integration"
 msgstr "Całka &oznaczona"
 
-#: ../src/wxMaximaFrame.cpp:896
+#: ../src/wxMaximaFrame.cpp:895
 msgid "&Demoivre"
 msgstr "&Demoivre"
 
-#: ../src/wxMaximaFrame.cpp:752
+#: ../src/wxMaximaFrame.cpp:751
 msgid "&Determinant"
 msgstr "&Wyznacznik"
 
-#: ../src/wxMaximaFrame.cpp:785
+#: ../src/wxMaximaFrame.cpp:784
 msgid "&Differentiate..."
 msgstr "&Pochodna..."
 
-#: ../src/wxMaximaFrame.cpp:543
+#: ../src/wxMaximaFrame.cpp:542
 msgid "&Edit"
 msgstr "&Edycja"
 
 # Wyznacz zmienną
-#: ../src/wxMaximaFrame.cpp:709
+#: ../src/wxMaximaFrame.cpp:708
 msgid "&Eliminate Variable..."
 msgstr "&Ruguj zmienną"
 
-#: ../src/wxMaximaFrame.cpp:744
+#: ../src/wxMaximaFrame.cpp:743
 msgid "&Enter Matrix..."
 msgstr "&Wprowadź macierz"
 
-#: ../src/wxMaximaFrame.cpp:961
+#: ../src/wxMaximaFrame.cpp:960
 msgid "&Example..."
 msgstr "&Przykład..."
 
-#: ../src/wxMaximaFrame.cpp:839
+#: ../src/wxMaximaFrame.cpp:838
 msgid "&Expand Expression"
 msgstr "&Rozwiń wyrażenie"
 
-#: ../src/wxMaximaFrame.cpp:873
+#: ../src/wxMaximaFrame.cpp:872
 msgid "&Expand Trigonometric"
 msgstr "Rozwiń &trygonometrycznie"
 
-#: ../src/wxMaximaFrame.cpp:899
+#: ../src/wxMaximaFrame.cpp:898
 msgid "&Exponentialize"
 msgstr "&Exponentialize"
 
-#: ../src/wxMaximaFrame.cpp:480
+#: ../src/wxMaximaFrame.cpp:479
 msgid "&Export..."
 msgstr "E&ksportuj"
 
-#: ../src/wxMaximaFrame.cpp:834
+#: ../src/wxMaximaFrame.cpp:833
 msgid "&Factor Expression"
 msgstr "&Faktoryzuj wyrażenie"
 
-#: ../src/wxMaximaFrame.cpp:489
+#: ../src/wxMaximaFrame.cpp:488
 msgid "&File"
 msgstr "&Plik"
 
-#: ../src/wxMaximaFrame.cpp:692
+#: ../src/wxMaximaFrame.cpp:691
 msgid "&Find Root..."
 msgstr "Znajdź &pierwiastek"
 
-#: ../src/wxMaximaFrame.cpp:738
+#: ../src/wxMaximaFrame.cpp:737
 msgid "&Generate Matrix..."
 msgstr "&Generuj macierz"
 
-#: ../src/wxMaximaFrame.cpp:809
+#: ../src/wxMaximaFrame.cpp:808
 msgid "&Greatest Common Divisor..."
 msgstr "&Największy wspólny dzielnik"
 
-#: ../src/wxMaximaFrame.cpp:994
+#: ../src/wxMaximaFrame.cpp:993
 msgid "&Help"
 msgstr "&Pomoc"
 
-#: ../src/wxMaximaFrame.cpp:777
+#: ../src/wxMaximaFrame.cpp:776
 msgid "&Integrate..."
 msgstr "&Całkowanie..."
 
-#: ../src/wxMaximaFrame.cpp:645
+#: ../src/wxMaximaFrame.cpp:644
 msgid "&Interrupt\tCtrl-."
 msgstr "&Przerwij\tCtrl-."
 
-#: ../src/wxMaximaFrame.cpp:649
+#: ../src/wxMaximaFrame.cpp:648
 msgid "&Interrupt\tCtrl-G"
 msgstr "&Przerwij\tCtrl-G"
 
-#: ../src/wxMaximaFrame.cpp:746
+#: ../src/wxMaximaFrame.cpp:745
 msgid "&Invert Matrix"
 msgstr "Macierz &odwrotna"
 
-#: ../src/wxMaximaFrame.cpp:476
+#: ../src/wxMaximaFrame.cpp:475
 msgid "&Load Package...\tCtrl-L"
 msgstr "&Wczytaj pakiet\tCtrl-L"
 
-#: ../src/wxMaximaFrame.cpp:769
+#: ../src/wxMaximaFrame.cpp:768
 #, fuzzy
 msgid "&Map to List(s)..."
 msgstr "&Mapuj listę"
 
-#: ../src/wxMaximaFrame.cpp:684
+#: ../src/wxMaximaFrame.cpp:683
 msgid "&Maxima"
 msgstr "&Maxima"
 
-#: ../src/wxMaximaFrame.cpp:958
+#: ../src/wxMaximaFrame.cpp:957
 #, fuzzy
 msgid "&Maxima help"
 msgstr "Pokaż pomoc Maximy"
 
-#: ../src/wxMaximaFrame.cpp:917
+#: ../src/wxMaximaFrame.cpp:916
 msgid "&Modulus Computation..."
 msgstr "Obliczenia &modulo..."
 
@@ -282,7 +282,7 @@ msgstr "Obliczenia &modulo..."
 msgid "&New\tCtrl-N"
 msgstr "Nowy\tCtrl-N"
 
-#: ../src/wxMaximaFrame.cpp:947
+#: ../src/wxMaximaFrame.cpp:946
 msgid "&Numeric"
 msgstr "&Numeryczne"
 
@@ -298,11 +298,11 @@ msgstr "&Nusum"
 msgid "&Open\tCtrl-O"
 msgstr "&Otwórz\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:463
+#: ../src/wxMaximaFrame.cpp:462
 msgid "&Open...\tCtrl-O"
 msgstr "&Otwórz...\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:929
+#: ../src/wxMaximaFrame.cpp:928
 msgid "&Plot"
 msgstr "&Wykres"
 
@@ -310,7 +310,7 @@ msgstr "&Wykres"
 msgid "&Power series"
 msgstr "&Szereg potęgowy"
 
-#: ../src/wxMaximaFrame.cpp:483
+#: ../src/wxMaximaFrame.cpp:482
 msgid "&Print...\tCtrl-P"
 msgstr "&Drukuj...\tCtrl-P"
 
@@ -318,39 +318,39 @@ msgstr "&Drukuj...\tCtrl-P"
 msgid "&Rational"
 msgstr "&Wymierne"
 
-#: ../src/wxMaximaFrame.cpp:870
+#: ../src/wxMaximaFrame.cpp:869
 msgid "&Reduce Trigonometric"
 msgstr "Redukuj &trygonometrycznie"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "&Restart Maxima"
 msgstr "&Restart Maxima"
 
-#: ../src/wxMaximaFrame.cpp:700
+#: ../src/wxMaximaFrame.cpp:699
 msgid "&Roots of Polynomial (Real)"
 msgstr "Pierwiastki &wielomianiu (rzeczywiste)"
 
-#: ../src/wxMaximaFrame.cpp:472
+#: ../src/wxMaximaFrame.cpp:471
 msgid "&Save\tCtrl-S"
 msgstr "Zapisz\tCtrl-S"
 
-#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:919
+#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:918
 msgid "&Simplify"
 msgstr "&Upraszczanie"
 
-#: ../src/wxMaximaFrame.cpp:829
+#: ../src/wxMaximaFrame.cpp:828
 msgid "&Simplify Expression"
 msgstr "Uprość &wyrażenie"
 
-#: ../src/wxMaximaFrame.cpp:856
+#: ../src/wxMaximaFrame.cpp:855
 msgid "&Simplify Factorials"
 msgstr "Uprość &silnie"
 
-#: ../src/wxMaximaFrame.cpp:867
+#: ../src/wxMaximaFrame.cpp:866
 msgid "&Simplify Trigonometric"
 msgstr "Uprość &trygonometrycznie"
 
-#: ../src/wxMaximaFrame.cpp:688
+#: ../src/wxMaximaFrame.cpp:687
 msgid "&Solve..."
 msgstr "&Rozwiąż..."
 
@@ -362,11 +362,11 @@ msgstr "&Specjalny"
 msgid "&Taylor series"
 msgstr "Szereg &Taylora"
 
-#: ../src/wxMaximaFrame.cpp:762
+#: ../src/wxMaximaFrame.cpp:761
 msgid "&Transpose Matrix"
 msgstr "&Transponuj macierz"
 
-#: ../src/wxMaximaFrame.cpp:879
+#: ../src/wxMaximaFrame.cpp:878
 msgid "&Trigonometric Simplification"
 msgstr "Uproszczenia &trygonometryczne"
 
@@ -384,7 +384,7 @@ msgstr "(Używaj domyślnego języka)"
 msgid "- Infinity"
 msgstr "- Nieskończoność"
 
-#: ../src/wxMaxima.cpp:351
+#: ../src/wxMaxima.cpp:356
 msgid ""
 "... [suppressed additional lines since the output is longer than allowed in "
 "the configuration] "
@@ -394,16 +394,16 @@ msgstr ""
 msgid "1/2"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:103
+#: ../src/wxMaximaFrame.cpp:102
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4601
+#: ../src/wxMaxima.cpp:4613
 msgid "<br>Lisp: "
 msgstr "<br>Lisp: "
 
-#: ../src/wxMaxima.cpp:5487
+#: ../src/wxMaxima.cpp:5503
 msgid ""
 "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
@@ -437,11 +437,11 @@ msgid ""
 "\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1472
+#: ../src/wxMaximaFrame.cpp:1495
 msgid "A symbol from the configuration dialogue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:731
+#: ../src/wxMaximaFrame.cpp:730
 msgid "A&t Value..."
 msgstr "Wartość wyrażenia"
 
@@ -449,12 +449,12 @@ msgstr "Wartość wyrażenia"
 msgid "Abort evaluation on error"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaxima.cpp:4603
+#: ../src/wxMaxima.cpp:4615 ../src/wxMaximaFrame.cpp:985
 msgid "About"
 msgstr "O"
 
-#: ../src/wxMaximaFrame.cpp:987 ../src/wxMaximaFrame.cpp:990
-#: ../src/wxMaximaFrame.cpp:991
+#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaximaFrame.cpp:989
+#: ../src/wxMaximaFrame.cpp:990
 msgid "About wxMaxima"
 msgstr "O wxMaxima"
 
@@ -462,23 +462,23 @@ msgstr "O wxMaxima"
 msgid "Active cell bracket"
 msgstr "Obramowanie aktywnej komórki"
 
-#: ../src/wxMaximaFrame.cpp:760
+#: ../src/wxMaximaFrame.cpp:759
 msgid "Ad&joint Matrix"
 msgstr "Macierz &dołączona"
 
-#: ../src/wxMaximaFrame.cpp:914
+#: ../src/wxMaximaFrame.cpp:913
 msgid "Add Algebraic E&quality..."
 msgstr "Dodaj nierówność algebraiczną"
 
-#: ../src/wxMaximaFrame.cpp:657
+#: ../src/wxMaximaFrame.cpp:656
 msgid "Add a directory to search path"
 msgstr "Dodaj katalogi do zmiennej Path"
 
-#: ../src/wxMaxima.cpp:3353
+#: ../src/wxMaxima.cpp:3365
 msgid "Add dir to path:"
 msgstr "Dodaj do zmiennej Path"
 
-#: ../src/wxMaximaFrame.cpp:915
+#: ../src/wxMaximaFrame.cpp:914
 msgid "Add equality to the rational simplifier"
 msgstr ""
 
@@ -486,7 +486,7 @@ msgstr ""
 msgid "Add the .wxmx file to the HTML export"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:656
+#: ../src/wxMaximaFrame.cpp:655
 msgid "Add to &Path..."
 msgstr "Dodaj do zmiennej &Path"
 
@@ -527,27 +527,27 @@ msgstr "Stara zmienna:"
 msgid "All|*"
 msgstr "Wszystkie|*"
 
-#: ../src/wxMaximaFrame.cpp:1364
+#: ../src/wxMaximaFrame.cpp:1363
 msgid "Alpha"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3838
+#: ../src/wxMaxima.cpp:3850
 msgid "Apply"
 msgstr "Zastosuj"
 
-#: ../src/wxMaximaFrame.cpp:768
+#: ../src/wxMaximaFrame.cpp:767
 msgid "Apply function to a list"
 msgstr "Zastosuj funkcję do listy"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Apropos"
 msgstr "Apropos"
 
-#: ../src/wxMaxima.cpp:3764
+#: ../src/wxMaxima.cpp:3776
 msgid "Array:"
 msgstr "Tablica:"
 
-#: ../src/wxMaxima.cpp:4462
+#: ../src/wxMaxima.cpp:4474
 msgid "Artwork by"
 msgstr ""
 
@@ -555,7 +555,7 @@ msgstr ""
 msgid "Ask to save untitled documents"
 msgstr "Pytaj o zapis dokumentów bez nazwy"
 
-#: ../src/wxMaxima.cpp:3650
+#: ../src/wxMaxima.cpp:3662
 msgid "At value"
 msgstr "Dla wartości"
 
@@ -576,11 +576,11 @@ msgstr ""
 msgid "Autosave interval (minutes, 0 means: off):"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3557
+#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3569
 msgid "BC2"
 msgstr "Warunki brzegowe"
 
-#: ../src/wxMaximaFrame.cpp:1272
+#: ../src/wxMaximaFrame.cpp:1271
 msgid "Barsplot..."
 msgstr "Wykres słupkowy..."
 
@@ -588,7 +588,7 @@ msgstr "Wykres słupkowy..."
 msgid "Bat files (*.bat)|*.bat|All|*"
 msgstr "Pliki wsadowe (*.bat)|*.bat|Wszystkie*"
 
-#: ../src/wxMaxima.cpp:2943
+#: ../src/wxMaxima.cpp:2951
 msgid "Batch File"
 msgstr "Plik wsadowy"
 
@@ -601,7 +601,7 @@ msgid ""
 "cells."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1365
+#: ../src/wxMaximaFrame.cpp:1364
 msgid "Beta"
 msgstr ""
 
@@ -613,11 +613,11 @@ msgstr ""
 msgid "Bold"
 msgstr "Pogrubienie"
 
-#: ../src/wxMaxima.cpp:2359
+#: ../src/wxMaxima.cpp:2366
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1274
+#: ../src/wxMaximaFrame.cpp:1273
 msgid "Boxplot..."
 msgstr "Wykres pudełkowy..."
 
@@ -629,15 +629,15 @@ msgstr "Przeglądaj"
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2080
+#: ../src/MathCtrl.cpp:2127
 msgid "Bug: Cell left but not entered."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1178
+#: ../src/wxMaxima.cpp:1183
 msgid "Bug: Found a math end marker without any start marker."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1222
+#: ../src/wxMaxima.cpp:1227
 msgid "Bug: Found the end of autocompletion symbols but no beginning"
 msgstr ""
 
@@ -649,22 +649,22 @@ msgstr ""
 msgid "Bug: Fraction without enumerator"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2312
+#: ../src/MathCtrl.cpp:2359
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5839
+#: ../src/MathCtrl.cpp:5891
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of "
 "the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5913
+#: ../src/MathCtrl.cpp:5965
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5882
+#: ../src/MathCtrl.cpp:5934
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
@@ -674,49 +674,49 @@ msgstr ""
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
 msgstr ""
 
-#: ../src/GroupCell.cpp:780 ../src/GroupCell.cpp:951
+#: ../src/GroupCell.cpp:781 ../src/GroupCell.cpp:952
 msgid "Bug: No image counter to write to!"
 msgstr ""
 
-#: ../src/AbsCell.cpp:193
+#: ../src/AbsCell.cpp:199
 msgid "Bug: No last cell in an absCell!"
 msgstr ""
 
-#: ../src/ConjugateCell.cpp:185
+#: ../src/ConjugateCell.cpp:194
 msgid "Bug: No last cell in an conjugateCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:471
+#: ../src/FracCell.cpp:472
 msgid "Bug: No last cell in an denominator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:267
+#: ../src/ExptCell.cpp:270
 msgid "Bug: No last cell in an exponent of an exptCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:459
+#: ../src/FracCell.cpp:460
 msgid "Bug: No last cell in an numerator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:257
+#: ../src/ExptCell.cpp:260
 msgid "Bug: No last cell in the base of an exptCell!"
 msgstr ""
 
-#: ../src/ParenCell.cpp:534
+#: ../src/ParenCell.cpp:535
 msgid "Bug: No last cell inside a parenthesis!"
 msgstr ""
 
-#: ../src/SqrtCell.cpp:312
+#: ../src/SqrtCell.cpp:317
 msgid "Bug: No last cell inside a square root!"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2123
+#: ../src/MathCtrl.cpp:2170
 msgid ""
 "Bug: Start or end of merging of subsequent editing actions was requested two "
 "times in a row."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2090
+#: ../src/MathCtrl.cpp:2137
 msgid "Bug: Text changed, but no active cell."
 msgstr ""
 
@@ -724,39 +724,39 @@ msgstr ""
 msgid "Bug: Trying to append NULL to a group cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:555
+#: ../src/MathCtrl.cpp:600
 msgid "Bug: Trying to append maxima's output to a cell outside the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2014
+#: ../src/MathCtrl.cpp:2061
 msgid ""
 "Bug: Trying to merge individual cell adds to a region in the undo buffer but "
 "there are other cells between them."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6522
+#: ../src/MathCtrl.cpp:6577
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2092
+#: ../src/MathCtrl.cpp:2139
 msgid "Bug: Trying to record a cell contents change without a cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1495
+#: ../src/MathCtrl.cpp:1540
 msgid "Bug: Trying to select inside a cell without having a current cell"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5883
+#: ../src/MathCtrl.cpp:5935
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5844 ../src/MathCtrl.cpp:5918 ../src/MathCtrl.cpp:5952
+#: ../src/MathCtrl.cpp:5896 ../src/MathCtrl.cpp:5970 ../src/MathCtrl.cpp:6004
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:973
+#: ../src/wxMaximaFrame.cpp:972
 msgid "Build &Info"
 msgstr "Informacje o kompilacji"
 
@@ -771,52 +771,52 @@ msgstr ""
 "Domyślnie Shift-Enter wykonuje aktywną komórkę natomiast Enter wstawia nową "
 "linię do wyrażenia. Zachowanie to, można zmienić w 'Edycja->Preferencje'."
 
-#: ../src/wxMaximaFrame.cpp:782
+#: ../src/wxMaximaFrame.cpp:781
 msgid "C&hange Variable..."
 msgstr "Zmiana &zmiennych ..."
 
-#: ../src/wxMaximaFrame.cpp:540
+#: ../src/wxMaximaFrame.cpp:539
 msgid "C&onfigure"
 msgstr "Preferencje"
 
-#: ../src/wxMaximaFrame.cpp:801
+#: ../src/wxMaximaFrame.cpp:800
 msgid "Calculate &Product..."
 msgstr "Oblicz &iloczyn ..."
 
-#: ../src/wxMaximaFrame.cpp:799
+#: ../src/wxMaximaFrame.cpp:798
 msgid "Calculate Su&m..."
 msgstr "Oblicz &sumę ..."
 
-#: ../src/wxMaximaFrame.cpp:939
+#: ../src/wxMaximaFrame.cpp:938
 msgid "Calculate bigfloat value of the last result"
 msgstr "Oblicz ostatni wynik w podwyższonej precyzji (bigfloat)"
 
-#: ../src/wxMaximaFrame.cpp:936
+#: ../src/wxMaximaFrame.cpp:935
 msgid "Calculate float value of the last result"
 msgstr "Wartość zmiennoprzecinkowa wyrażenia"
 
-#: ../src/wxMaxima.cpp:3971
+#: ../src/wxMaxima.cpp:3983
 msgid "Calculate modulus:"
 msgstr "Obliczenia modulo:"
 
-#: ../src/wxMaximaFrame.cpp:942
+#: ../src/wxMaximaFrame.cpp:941
 #, fuzzy
 msgid "Calculate numeric value of the last result"
 msgstr "Wartość zmiennoprzecinkowa wyrażenia"
 
-#: ../src/wxMaximaFrame.cpp:802
+#: ../src/wxMaximaFrame.cpp:801
 msgid "Calculate products"
 msgstr "Oblicz iloczyn"
 
-#: ../src/wxMaximaFrame.cpp:800
+#: ../src/wxMaximaFrame.cpp:799
 msgid "Calculate sums"
 msgstr "Oblicz sumę"
 
-#: ../src/wxMaxima.cpp:5830
+#: ../src/wxMaxima.cpp:5845
 msgid "Can not connect to the web server."
 msgstr "Brak łączności z serwerem internetowym."
 
-#: ../src/wxMaxima.cpp:5881
+#: ../src/wxMaxima.cpp:5896
 msgid "Can not download version info."
 msgstr ""
 
@@ -832,15 +832,15 @@ msgstr ""
 #: ../src/PlotFormatWiz.cpp:48 ../src/SeriesWiz.cpp:49 ../src/SeriesWiz.cpp:51
 #: ../src/SubstituteWiz.cpp:41 ../src/SubstituteWiz.cpp:43 ../src/SumWiz.cpp:44
 #: ../src/SumWiz.cpp:46 ../src/SystemWiz.cpp:38 ../src/SystemWiz.cpp:40
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: ../src/wxMaximaFrame.cpp:126 ../src/wxMaxima.cpp:932
+#: ../src/wxMaxima.cpp:937 ../src/wxMaximaFrame.cpp:125
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1217
+#: ../src/wxMaximaFrame.cpp:1216
 msgid "Canonical (tr)"
 msgstr "Postać kanoniczna (tr)"
 
@@ -848,7 +848,7 @@ msgstr "Postać kanoniczna (tr)"
 msgid "Catalan"
 msgstr "Katalonski"
 
-#: ../src/wxMaximaFrame.cpp:638
+#: ../src/wxMaximaFrame.cpp:637
 msgid "Ce&ll"
 msgstr "&Komórka"
 
@@ -856,39 +856,39 @@ msgstr "&Komórka"
 msgid "Cell bracket"
 msgstr "Obramowanie komórki"
 
-#: ../src/wxMaxima.cpp:5261
+#: ../src/wxMaxima.cpp:5273
 msgid "Cell ends in a backslash"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:676
+#: ../src/wxMaximaFrame.cpp:675
 msgid "Change &2d Display"
 msgstr "Zmień format wyników"
 
-#: ../src/wxMaximaFrame.cpp:677
+#: ../src/wxMaximaFrame.cpp:676
 msgid "Change the 2d display algorithm used to display math output"
 msgstr "Zmień format podawania wyników"
 
-#: ../src/wxMaxima.cpp:3995
+#: ../src/wxMaxima.cpp:4007
 msgid "Change variable"
 msgstr "Zmień zmienną"
 
-#: ../src/wxMaximaFrame.cpp:783
+#: ../src/wxMaximaFrame.cpp:782
 msgid "Change variable in integral or sum"
 msgstr "Zmień zmienną w całce lub sumie"
 
-#: ../src/wxMaxima.cpp:3751
+#: ../src/wxMaxima.cpp:3763
 msgid "Char poly"
 msgstr "Char poly"
 
-#: ../src/wxMaximaFrame.cpp:978
+#: ../src/wxMaximaFrame.cpp:977
 msgid "Check for Updates"
 msgstr "Sprawdź, czy jest nowsza wersja"
 
-#: ../src/wxMaximaFrame.cpp:979
+#: ../src/wxMaximaFrame.cpp:978
 msgid "Check if a newer version of wxMaxima/Maxima exist."
 msgstr "Sprawdź najawność nowszej wersji wxMaxima/Maxima."
 
-#: ../src/wxMaximaFrame.cpp:1385
+#: ../src/wxMaximaFrame.cpp:1384
 msgid "Chi"
 msgstr ""
 
@@ -909,15 +909,15 @@ msgstr "Wybierz czcionkę"
 msgid "Choose new plot format:"
 msgstr "Wybierz nowy format wykresów:"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710
 msgid "Classes:"
 msgstr "Klasy:"
 
-#: ../src/wxMaximaFrame.cpp:469
+#: ../src/wxMaximaFrame.cpp:468
 msgid "Close\tCtrl-W"
 msgstr "&Zamknij\tCtrl-W"
 
-#: ../src/wxMaximaFrame.cpp:470
+#: ../src/wxMaximaFrame.cpp:469
 msgid "Close window"
 msgstr "Zamknij okno"
 
@@ -949,19 +949,19 @@ msgstr ""
 msgid "Code highlighting: Variables"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4806
+#: ../src/wxMaxima.cpp:4818
 msgid "Col. names:"
 msgstr "Nazwy kolumn:"
 
-#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Columns:"
 msgstr "Kolumny:"
 
-#: ../src/wxMaximaFrame.cpp:860
+#: ../src/wxMaximaFrame.cpp:859
 msgid "Combine factorials in an expression"
 msgstr "Połącz silnie występujące w wyrażeniu - np. 'n*(n-1)! => n!'"
 
-#: ../src/wxMaxima.cpp:5293
+#: ../src/wxMaxima.cpp:5305
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
@@ -973,24 +973,24 @@ msgstr "Przecinek oddziela kolejne współrzędne na osi OX"
 msgid "Comma separated y coordinates"
 msgstr "Przecinek oddziela kolejne współrzędne na osi OY"
 
-#: ../src/MathCtrl.cpp:1030
+#: ../src/MathCtrl.cpp:1072
 msgid "Comment Selection"
 msgstr "Zakomentuj zaznaczenie"
 
-#: ../src/wxMaximaFrame.cpp:533
+#: ../src/wxMaximaFrame.cpp:532
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:532
+#: ../src/wxMaximaFrame.cpp:531
 #, fuzzy
 msgid "Comment selection\tCtrl-/"
 msgstr "Zakomentuj zaznaczenie"
 
-#: ../src/wxMaximaFrame.cpp:601
+#: ../src/wxMaximaFrame.cpp:600
 msgid "Complete Word\tCtrl-K"
 msgstr "Uzupełnij słowo\tCtrl-K"
 
-#: ../src/wxMaximaFrame.cpp:602
+#: ../src/wxMaximaFrame.cpp:601
 msgid "Complete word"
 msgstr "Uzupełnij słowo"
 
@@ -998,37 +998,37 @@ msgstr "Uzupełnij słowo"
 msgid "Completely stop maxima and restart it"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:823
+#: ../src/wxMaximaFrame.cpp:822
 msgid "Compute continued fraction of a value"
 msgstr "Przedstaw wyrażenie w postaci ułamka łańcuchowego"
 
-#: ../src/wxMaximaFrame.cpp:761
+#: ../src/wxMaximaFrame.cpp:760
 msgid "Compute the adjoint matrix"
 msgstr "Znajdź macierz dołączoną"
 
-#: ../src/wxMaximaFrame.cpp:750
+#: ../src/wxMaximaFrame.cpp:749
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr "Oblicz wielomian charakterystyczny macierzy"
 
-#: ../src/wxMaximaFrame.cpp:753
+#: ../src/wxMaximaFrame.cpp:752
 msgid "Compute the determinant of a matrix"
 msgstr "Oblicz wyznacznik macierzy"
 
-#: ../src/wxMaximaFrame.cpp:810
+#: ../src/wxMaximaFrame.cpp:809
 msgid "Compute the greatest common divisor"
 msgstr "Znajdź największy wspólny dzielnik (NWD)"
 
-#: ../src/wxMaximaFrame.cpp:747
+#: ../src/wxMaximaFrame.cpp:746
 msgid "Compute the inverse of a matrix"
 msgstr "Znajdź macierz odwrotną"
 
-#: ../src/wxMaximaFrame.cpp:813
+#: ../src/wxMaximaFrame.cpp:812
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
 "Znajdź najmniejszą wspólną wielokrotność (NWW) (przed użyciem wykonaj "
 "'load(functs)')"
 
-#: ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4868
 msgid "Condition:"
 msgstr "Warunek:"
 
@@ -1040,8 +1040,8 @@ msgstr "Plik konfiguracyjny (*.ini)|*.ini"
 msgid "Configuration warning"
 msgstr "Uwaga na temat konfiguracji"
 
-#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:538
-#: ../src/wxMaximaFrame.cpp:541
+#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:540
 msgid "Configure wxMaxima"
 msgstr "Preferencje programu wxMaxima"
 
@@ -1050,130 +1050,132 @@ msgstr "Preferencje programu wxMaxima"
 msgid "Constant"
 msgstr "Stała"
 
-#: ../src/wxMaximaFrame.cpp:844
+#: ../src/wxMaximaFrame.cpp:843
 msgid "Contract Logarithms"
 msgstr "Zwiń logarytmy"
 
-#: ../src/wxMaximaFrame.cpp:851
+#: ../src/wxMaximaFrame.cpp:850
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr "Zamień dwumian Newtona, funkcje beta lub gamma na silnie"
 
-#: ../src/wxMaximaFrame.cpp:854
+#: ../src/wxMaximaFrame.cpp:853
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr "Zamień dwumian Newtona, silnie, funkcję beta na funkcję gamma"
 
-#: ../src/wxMaximaFrame.cpp:888
+#: ../src/wxMaximaFrame.cpp:887
 msgid "Convert complex expression to polar form"
 msgstr "Zamień wyrażenie zespolone na postać biegunową"
 
-#: ../src/wxMaximaFrame.cpp:885
+#: ../src/wxMaximaFrame.cpp:884
 msgid "Convert complex expression to rect form"
 msgstr "Zamień wyrażenie zespolone na postać alebraiczną"
 
-#: ../src/wxMaximaFrame.cpp:897
+#: ../src/wxMaximaFrame.cpp:896
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr "Zamień postać wykładniczą liczby zespolonej na postać trygonometryczną"
 
-#: ../src/wxMaximaFrame.cpp:842
+#: ../src/wxMaximaFrame.cpp:841
 msgid "Convert logarithm of product to sum of logarithms"
 msgstr "Zamień logarytm iloczynu na sumę logarytmów"
 
-#: ../src/wxMaximaFrame.cpp:845
+#: ../src/wxMaximaFrame.cpp:844
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "Zamień sumę logarytmów na logarytm iloczynu"
 
-#: ../src/wxMaximaFrame.cpp:850
+#: ../src/wxMaximaFrame.cpp:849
 msgid "Convert to &Factorials"
 msgstr "Zamień na &silnie"
 
-#: ../src/wxMaximaFrame.cpp:853
+#: ../src/wxMaximaFrame.cpp:852
 msgid "Convert to &Gamma"
 msgstr "Zamień na funkcję &gamma"
 
-#: ../src/wxMaximaFrame.cpp:887
+#: ../src/wxMaximaFrame.cpp:886
 msgid "Convert to &Polarform"
 msgstr "Forma &biegunowa"
 
-#: ../src/wxMaximaFrame.cpp:884
+#: ../src/wxMaximaFrame.cpp:883
 msgid "Convert to &Rectform"
 msgstr "Forma &algebraiczna"
 
-#: ../src/wxMaximaFrame.cpp:877
+#: ../src/wxMaximaFrame.cpp:876
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr "Uprość wyrażenie trygonometryczne zawierające ułamki."
 
-#: ../src/wxMaximaFrame.cpp:900
+#: ../src/wxMaximaFrame.cpp:899
 msgid "Convert trigonometric functions to exponential form"
 msgstr "Zamień funkcje trygonometryczne i hiperboliczne na eksponencjalne"
 
-#: ../src/ToolBar.cpp:140 ../src/MathCtrl.cpp:918 ../src/MathCtrl.cpp:931
-#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1024
+#: ../src/MathCtrl.cpp:960 ../src/MathCtrl.cpp:973 ../src/MathCtrl.cpp:1019
+#: ../src/MathCtrl.cpp:1066 ../src/ToolBar.cpp:140
 msgid "Copy"
 msgstr "Kopiuj"
 
-#: ../src/wxMaximaFrame.cpp:597
+#: ../src/wxMaximaFrame.cpp:596
 msgid "Copy Previous Input\tCtrl-I"
 msgstr "Kopiuj ostatnie wejście\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:599
+#: ../src/wxMaximaFrame.cpp:598
 #, fuzzy
 msgid "Copy Previous Output\tCtrl-U"
 msgstr "Kopiuj ostatnie wejście\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:514 ../src/MathCtrl.cpp:936 ../src/MathCtrl.cpp:982
+#: ../src/MathCtrl.cpp:978 ../src/MathCtrl.cpp:1024
+#: ../src/wxMaximaFrame.cpp:513
 msgid "Copy as Image"
 msgstr "Kopiuj jako obrazek"
 
-#: ../src/wxMaximaFrame.cpp:507 ../src/MathCtrl.cpp:932 ../src/MathCtrl.cpp:978
+#: ../src/MathCtrl.cpp:974 ../src/MathCtrl.cpp:1020
+#: ../src/wxMaximaFrame.cpp:506
 msgid "Copy as LaTeX"
 msgstr "Kopiuj jako LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:510
+#: ../src/wxMaximaFrame.cpp:509
 #, fuzzy
 msgid "Copy as MathML"
 msgstr "Kopiuj jako obrazek"
 
-#: ../src/MathCtrl.cpp:935 ../src/MathCtrl.cpp:980
+#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1022
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:504
+#: ../src/wxMaximaFrame.cpp:503
 msgid "Copy as Text\tCtrl-Shift-C"
 msgstr "Kopiuj jako tekst\tCtrl-Shift-C"
 
-#: ../src/MathCtrl.cpp:933 ../src/MathCtrl.cpp:979
+#: ../src/MathCtrl.cpp:975 ../src/MathCtrl.cpp:1021
 #, fuzzy
 msgid "Copy as plain text"
 msgstr "Kopiuj jako obrazek"
 
-#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:503
+#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:502
 msgid "Copy selection"
 msgstr "Kopiuj zaznaczenie"
 
-#: ../src/wxMaximaFrame.cpp:515
+#: ../src/wxMaximaFrame.cpp:514
 msgid "Copy selection from document as an image"
 msgstr "Kopiuj zaznaczenie z dokumentu jako obrazek"
 
-#: ../src/wxMaximaFrame.cpp:505
+#: ../src/wxMaximaFrame.cpp:504
 msgid "Copy selection from document as text"
 msgstr "Kopiuj zaznaczenie z dokumentu jako tekst"
 
-#: ../src/wxMaximaFrame.cpp:508
+#: ../src/wxMaximaFrame.cpp:507
 msgid "Copy selection from document in LaTeX format"
 msgstr "Kopiuj zaznaczenie z dokumentu w formacje LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:511
+#: ../src/wxMaximaFrame.cpp:510
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:598
+#: ../src/wxMaximaFrame.cpp:597
 msgid "Create a new cell with previous input"
 msgstr "Utwórz nową komórkę z ostatnim wejściem"
 
-#: ../src/wxMaximaFrame.cpp:600
+#: ../src/wxMaximaFrame.cpp:599
 #, fuzzy
 msgid "Create a new cell with previous output"
 msgstr "Utwórz nową komórkę z ostatnim wejściem"
@@ -1182,15 +1184,15 @@ msgstr "Utwórz nową komórkę z ostatnim wejściem"
 msgid "Cursor"
 msgstr "Kursor"
 
-#: ../src/ToolBar.cpp:137 ../src/MathCtrl.cpp:1023
+#: ../src/MathCtrl.cpp:1065 ../src/ToolBar.cpp:137
 msgid "Cut"
 msgstr "Wytnij"
 
-#: ../src/wxMaximaFrame.cpp:499
+#: ../src/wxMaximaFrame.cpp:498
 msgid "Cut\tCtrl-X"
 msgstr "&Wytnij\tCtrl-X"
 
-#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:500
+#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:499
 msgid "Cut selection"
 msgstr "Wytnij zaznaczenie"
 
@@ -1202,18 +1204,18 @@ msgstr "Czeski"
 msgid "Danish"
 msgstr "Duński"
 
-#: ../src/wxMaxima.cpp:4799 ../src/wxMaxima.cpp:4806 ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4811 ../src/wxMaxima.cpp:4818 ../src/wxMaxima.cpp:4868
 msgid "Data Matrix:"
 msgstr "Macierz danych:"
 
-#: ../src/wxMaxima.cpp:4826
+#: ../src/wxMaxima.cpp:4838
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr "Plik z danymi (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698 ../src/wxMaxima.cpp:4712
-#: ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726 ../src/wxMaxima.cpp:4734
-#: ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748 ../src/wxMaxima.cpp:4755
-#: ../src/wxMaxima.cpp:4791
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710 ../src/wxMaxima.cpp:4724
+#: ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738 ../src/wxMaxima.cpp:4746
+#: ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760 ../src/wxMaxima.cpp:4767
+#: ../src/wxMaxima.cpp:4803
 msgid "Data:"
 msgstr "Dane:"
 
@@ -1221,7 +1223,7 @@ msgstr "Dane:"
 msgid "Debug: watch maxima's stdout stream"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:820
+#: ../src/wxMaximaFrame.cpp:819
 msgid "Decompose rational function to partial fractions"
 msgstr "Przedstaw wyrażenie w postaci ułamka prostego"
 
@@ -1252,47 +1254,47 @@ msgid ""
 "with."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3403 ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3415 ../src/wxMaxima.cpp:3424
 msgid "Delete"
 msgstr "Usuń"
 
-#: ../src/wxMaximaFrame.cpp:667
+#: ../src/wxMaximaFrame.cpp:666
 msgid "Delete F&unction..."
 msgstr "Usuń &funkcję"
 
-#: ../src/MathCtrl.cpp:939 ../src/MathCtrl.cpp:985
+#: ../src/MathCtrl.cpp:981 ../src/MathCtrl.cpp:1027
 msgid "Delete Selection"
 msgstr "Usuń zaznaczenie"
 
-#: ../src/wxMaximaFrame.cpp:669
+#: ../src/wxMaximaFrame.cpp:668
 msgid "Delete V&ariable..."
 msgstr "Usuń &zmienną"
 
-#: ../src/wxMaximaFrame.cpp:668
+#: ../src/wxMaximaFrame.cpp:667
 msgid "Delete a function"
 msgstr "Usuń funkcję"
 
-#: ../src/wxMaximaFrame.cpp:670
+#: ../src/wxMaximaFrame.cpp:669
 msgid "Delete a variable"
 msgstr "Usuń zmienną"
 
-#: ../src/wxMaximaFrame.cpp:655
+#: ../src/wxMaximaFrame.cpp:654
 msgid "Delete all values from memory"
 msgstr "Usuń wszystkie dane z pamięci"
 
-#: ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3424
 msgid "Delete function(s):"
 msgstr "Usuń funkcję(e):"
 
-#: ../src/wxMaxima.cpp:3403
+#: ../src/wxMaxima.cpp:3415
 msgid "Delete variable(s):"
 msgstr "Usuń zmienną(e):"
 
-#: ../src/wxMaximaFrame.cpp:1367
+#: ../src/wxMaximaFrame.cpp:1366
 msgid "Delta"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4011
+#: ../src/wxMaxima.cpp:4023
 msgid "Denom. deg:"
 msgstr "st. mianownika:"
 
@@ -1300,35 +1302,35 @@ msgstr "st. mianownika:"
 msgid "Depth:"
 msgstr "Stopień:"
 
-#: ../src/wxMaxima.cpp:3541
+#: ../src/wxMaxima.cpp:3553
 msgid "Derivative:"
 msgstr "Pochodna:"
 
-#: ../src/wxMaximaFrame.cpp:1258
+#: ../src/wxMaximaFrame.cpp:1257
 msgid "Deviation..."
 msgstr "Odchylenie..."
 
-#: ../src/wxMaximaFrame.cpp:816
+#: ../src/wxMaximaFrame.cpp:815
 msgid "Di&vide Polynomials..."
 msgstr "Podziel wielomiany..."
 
-#: ../src/wxMaximaFrame.cpp:1223
+#: ../src/wxMaximaFrame.cpp:1222
 msgid "Diff..."
 msgstr "Pochodna..."
 
-#: ../src/wxMaxima.cpp:4154 ../src/wxMaxima.cpp:5066
+#: ../src/wxMaxima.cpp:4166 ../src/wxMaxima.cpp:5078
 msgid "Differentiate"
 msgstr "Pochodna"
 
-#: ../src/wxMaximaFrame.cpp:786
+#: ../src/wxMaximaFrame.cpp:785
 msgid "Differentiate expression"
 msgstr "Oblicz pochodną wyrażenia"
 
-#: ../src/MathCtrl.cpp:1001
+#: ../src/MathCtrl.cpp:1043
 msgid "Differentiate..."
 msgstr "Pochodna..."
 
-#: ../src/LimitWiz.cpp:37 ../src/FindReplacePane.cpp:76
+#: ../src/FindReplacePane.cpp:76 ../src/LimitWiz.cpp:37
 msgid "Direction:"
 msgstr "Z:"
 
@@ -1336,48 +1338,49 @@ msgstr "Z:"
 msgid "Discrete plot"
 msgstr "Dyskretny"
 
-#: ../src/wxMaximaFrame.cpp:679
+#: ../src/wxMaximaFrame.cpp:678
 msgid "Display Te&X Form"
 msgstr "Wyświetl w formacie Te&X"
 
-#: ../src/wxMaxima.cpp:3320
+#: ../src/wxMaxima.cpp:3332
 msgid "Display algorithm"
 msgstr "Format wyświetlania wyników"
 
-#: ../src/wxMaximaFrame.cpp:680
+#: ../src/wxMaximaFrame.cpp:679
 msgid "Display last result in TeX form"
 msgstr "Zapisz ostatni wynik w formacie TeX"
 
-#: ../src/wxMaximaFrame.cpp:674
+#: ../src/wxMaximaFrame.cpp:673
 msgid "Display time used for evaluation"
 msgstr "Wyświetl czas przeprowadzania obliczeń"
 
-#: ../src/wxMaxima.cpp:4061
+#: ../src/wxMaxima.cpp:4073
 msgid "Divide"
 msgstr "Podziel"
 
-#: ../src/MathCtrl.cpp:1032
+#: ../src/MathCtrl.cpp:1074
 msgid "Divide Cell"
 msgstr "Podziel komórki"
 
-#: ../src/wxMaximaFrame.cpp:635
+#: ../src/wxMaximaFrame.cpp:634
 #, fuzzy
 msgid "Divide Cell\tCtrl-D"
 msgstr "Podziel komórki"
 
-#: ../src/wxMaximaFrame.cpp:817
+#: ../src/wxMaximaFrame.cpp:816
 msgid "Divide numbers or polynomials"
 msgstr "Podziel liczby lub wielomiany"
 
-#: ../src/wxMaximaFrame.cpp:636
+#: ../src/wxMaximaFrame.cpp:635
 msgid "Divide this input cell into two cells"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5917
-msgid "Do you want to save the changes you made in the document \""
+#: ../src/wxMaxima.cpp:5932
+#, fuzzy, c-format
+msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr "Czy chcesz zapisać wprowadzone zmiany?"
 
-#: ../src/wxMaxima.cpp:1664 ../src/wxMaxima.cpp:1672
+#: ../src/wxMaxima.cpp:1669 ../src/wxMaxima.cpp:1677
 msgid "Document "
 msgstr "Dokument "
 
@@ -1396,7 +1399,7 @@ msgid ""
 "differences."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Don't save"
 msgstr "Nie zapisuj"
 
@@ -1404,27 +1407,27 @@ msgstr "Nie zapisuj"
 msgid "Down"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:734
+#: ../src/wxMaximaFrame.cpp:733
 msgid "E&quations"
 msgstr "&Równania"
 
-#: ../src/wxMaximaFrame.cpp:487
+#: ../src/wxMaximaFrame.cpp:486
 msgid "E&xit\tCtrl-Q"
 msgstr "Wyjście\tCtrl-Q"
 
-#: ../src/wxMaximaFrame.cpp:757
+#: ../src/wxMaximaFrame.cpp:756
 msgid "Eige&nvectors"
 msgstr "Wektory własne"
 
-#: ../src/wxMaximaFrame.cpp:755
+#: ../src/wxMaximaFrame.cpp:754
 msgid "Eigen&values"
 msgstr "Wartości własne"
 
-#: ../src/wxMaxima.cpp:3572
+#: ../src/wxMaxima.cpp:3584
 msgid "Eliminate"
 msgstr "Wyznacz"
 
-#: ../src/wxMaximaFrame.cpp:710
+#: ../src/wxMaximaFrame.cpp:709
 msgid "Eliminate a variable from a system of equations"
 msgstr "Wyznacz zmienną z układu równań"
 
@@ -1436,21 +1439,21 @@ msgstr ""
 msgid "English"
 msgstr "Angielski"
 
-#: ../src/wxMaxima.cpp:4712 ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726
-#: ../src/wxMaxima.cpp:4734 ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748
-#: ../src/wxMaxima.cpp:4755 ../src/wxMaxima.cpp:4791 ../src/wxMaxima.cpp:4799
+#: ../src/wxMaxima.cpp:4724 ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738
+#: ../src/wxMaxima.cpp:4746 ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760
+#: ../src/wxMaxima.cpp:4767 ../src/wxMaxima.cpp:4803 ../src/wxMaxima.cpp:4811
 msgid "Enter Data"
 msgstr "Wprowadź dane"
 
-#: ../src/wxMaximaFrame.cpp:1279
+#: ../src/wxMaximaFrame.cpp:1278
 msgid "Enter Matrix..."
 msgstr "Wprowadź macierz..."
 
-#: ../src/wxMaximaFrame.cpp:745
+#: ../src/wxMaximaFrame.cpp:744
 msgid "Enter a matrix"
 msgstr "Wprowadź macierz"
 
-#: ../src/wxMaxima.cpp:3962
+#: ../src/wxMaxima.cpp:3974
 msgid "Enter an equation for rational simplification:"
 msgstr "Wprowadź równanie do upraszczania racjonalnego:"
 
@@ -1462,11 +1465,11 @@ msgstr "Wprowadź listę zmiennych oddzielonych przecinkami"
 msgid "Enter evaluates cells"
 msgstr "Klawisz 'Enter' wykonuje komórki"
 
-#: ../src/wxMaxima.cpp:3734
+#: ../src/wxMaxima.cpp:3746
 msgid "Enter matrix"
 msgstr "Wprowadź macierz"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 #, fuzzy
 msgid "Enter new precision for bigfloats:"
 msgstr "Wprowadź nową dokładność:"
@@ -1475,12 +1478,12 @@ msgstr "Wprowadź nową dokładność:"
 msgid "Enter the path to the Maxima executable."
 msgstr "Wprowadź ścieżkę do programu Maxima"
 
-#: ../src/wxMaximaFrame.cpp:1368
+#: ../src/wxMaximaFrame.cpp:1367
 #, fuzzy
 msgid "Epsilon"
 msgstr "Epsilon:"
 
-#: ../src/wxMaxima.cpp:4208
+#: ../src/wxMaxima.cpp:4220
 msgid "Epsilon:"
 msgstr "Epsilon:"
 
@@ -1489,13 +1492,13 @@ msgstr "Epsilon:"
 msgid "Equation %d:"
 msgstr "Równanie %d:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:3633
-#: ../src/wxMaxima.cpp:5019
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:3645
+#: ../src/wxMaxima.cpp:5031
 msgid "Equation(s):"
 msgstr "Równanie(a):"
 
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3993
-#: ../src/wxMaxima.cpp:4807 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:4005
+#: ../src/wxMaxima.cpp:4819 ../src/wxMaxima.cpp:5045
 msgid "Equation:"
 msgstr "Równanie:"
 
@@ -1506,79 +1509,79 @@ msgid ""
 "be introduced one into another. Also they are always printed out as 2D maths."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3570
+#: ../src/wxMaxima.cpp:3582
 msgid "Equations:"
 msgstr "Równania:"
 
-#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1455
-#: ../src/wxMaxima.cpp:1469 ../src/wxMaxima.cpp:1620 ../src/wxMaxima.cpp:1633
-#: ../src/wxMaxima.cpp:1643 ../src/wxMaxima.cpp:1666 ../src/wxMaxima.cpp:2034
-#: ../src/wxMaxima.cpp:2206 ../src/wxMaxima.cpp:5381 ../src/wxMaxima.cpp:5830
-#: ../src/wxMaxima.cpp:5881
+#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1460
+#: ../src/wxMaxima.cpp:1474 ../src/wxMaxima.cpp:1625 ../src/wxMaxima.cpp:1638
+#: ../src/wxMaxima.cpp:1648 ../src/wxMaxima.cpp:1671 ../src/wxMaxima.cpp:2039
+#: ../src/wxMaxima.cpp:2211 ../src/wxMaxima.cpp:5397 ../src/wxMaxima.cpp:5845
+#: ../src/wxMaxima.cpp:5896
 msgid "Error"
 msgstr "Błąd"
 
-#: ../src/wxMaxima.cpp:2886 ../src/wxMaxima.cpp:2900 ../src/wxMaxima.cpp:2913
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617 ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:2894 ../src/wxMaxima.cpp:2908 ../src/wxMaxima.cpp:2921
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629 ../src/wxMaxima.cpp:3740
 msgid "Error!"
 msgstr "Błąd!"
 
-#: ../src/wxMaximaFrame.cpp:1370
+#: ../src/wxMaximaFrame.cpp:1369
 msgid "Eta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:909
+#: ../src/wxMaximaFrame.cpp:908
 msgid "Evaluate &Noun Forms"
 msgstr "Oblicz wyrażenie &nominalne"
 
-#: ../src/wxMaximaFrame.cpp:589
+#: ../src/wxMaximaFrame.cpp:588
 #, fuzzy
 msgid "Evaluate All Cells\tCtrl-Shift-R"
 msgstr "Wykonaj wszystkie komórki\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:587
+#: ../src/wxMaximaFrame.cpp:586
 #, fuzzy
 msgid "Evaluate All Visible Cells\tCtrl-R"
 msgstr "Wykonaj wszystkie komórki\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:585 ../src/MathCtrl.cpp:942
+#: ../src/MathCtrl.cpp:984 ../src/wxMaximaFrame.cpp:584
 msgid "Evaluate Cell(s)"
 msgstr "Wykonaj komórki"
 
-#: ../src/wxMaximaFrame.cpp:591
+#: ../src/wxMaximaFrame.cpp:590
 #, fuzzy
 msgid "Evaluate Cells Above\tCtrl-Shift-P"
 msgstr "Wykonaj wszystkie komórki\tCtrl-R"
 
-#: ../src/MathCtrl.cpp:956 ../src/MathCtrl.cpp:1051
+#: ../src/MathCtrl.cpp:998 ../src/MathCtrl.cpp:1093
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:961 ../src/MathCtrl.cpp:1053
+#: ../src/MathCtrl.cpp:1003 ../src/MathCtrl.cpp:1095
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:971 ../src/MathCtrl.cpp:1057
+#: ../src/MathCtrl.cpp:1013 ../src/MathCtrl.cpp:1099
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:966 ../src/MathCtrl.cpp:1055
+#: ../src/MathCtrl.cpp:1008 ../src/MathCtrl.cpp:1097
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:586
+#: ../src/wxMaximaFrame.cpp:585
 msgid "Evaluate active or selected cell(s)"
 msgstr "Wykonaj aktywne lub zaznaczone komórki"
 
-#: ../src/wxMaximaFrame.cpp:590
+#: ../src/wxMaximaFrame.cpp:589
 msgid "Evaluate all cells in the document"
 msgstr "Wykonaj wszystkie komórki w dokumencie"
 
-#: ../src/wxMaximaFrame.cpp:910
+#: ../src/wxMaximaFrame.cpp:909
 msgid "Evaluate all noun forms in expression"
 msgstr "Oblicz wszystkie wyrażenie nominalne"
 
-#: ../src/wxMaximaFrame.cpp:588
+#: ../src/wxMaximaFrame.cpp:587
 #, fuzzy
 msgid "Evaluate all visible cells in the document"
 msgstr "Wykonaj wszystkie komórki w dokumencie"
@@ -1592,7 +1595,7 @@ msgstr ""
 msgid "Evaluate to point"
 msgstr "Oblicz wyrażenie &nominalne"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Example"
 msgstr "Przykład"
 
@@ -1605,31 +1608,31 @@ msgstr "Przykładowy tekst"
 msgid "Examples:"
 msgstr "Przykład"
 
-#: ../src/wxMaximaFrame.cpp:488
+#: ../src/wxMaximaFrame.cpp:487
 msgid "Exit wxMaxima"
 msgstr "Wyjdź z wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:1214
+#: ../src/wxMaximaFrame.cpp:1213
 msgid "Expand"
 msgstr "Rozwiń"
 
-#: ../src/wxMaximaFrame.cpp:1219
+#: ../src/wxMaximaFrame.cpp:1218
 msgid "Expand (tr)"
 msgstr "Rozwiń (tr)"
 
-#: ../src/MathCtrl.cpp:997
+#: ../src/MathCtrl.cpp:1039
 msgid "Expand Expression"
 msgstr "Rozwiń wyrażenie"
 
-#: ../src/wxMaximaFrame.cpp:841
+#: ../src/wxMaximaFrame.cpp:840
 msgid "Expand Logarithms"
 msgstr "Rozwiń logarytmy"
 
-#: ../src/wxMaximaFrame.cpp:840
+#: ../src/wxMaximaFrame.cpp:839
 msgid "Expand an expression"
 msgstr "Rozwiń wyrażenie"
 
-#: ../src/wxMaximaFrame.cpp:874
+#: ../src/wxMaximaFrame.cpp:873
 msgid "Expand trigonometric expression"
 msgstr "Rozwiń wyrażenie trygonometryczne"
 
@@ -1637,7 +1640,7 @@ msgstr "Rozwiń wyrażenie trygonometryczne"
 msgid "Expected the icon files to be found at"
 msgstr ""
 
-#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2834
+#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2842
 msgid "Export"
 msgstr "Eksportuj"
 
@@ -1646,33 +1649,33 @@ msgid ""
 "Export animations to TeX (Images only move if the PDF viewer supports this)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:481
+#: ../src/wxMaximaFrame.cpp:480
 msgid "Export document to a HTML or pdfLaTeX file"
 msgstr "Eksportuj dokument do pliku HTML lub pdfLaTeX"
 
-#: ../src/wxMaximaFrame.cpp:253
+#: ../src/wxMaximaFrame.cpp:252
 #, fuzzy
 msgid "Export failed."
 msgstr "Eksport do TeX zakończył się niepowodzeniem!"
 
-#: ../src/wxMaximaFrame.cpp:239
+#: ../src/wxMaximaFrame.cpp:238
 msgid "Export successful."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2913
+#: ../src/wxMaxima.cpp:2921
 msgid "Exporting to HTML failed!"
 msgstr "Eksport do HTML zakończył się niepowodzeniem!"
 
-#: ../src/wxMaxima.cpp:2886
+#: ../src/wxMaxima.cpp:2894
 msgid "Exporting to TeX failed!"
 msgstr "Eksport do TeX zakończył się niepowodzeniem!"
 
-#: ../src/wxMaxima.cpp:2900
+#: ../src/wxMaxima.cpp:2908
 #, fuzzy
 msgid "Exporting to maxima batch file failed!"
 msgstr "Eksport do TeX zakończył się niepowodzeniem!"
 
-#: ../src/wxMaximaFrame.cpp:229
+#: ../src/wxMaximaFrame.cpp:228
 #, fuzzy
 msgid "Exporting..."
 msgstr "E&ksportuj"
@@ -1686,42 +1689,42 @@ msgid "Expression(s):"
 msgstr "Wyrażenie(a):"
 
 #: ../src/IntegrateWiz.cpp:30 ../src/LimitWiz.cpp:27 ../src/SeriesWiz.cpp:33
-#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3648
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:4205 ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5064
+#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3660
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:4217 ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5076
 msgid "Expression:"
 msgstr "Wyrażenie:"
 
-#: ../src/wxMaximaFrame.cpp:1213
+#: ../src/wxMaximaFrame.cpp:1212
 msgid "Factor"
 msgstr "Faktoryzuj"
 
-#: ../src/wxMaximaFrame.cpp:836
+#: ../src/wxMaximaFrame.cpp:835
 msgid "Factor Complex"
 msgstr "Faktoryzuj zespolenie"
 
-#: ../src/MathCtrl.cpp:996
+#: ../src/MathCtrl.cpp:1038
 msgid "Factor Expression"
 msgstr "Faktoryzuj wyrażenie"
 
-#: ../src/wxMaximaFrame.cpp:835
+#: ../src/wxMaximaFrame.cpp:834
 msgid "Factor an expression"
 msgstr "Faktoryzuj wyrażenie"
 
-#: ../src/wxMaximaFrame.cpp:837
+#: ../src/wxMaximaFrame.cpp:836
 msgid "Factor an expression in Gaussian numbers"
 msgstr "Faktoryzuj wyrażenie w liczbach Gaussa"
 
-#: ../src/wxMaximaFrame.cpp:862
+#: ../src/wxMaximaFrame.cpp:861
 msgid "Factorials and &Gamma"
 msgstr "Silnie i funkcja &gamma"
 
-#: ../src/wxMaxima.cpp:285
+#: ../src/wxMaxima.cpp:286
 msgid "Fatal error"
 msgstr "Krytyczny błąd"
 
-#: ../src/GroupCell.cpp:1571
+#: ../src/GroupCell.cpp:1572
 #, c-format
 msgid "Figure %d:"
 msgstr "Obrazek %d:"
@@ -1730,22 +1733,22 @@ msgstr "Obrazek %d:"
 msgid "File"
 msgstr "Plik"
 
-#: ../src/wxMaxima.cpp:1457 ../src/wxMaxima.cpp:1623 ../src/wxMaxima.cpp:1636
-#: ../src/wxMaxima.cpp:1646 ../src/wxMaxima.cpp:1668
+#: ../src/wxMaxima.cpp:1462 ../src/wxMaxima.cpp:1628 ../src/wxMaxima.cpp:1641
+#: ../src/wxMaxima.cpp:1651 ../src/wxMaxima.cpp:1673
 #, fuzzy
 msgid "File could not be opened"
 msgstr "Nie znaleziono pliku"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File not found"
 msgstr "Nie znaleziono pliku"
 
-#: ../src/wxMaxima.cpp:1511 ../src/wxMaxima.cpp:1729
+#: ../src/wxMaxima.cpp:1516 ../src/wxMaxima.cpp:1734
 #, fuzzy
 msgid "File opened"
 msgstr "Nie znaleziono pliku"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File you tried to open does not exist."
 msgstr "Plik, który próbujesz otworzyć nie istnieje"
 
@@ -1757,67 +1760,67 @@ msgstr "Plik:"
 msgid "Find"
 msgstr "Znajdź"
 
-#: ../src/wxMaximaFrame.cpp:523
+#: ../src/wxMaximaFrame.cpp:522
 msgid "Find\tCtrl-F"
 msgstr "Znajdź\tCtrl-F"
 
-#: ../src/wxMaximaFrame.cpp:787
+#: ../src/wxMaximaFrame.cpp:786
 msgid "Find &Limit..."
 msgstr "Znajdź &granicę..."
 
-#: ../src/wxMaximaFrame.cpp:790
+#: ../src/wxMaximaFrame.cpp:789
 msgid "Find Minimum..."
 msgstr "Znajdź minimum..."
 
-#: ../src/MathCtrl.cpp:993
+#: ../src/MathCtrl.cpp:1035
 msgid "Find Root..."
 msgstr "Znajdź pierwiastek..."
 
-#: ../src/wxMaximaFrame.cpp:791
+#: ../src/wxMaximaFrame.cpp:790
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr "Znajdź minimum wyrażenia"
 
-#: ../src/wxMaximaFrame.cpp:788
+#: ../src/wxMaximaFrame.cpp:787
 msgid "Find a limit of an expression"
 msgstr "Znajdź granicę wyrażenia"
 
-#: ../src/wxMaximaFrame.cpp:693
+#: ../src/wxMaximaFrame.cpp:692
 msgid "Find a root of an equation on an interval"
 msgstr "Znajdź pierwiastek wyrażenia w danym przedziale"
 
-#: ../src/wxMaximaFrame.cpp:695
+#: ../src/wxMaximaFrame.cpp:694
 msgid "Find all roots of a polynomial"
 msgstr "Znajdź wszystkie pierwiastki wielomianu"
 
-#: ../src/wxMaximaFrame.cpp:698
+#: ../src/wxMaximaFrame.cpp:697
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr "Znajdź wszystkie pierwiastki wielomianu (bfloat)"
 
-#: ../src/wxMaxima.cpp:3220
+#: ../src/wxMaxima.cpp:3215
 msgid "Find and Replace"
 msgstr "Znajdź i Zmień"
 
-#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:523
+#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:522
 msgid "Find and replace"
 msgstr "Znajdź i zmień"
 
-#: ../src/wxMaximaFrame.cpp:756
+#: ../src/wxMaximaFrame.cpp:755
 msgid "Find eigenvalues of a matrix"
 msgstr "Znajdź wartości własne macierzy"
 
-#: ../src/wxMaximaFrame.cpp:758
+#: ../src/wxMaximaFrame.cpp:757
 msgid "Find eigenvectors of a matrix"
 msgstr "Znajdź wektory własne macierzy"
 
-#: ../src/wxMaxima.cpp:4210
+#: ../src/wxMaxima.cpp:4222
 msgid "Find minimum"
 msgstr "Znajdź minimum"
 
-#: ../src/wxMaximaFrame.cpp:701
+#: ../src/wxMaximaFrame.cpp:700
 msgid "Find real roots of a polynomial"
 msgstr "Znajdź rzeczywiste pierwiastki wielomianu"
 
-#: ../src/wxMaxima.cpp:3493 ../src/wxMaxima.cpp:5036
+#: ../src/wxMaxima.cpp:3505 ../src/wxMaxima.cpp:5048
 msgid "Find root"
 msgstr "Znajdź pierwiastek"
 
@@ -1840,12 +1843,12 @@ msgstr ""
 msgid "Fixed font in text controls"
 msgstr "Czcionka o stałej szerokości w kontrolkach tekstowych"
 
-#: ../src/wxMaximaFrame.cpp:623
+#: ../src/wxMaximaFrame.cpp:622
 #, fuzzy
 msgid "Fold All\tCtrl-Alt-["
 msgstr "Zaznacz wszystko\tCtrl-A"
 
-#: ../src/wxMaximaFrame.cpp:624
+#: ../src/wxMaximaFrame.cpp:623
 msgid "Fold all sections"
 msgstr ""
 
@@ -1853,25 +1856,25 @@ msgstr ""
 msgid "Follow"
 msgstr ""
 
-#: ../src/ParenCell.cpp:319
+#: ../src/ParenCell.cpp:320
 msgid "Font issue: The Parenthesis sign is too small!"
 msgstr ""
 
-#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:381
+#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:382
 msgid ""
 "Font issue: The char height is too small! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:199
+#: ../src/SqrtCell.cpp:202
 msgid ""
 "Font issue: The sqrt() sign has the size 0! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:198
+#: ../src/SqrtCell.cpp:201
 msgid "Font issue? The contents of a sqrt() has the size 0."
 msgstr ""
 
@@ -1902,15 +1905,15 @@ msgstr "Francuski"
 
 #: ../src/IntegrateWiz.cpp:37 ../src/Plot2dWiz.cpp:37 ../src/Plot2dWiz.cpp:47
 #: ../src/Plot2dWiz.cpp:536 ../src/Plot3dWiz.cpp:36 ../src/Plot3dWiz.cpp:45
-#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4240
+#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4252
 msgid "From:"
 msgstr "Od:"
 
-#: ../src/wxMaximaFrame.cpp:576
+#: ../src/wxMaximaFrame.cpp:575
 msgid "Full Screen\tAlt-Enter"
 msgstr "Pełny ekran\tAlt-Enter"
 
-#: ../src/wxMaxima.cpp:3342
+#: ../src/wxMaxima.cpp:3354
 msgid "Function"
 msgstr "Funkcja"
 
@@ -1918,32 +1921,32 @@ msgstr "Funkcja"
 msgid "Function names"
 msgstr "Nazwa funkcji"
 
-#: ../src/wxMaxima.cpp:3633
+#: ../src/wxMaxima.cpp:3645
 msgid "Function(s):"
 msgstr "Funkcja(e):"
 
-#: ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3803
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3815
+#: ../src/wxMaxima.cpp:3848
 msgid "Function:"
 msgstr "Funkcja:"
 
-#: ../src/wxMaximaFrame.cpp:904
+#: ../src/wxMaximaFrame.cpp:903
 msgid "Functions for complex simplification"
 msgstr "Funkcje do uproszczeń zespolonych"
 
-#: ../src/wxMaximaFrame.cpp:864
+#: ../src/wxMaximaFrame.cpp:863
 msgid "Functions for simplifying factorials and gamma function"
 msgstr "Funkcje do uproszczeń silni i funkcji gamma"
 
-#: ../src/wxMaximaFrame.cpp:881
+#: ../src/wxMaximaFrame.cpp:880
 msgid "Functions for simplifying trigonometric expressions"
 msgstr "Funkcje do uproszczeń trygonometrycznych"
 
-#: ../src/wxMaxima.cpp:4046
+#: ../src/wxMaxima.cpp:4058
 msgid "GCD"
 msgstr "NWD"
 
-#: ../src/wxMaxima.cpp:5152
+#: ../src/wxMaxima.cpp:5164
 msgid "GIF image (*.gif)|*.gif"
 msgstr "obraz GIF (*.gif)|*.gi"
 
@@ -1951,31 +1954,31 @@ msgstr "obraz GIF (*.gif)|*.gi"
 msgid "Galician"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1366
+#: ../src/wxMaximaFrame.cpp:1365
 msgid "Gamma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:391
+#: ../src/wxMaximaFrame.cpp:390
 msgid "General Math"
 msgstr "Podstawowa Matem."
 
-#: ../src/wxMaximaFrame.cpp:549
+#: ../src/wxMaximaFrame.cpp:548
 msgid "General Math\tAlt-Shift-M"
 msgstr "Podstawowa Matem.\tAlt-Shift-M"
 
-#: ../src/wxMaxima.cpp:3766 ../src/wxMaxima.cpp:3785
+#: ../src/wxMaxima.cpp:3778 ../src/wxMaxima.cpp:3797
 msgid "Generate Matrix"
 msgstr "Utwórz macierz"
 
-#: ../src/wxMaximaFrame.cpp:741
+#: ../src/wxMaximaFrame.cpp:740
 msgid "Generate Matrix from Expression..."
 msgstr "Generuj macierz z wyrazu..."
 
-#: ../src/wxMaximaFrame.cpp:739
+#: ../src/wxMaximaFrame.cpp:738
 msgid "Generate a matrix from a 2-dimensional array"
 msgstr "Utwórz macierz z tablicy 2D"
 
-#: ../src/wxMaximaFrame.cpp:742
+#: ../src/wxMaximaFrame.cpp:741
 msgid "Generate a matrix from a lambda expression"
 msgstr "Generuj macierz z wyrazu lambda"
 
@@ -1983,39 +1986,39 @@ msgstr "Generuj macierz z wyrazu lambda"
 msgid "German"
 msgstr "Niemiecki"
 
-#: ../src/wxMaximaFrame.cpp:893
+#: ../src/wxMaximaFrame.cpp:892
 msgid "Get &Imaginary Part"
 msgstr "Część &urojona"
 
-#: ../src/wxMaximaFrame.cpp:793
+#: ../src/wxMaximaFrame.cpp:792
 msgid "Get &Series..."
 msgstr "Rozwiń w &szereg"
 
-#: ../src/wxMaximaFrame.cpp:804
+#: ../src/wxMaximaFrame.cpp:803
 msgid "Get Laplace transformation of an expression"
 msgstr "Transformata Laplace'a wyrażenia"
 
-#: ../src/wxMaximaFrame.cpp:890
+#: ../src/wxMaximaFrame.cpp:889
 msgid "Get Real P&art"
 msgstr "Część &rzeczywista"
 
-#: ../src/wxMaximaFrame.cpp:807
+#: ../src/wxMaximaFrame.cpp:806
 msgid "Get inverse Laplace transformation of an expression"
 msgstr "Odwrotna transformata Laplace'a wyrażenia"
 
-#: ../src/wxMaximaFrame.cpp:794
+#: ../src/wxMaximaFrame.cpp:793
 msgid "Get the Taylor or power series of expression"
 msgstr "Rozwiń wyrażenie w szereg Taylora"
 
-#: ../src/wxMaximaFrame.cpp:894
+#: ../src/wxMaximaFrame.cpp:893
 msgid "Get the imaginary part of complex expression"
 msgstr "Część urojona wyrażenia zespolonego"
 
-#: ../src/wxMaximaFrame.cpp:891
+#: ../src/wxMaximaFrame.cpp:890
 msgid "Get the real part of complex expression"
 msgstr "Część rzeczywista wyrażenia zespolonego"
 
-#: ../src/MathCtrl.cpp:5932
+#: ../src/MathCtrl.cpp:5984
 msgid ""
 "Got a request to undo an action that involves an delete which isn't possible "
 "at this moment."
@@ -2025,12 +2028,12 @@ msgstr ""
 msgid "Greek"
 msgstr "Grecki"
 
-#: ../src/wxMaximaFrame.cpp:356
+#: ../src/wxMaximaFrame.cpp:355
 #, fuzzy
 msgid "Greek Letters"
 msgstr "Greckie stałe"
 
-#: ../src/wxMaximaFrame.cpp:552
+#: ../src/wxMaximaFrame.cpp:551
 #, fuzzy
 msgid "Greek Letters\tAlt-Shift-G"
 msgstr "Podstawowa Matem.\tAlt-Shift-M"
@@ -2043,7 +2046,7 @@ msgstr "Greckie stałe"
 msgid "Grid:"
 msgstr "Siatka:"
 
-#: ../src/wxMaxima.cpp:2836
+#: ../src/wxMaxima.cpp:2844
 #, fuzzy
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|pdfLaTeX file (*."
@@ -2058,12 +2061,12 @@ msgstr ""
 msgid "Help"
 msgstr "Pomoc"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 #, fuzzy
 msgid "Hide All Toolbars\tAlt-Shift--"
 msgstr "Ukryj wszystkie\tAlt-Shift--"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide all panes"
 msgstr "Ukryj wszystkie panele"
 
@@ -2071,19 +2074,19 @@ msgstr "Ukryj wszystkie panele"
 msgid "Highlight (dpart)"
 msgstr "Podkreśl (dpart)"
 
-#: ../src/wxMaxima.cpp:4685
+#: ../src/wxMaxima.cpp:4697
 msgid "Histogram"
 msgstr "Histogram"
 
-#: ../src/wxMaximaFrame.cpp:1270
+#: ../src/wxMaximaFrame.cpp:1269
 msgid "Histogram..."
 msgstr "Histogram..."
 
-#: ../src/wxMaximaFrame.cpp:309
+#: ../src/wxMaximaFrame.cpp:308
 msgid "History"
 msgstr "Historia"
 
-#: ../src/wxMaximaFrame.cpp:555
+#: ../src/wxMaximaFrame.cpp:554
 #, fuzzy
 msgid "History\tAlt-Shift-I"
 msgstr "Historia\tAlt-Shift-H"
@@ -2104,11 +2107,11 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Węgierski"
 
-#: ../src/wxMaxima.cpp:3527
+#: ../src/wxMaxima.cpp:3539
 msgid "IC1"
 msgstr "IC1"
 
-#: ../src/wxMaxima.cpp:3543
+#: ../src/wxMaxima.cpp:3555
 msgid "IC2"
 msgstr "IC2"
 
@@ -2124,7 +2127,7 @@ msgid ""
 "same output cell."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:683
+#: ../src/wxMaximaFrame.cpp:682
 msgid ""
 "If maxima ever finishes evaluating without wxMaxima realizing this this menu "
 "item can force wxMaxima to try to send commands to maxima again."
@@ -2186,11 +2189,11 @@ msgstr ""
 "Jeśli obliczenia trwają zbyt długo, możesz je przerwać wybierając 'Maxima-"
 ">Przerwij' albo 'Maxima->Uruchom ponownie'"
 
-#: ../src/wxMaximaFrame.cpp:1499
+#: ../src/wxMaximaFrame.cpp:1518
 msgid "Image"
 msgstr "Obrazek"
 
-#: ../src/wxMaxima.cpp:5644
+#: ../src/wxMaxima.cpp:5659
 msgid "Image files (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 msgstr "Pliki graficzne (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 
@@ -2217,7 +2220,7 @@ msgid ""
 "above it. Might increase readability for some fonts and short subscripts."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Include columns:"
 msgstr "Załącz kolumny:"
 
@@ -2236,19 +2239,19 @@ msgstr ""
 msgid "Infinity"
 msgstr "Nieskończoność"
 
-#: ../src/wxMaximaFrame.cpp:974
+#: ../src/wxMaximaFrame.cpp:973
 msgid "Info about Maxima build"
 msgstr "Informacje o kompilacji"
 
-#: ../src/wxMaxima.cpp:4207
+#: ../src/wxMaxima.cpp:4219
 msgid "Initial Estimates:"
 msgstr "Wstępne oszacowanie:"
 
-#: ../src/wxMaximaFrame.cpp:718
+#: ../src/wxMaximaFrame.cpp:717
 msgid "Initial Value Problem (&1)..."
 msgstr "Warunki początkowe (&1)..."
 
-#: ../src/wxMaximaFrame.cpp:721
+#: ../src/wxMaximaFrame.cpp:720
 msgid "Initial Value Problem (&2)..."
 msgstr "Warunki początkowe (&2)..."
 
@@ -2256,7 +2259,7 @@ msgstr "Warunki początkowe (&2)..."
 msgid "Input labels"
 msgstr "Etykiety wejściowe"
 
-#: ../src/wxMaximaFrame.cpp:403
+#: ../src/wxMaximaFrame.cpp:402
 msgid "Insert"
 msgstr "Wstaw"
 
@@ -2264,98 +2267,98 @@ msgstr "Wstaw"
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:612
+#: ../src/wxMaximaFrame.cpp:611
 msgid "Insert &Section Cell\tCtrl-3"
 msgstr "Wstaw komórkę &rozdziału\tCtrl-3"
 
-#: ../src/wxMaximaFrame.cpp:608
+#: ../src/wxMaximaFrame.cpp:607
 msgid "Insert &Text Cell\tCtrl-1"
 msgstr "Wstaw komórkę t&ekstowa \tCtrl-1"
 
-#: ../src/wxMaximaFrame.cpp:558
+#: ../src/wxMaximaFrame.cpp:557
 msgid "Insert Cell\tAlt-Shift-C"
 msgstr "Wstaw komórkę\tAlt-Shift-C"
 
-#: ../src/wxMaxima.cpp:5642
+#: ../src/wxMaxima.cpp:5657
 msgid "Insert Image"
 msgstr "Wstaw obrazek"
 
-#: ../src/wxMaximaFrame.cpp:620
+#: ../src/wxMaximaFrame.cpp:619
 msgid "Insert Image..."
 msgstr "Wstaw obrazek..."
 
-#: ../src/wxMaximaFrame.cpp:606
+#: ../src/wxMaximaFrame.cpp:605
 msgid "Insert Input &Cell"
 msgstr "Wstaw komórkę &wejściowa"
 
-#: ../src/wxMaximaFrame.cpp:618
+#: ../src/wxMaximaFrame.cpp:617
 msgid "Insert Page Break"
 msgstr "Wstaw znak końca strony"
 
-#: ../src/wxMaximaFrame.cpp:614
+#: ../src/wxMaximaFrame.cpp:613
 msgid "Insert S&ubsection Cell\tCtrl-4"
 msgstr "Wstaw komórkę &podrozdziału\tCtrl-4"
 
-#: ../src/wxMaximaFrame.cpp:616
+#: ../src/wxMaximaFrame.cpp:615
 #, fuzzy
 msgid "Insert S&ubsubsection Cell\tCtrl-5"
 msgstr "Wstaw komórkę &podrozdziału\tCtrl-4"
 
-#: ../src/MathCtrl.cpp:1015
+#: ../src/MathCtrl.cpp:1057
 msgid "Insert Section Cell"
 msgstr "Wstaw komórkę &rozdziału"
 
-#: ../src/MathCtrl.cpp:1016
+#: ../src/MathCtrl.cpp:1058
 msgid "Insert Subsection Cell"
 msgstr "Wstaw komórkę &podrozdziału"
 
-#: ../src/MathCtrl.cpp:1017
+#: ../src/MathCtrl.cpp:1059
 #, fuzzy
 msgid "Insert Subsubsection Cell"
 msgstr "Wstaw komórkę &podrozdziału"
 
-#: ../src/wxMaximaFrame.cpp:610
+#: ../src/wxMaximaFrame.cpp:609
 msgid "Insert T&itle Cell\tCtrl-2"
 msgstr "Wstaw komórkę &tytułową\tCtrl-2"
 
-#: ../src/MathCtrl.cpp:1013
+#: ../src/MathCtrl.cpp:1055
 msgid "Insert Text Cell"
 msgstr "Wstaw komórkę t&ekstową"
 
-#: ../src/MathCtrl.cpp:1014
+#: ../src/MathCtrl.cpp:1056
 msgid "Insert Title Cell"
 msgstr "Wstaw komórkę &tytułowa"
 
-#: ../src/wxMaximaFrame.cpp:607
+#: ../src/wxMaximaFrame.cpp:606
 msgid "Insert a new input cell"
 msgstr "Wstaw nową komórkę wejściową"
 
-#: ../src/wxMaximaFrame.cpp:613
+#: ../src/wxMaximaFrame.cpp:612
 msgid "Insert a new section cell"
 msgstr "Wstaw komórkę nowego rozdziału"
 
-#: ../src/wxMaximaFrame.cpp:615
+#: ../src/wxMaximaFrame.cpp:614
 msgid "Insert a new subsection cell"
 msgstr "Wstaw komórkę nowego podrozdziału"
 
-#: ../src/wxMaximaFrame.cpp:617
+#: ../src/wxMaximaFrame.cpp:616
 #, fuzzy
 msgid "Insert a new subsubsection cell"
 msgstr "Wstaw komórkę nowego podrozdziału"
 
-#: ../src/wxMaximaFrame.cpp:609
+#: ../src/wxMaximaFrame.cpp:608
 msgid "Insert a new text cell"
 msgstr "Wstaw nową komórkę tekstową"
 
-#: ../src/wxMaximaFrame.cpp:611
+#: ../src/wxMaximaFrame.cpp:610
 msgid "Insert a new title cell"
 msgstr "Wstaw nową komórkę nagłówka"
 
-#: ../src/wxMaximaFrame.cpp:619
+#: ../src/wxMaximaFrame.cpp:618
 msgid "Insert a page break"
 msgstr "Wstaw znak końca strony"
 
-#: ../src/wxMaximaFrame.cpp:621
+#: ../src/wxMaximaFrame.cpp:620
 msgid "Insert image"
 msgstr "Wstaw obrazek"
 
@@ -2368,27 +2371,27 @@ msgstr ""
 msgid "Integral sign"
 msgstr "Całkuj wyrażenie"
 
-#: ../src/wxMaxima.cpp:3992
+#: ../src/wxMaxima.cpp:4004
 msgid "Integral/Sum:"
 msgstr "Całka/Suma:"
 
-#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4105 ../src/wxMaxima.cpp:5051
+#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4117 ../src/wxMaxima.cpp:5063
 msgid "Integrate"
 msgstr "Całkuj"
 
-#: ../src/wxMaxima.cpp:4091
+#: ../src/wxMaxima.cpp:4103
 msgid "Integrate (risch)"
 msgstr "Całkuj (risch)"
 
-#: ../src/wxMaximaFrame.cpp:778
+#: ../src/wxMaximaFrame.cpp:777
 msgid "Integrate expression"
 msgstr "Całkuj wyrażenie"
 
-#: ../src/wxMaximaFrame.cpp:780
+#: ../src/wxMaximaFrame.cpp:779
 msgid "Integrate expression with Risch algorithm"
 msgstr "Całkuj wyrażenie używając algorytmu Ruscha"
 
-#: ../src/wxMaximaFrame.cpp:1224 ../src/MathCtrl.cpp:1000
+#: ../src/MathCtrl.cpp:1042 ../src/wxMaximaFrame.cpp:1223
 msgid "Integrate..."
 msgstr "Całkuj..."
 
@@ -2396,7 +2399,7 @@ msgstr "Całkuj..."
 msgid "Interrupt"
 msgstr "Przerwij"
 
-#: ../src/wxMaximaFrame.cpp:646 ../src/wxMaximaFrame.cpp:650
+#: ../src/wxMaximaFrame.cpp:645 ../src/wxMaximaFrame.cpp:649
 msgid "Interrupt current computation"
 msgstr "Przerwij bieżące obliczenia"
 
@@ -2416,15 +2419,15 @@ msgstr ""
 "\n"
 "Wprowadź ponownie ścieżkę do programu Maxima."
 
-#: ../src/wxMaxima.cpp:4137
+#: ../src/wxMaxima.cpp:4149
 msgid "Inverse Laplace"
 msgstr "Odwrotna Transformata Laplace'a"
 
-#: ../src/wxMaximaFrame.cpp:806
+#: ../src/wxMaximaFrame.cpp:805
 msgid "Inverse Laplace T&ransform..."
 msgstr "Odwrotna Transformata &Laplace'a"
 
-#: ../src/wxMaximaFrame.cpp:1372
+#: ../src/wxMaximaFrame.cpp:1371
 msgid "Iota"
 msgstr ""
 
@@ -2458,7 +2461,7 @@ msgstr "Japoński"
 msgid "Kabyle"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1373
+#: ../src/wxMaximaFrame.cpp:1372
 msgid "Kappa"
 msgstr ""
 
@@ -2467,7 +2470,7 @@ msgstr ""
 msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr "Używaj znak procentu dla zmiennych specjalnych: %e, %i, itp."
 
-#: ../src/wxMaxima.cpp:4031
+#: ../src/wxMaxima.cpp:4043
 msgid "LCM"
 msgstr "NWW"
 
@@ -2483,7 +2486,7 @@ msgstr ""
 msgid "Label width:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1374
+#: ../src/wxMaximaFrame.cpp:1373
 msgid "Lambda"
 msgstr ""
 
@@ -2495,11 +2498,11 @@ msgstr "Język używany w GUI wxMaximy"
 msgid "Language:"
 msgstr "Język:"
 
-#: ../src/wxMaxima.cpp:4120
+#: ../src/wxMaxima.cpp:4132
 msgid "Laplace"
 msgstr "Laplace"
 
-#: ../src/wxMaximaFrame.cpp:803
+#: ../src/wxMaximaFrame.cpp:802
 msgid "Laplace &Transform..."
 msgstr "&Transformata Laplace'a..."
 
@@ -2507,15 +2510,15 @@ msgstr "&Transformata Laplace'a..."
 msgid "Leads to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:812
+#: ../src/wxMaximaFrame.cpp:811
 msgid "Least Common Multiple..."
 msgstr "Najmniejsza wspólna wielokrotność..."
 
-#: ../src/wxMaxima.cpp:4809
+#: ../src/wxMaxima.cpp:4821
 msgid "Least Squares Fit"
 msgstr "Metoda najmniejszych kwadratów"
 
-#: ../src/wxMaximaFrame.cpp:1266
+#: ../src/wxMaximaFrame.cpp:1265
 msgid "Least Squares Fit..."
 msgstr "Metoda najmniejszych kwadratów..."
 
@@ -2526,24 +2529,24 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4192
+#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4204
 msgid "Limit"
 msgstr "Granica"
 
-#: ../src/wxMaximaFrame.cpp:1225
+#: ../src/wxMaximaFrame.cpp:1224
 msgid "Limit..."
 msgstr "Granica..."
 
-#: ../src/wxMaximaFrame.cpp:1265
+#: ../src/wxMaximaFrame.cpp:1264
 msgid "Linear Regression..."
 msgstr "Regresja liniowa..."
 
-#: ../src/wxMaxima.cpp:3803
+#: ../src/wxMaxima.cpp:3815
 #, fuzzy
 msgid "List(s):"
 msgstr "Lista:"
 
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3848
 msgid "List:"
 msgstr "Lista:"
 
@@ -2551,15 +2554,15 @@ msgstr "Lista:"
 msgid "Load"
 msgstr "Wczytaj"
 
-#: ../src/wxMaxima.cpp:2932
+#: ../src/wxMaxima.cpp:2940
 msgid "Load Package"
 msgstr "Wczytaj pakiet"
 
-#: ../src/wxMaximaFrame.cpp:479
+#: ../src/wxMaximaFrame.cpp:478
 msgid "Load a Maxima file using the batch command"
 msgstr "Wczytaj plik używając polecenia batch"
 
-#: ../src/wxMaximaFrame.cpp:477
+#: ../src/wxMaximaFrame.cpp:476
 msgid "Load a Maxima package file"
 msgstr "Wczytaj pakiet Maximy"
 
@@ -2571,49 +2574,49 @@ msgstr "Wczytaj styl z pliku"
 msgid "Long Right arrow"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Lower bound:"
 msgstr "Dolna granica:"
 
-#: ../src/wxMaximaFrame.cpp:771
+#: ../src/wxMaximaFrame.cpp:770
 msgid "Ma&p to Matrix..."
 msgstr "Mapuj macierz..."
 
-#: ../src/wxMaximaFrame.cpp:547
+#: ../src/wxMaximaFrame.cpp:546
 #, fuzzy
 msgid "Main Toolbar\tAlt-Shift-B"
 msgstr "Pasek narzędzi\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:765
+#: ../src/wxMaximaFrame.cpp:764
 msgid "Make &List..."
 msgstr "Utwórz &listę..."
 
-#: ../src/wxMaxima.cpp:3821
+#: ../src/wxMaxima.cpp:3833
 msgid "Make list"
 msgstr "Utwórz listę"
 
-#: ../src/wxMaximaFrame.cpp:766
+#: ../src/wxMaximaFrame.cpp:765
 msgid "Make list from expression"
 msgstr "Utwórz listę z wyrażenia"
 
-#: ../src/wxMaximaFrame.cpp:907
+#: ../src/wxMaximaFrame.cpp:906
 msgid "Make substitution in expression"
 msgstr "Wykonaj podstawienie w wyrażeniu"
 
-#: ../src/wxMaximaFrame.cpp:682
+#: ../src/wxMaximaFrame.cpp:681
 #, fuzzy
 msgid "Manually Trigger Evaluation"
 msgstr "Wyświetl czas przeprowadzania obliczeń"
 
-#: ../src/wxMaxima.cpp:3805
+#: ../src/wxMaxima.cpp:3817
 msgid "Map"
 msgstr "Mapuj"
 
-#: ../src/wxMaximaFrame.cpp:770
+#: ../src/wxMaximaFrame.cpp:769
 msgid "Map function to a list"
 msgstr "Mapuj funkcję do listy"
 
-#: ../src/wxMaximaFrame.cpp:772
+#: ../src/wxMaximaFrame.cpp:771
 msgid "Map function to a matrix"
 msgstr "Mapuj funkcję do macierzy"
 
@@ -2630,23 +2633,23 @@ msgstr ""
 msgid "Math font:"
 msgstr "Czcionka matematyczna:"
 
-#: ../src/wxMaximaFrame.cpp:374
+#: ../src/wxMaximaFrame.cpp:373
 msgid "Mathematical Symbols"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3716
+#: ../src/wxMaxima.cpp:3728
 msgid "Matrix"
 msgstr "Macierz"
 
-#: ../src/wxMaxima.cpp:3702
+#: ../src/wxMaxima.cpp:3714
 msgid "Matrix map"
 msgstr "Mapuj macierz"
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Matrix name:"
 msgstr "Nazwa macierzy:"
 
-#: ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3749
+#: ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3761
 msgid "Matrix:"
 msgstr "Macierz:"
 
@@ -2654,7 +2657,7 @@ msgstr "Macierz:"
 msgid "Maxima"
 msgstr "Maxima"
 
-#: ../src/wxMaximaFrame.cpp:137
+#: ../src/wxMaximaFrame.cpp:136
 #, fuzzy
 msgid "Maxima has a question"
 msgstr "Zapytania Maximy"
@@ -2663,24 +2666,24 @@ msgstr "Zapytania Maximy"
 msgid "Maxima input"
 msgstr "Maxima wejście"
 
-#: ../src/wxMaximaFrame.cpp:166
+#: ../src/wxMaximaFrame.cpp:165
 msgid "Maxima is calculating"
 msgstr "Maxima wykonuje obliczenia"
 
-#: ../src/wxMaximaFrame.cpp:111
+#: ../src/wxMaximaFrame.cpp:110
 #, fuzzy
 msgid "Maxima is ready for input."
 msgstr "Maxima wejście"
 
-#: ../src/wxMaxima.cpp:2945
+#: ../src/wxMaxima.cpp:2953
 msgid "Maxima package (*.mac)|*.mac"
 msgstr "Pakiet Maxima (*.mac)|*.mac|"
 
-#: ../src/wxMaxima.cpp:2934
+#: ../src/wxMaxima.cpp:2942
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr "Pakiet Maxima (*.mac)|*.mac|Pakiet Lispa (*.lisp)|*.lisp|Wszystkie|*"
 
-#: ../src/wxMaxima.cpp:1014
+#: ../src/wxMaxima.cpp:1019
 msgid "Maxima process terminated."
 msgstr "Maxima zakończyła działanie"
 
@@ -2692,7 +2695,7 @@ msgstr "Maxima program:"
 msgid "Maxima questions"
 msgstr "Zapytania Maximy"
 
-#: ../src/wxMaxima.cpp:942
+#: ../src/wxMaxima.cpp:947
 msgid "Maxima started. Waiting for connection..."
 msgstr "Uruchomiono Maximę. Oczekiwanie na połączenie..."
 
@@ -2716,7 +2719,7 @@ msgstr ""
 "Maxima używa ':' jako operatora przypisania ('a : 3;') a ':=' do "
 "definiowania funkcji ('f(x):=x^2;')."
 
-#: ../src/wxMaxima.cpp:4597
+#: ../src/wxMaxima.cpp:4609
 msgid "Maxima version: "
 msgstr "Wersja Maximy: "
 
@@ -2753,40 +2756,40 @@ msgstr ""
 msgid "Maximum displayed number of digits:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1263
+#: ../src/wxMaximaFrame.cpp:1262
 msgid "Mean Difference Test..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1262
+#: ../src/wxMaximaFrame.cpp:1261
 msgid "Mean Test..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1255
+#: ../src/wxMaximaFrame.cpp:1254
 msgid "Mean..."
 msgstr "Średnia..."
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Mean:"
 msgstr "Średnia:"
 
-#: ../src/wxMaximaFrame.cpp:1256
+#: ../src/wxMaximaFrame.cpp:1255
 msgid "Median..."
 msgstr "Mediana..."
 
-#: ../src/MathCtrl.cpp:945
+#: ../src/MathCtrl.cpp:987
 msgid "Merge Cells"
 msgstr "Scal komórki"
 
-#: ../src/wxMaximaFrame.cpp:633
+#: ../src/wxMaximaFrame.cpp:632
 #, fuzzy
 msgid "Merge Cells\tCtrl-M"
 msgstr "Scal komórki"
 
-#: ../src/wxMaximaFrame.cpp:634
+#: ../src/wxMaximaFrame.cpp:633
 msgid "Merge the text from two input cells into one"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2668
+#: ../src/wxMaxima.cpp:2676
 msgid "Message from the stdout of Maxima: "
 msgstr ""
 
@@ -2794,19 +2797,19 @@ msgstr ""
 msgid "Method:"
 msgstr "Metoda:"
 
-#: ../src/wxMaxima.cpp:5289
+#: ../src/wxMaxima.cpp:5301
 msgid "Mismatched parenthesis"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3972
+#: ../src/wxMaxima.cpp:3984
 msgid "Modulus"
 msgstr "Modulo"
 
-#: ../src/wxMaximaFrame.cpp:1375
+#: ../src/wxMaximaFrame.cpp:1374
 msgid "Mu"
 msgstr ""
 
-#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Name:"
 msgstr "Nazwa:"
 
@@ -2814,7 +2817,7 @@ msgstr "Nazwa:"
 msgid "New"
 msgstr "Nowy"
 
-#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
+#: ../src/wxMaximaFrame.cpp:456 ../src/wxMaximaFrame.cpp:459
 msgid "New\tCtrl-N"
 msgstr "Nowy\tCtrl-N"
 
@@ -2830,11 +2833,11 @@ msgstr ""
 msgid "New value:"
 msgstr "Nowa wartość:"
 
-#: ../src/wxMaxima.cpp:3993 ../src/wxMaxima.cpp:4119 ../src/wxMaxima.cpp:4136
+#: ../src/wxMaxima.cpp:4005 ../src/wxMaxima.cpp:4131 ../src/wxMaxima.cpp:4148
 msgid "New variable:"
 msgstr "Nowa zmienna:"
 
-#: ../src/wxMaximaFrame.cpp:630
+#: ../src/wxMaximaFrame.cpp:629
 msgid "Next Command\tAlt-Down"
 msgstr "Następne polecenie\tAlt-Down"
 
@@ -2842,15 +2845,15 @@ msgstr "Następne polecenie\tAlt-Down"
 msgid "No"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5362
+#: ../src/wxMaxima.cpp:5378
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3249 ../src/wxMaxima.cpp:3271
+#: ../src/wxMaxima.cpp:3260 ../src/wxMaxima.cpp:3283
 msgid "No matches found!"
 msgstr "Nie znaleziono!"
 
-#: ../src/wxMaximaFrame.cpp:1264
+#: ../src/wxMaximaFrame.cpp:1263
 msgid "Normality Test..."
 msgstr ""
 
@@ -2873,34 +2876,34 @@ msgstr ""
 msgid "Norwegian"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:3740
 msgid "Not a valid matrix dimension!"
 msgstr "Nieprawidłowy wymiar macierzy!"
 
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629
 msgid "Not a valid number of equations!"
 msgstr "Nieprawidłowa liczba równań!"
 
-#: ../src/wxMaximaFrame.cpp:197
+#: ../src/wxMaximaFrame.cpp:196
 #, fuzzy
 msgid "Not connected to maxima"
 msgstr ""
 "\n"
 "Nie połączono z Maxima!\n"
 
-#: ../src/wxMaxima.cpp:4599
+#: ../src/wxMaxima.cpp:4611
 msgid "Not connected."
 msgstr "Nie połączono."
 
-#: ../src/wxMaximaFrame.cpp:1376
+#: ../src/wxMaximaFrame.cpp:1375
 msgid "Nu"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Num. deg:"
 msgstr "st. licznika"
 
-#: ../src/wxMaxima.cpp:3585 ../src/wxMaxima.cpp:3609
+#: ../src/wxMaxima.cpp:3597 ../src/wxMaxima.cpp:3621
 msgid "Number of equations:"
 msgstr "Ilość równań:"
 
@@ -2927,15 +2930,15 @@ msgstr "OK"
 msgid "Old value:"
 msgstr "Stara wartość:"
 
-#: ../src/wxMaxima.cpp:3992 ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135
+#: ../src/wxMaxima.cpp:4004 ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147
 msgid "Old variable:"
 msgstr "Stara zmienna:"
 
-#: ../src/wxMaximaFrame.cpp:1387
+#: ../src/wxMaximaFrame.cpp:1386
 msgid "Omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1378
+#: ../src/wxMaximaFrame.cpp:1377
 msgid "Omicron"
 msgstr ""
 
@@ -2949,20 +2952,20 @@ msgid ""
 "stream for messages."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4763
+#: ../src/wxMaxima.cpp:4775
 msgid "One sample t-test"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:971
+#: ../src/wxMaximaFrame.cpp:970
 msgid "Online tutorials"
 msgstr "Kursy Online"
 
 #: ../src/ConfigDialogue.cpp:656 ../src/main.cpp:347 ../src/ToolBar.cpp:119
-#: ../src/wxMaxima.cpp:2797
+#: ../src/wxMaxima.cpp:2805
 msgid "Open"
 msgstr "Otwórz"
 
-#: ../src/wxMaximaFrame.cpp:466
+#: ../src/wxMaximaFrame.cpp:465
 msgid "Open Recent"
 msgstr "Otwórz ostatnie"
 
@@ -2970,11 +2973,11 @@ msgstr "Otwórz ostatnie"
 msgid "Open a cell when Maxima expects input"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:464
+#: ../src/wxMaximaFrame.cpp:463
 msgid "Open a document"
 msgstr "Otwórz dokument"
 
-#: ../src/wxMaximaFrame.cpp:458 ../src/wxMaximaFrame.cpp:461
+#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
 msgid "Open a new window"
 msgstr "Otwórz nowe okno"
 
@@ -2982,11 +2985,11 @@ msgstr "Otwórz nowe okno"
 msgid "Open document"
 msgstr "Otwórz dokument"
 
-#: ../src/wxMaxima.cpp:4824
+#: ../src/wxMaxima.cpp:4836
 msgid "Open matrix"
 msgstr "Otwórz macierz"
 
-#: ../src/wxMaxima.cpp:1446 ../src/wxMaxima.cpp:1518
+#: ../src/wxMaxima.cpp:1451 ../src/wxMaxima.cpp:1523
 msgid "Opening file"
 msgstr "Otwieranie pliku"
 
@@ -3010,11 +3013,11 @@ msgstr "Komórki nieaktualne"
 msgid "Output labels"
 msgstr "Identyfikatory wyjść"
 
-#: ../src/wxMaximaFrame.cpp:796
+#: ../src/wxMaximaFrame.cpp:795
 msgid "P&ade Approximation..."
 msgstr "Przybliżenie &Pade..."
 
-#: ../src/wxMaxima.cpp:3132 ../src/wxMaxima.cpp:5133
+#: ../src/wxMaxima.cpp:3141 ../src/wxMaxima.cpp:5145
 #, fuzzy
 msgid ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
@@ -3026,15 +3029,15 @@ msgstr ""
 
 # msgid "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*.bmp|X pixmap (*.xpm)|*.xpm"
 # msgstr "PNG  (*.png)|*.png|JPEG  (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*.bmp|X pixmap (*.xpm)|*.xpm"
-#: ../src/wxMaxima.cpp:4012
+#: ../src/wxMaxima.cpp:4024
 msgid "Pade approximation"
 msgstr "Przybliżenie Pade"
 
-#: ../src/wxMaximaFrame.cpp:797
+#: ../src/wxMaximaFrame.cpp:796
 msgid "Pade approximation of a Taylor series"
 msgstr "Przybliżenie Pade szeregu Taylora"
 
-#: ../src/wxMaximaFrame.cpp:1500
+#: ../src/wxMaximaFrame.cpp:1519
 msgid "Pagebreak"
 msgstr "Podział strony"
 
@@ -3046,19 +3049,19 @@ msgstr ""
 msgid "Parametric plot"
 msgstr "Wykres parametryczny"
 
-#: ../src/wxMaximaFrame.cpp:188
+#: ../src/wxMaximaFrame.cpp:187
 msgid "Parsing output"
 msgstr "Parsowanie wyjścia"
 
-#: ../src/wxMaximaFrame.cpp:819
+#: ../src/wxMaximaFrame.cpp:818
 msgid "Partial &Fractions..."
 msgstr "&Ułamek prosty"
 
-#: ../src/wxMaxima.cpp:4076
+#: ../src/wxMaxima.cpp:4088
 msgid "Partial fractions"
 msgstr "Ułamek prosty"
 
-#: ../src/wxMaxima.cpp:1769
+#: ../src/wxMaxima.cpp:1774
 msgid "Parts of the document will not be loaded correctly!"
 msgstr "Części dokumentu nie zostaną wczytane poprawnie"
 
@@ -3069,11 +3072,11 @@ msgid ""
 "Found unknown XML Tag name "
 msgstr "Części dokumentu nie zostaną wczytane poprawnie"
 
-#: ../src/ToolBar.cpp:143 ../src/MathCtrl.cpp:1010 ../src/MathCtrl.cpp:1025
+#: ../src/MathCtrl.cpp:1052 ../src/MathCtrl.cpp:1067 ../src/ToolBar.cpp:143
 msgid "Paste"
 msgstr "Wklej"
 
-#: ../src/wxMaximaFrame.cpp:518
+#: ../src/wxMaximaFrame.cpp:517
 msgid "Paste\tCtrl-V"
 msgstr "Wklej\tCtrl-V"
 
@@ -3081,7 +3084,7 @@ msgstr "Wklej\tCtrl-V"
 msgid "Paste from clipboard"
 msgstr "Wklej ze schowka"
 
-#: ../src/wxMaximaFrame.cpp:519
+#: ../src/wxMaximaFrame.cpp:518
 msgid "Paste text from clipboard"
 msgstr "Wklej tekst ze schowka"
 
@@ -3089,19 +3092,19 @@ msgstr "Wklej tekst ze schowka"
 msgid "Perpendicular to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1384
+#: ../src/wxMaximaFrame.cpp:1383
 msgid "Phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1379
+#: ../src/wxMaximaFrame.cpp:1378
 msgid "Pi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1273
+#: ../src/wxMaximaFrame.cpp:1272
 msgid "Piechart..."
 msgstr "Diagram kołowy..."
 
-#: ../src/wxMaxima.cpp:1952
+#: ../src/wxMaxima.cpp:1957
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr "Skonfiguruj wxMaxime 'Edycja->Preferencje'."
 
@@ -3109,52 +3112,52 @@ msgstr "Skonfiguruj wxMaxime 'Edycja->Preferencje'."
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr "Uruchom ponownie wxMaxime, aby zmiany zaczęły obowiązywać"
 
-#: ../src/wxMaximaFrame.cpp:923
+#: ../src/wxMaximaFrame.cpp:922
 msgid "Plot &2d..."
 msgstr "Wykres &2D..."
 
-#: ../src/wxMaximaFrame.cpp:925
+#: ../src/wxMaximaFrame.cpp:924
 msgid "Plot &3d..."
 msgstr "Wykres &3D..."
 
-#: ../src/wxMaximaFrame.cpp:927
+#: ../src/wxMaximaFrame.cpp:926
 msgid "Plot &Format..."
 msgstr "&Format wykresu"
 
 #: ../src/Plot2dWiz.cpp:104 ../src/Plot2dWiz.cpp:450 ../src/Plot2dWiz.cpp:464
-#: ../src/wxMaxima.cpp:4283 ../src/wxMaxima.cpp:5102
+#: ../src/wxMaxima.cpp:4295 ../src/wxMaxima.cpp:5114
 msgid "Plot 2D"
 msgstr "Wykres 2D"
 
-#: ../src/wxMaximaFrame.cpp:1227
+#: ../src/wxMaximaFrame.cpp:1226
 msgid "Plot 2D..."
 msgstr "Wykres 2D..."
 
-#: ../src/MathCtrl.cpp:1003
+#: ../src/MathCtrl.cpp:1045
 msgid "Plot 2d..."
 msgstr "Wykres 2D..."
 
-#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4269 ../src/wxMaxima.cpp:5115
+#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4281 ../src/wxMaxima.cpp:5127
 msgid "Plot 3D"
 msgstr "Wykres 3D"
 
-#: ../src/wxMaximaFrame.cpp:1228
+#: ../src/wxMaximaFrame.cpp:1227
 msgid "Plot 3D..."
 msgstr "Wykres 3D..."
 
-#: ../src/MathCtrl.cpp:1004
+#: ../src/MathCtrl.cpp:1046
 msgid "Plot 3d..."
 msgstr "Wykres 3D..."
 
-#: ../src/wxMaxima.cpp:4296
+#: ../src/wxMaxima.cpp:4308
 msgid "Plot format"
 msgstr "Format wykresu"
 
-#: ../src/wxMaximaFrame.cpp:924
+#: ../src/wxMaximaFrame.cpp:923
 msgid "Plot in 2 dimensions"
 msgstr "Utwórz wykres dwuwymiarowy"
 
-#: ../src/wxMaximaFrame.cpp:926
+#: ../src/wxMaximaFrame.cpp:925
 msgid "Plot in 3 dimensions"
 msgstr "Utwórz wykres trójwymiarowy"
 
@@ -3163,8 +3166,8 @@ msgid "Plot to file:"
 msgstr "Zapisz wykres do pliku:"
 
 #: ../src/BC2Wiz.cpp:30 ../src/BC2Wiz.cpp:36 ../src/LimitWiz.cpp:33
-#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
-#: ../src/wxMaxima.cpp:3648
+#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
+#: ../src/wxMaxima.cpp:3660
 msgid "Point:"
 msgstr "Punkty:"
 
@@ -3172,11 +3175,11 @@ msgstr "Punkty:"
 msgid "Polish"
 msgstr "Polski"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 1:"
 msgstr "Wielomian 1:"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 2:"
 msgstr "Wielomian 2:"
 
@@ -3188,11 +3191,11 @@ msgstr "Portugalski (Brazylia)"
 msgid "Postscript file (*.eps)|*.eps|All|*"
 msgstr "Plik Postscript (*.eps)|*.eps|Wszystkie|*"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Precision"
 msgstr "Dokładność"
 
-#: ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:536
 msgid "Preferences...\tCtrl+,"
 msgstr ""
 
@@ -3204,7 +3207,7 @@ msgid ""
 "packages and from functions that are defined in the current file."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:628
+#: ../src/wxMaximaFrame.cpp:627
 msgid "Previous Command\tAlt-Up"
 msgstr "Poprzenie polecenie\tAlt-Up"
 
@@ -3212,11 +3215,11 @@ msgstr "Poprzenie polecenie\tAlt-Up"
 msgid "Print"
 msgstr "Drukuj"
 
-#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:484
+#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:483
 msgid "Print document"
 msgstr "Drukuj dokument"
 
-#: ../src/wxMaxima.cpp:4242
+#: ../src/wxMaxima.cpp:4254
 msgid "Product"
 msgstr "Iloczyn"
 
@@ -3225,36 +3228,36 @@ msgstr "Iloczyn"
 msgid "Product sign"
 msgstr "Iloczyn"
 
-#: ../src/wxMaximaFrame.cpp:1386
+#: ../src/wxMaximaFrame.cpp:1385
 msgid "Psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:331
+#: ../src/wxMaximaFrame.cpp:330
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:592
+#: ../src/wxMaximaFrame.cpp:591
 #, fuzzy
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr "Wykonaj wszystkie komórki w dokumencie"
 
-#: ../src/wxMaximaFrame.cpp:1278
+#: ../src/wxMaximaFrame.cpp:1277
 msgid "Read Matrix..."
 msgstr "Wczytaj macierz..."
 
-#: ../src/wxMaximaFrame.cpp:177
+#: ../src/wxMaximaFrame.cpp:176
 msgid "Reading Maxima output"
 msgstr "Przetwarzanie wyników zwróconych przez Maxime"
 
-#: ../src/wxMaximaFrame.cpp:153
+#: ../src/wxMaximaFrame.cpp:152
 msgid "Ready for user input"
 msgstr "Oczekiwanie na wejście"
 
-#: ../src/wxMaximaFrame.cpp:631
+#: ../src/wxMaximaFrame.cpp:630
 msgid "Recall next command from history"
 msgstr "Wywołaj następne polecenie z historii"
 
-#: ../src/wxMaximaFrame.cpp:629
+#: ../src/wxMaximaFrame.cpp:628
 msgid "Recall previous command from history"
 msgstr "Wywołaj poprzednie polecenie z historii"
 
@@ -3262,37 +3265,37 @@ msgstr "Wywołaj poprzednie polecenie z historii"
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1215
+#: ../src/wxMaximaFrame.cpp:1214
 msgid "Rectform"
 msgstr "Forma algebraiczna"
 
-#: ../src/wxMaximaFrame.cpp:495
+#: ../src/wxMaximaFrame.cpp:494
 #, fuzzy
 msgid "Redo\tCtrl-Y"
 msgstr "Cofnij\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:496
+#: ../src/wxMaximaFrame.cpp:495
 #, fuzzy
 msgid "Redo last change"
 msgstr "Cofnij ostatnią zmianę"
 
-#: ../src/wxMaximaFrame.cpp:1220
+#: ../src/wxMaximaFrame.cpp:1219
 msgid "Reduce (tr)"
 msgstr "Redukcja (tr)"
 
-#: ../src/wxMaximaFrame.cpp:871
+#: ../src/wxMaximaFrame.cpp:870
 msgid "Reduce trigonometric expression"
 msgstr "Redukuj wyrażenie trygonometryczne"
 
-#: ../src/wxMaxima.cpp:622 ../src/wxMaxima.cpp:5495
+#: ../src/wxMaxima.cpp:627 ../src/wxMaxima.cpp:5511
 msgid "Refusing to send cell to maxima: "
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:594
+#: ../src/wxMaximaFrame.cpp:593
 msgid "Remove All Output"
 msgstr "Usuń wszytskie komórki wyjściowe"
 
-#: ../src/wxMaximaFrame.cpp:595
+#: ../src/wxMaximaFrame.cpp:594
 msgid "Remove output from input cells"
 msgstr "Usuń wyjście z wszystkich komórek wejściowych"
 
@@ -3301,7 +3304,7 @@ msgstr "Usuń wyjście z wszystkich komórek wejściowych"
 msgid "Replace All"
 msgstr "Zaznacz wszystko"
 
-#: ../src/wxMaxima.cpp:3282
+#: ../src/wxMaxima.cpp:3294
 #, c-format
 msgid "Replaced %d occurrences."
 msgstr "Zastąpiono %d razy."
@@ -3310,11 +3313,11 @@ msgstr "Zastąpiono %d razy."
 msgid "Replacement:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:976
+#: ../src/wxMaximaFrame.cpp:975
 msgid "Report bug"
 msgstr "Zgłoś błąd"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "Restart Maxima"
 msgstr "Uruchom ponownie Maxime"
 
@@ -3323,7 +3326,7 @@ msgstr "Uruchom ponownie Maxime"
 msgid "Restart maxima"
 msgstr "Uruchom ponownie Maxime"
 
-#: ../src/MathCtrl.cpp:4442
+#: ../src/MathCtrl.cpp:4497
 msgid "Result"
 msgstr ""
 
@@ -3331,7 +3334,7 @@ msgstr ""
 msgid "Return to the cell that is currently being evaluated"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1380
+#: ../src/wxMaximaFrame.cpp:1379
 msgid "Rho"
 msgstr ""
 
@@ -3339,19 +3342,19 @@ msgstr ""
 msgid "Right arrow"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:779
+#: ../src/wxMaximaFrame.cpp:778
 msgid "Risch Integration..."
 msgstr "Całkuj metodą Rischa..."
 
-#: ../src/wxMaximaFrame.cpp:694
+#: ../src/wxMaximaFrame.cpp:693
 msgid "Roots of &Polynomial"
 msgstr "Pierwiastki &wielomianiu"
 
-#: ../src/wxMaximaFrame.cpp:697
+#: ../src/wxMaximaFrame.cpp:696
 msgid "Roots of Polynomial (bfloat)"
 msgstr "Pierwiastki wielomianiu (bfloat)"
 
-#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Rows:"
 msgstr "Wiersze:"
 
@@ -3359,56 +3362,56 @@ msgstr "Wiersze:"
 msgid "Russian"
 msgstr "Rosyjski"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 1:"
 msgstr "Przykład 1:"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 2:"
 msgstr "Przykład 2:"
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Sample:"
 msgstr "Próbka:"
 
 #: ../src/ConfigDialogue.cpp:781 ../src/ToolBar.cpp:122
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Save"
 msgstr "Zapisz"
 
-#: ../src/MathCtrl.cpp:921
+#: ../src/MathCtrl.cpp:963
 msgid "Save Animation..."
 msgstr "Zapisz animację..."
 
-#: ../src/wxMaxima.cpp:2565
+#: ../src/wxMaxima.cpp:2572
 msgid "Save As"
 msgstr "Zapisz jako"
 
-#: ../src/wxMaximaFrame.cpp:474
+#: ../src/wxMaximaFrame.cpp:473
 msgid "Save As...\tShift-Ctrl-S"
 msgstr "Zapisz jako...\tShift-Ctrl-S"
 
-#: ../src/MathCtrl.cpp:919
+#: ../src/MathCtrl.cpp:961
 msgid "Save Image..."
 msgstr "Zapisz obrazek..."
 
-#: ../src/wxMaxima.cpp:3130
+#: ../src/wxMaxima.cpp:3139
 msgid "Save Selection to Image"
 msgstr "Zapisz zaznaczenie jako obrazek"
 
-#: ../src/wxMaximaFrame.cpp:528
+#: ../src/wxMaximaFrame.cpp:527
 msgid "Save Selection to Image..."
 msgstr "Zapisz zaznaczenie jako obrazek..."
 
-#: ../src/wxMaxima.cpp:5150
+#: ../src/wxMaxima.cpp:5162
 msgid "Save animation to file"
 msgstr "Zapisz animację do pliku"
 
-#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:473
+#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:472
 msgid "Save document"
 msgstr "Zapisz dokument"
 
-#: ../src/wxMaximaFrame.cpp:475
+#: ../src/wxMaximaFrame.cpp:474
 msgid "Save document as"
 msgstr "Zapisz dokument jako"
 
@@ -3430,11 +3433,11 @@ msgstr "Zapisz układ paneli pomiędzy sesjami."
 msgid "Save plot to file"
 msgstr "Zapisz wykres do pliku"
 
-#: ../src/wxMaximaFrame.cpp:529
+#: ../src/wxMaximaFrame.cpp:528
 msgid "Save selection from document to an image file"
 msgstr "Zapisz zaznaczenie z dokumentu jako obrazek"
 
-#: ../src/wxMaxima.cpp:5131
+#: ../src/wxMaxima.cpp:5143
 msgid "Save selection to file"
 msgstr "Zapisz zaznaczenie do pliku"
 
@@ -3450,28 +3453,28 @@ msgstr "Zapisz rozmiar/położenie okna wxMaximy"
 msgid "Save wxMaxima window size/position between sessions."
 msgstr "Zapisz rozmiar/położenie okna wxMaximy"
 
-#: ../src/wxMaximaFrame.cpp:246
+#: ../src/wxMaximaFrame.cpp:245
 #, fuzzy
 msgid "Saving failed."
 msgstr "Nie udało się uruchomić serwera"
 
-#: ../src/wxMaximaFrame.cpp:222
+#: ../src/wxMaximaFrame.cpp:221
 msgid "Saving successful."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:212
+#: ../src/wxMaximaFrame.cpp:211
 msgid "Saving..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4699
+#: ../src/wxMaxima.cpp:4711
 msgid "Scatterplot"
 msgstr "Wykres punktowy"
 
-#: ../src/wxMaximaFrame.cpp:1271
+#: ../src/wxMaximaFrame.cpp:1270
 msgid "Scatterplot..."
 msgstr "Wykres punktowy...."
 
-#: ../src/wxMaximaFrame.cpp:1498
+#: ../src/wxMaximaFrame.cpp:1517
 msgid "Section"
 msgstr "Rozdział"
 
@@ -3479,26 +3482,26 @@ msgstr "Rozdział"
 msgid "Section cell"
 msgstr "Komórka rozdziału"
 
-#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:292 ../src/TextCell.cpp:306
-#: ../src/TextCell.cpp:322 ../src/TextCell.cpp:334
+#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:290 ../src/TextCell.cpp:304
+#: ../src/TextCell.cpp:320 ../src/TextCell.cpp:332
 msgid ""
 "Seems like something is broken with a font. Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/TextCell.cpp:139
+#: ../src/TextCell.cpp:137
 msgid ""
 "Seems like something is broken with the maths font. Installing http://www."
 "math.union.edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use "
 "JSmath fonts\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1011 ../src/MathCtrl.cpp:1027
+#: ../src/MathCtrl.cpp:1053 ../src/MathCtrl.cpp:1069
 msgid "Select All"
 msgstr "Zaznacz wszystko"
 
-#: ../src/wxMaximaFrame.cpp:525
+#: ../src/wxMaximaFrame.cpp:524
 msgid "Select All\tCtrl-A"
 msgstr "Zaznacz wszystko\tCtrl-A"
 
@@ -3506,7 +3509,7 @@ msgstr "Zaznacz wszystko\tCtrl-A"
 msgid "Select Maxima program"
 msgstr "Wybierz program Maxima"
 
-#: ../src/wxMaxima.cpp:4860
+#: ../src/wxMaxima.cpp:4872
 msgid "Select Subsample"
 msgstr ""
 
@@ -3515,11 +3518,11 @@ msgstr ""
 msgid "Select a constant"
 msgstr "Wybierz stałą"
 
-#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:526
+#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:525
 msgid "Select all"
 msgstr "Zaznacz wszystko"
 
-#: ../src/wxMaxima.cpp:3319
+#: ../src/wxMaxima.cpp:3331
 msgid "Select math display algorithm"
 msgstr "Wybierz format podawania wyników"
 
@@ -3537,23 +3540,23 @@ msgstr ""
 msgid "Selection"
 msgstr "Zaznaczenie"
 
-#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4178
+#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4190
 msgid "Series"
 msgstr "Szeregi"
 
-#: ../src/wxMaximaFrame.cpp:1226
+#: ../src/wxMaximaFrame.cpp:1225
 msgid "Series..."
 msgstr "Szeregi..."
 
-#: ../src/wxMaxima.cpp:863
+#: ../src/wxMaxima.cpp:868
 msgid "Server started"
 msgstr "Uruchomiono serwer"
 
-#: ../src/wxMaximaFrame.cpp:575
+#: ../src/wxMaximaFrame.cpp:574
 msgid "Set Zoom"
 msgstr "Ustaw przybliżenie"
 
-#: ../src/wxMaximaFrame.cpp:944
+#: ../src/wxMaximaFrame.cpp:943
 #, fuzzy
 msgid "Set bigfloat &Precision..."
 msgstr "Ustaw dokładność bigfloat"
@@ -3562,61 +3565,61 @@ msgstr "Ustaw dokładność bigfloat"
 msgid "Set fixed font in text controls."
 msgstr "Ustaw czcionkę o stałej szerokości w kontrolkach tekstowych."
 
-#: ../src/wxMaximaFrame.cpp:928
+#: ../src/wxMaximaFrame.cpp:927
 msgid "Set plot format"
 msgstr "Ustaw format wykresów"
 
-#: ../src/wxMaximaFrame.cpp:945
+#: ../src/wxMaximaFrame.cpp:944
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can "
 "be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:569
+#: ../src/wxMaximaFrame.cpp:568
 msgid "Set zoom to 100%"
 msgstr "Ustaw powiększenie na 100%"
 
-#: ../src/wxMaximaFrame.cpp:570
+#: ../src/wxMaximaFrame.cpp:569
 msgid "Set zoom to 120%"
 msgstr "Ustaw powiększenie na 120%"
 
-#: ../src/wxMaximaFrame.cpp:571
+#: ../src/wxMaximaFrame.cpp:570
 msgid "Set zoom to 150%"
 msgstr "Ustaw powiększenie na 150%"
 
-#: ../src/wxMaximaFrame.cpp:572
+#: ../src/wxMaximaFrame.cpp:571
 msgid "Set zoom to 200%"
 msgstr "Ustaw powiększenie na 200%"
 
-#: ../src/wxMaximaFrame.cpp:573
+#: ../src/wxMaximaFrame.cpp:572
 msgid "Set zoom to 300%"
 msgstr "Ustaw powiększenie na 300%"
 
-#: ../src/wxMaximaFrame.cpp:568
+#: ../src/wxMaximaFrame.cpp:567
 msgid "Set zoom to 80%"
 msgstr "Ustaw powiększenie na 80%"
 
-#: ../src/wxMaximaFrame.cpp:732
+#: ../src/wxMaximaFrame.cpp:731
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:918
+#: ../src/wxMaximaFrame.cpp:917
 msgid "Setup modulus computation"
 msgstr "Ustawienia obliczeń modulo"
 
-#: ../src/wxMaximaFrame.cpp:662
+#: ../src/wxMaximaFrame.cpp:661
 msgid "Show &Definition..."
 msgstr "Pokaż &definicje..."
 
-#: ../src/wxMaximaFrame.cpp:660
+#: ../src/wxMaximaFrame.cpp:659
 msgid "Show &Functions"
 msgstr "Pokaż &funkcje"
 
-#: ../src/wxMaximaFrame.cpp:967
+#: ../src/wxMaximaFrame.cpp:966
 msgid "Show &Tips..."
 msgstr "&Wskazówka"
 
-#: ../src/wxMaximaFrame.cpp:665
+#: ../src/wxMaximaFrame.cpp:664
 msgid "Show &Variables"
 msgstr "Pokaż &zmienną"
 
@@ -3624,43 +3627,43 @@ msgstr "Pokaż &zmienną"
 msgid "Show Maxima help"
 msgstr "Pokaż pomoc Maximy"
 
-#: ../src/wxMaximaFrame.cpp:603
+#: ../src/wxMaximaFrame.cpp:602
 msgid "Show Template\tCtrl-Shift-K"
 msgstr "Pokaż szablon\tCtrl-Shift-K"
 
-#: ../src/wxMaximaFrame.cpp:968
+#: ../src/wxMaximaFrame.cpp:967
 msgid "Show a tip"
 msgstr "Pokaż wskazówkę"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Show all commands similar to:"
 msgstr "Pokaż wszystkie polecenia podobne do:"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Show an example for the command:"
 msgstr "Pokaż przykład na polecenia:"
 
-#: ../src/wxMaximaFrame.cpp:962
+#: ../src/wxMaximaFrame.cpp:961
 msgid "Show an example of usage"
 msgstr "Pokaż przykład użycia"
 
-#: ../src/wxMaximaFrame.cpp:965
+#: ../src/wxMaximaFrame.cpp:964
 msgid "Show commands similar to"
 msgstr "Pokaż wszystkie polecenia podobne do"
 
-#: ../src/wxMaximaFrame.cpp:661
+#: ../src/wxMaximaFrame.cpp:660
 msgid "Show defined functions"
 msgstr "Pokaż zdefiniowane przez użytkownika funkcje"
 
-#: ../src/wxMaximaFrame.cpp:666
+#: ../src/wxMaximaFrame.cpp:665
 msgid "Show defined variables"
 msgstr "Pokaż zdefiniowane przez użytkownika zmienne"
 
-#: ../src/wxMaximaFrame.cpp:663
+#: ../src/wxMaximaFrame.cpp:662
 msgid "Show definition of a function"
 msgstr "Pokaż definicję funkcji"
 
-#: ../src/wxMaximaFrame.cpp:604
+#: ../src/wxMaximaFrame.cpp:603
 msgid "Show function template"
 msgstr "Pokaż szablon funkcji"
 
@@ -3673,7 +3676,7 @@ msgstr "Pokazuj długie wyrażenia w dokumentach wxMaximy"
 msgid "Show long expressions:"
 msgstr "Pokazuj długie wyrażenia"
 
-#: ../src/wxMaxima.cpp:3341
+#: ../src/wxMaxima.cpp:3353
 msgid "Show the definition of function:"
 msgstr "Pokaż definicję funkcji:"
 
@@ -3682,44 +3685,44 @@ msgstr "Pokaż definicję funkcji:"
 msgid "Show user-defined labels instead of (%oxx)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:953 ../src/wxMaximaFrame.cpp:956
+#: ../src/wxMaximaFrame.cpp:952 ../src/wxMaximaFrame.cpp:955
 #, fuzzy
 msgid "Show wxMaxima help"
 msgstr "Pokaż pomoc Maximy"
 
-#: ../src/wxMaximaFrame.cpp:1381
+#: ../src/wxMaximaFrame.cpp:1380
 msgid "Sigma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1211
+#: ../src/wxMaximaFrame.cpp:1210
 msgid "Simplify"
 msgstr "Uprość"
 
-#: ../src/wxMaximaFrame.cpp:831
+#: ../src/wxMaximaFrame.cpp:830
 msgid "Simplify &Radicals"
 msgstr "Uprość &Pierwiastki"
 
-#: ../src/wxMaximaFrame.cpp:1212
+#: ../src/wxMaximaFrame.cpp:1211
 msgid "Simplify (r)"
 msgstr "Uprość (r)"
 
-#: ../src/wxMaximaFrame.cpp:1218
+#: ../src/wxMaximaFrame.cpp:1217
 msgid "Simplify (tr)"
 msgstr "Uprość (tr)"
 
-#: ../src/MathCtrl.cpp:995
+#: ../src/MathCtrl.cpp:1037
 msgid "Simplify Expression"
 msgstr "Uprość wyrażenie"
 
-#: ../src/wxMaximaFrame.cpp:857
+#: ../src/wxMaximaFrame.cpp:856
 msgid "Simplify an expression containing factorials"
 msgstr "Uprość wyrażenie zawierające silnie"
 
-#: ../src/wxMaximaFrame.cpp:832
+#: ../src/wxMaximaFrame.cpp:831
 msgid "Simplify expression containing radicals"
 msgstr "Uprość wyrażenie zawierające pierwiastki"
 
-#: ../src/wxMaximaFrame.cpp:830
+#: ../src/wxMaximaFrame.cpp:829
 msgid "Simplify rational expression"
 msgstr "Uprość wyrażenie wymierne"
 
@@ -3727,7 +3730,7 @@ msgstr "Uprość wyrażenie wymierne"
 msgid "Simplify the sum"
 msgstr "Uprość sumę"
 
-#: ../src/wxMaximaFrame.cpp:868
+#: ../src/wxMaximaFrame.cpp:867
 msgid "Simplify trigonometric expression"
 msgstr "Uprość wyrażenie trygonometryczne"
 
@@ -3742,89 +3745,89 @@ msgstr ""
 "'Edycja->Wstaw obrazek...'. Aby obrazek zapisywał się wewnątrz dokumentu "
 "należy używać formatu 'wxMaxima XML'"
 
-#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
+#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
 msgid "Solution:"
 msgstr "Rozwiązania:"
 
-#: ../src/wxMaxima.cpp:3461 ../src/wxMaxima.cpp:3475 ../src/wxMaxima.cpp:5020
+#: ../src/wxMaxima.cpp:3473 ../src/wxMaxima.cpp:3487 ../src/wxMaxima.cpp:5032
 msgid "Solve"
 msgstr "Rozwiąż"
 
-#: ../src/wxMaximaFrame.cpp:706
+#: ../src/wxMaximaFrame.cpp:705
 msgid "Solve &Algebraic System..."
 msgstr "Rozwiąż &układ równań ..."
 
-#: ../src/wxMaximaFrame.cpp:703
+#: ../src/wxMaximaFrame.cpp:702
 msgid "Solve &Linear System..."
 msgstr "Rozwiąż układ równań &liniowych"
 
-#: ../src/wxMaximaFrame.cpp:714
+#: ../src/wxMaximaFrame.cpp:713
 msgid "Solve &ODE..."
 msgstr "Rozwiąż &RRZ"
 
-#: ../src/wxMaximaFrame.cpp:690
+#: ../src/wxMaximaFrame.cpp:689
 msgid "Solve (to_poly)..."
 msgstr "Rozwiąż (to_poly)..."
 
-#: ../src/wxMaxima.cpp:3511 ../src/wxMaxima.cpp:3635
+#: ../src/wxMaxima.cpp:3523 ../src/wxMaxima.cpp:3647
 msgid "Solve ODE"
 msgstr "Rozwiąż RRZ"
 
-#: ../src/wxMaximaFrame.cpp:728
+#: ../src/wxMaximaFrame.cpp:727
 msgid "Solve ODE with Lapla&ce..."
 msgstr "Rozwiąż RRZ z Trans. Laplace'a"
 
-#: ../src/wxMaximaFrame.cpp:1222
+#: ../src/wxMaximaFrame.cpp:1221
 msgid "Solve ODE..."
 msgstr "Rozwiąż RRZ..."
 
-#: ../src/wxMaxima.cpp:3586 ../src/wxMaxima.cpp:3597
+#: ../src/wxMaxima.cpp:3598 ../src/wxMaxima.cpp:3609
 msgid "Solve algebraic system"
 msgstr "Rozwiąż układ równań"
 
-#: ../src/wxMaximaFrame.cpp:707
+#: ../src/wxMaximaFrame.cpp:706
 msgid "Solve algebraic system of equations"
 msgstr "Rozwiąż układ równań algebraicznych"
 
-#: ../src/wxMaximaFrame.cpp:725
+#: ../src/wxMaximaFrame.cpp:724
 msgid "Solve boundary value problem for second degree ODE"
 msgstr "Nałóż warunek brzegowy na RRZ drugiego rzędu"
 
-#: ../src/wxMaximaFrame.cpp:689
+#: ../src/wxMaximaFrame.cpp:688
 msgid "Solve equation(s)"
 msgstr "Rozwiąż równanie(a)"
 
-#: ../src/wxMaximaFrame.cpp:691
+#: ../src/wxMaximaFrame.cpp:690
 msgid "Solve equation(s) with to_poly_solve"
 msgstr "Rozwiąż równanie(a) z użyciem to_poly_solve"
 
-#: ../src/wxMaximaFrame.cpp:719
+#: ../src/wxMaximaFrame.cpp:718
 msgid "Solve initial value problem for first degree ODE"
 msgstr "Nałóż warunki początkowe na RRZ pierwszego rzędu"
 
-#: ../src/wxMaximaFrame.cpp:722
+#: ../src/wxMaximaFrame.cpp:721
 msgid "Solve initial value problem for second degree ODE"
 msgstr "Nałóż warunki początkowe na RRZ drugiego rzędu"
 
-#: ../src/wxMaxima.cpp:3610 ../src/wxMaxima.cpp:3621
+#: ../src/wxMaxima.cpp:3622 ../src/wxMaxima.cpp:3633
 msgid "Solve linear system"
 msgstr "Rozwiąż układ liniowy"
 
-#: ../src/wxMaximaFrame.cpp:704
+#: ../src/wxMaximaFrame.cpp:703
 msgid "Solve linear system of equations"
 msgstr "Rozwiąż układ równań liniowych"
 
-#: ../src/wxMaximaFrame.cpp:715
+#: ../src/wxMaximaFrame.cpp:714
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr "Rozwiąż równanie różniczkowe zwyczajne maksymalnie rzędu 2"
 
-#: ../src/wxMaximaFrame.cpp:729
+#: ../src/wxMaximaFrame.cpp:728
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
 "Rozwiąż układ liniowych równań różniczkowych przy pomocy transformaty "
 "Laplace'a"
 
-#: ../src/wxMaximaFrame.cpp:1221 ../src/MathCtrl.cpp:992
+#: ../src/MathCtrl.cpp:1034 ../src/wxMaximaFrame.cpp:1220
 msgid "Solve..."
 msgstr "Rozwiąż..."
 
@@ -3848,7 +3851,7 @@ msgstr "Szczególne"
 msgid "Special constants"
 msgstr "Szczególne stałe"
 
-#: ../src/MathCtrl.cpp:922
+#: ../src/MathCtrl.cpp:964
 msgid "Start Animation"
 msgstr "Uruchom Animacje"
 
@@ -3867,28 +3870,28 @@ msgstr ""
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:294
+#: ../src/wxMaxima.cpp:295
 msgid "Starting Maxima process failed"
 msgstr "Nie udało się uruchomić Maximy"
 
-#: ../src/wxMaxima.cpp:928
+#: ../src/wxMaxima.cpp:933
 msgid "Starting Maxima..."
 msgstr "Uruchamianie Maximy..."
 
-#: ../src/wxMaxima.cpp:292 ../src/wxMaxima.cpp:860
+#: ../src/wxMaxima.cpp:293 ../src/wxMaxima.cpp:865
 msgid "Starting server failed"
 msgstr "Nie udało się uruchomić serwera"
 
-#: ../src/wxMaxima.cpp:841
+#: ../src/wxMaxima.cpp:846
 #, c-format
 msgid "Starting server on port %d"
 msgstr "Uruchomianie serweru na porcie %d"
 
-#: ../src/wxMaximaFrame.cpp:342
+#: ../src/wxMaximaFrame.cpp:341
 msgid "Statistics"
 msgstr "Statystyka"
 
-#: ../src/wxMaximaFrame.cpp:550
+#: ../src/wxMaximaFrame.cpp:549
 msgid "Statistics\tAlt-Shift-S"
 msgstr "Statystyka\tAlt-Shift-S"
 
@@ -3904,11 +3907,11 @@ msgstr "Wygląd"
 msgid "Styles"
 msgstr "Style"
 
-#: ../src/wxMaximaFrame.cpp:1283
+#: ../src/wxMaximaFrame.cpp:1282
 msgid "Subsample..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1496
+#: ../src/wxMaximaFrame.cpp:1515
 msgid "Subsection"
 msgstr "Podrozdział"
 
@@ -3916,20 +3919,20 @@ msgstr "Podrozdział"
 msgid "Subsection cell"
 msgstr "Komórka podrozdziału"
 
-#: ../src/wxMaximaFrame.cpp:1216
+#: ../src/wxMaximaFrame.cpp:1215
 msgid "Subst..."
 msgstr "Podstaw..."
 
-#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3423
-#: ../src/wxMaxima.cpp:5089
+#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3435
+#: ../src/wxMaxima.cpp:5101
 msgid "Substitute"
 msgstr "Podstaw"
 
-#: ../src/wxMaximaFrame.cpp:906 ../src/MathCtrl.cpp:998
+#: ../src/MathCtrl.cpp:1040 ../src/wxMaximaFrame.cpp:905
 msgid "Substitute..."
 msgstr "Podstaw..."
 
-#: ../src/wxMaximaFrame.cpp:1497
+#: ../src/wxMaximaFrame.cpp:1516
 #, fuzzy
 msgid "Subsubsection"
 msgstr "Podrozdział"
@@ -3939,7 +3942,7 @@ msgstr "Podrozdział"
 msgid "Subsubsection cell"
 msgstr "Komórka podrozdziału"
 
-#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4226
+#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4238
 msgid "Sum"
 msgstr "Suma"
 
@@ -3947,37 +3950,37 @@ msgstr "Suma"
 msgid "Sum sign"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:553
+#: ../src/wxMaximaFrame.cpp:552
 #, fuzzy
 msgid "Symbols\tAlt-Shift-Y"
 msgstr "Statystyka\tAlt-Shift-S"
 
-#: ../src/wxMaxima.cpp:4456
+#: ../src/wxMaxima.cpp:4468
 msgid "System info"
 msgstr "Informacja o systemie"
 
-#: ../src/wxMaximaFrame.cpp:320
+#: ../src/wxMaximaFrame.cpp:319
 msgid "Table of Contents"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:556
+#: ../src/wxMaximaFrame.cpp:555
 #, fuzzy
 msgid "Table of Contents\tAlt-Shift-T"
 msgstr "Pasek narzędzi\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:1382
+#: ../src/wxMaximaFrame.cpp:1381
 msgid "Tau"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Taylor series:"
 msgstr "Szereg Taylora:"
 
-#: ../src/wxMaxima.cpp:3963
+#: ../src/wxMaxima.cpp:3975
 msgid "Tellrat"
 msgstr "Tellrat"
 
-#: ../src/wxMaximaFrame.cpp:1494
+#: ../src/wxMaximaFrame.cpp:1513
 msgid "Text"
 msgstr "Tekst"
 
@@ -4023,7 +4026,7 @@ msgstr ""
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr ""
 
-#: ../src/TextCell.cpp:136
+#: ../src/TextCell.cpp:134
 msgid ""
 "The letter \"X\" is of width zero. Installing http://www.math.union.edu/"
 "~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts\" in "
@@ -4040,7 +4043,7 @@ msgstr ""
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:959
+#: ../src/wxMaximaFrame.cpp:958
 msgid "The offline manual of maxima"
 msgstr ""
 
@@ -4078,7 +4081,7 @@ msgstr ""
 "wxmaxima.sourceforge.net/wiki/index.php/Tutorials aby dowiedzieć się więcej "
 "o tym jak używać wxMaximy i Maximy"
 
-#: ../src/SlideShowCell.cpp:332
+#: ../src/SlideShowCell.cpp:336
 msgid ""
 "There was an error during GIF export!\n"
 "\n"
@@ -4089,7 +4092,7 @@ msgstr ""
 "Upewnij się, że pakiet ImageMagick jest zainstalowany a wxMaxima potrafi "
 "odnaleźć program convert. "
 
-#: ../src/wxMaxima.cpp:442
+#: ../src/wxMaxima.cpp:447
 msgid ""
 "There was an error in generated XML!\n"
 "\n"
@@ -4099,7 +4102,7 @@ msgstr ""
 "\n"
 "Proszę zgłosić ten błąd"
 
-#: ../src/wxMaximaFrame.cpp:1371
+#: ../src/wxMaximaFrame.cpp:1370
 msgid "Theta"
 msgstr ""
 
@@ -4107,7 +4110,7 @@ msgstr ""
 msgid "Ticks:"
 msgstr "Znaczniki:"
 
-#: ../src/wxMaxima.cpp:4153 ../src/wxMaxima.cpp:5065
+#: ../src/wxMaxima.cpp:4165 ../src/wxMaxima.cpp:5077
 msgid "Times:"
 msgstr "Stopień:"
 
@@ -4115,7 +4118,7 @@ msgstr "Stopień:"
 msgid "Tips not available, sorry!"
 msgstr "Wskazówki niedostępne!"
 
-#: ../src/wxMaximaFrame.cpp:1495
+#: ../src/wxMaximaFrame.cpp:1514
 msgid "Title"
 msgstr "Tytuł"
 
@@ -4133,19 +4136,19 @@ msgstr ""
 "zawartość. Do zwinięcia/rozwinięcia wystarczy klikniecie na prostokąt obok "
 "komórki. Shift-kliknięcie rozwija/zwija wszystkie poziomy komórki."
 
-#: ../src/wxMaximaFrame.cpp:938
+#: ../src/wxMaximaFrame.cpp:937
 msgid "To &Bigfloat"
 msgstr "To &Bigfloat"
 
-#: ../src/wxMaximaFrame.cpp:935
+#: ../src/wxMaximaFrame.cpp:934
 msgid "To &Float"
 msgstr "Wartość &zmiennoprzecinkowa"
 
-#: ../src/MathCtrl.cpp:990
+#: ../src/MathCtrl.cpp:1032
 msgid "To Float"
 msgstr "Wartość zmiennoprzecinkowa"
 
-#: ../src/wxMaximaFrame.cpp:941
+#: ../src/wxMaximaFrame.cpp:940
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr ""
 
@@ -4188,51 +4191,51 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:41 ../src/Plot2dWiz.cpp:40 ../src/Plot2dWiz.cpp:50
 #: ../src/Plot2dWiz.cpp:539 ../src/Plot3dWiz.cpp:39 ../src/Plot3dWiz.cpp:48
-#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4241
+#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4253
 msgid "To:"
 msgstr "Do:"
 
-#: ../src/wxMaximaFrame.cpp:912
+#: ../src/wxMaximaFrame.cpp:911
 msgid "Toggle &Algebraic Flag"
 msgstr "Wł/wył tryb &algebraiczny"
 
-#: ../src/wxMaximaFrame.cpp:933
+#: ../src/wxMaximaFrame.cpp:932
 msgid "Toggle &Numeric Output"
 msgstr "Wł/wył wyjście &numeryczne"
 
-#: ../src/wxMaximaFrame.cpp:673
+#: ../src/wxMaximaFrame.cpp:672
 msgid "Toggle &Time Display"
 msgstr "Wł/wył &czas wykonania"
 
-#: ../src/wxMaximaFrame.cpp:913
+#: ../src/wxMaximaFrame.cpp:912
 msgid "Toggle algebraic flag"
 msgstr "Wł/wył tryb algebraiczny"
 
-#: ../src/wxMaximaFrame.cpp:577
+#: ../src/wxMaximaFrame.cpp:576
 msgid "Toggle full screen editing"
 msgstr "Wł/wył widok pełnoekranowy"
 
-#: ../src/wxMaximaFrame.cpp:934
+#: ../src/wxMaximaFrame.cpp:933
 msgid "Toggle numeric output"
 msgstr "Wł/wył wyjście numeryczne"
 
-#: ../src/wxMaxima.cpp:4464
+#: ../src/wxMaxima.cpp:4476
 msgid "Toolbar icons"
 msgstr "Ikony pasku narzędzi"
 
-#: ../src/wxMaxima.cpp:4465
+#: ../src/wxMaxima.cpp:4477
 msgid "Translated by"
 msgstr "Przetłumaczono przez:"
 
-#: ../src/wxMaximaFrame.cpp:763
+#: ../src/wxMaximaFrame.cpp:762
 msgid "Transpose a matrix"
 msgstr "Transponuj macierz"
 
-#: ../src/MathCtrl.cpp:5834
+#: ../src/MathCtrl.cpp:5886
 msgid "Trying to undo an action without starting cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5901
+#: ../src/MathCtrl.cpp:5953
 msgid "Trying to undo something but the undo action is empty."
 msgstr ""
 
@@ -4240,11 +4243,11 @@ msgstr ""
 msgid "Turkish"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:970
+#: ../src/wxMaximaFrame.cpp:969
 msgid "Tutorials"
 msgstr "Tutoriale"
 
-#: ../src/wxMaxima.cpp:4778
+#: ../src/wxMaxima.cpp:4790
 msgid "Two sample t-test"
 msgstr ""
 
@@ -4256,15 +4259,15 @@ msgstr "Typ:"
 msgid "Ukrainian"
 msgstr "Ukraiński"
 
-#: ../src/wxMaxima.cpp:5356
+#: ../src/wxMaxima.cpp:5372
 msgid "Un-closed parenthesis"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5323
+#: ../src/wxMaxima.cpp:5335
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5889
 msgid ""
 "Unable to interpret the version info I got from http://andrejv.github.io//"
 "wxmaxima/version.txt: "
@@ -4278,11 +4281,11 @@ msgstr "Podkreślenie"
 msgid "Underscore converts to subscripts:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:492
+#: ../src/wxMaximaFrame.cpp:491
 msgid "Undo\tCtrl-Z"
 msgstr "Cofnij\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:493
+#: ../src/wxMaximaFrame.cpp:492
 msgid "Undo last change"
 msgstr "Cofnij ostatnią zmianę"
 
@@ -4290,24 +4293,24 @@ msgstr "Cofnij ostatnią zmianę"
 msgid "Undo limit (0 for none):"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:625
+#: ../src/wxMaximaFrame.cpp:624
 #, fuzzy
 msgid "Unfold All\tCtrl-Alt-]"
 msgstr "Zaznacz wszystko\tCtrl-A"
 
-#: ../src/wxMaximaFrame.cpp:626
+#: ../src/wxMaximaFrame.cpp:625
 msgid "Unfold all folded sections"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4458
+#: ../src/wxMaxima.cpp:4470
 msgid "Unicode Support"
 msgstr "Wsparcie Unicode"
 
-#: ../src/wxMaxima.cpp:5335
+#: ../src/wxMaxima.cpp:5347
 msgid "Unterminated comment."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5309
+#: ../src/wxMaxima.cpp:5321
 msgid "Unterminated string."
 msgstr ""
 
@@ -4315,15 +4318,15 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5859 ../src/wxMaxima.cpp:5866 ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5874 ../src/wxMaxima.cpp:5881 ../src/wxMaxima.cpp:5889
 msgid "Upgrade"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Upper bound:"
 msgstr "Górna granica:"
 
-#: ../src/wxMaximaFrame.cpp:1383
+#: ../src/wxMaximaFrame.cpp:1382
 #, fuzzy
 msgid "Upsilon"
 msgstr "Epsilon:"
@@ -4368,22 +4371,22 @@ msgstr ""
 msgid "User-defined labels"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3525
-#: ../src/wxMaxima.cpp:3541 ../src/wxMaxima.cpp:3649
+#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3537
+#: ../src/wxMaxima.cpp:3553 ../src/wxMaxima.cpp:3661
 msgid "Value:"
 msgstr "Wartość:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:5019 ../src/wxMaxima.cpp:5064
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:5031 ../src/wxMaxima.cpp:5076
 msgid "Variable(s):"
 msgstr "Zmienna(e):"
 
 #: ../src/IntegrateWiz.cpp:33 ../src/LimitWiz.cpp:30 ../src/Plot2dWiz.cpp:34
 #: ../src/Plot2dWiz.cpp:44 ../src/Plot2dWiz.cpp:533 ../src/Plot3dWiz.cpp:33
 #: ../src/Plot3dWiz.cpp:42 ../src/SeriesWiz.cpp:36 ../src/SumWiz.cpp:30
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3749
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3761
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5045
 msgid "Variable:"
 msgstr "Zmienna:"
 
@@ -4391,25 +4394,25 @@ msgstr "Zmienna:"
 msgid "Variables"
 msgstr "Zmienne"
 
-#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3571 ../src/wxMaxima.cpp:4206
-#: ../src/wxMaxima.cpp:4807
+#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3583 ../src/wxMaxima.cpp:4218
+#: ../src/wxMaxima.cpp:4819
 msgid "Variables:"
 msgstr "Zmienne:"
 
-#: ../src/wxMaximaFrame.cpp:1257
+#: ../src/wxMaximaFrame.cpp:1256
 msgid "Variance..."
 msgstr "Wariancja..."
 
-#: ../src/wxMaximaFrame.cpp:580
+#: ../src/wxMaximaFrame.cpp:579
 msgid "View"
 msgstr ""
 
-#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1674 ../src/wxMaxima.cpp:1769
-#: ../src/wxMaxima.cpp:1950
+#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1679 ../src/wxMaxima.cpp:1774
+#: ../src/wxMaxima.cpp:1955
 msgid "Warning"
 msgstr "Ostrzeżenie"
 
-#: ../src/wxMaximaFrame.cpp:109 ../src/wxMaximaFrame.cpp:295
+#: ../src/wxMaximaFrame.cpp:108 ../src/wxMaximaFrame.cpp:294
 msgid "Welcome to wxMaxima"
 msgstr ""
 "Witaj w wxMaxima. Polskie tłumaczenie w wesji rozwojowej, proszę zgłaszać "
@@ -4435,7 +4438,7 @@ msgid ""
 "introducing an empty line."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2567
+#: ../src/wxMaxima.cpp:2574
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) "
 "(*.wxm)|*.wxm"
@@ -4451,7 +4454,7 @@ msgid ""
 "as equation markers"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6798
+#: ../src/MathCtrl.cpp:6856
 msgid "Wrapped search"
 msgstr ""
 
@@ -4459,15 +4462,15 @@ msgstr ""
 msgid "Write matching parenthesis in text controls."
 msgstr "Automatycznie zamyka nawiasy w polach tekstowych."
 
-#: ../src/wxMaxima.cpp:4461
+#: ../src/wxMaxima.cpp:4473
 msgid "Written by"
 msgstr "Napisany przez"
 
-#: ../src/wxMaximaFrame.cpp:557
+#: ../src/wxMaximaFrame.cpp:556
 msgid "XML Inspector"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1377
+#: ../src/wxMaximaFrame.cpp:1376
 msgid "Xi"
 msgstr ""
 
@@ -4537,7 +4540,7 @@ msgstr ""
 "w trybie kursoru poziomego. To się przydaje, jeżeli chceszusunąć lub "
 "powtórzyć obliczenia w zaznaczonych komórkach."
 
-#: ../src/wxMaxima.cpp:5856
+#: ../src/wxMaxima.cpp:5871
 #, c-format
 msgid ""
 "You have version %s. Current version is %s.\n"
@@ -4548,41 +4551,41 @@ msgstr ""
 "\n"
 "Nacisnij OK zeby przejść do strony wxMaxima."
 
-#: ../src/wxMaxima.cpp:5921
+#: ../src/wxMaxima.cpp:5936
 msgid "Your changes will be lost if you don't save them."
 msgstr "Wprowadzone zmiany zostaną utracone, jężeli nie zostaną zapisane."
 
-#: ../src/wxMaxima.cpp:5866
+#: ../src/wxMaxima.cpp:5881
 msgid "Your version of wxMaxima is up to date."
 msgstr "Masz najnowszą wersję wxMaxima."
 
-#: ../src/wxMaximaFrame.cpp:1369
+#: ../src/wxMaximaFrame.cpp:1368
 msgid "Zeta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:562
+#: ../src/wxMaximaFrame.cpp:561
 #, fuzzy
 msgid "Zoom &In\tCtrl-+"
 msgstr "Przybliż \tAlt-I"
 
-#: ../src/wxMaximaFrame.cpp:564
+#: ../src/wxMaximaFrame.cpp:563
 #, fuzzy
 msgid "Zoom Ou&t\tCtrl--"
 msgstr "Oddal\tAlt-O"
 
-#: ../src/wxMaximaFrame.cpp:563
+#: ../src/wxMaximaFrame.cpp:562
 msgid "Zoom in 10%"
 msgstr "Powiększ o 10%"
 
-#: ../src/wxMaximaFrame.cpp:565
+#: ../src/wxMaximaFrame.cpp:564
 msgid "Zoom out 10%"
 msgstr "Pomniejsz o 10%"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaximaFrame.cpp:287
 msgid "[ unsaved ]"
 msgstr "[ nie zapisane ]"
 
-#: ../src/wxMaxima.cpp:5700
+#: ../src/wxMaxima.cpp:5715
 msgid "[ unsaved* ]"
 msgstr "[ nie zapisane* ]"
 
@@ -4591,17 +4594,17 @@ msgstr "[ nie zapisane* ]"
 msgid "[%i digits]"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4392
+#: ../src/MathCtrl.cpp:4447
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" style=\"max-width:90%%;\" >\n"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4517
+#: ../src/MathCtrl.cpp:4572
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" >"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1333
+#: ../src/wxMaximaFrame.cpp:1332
 msgid "alpha"
 msgstr ""
 
@@ -4614,7 +4617,7 @@ msgstr "Rozwiń"
 msgid "antisymmetric"
 msgstr "antysymetryczna"
 
-#: ../src/wxMaximaFrame.cpp:1334
+#: ../src/wxMaximaFrame.cpp:1333
 msgid "beta"
 msgstr ""
 
@@ -4658,7 +4661,7 @@ msgstr ""
 msgid "bug:Invalid sup tag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1354
+#: ../src/wxMaximaFrame.cpp:1353
 msgid "chi"
 msgstr ""
 
@@ -4671,7 +4674,7 @@ msgstr ""
 msgid "default"
 msgstr "domyślny"
 
-#: ../src/wxMaximaFrame.cpp:1336
+#: ../src/wxMaximaFrame.cpp:1335
 msgid "delta"
 msgstr ""
 
@@ -4683,7 +4686,7 @@ msgstr "diagonalna"
 msgid "empty"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1337
+#: ../src/wxMaximaFrame.cpp:1336
 #, fuzzy
 msgid "epsilon"
 msgstr "Epsilon:"
@@ -4692,7 +4695,7 @@ msgstr "Epsilon:"
 msgid "equivalent"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1339
+#: ../src/wxMaximaFrame.cpp:1338
 msgid "eta"
 msgstr ""
 
@@ -4708,7 +4711,7 @@ msgid ""
 "all=_ marks subscripts."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1335
+#: ../src/wxMaximaFrame.cpp:1334
 msgid "gamma"
 msgstr ""
 
@@ -4737,15 +4740,15 @@ msgstr "wbudowany"
 msgid "intersection"
 msgstr "Z:"
 
-#: ../src/wxMaximaFrame.cpp:1341
+#: ../src/wxMaximaFrame.cpp:1340
 msgid "iota"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1342
+#: ../src/wxMaximaFrame.cpp:1341
 msgid "kappa"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1343
+#: ../src/wxMaximaFrame.cpp:1342
 msgid "lambda"
 msgstr ""
 
@@ -4762,7 +4765,7 @@ msgstr "Komórka podrozdziału"
 msgid "logscale"
 msgstr "skala logarytmiczna"
 
-#: ../src/wxMaxima.cpp:3783
+#: ../src/wxMaxima.cpp:3795
 msgid "matrix[i,j]:"
 msgstr "matrix[i,j]:"
 
@@ -4770,7 +4773,7 @@ msgstr "matrix[i,j]:"
 msgid "maxima's pwd is path to document"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1344
+#: ../src/wxMaximaFrame.cpp:1343
 msgid "mu"
 msgstr ""
 
@@ -4787,7 +4790,7 @@ msgstr ""
 msgid "nand"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4524
+#: ../src/wxMaxima.cpp:4536
 msgid "no"
 msgstr "nie"
 
@@ -4813,15 +4816,15 @@ msgstr ""
 msgid "not subset or equal"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1345
+#: ../src/wxMaximaFrame.cpp:1344
 msgid "nu"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1356
+#: ../src/wxMaximaFrame.cpp:1355
 msgid "omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1347
+#: ../src/wxMaximaFrame.cpp:1346
 msgid "omicron"
 msgstr ""
 
@@ -4834,11 +4837,11 @@ msgstr ""
 msgid "partial sign"
 msgstr "Ułamek prosty"
 
-#: ../src/wxMaximaFrame.cpp:1353
+#: ../src/wxMaximaFrame.cpp:1352
 msgid "phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1348
+#: ../src/wxMaximaFrame.cpp:1347
 msgid "pi"
 msgstr ""
 
@@ -4850,11 +4853,11 @@ msgstr ""
 msgid "proportional to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1355
+#: ../src/wxMaximaFrame.cpp:1354
 msgid "psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1349
+#: ../src/wxMaximaFrame.cpp:1348
 msgid "rho"
 msgstr ""
 
@@ -4862,7 +4865,7 @@ msgstr ""
 msgid "right"
 msgstr "prawej strony"
 
-#: ../src/wxMaximaFrame.cpp:1350
+#: ../src/wxMaximaFrame.cpp:1349
 msgid "sigma"
 msgstr ""
 
@@ -4884,7 +4887,7 @@ msgstr "Komórka podrozdziału"
 msgid "symmetric"
 msgstr "symetryczna"
 
-#: ../src/wxMaximaFrame.cpp:1351
+#: ../src/wxMaximaFrame.cpp:1350
 msgid "tau"
 msgstr ""
 
@@ -4896,7 +4899,7 @@ msgstr ""
 msgid "there is no"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1340
+#: ../src/wxMaximaFrame.cpp:1339
 msgid "theta"
 msgstr ""
 
@@ -4912,12 +4915,12 @@ msgstr ""
 msgid "union"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5903
+#: ../src/wxMaxima.cpp:5918
 msgid "unsaved"
 msgstr "nie zapisane"
 
-#: ../src/wxMaximaFrame.cpp:290 ../src/wxMaxima.cpp:2559
-#: ../src/wxMaxima.cpp:2826
+#: ../src/wxMaxima.cpp:2566 ../src/wxMaxima.cpp:2834
+#: ../src/wxMaximaFrame.cpp:289
 msgid "untitled"
 msgstr "beznazwy"
 
@@ -4926,27 +4929,27 @@ msgstr "beznazwy"
 msgid "untitled %d"
 msgstr "beznazwy %d"
 
-#: ../src/wxMaximaFrame.cpp:1352
+#: ../src/wxMaximaFrame.cpp:1351
 #, fuzzy
 msgid "upsilon"
 msgstr "Epsilon:"
 
-#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4538
+#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4550
 msgid "wxMaxima"
 msgstr "wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
-#: ../src/wxMaxima.cpp:5700 ../src/wxMaxima.cpp:5709 ../src/wxMaxima.cpp:5712
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaxima.cpp:5715 ../src/wxMaxima.cpp:5724
+#: ../src/wxMaxima.cpp:5727 ../src/wxMaximaFrame.cpp:287
 #, c-format
 msgid "wxMaxima %s "
 msgstr "wxMaxima %s "
 
-#: ../src/wxMaximaFrame.cpp:952
+#: ../src/wxMaximaFrame.cpp:951
 #, fuzzy
 msgid "wxMaxima &Help\tCtrl+?"
 msgstr "&Pomoc Maxima\tF1"
 
-#: ../src/wxMaximaFrame.cpp:955
+#: ../src/wxMaximaFrame.cpp:954
 #, fuzzy
 msgid "wxMaxima &Help\tF1"
 msgstr "&Pomoc Maxima\tF1"
@@ -4958,11 +4961,11 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1619
+#: ../src/wxMaxima.cpp:1624
 msgid "wxMaxima cannot open content.xml in the .wxmx zip archive "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1633
+#: ../src/wxMaxima.cpp:1638
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
@@ -4970,7 +4973,7 @@ msgstr ""
 msgid "wxMaxima configuration"
 msgstr "wxMaxima preferencje"
 
-#: ../src/wxMaxima.cpp:1947
+#: ../src/wxMaxima.cpp:1952
 msgid ""
 "wxMaxima could not find Maxima!\n"
 "\n"
@@ -4982,7 +4985,7 @@ msgstr ""
 "Skonfiguruj program wxMaxima 'Edycjja->Preferencje'.\n"
 "Następnie uruchom Maximę 'Maxima->Restart'."
 
-#: ../src/wxMaxima.cpp:2204
+#: ../src/wxMaxima.cpp:2209
 msgid ""
 "wxMaxima could not find help files.\n"
 "\n"
@@ -4992,7 +4995,7 @@ msgstr ""
 "\n"
 "Popraw instalację programu wxMaxima."
 
-#: ../src/wxMaxima.cpp:2032
+#: ../src/wxMaxima.cpp:2037
 msgid ""
 "wxMaxima could not find tip files.\n"
 "\n"
@@ -5002,7 +5005,7 @@ msgstr ""
 "\n"
 "Popraw instalację programu wxMaxima."
 
-#: ../src/wxMaxima.cpp:282
+#: ../src/wxMaxima.cpp:283
 msgid ""
 "wxMaxima could not start the server.\n"
 "\n"
@@ -5025,29 +5028,29 @@ msgstr ""
 "je innym wyrażeniem wystarczy, że wpiszesz je w linii wejścia lub zaznaczysz "
 "w konsoli."
 
-#: ../src/wxMaxima.cpp:2330
+#: ../src/wxMaxima.cpp:2336
 msgid "wxMaxima document"
 msgstr "Dokument wxMaxima"
 
-#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2799
+#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2807
 msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 msgstr "Dokument wxMaxima (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 
-#: ../src/wxMaxima.cpp:1455 ../src/wxMaxima.cpp:1469
+#: ../src/wxMaxima.cpp:1460 ../src/wxMaxima.cpp:1474
 msgid "wxMaxima encountered an error loading "
 msgstr "Napotkano błąd przy uruchamianiu wxMaximy"
 
-#: ../src/wxMaxima.cpp:4463
+#: ../src/wxMaxima.cpp:4475
 msgid "wxMaxima icon"
 msgstr "Ikona wxMaxima"
 
-#: ../src/wxMaxima.cpp:4455
+#: ../src/wxMaxima.cpp:4467
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "MAXIMA based on wxWidgets."
 msgstr "wxMaxima jest graficznym interfejsem MAXIMA bazującym na wxWidgets."
 
-#: ../src/wxMaxima.cpp:4516
+#: ../src/wxMaxima.cpp:4528
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "Maxima based on wxWidgets."
@@ -5065,11 +5068,11 @@ msgstr ""
 msgid "x"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1346
+#: ../src/wxMaximaFrame.cpp:1345
 msgid "xi"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1643
+#: ../src/wxMaxima.cpp:1648
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
@@ -5078,11 +5081,11 @@ msgstr ""
 msgid "xor"
 msgstr "Eksportuj"
 
-#: ../src/wxMaxima.cpp:4522
+#: ../src/wxMaxima.cpp:4534
 msgid "yes"
 msgstr "tak"
 
-#: ../src/wxMaximaFrame.cpp:1338
+#: ../src/wxMaximaFrame.cpp:1337
 msgid "zeta"
 msgstr ""
 

--- a/locales/pt_BR.po
+++ b/locales/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxMaxima\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-07 21:42+0200\n"
+"POT-Creation-Date: 2016-10-16 17:47+0900\n"
 "PO-Revision-Date: 2012-11-15 15:29-0200\n"
 "Last-Translator: Eduardo M Kalinowski <eduardo@kalinowski.com.br>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../src/wxMaxima.cpp:4519
+#: ../src/wxMaxima.cpp:4531
 #, c-format
 msgid ""
 "\n"
@@ -30,7 +30,7 @@ msgstr ""
 "wxWidgets: %d.%d.%d\n"
 "Suporte a Unicode: %s"
 
-#: ../src/wxMaxima.cpp:4532
+#: ../src/wxMaxima.cpp:4544
 msgid ""
 "\n"
 "Lisp: "
@@ -38,7 +38,7 @@ msgstr ""
 "\n"
 "Lisp: "
 
-#: ../src/wxMaxima.cpp:4528
+#: ../src/wxMaxima.cpp:4540
 msgid ""
 "\n"
 "Maxima version: "
@@ -46,7 +46,7 @@ msgstr ""
 "\n"
 "Versão do Maxima: "
 
-#: ../src/wxMaxima.cpp:5381
+#: ../src/wxMaxima.cpp:5397
 msgid ""
 "\n"
 "Not connected to Maxima!\n"
@@ -54,7 +54,7 @@ msgstr ""
 "\n"
 "Não conectado ao Maxima!\n"
 
-#: ../src/wxMaxima.cpp:4530
+#: ../src/wxMaxima.cpp:4542
 msgid ""
 "\n"
 "Not connected."
@@ -74,7 +74,7 @@ msgstr ""
 msgid " (Graphics) "
 msgstr ""
 
-#: ../src/EditorCell.cpp:3045 ../src/EditorCell.cpp:3227
+#: ../src/EditorCell.cpp:3088 ../src/EditorCell.cpp:3270
 #, c-format
 msgid " ... + %i hidden lines"
 msgstr ""
@@ -83,7 +83,7 @@ msgstr ""
 msgid " << Expression longer than allowed by the configuration setting! >>"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1673
+#: ../src/wxMaxima.cpp:1678
 msgid ""
 " was saved using a newer version of wxMaxima so it may not load correctly. "
 "Please update your wxMaxima."
@@ -91,7 +91,7 @@ msgstr ""
 " foi salvo com uma versão mais nova do wxMaxima e talvez não seja carregado "
 "corretamente. Por favor atualize seu wxMaxima."
 
-#: ../src/wxMaxima.cpp:1665
+#: ../src/wxMaxima.cpp:1670
 msgid ""
 " was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr ""
@@ -106,64 +106,64 @@ msgstr ""
 msgid "\"implies\" symbol"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:101
+#: ../src/wxMaximaFrame.cpp:100
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:773
+#: ../src/wxMaximaFrame.cpp:772
 msgid "&Algebra"
 msgstr "Ál&gebra"
 
-#: ../src/wxMaximaFrame.cpp:767
+#: ../src/wxMaximaFrame.cpp:766
 msgid "&Apply to List..."
 msgstr "&Aplicar a lista..."
 
-#: ../src/wxMaximaFrame.cpp:964
+#: ../src/wxMaximaFrame.cpp:963
 msgid "&Apropos..."
 msgstr "&Apropos"
 
-#: ../src/wxMaximaFrame.cpp:478
+#: ../src/wxMaximaFrame.cpp:477
 msgid "&Batch File...\tCtrl-B"
 msgstr "Carregar arquivo &batch...\tCtrl-B"
 
-#: ../src/wxMaximaFrame.cpp:724
+#: ../src/wxMaximaFrame.cpp:723
 msgid "&Boundary Value Problem..."
 msgstr "Problema de valor de &fronteira..."
 
-#: ../src/wxMaximaFrame.cpp:975
+#: ../src/wxMaximaFrame.cpp:974
 msgid "&Bug Report"
 msgstr "Relatar &bug"
 
-#: ../src/wxMaximaFrame.cpp:825
+#: ../src/wxMaximaFrame.cpp:824
 msgid "&Calculus"
 msgstr "&Cálculo"
 
-#: ../src/wxMaximaFrame.cpp:876
+#: ../src/wxMaximaFrame.cpp:875
 msgid "&Canonical Form"
 msgstr "Forma &canônica"
 
-#: ../src/wxMaximaFrame.cpp:749
+#: ../src/wxMaximaFrame.cpp:748
 msgid "&Characteristic Polynomial..."
 msgstr "Polinômio característico..."
 
-#: ../src/wxMaximaFrame.cpp:654
+#: ../src/wxMaximaFrame.cpp:653
 msgid "&Clear Memory"
 msgstr "&Limpar memória"
 
-#: ../src/wxMaximaFrame.cpp:859
+#: ../src/wxMaximaFrame.cpp:858
 msgid "&Combine Factorials"
 msgstr "&Combinar fatoriais"
 
-#: ../src/wxMaximaFrame.cpp:902
+#: ../src/wxMaximaFrame.cpp:901
 msgid "&Complex Simplification"
 msgstr "Simplificação &complexa"
 
-#: ../src/wxMaximaFrame.cpp:822
+#: ../src/wxMaximaFrame.cpp:821
 msgid "&Continued Fraction"
 msgstr "Fração &contínua"
 
-#: ../src/wxMaximaFrame.cpp:502
+#: ../src/wxMaximaFrame.cpp:501
 msgid "&Copy\tCtrl-C"
 msgstr "&Copiar\tCtrl-C"
 
@@ -171,109 +171,109 @@ msgstr "&Copiar\tCtrl-C"
 msgid "&Definite integration"
 msgstr "Integração &definida"
 
-#: ../src/wxMaximaFrame.cpp:896
+#: ../src/wxMaximaFrame.cpp:895
 msgid "&Demoivre"
 msgstr "&Demoivre"
 
-#: ../src/wxMaximaFrame.cpp:752
+#: ../src/wxMaximaFrame.cpp:751
 msgid "&Determinant"
 msgstr "&Determinante"
 
-#: ../src/wxMaximaFrame.cpp:785
+#: ../src/wxMaximaFrame.cpp:784
 msgid "&Differentiate..."
 msgstr "&Diferenciar..."
 
-#: ../src/wxMaximaFrame.cpp:543
+#: ../src/wxMaximaFrame.cpp:542
 msgid "&Edit"
 msgstr "&Editar"
 
-#: ../src/wxMaximaFrame.cpp:709
+#: ../src/wxMaximaFrame.cpp:708
 msgid "&Eliminate Variable..."
 msgstr "&Eliminar variável..."
 
-#: ../src/wxMaximaFrame.cpp:744
+#: ../src/wxMaximaFrame.cpp:743
 msgid "&Enter Matrix..."
 msgstr "&Introduzir matriz..."
 
-#: ../src/wxMaximaFrame.cpp:961
+#: ../src/wxMaximaFrame.cpp:960
 msgid "&Example..."
 msgstr "&Exemplo..."
 
-#: ../src/wxMaximaFrame.cpp:839
+#: ../src/wxMaximaFrame.cpp:838
 msgid "&Expand Expression"
 msgstr "&Expandir expressão"
 
-#: ../src/wxMaximaFrame.cpp:873
+#: ../src/wxMaximaFrame.cpp:872
 msgid "&Expand Trigonometric"
 msgstr "&Expandir trigonométricas"
 
-#: ../src/wxMaximaFrame.cpp:899
+#: ../src/wxMaximaFrame.cpp:898
 msgid "&Exponentialize"
 msgstr "&Exponencializar"
 
-#: ../src/wxMaximaFrame.cpp:480
+#: ../src/wxMaximaFrame.cpp:479
 msgid "&Export..."
 msgstr "&Exportar..."
 
-#: ../src/wxMaximaFrame.cpp:834
+#: ../src/wxMaximaFrame.cpp:833
 msgid "&Factor Expression"
 msgstr "&Fatorar expressão"
 
-#: ../src/wxMaximaFrame.cpp:489
+#: ../src/wxMaximaFrame.cpp:488
 msgid "&File"
 msgstr "&Arquivo"
 
-#: ../src/wxMaximaFrame.cpp:692
+#: ../src/wxMaximaFrame.cpp:691
 msgid "&Find Root..."
 msgstr "Encontrar &raiz..."
 
-#: ../src/wxMaximaFrame.cpp:738
+#: ../src/wxMaximaFrame.cpp:737
 msgid "&Generate Matrix..."
 msgstr "&Gerar matriz..."
 
-#: ../src/wxMaximaFrame.cpp:809
+#: ../src/wxMaximaFrame.cpp:808
 msgid "&Greatest Common Divisor..."
 msgstr "Máximo &divisor comum..."
 
-#: ../src/wxMaximaFrame.cpp:994
+#: ../src/wxMaximaFrame.cpp:993
 msgid "&Help"
 msgstr "Aj&uda"
 
-#: ../src/wxMaximaFrame.cpp:777
+#: ../src/wxMaximaFrame.cpp:776
 msgid "&Integrate..."
 msgstr "&Integrar..."
 
-#: ../src/wxMaximaFrame.cpp:645
+#: ../src/wxMaximaFrame.cpp:644
 msgid "&Interrupt\tCtrl-."
 msgstr "&Interromper\tCtrl-."
 
-#: ../src/wxMaximaFrame.cpp:649
+#: ../src/wxMaximaFrame.cpp:648
 msgid "&Interrupt\tCtrl-G"
 msgstr "&Interromper\tCtrl-G"
 
-#: ../src/wxMaximaFrame.cpp:746
+#: ../src/wxMaximaFrame.cpp:745
 msgid "&Invert Matrix"
 msgstr "&Inverter matriz"
 
-#: ../src/wxMaximaFrame.cpp:476
+#: ../src/wxMaximaFrame.cpp:475
 msgid "&Load Package...\tCtrl-L"
 msgstr "&Carregar pacote...\tCtrl-L"
 
-#: ../src/wxMaximaFrame.cpp:769
+#: ../src/wxMaximaFrame.cpp:768
 #, fuzzy
 msgid "&Map to List(s)..."
 msgstr "&Mapear a lista..."
 
-#: ../src/wxMaximaFrame.cpp:684
+#: ../src/wxMaximaFrame.cpp:683
 msgid "&Maxima"
 msgstr "&Maxima"
 
-#: ../src/wxMaximaFrame.cpp:958
+#: ../src/wxMaximaFrame.cpp:957
 #, fuzzy
 msgid "&Maxima help"
 msgstr "Mostrar ajuda do Maxima"
 
-#: ../src/wxMaximaFrame.cpp:917
+#: ../src/wxMaximaFrame.cpp:916
 msgid "&Modulus Computation..."
 msgstr "Cálculo com &módulo..."
 
@@ -281,7 +281,7 @@ msgstr "Cálculo com &módulo..."
 msgid "&New\tCtrl-N"
 msgstr "&Novo\tCtrl-N"
 
-#: ../src/wxMaximaFrame.cpp:947
+#: ../src/wxMaximaFrame.cpp:946
 msgid "&Numeric"
 msgstr "&Numérico"
 
@@ -297,11 +297,11 @@ msgstr "&Nusum"
 msgid "&Open\tCtrl-O"
 msgstr "&Abrir\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:463
+#: ../src/wxMaximaFrame.cpp:462
 msgid "&Open...\tCtrl-O"
 msgstr "&Abrir...\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:929
+#: ../src/wxMaximaFrame.cpp:928
 msgid "&Plot"
 msgstr "G&ráfico"
 
@@ -309,7 +309,7 @@ msgstr "G&ráfico"
 msgid "&Power series"
 msgstr "Séries de &potências"
 
-#: ../src/wxMaximaFrame.cpp:483
+#: ../src/wxMaximaFrame.cpp:482
 msgid "&Print...\tCtrl-P"
 msgstr "&Imprimir...\tCtrl-P"
 
@@ -317,39 +317,39 @@ msgstr "&Imprimir...\tCtrl-P"
 msgid "&Rational"
 msgstr "&Racional"
 
-#: ../src/wxMaximaFrame.cpp:870
+#: ../src/wxMaximaFrame.cpp:869
 msgid "&Reduce Trigonometric"
 msgstr "&Reduzir trigonometricas"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "&Restart Maxima"
 msgstr "&Reiniciar Maxima"
 
-#: ../src/wxMaximaFrame.cpp:700
+#: ../src/wxMaximaFrame.cpp:699
 msgid "&Roots of Polynomial (Real)"
 msgstr "&Raízes do polinômio (real)"
 
-#: ../src/wxMaximaFrame.cpp:472
+#: ../src/wxMaximaFrame.cpp:471
 msgid "&Save\tCtrl-S"
 msgstr "&Salvar\tCtrl-S"
 
-#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:919
+#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:918
 msgid "&Simplify"
 msgstr "&Simplificar"
 
-#: ../src/wxMaximaFrame.cpp:829
+#: ../src/wxMaximaFrame.cpp:828
 msgid "&Simplify Expression"
 msgstr "&Simplificar expressão"
 
-#: ../src/wxMaximaFrame.cpp:856
+#: ../src/wxMaximaFrame.cpp:855
 msgid "&Simplify Factorials"
 msgstr "&Simplificar fatoriais"
 
-#: ../src/wxMaximaFrame.cpp:867
+#: ../src/wxMaximaFrame.cpp:866
 msgid "&Simplify Trigonometric"
 msgstr "&Simplificar trigonométricas"
 
-#: ../src/wxMaximaFrame.cpp:688
+#: ../src/wxMaximaFrame.cpp:687
 msgid "&Solve..."
 msgstr "&Resolver..."
 
@@ -361,11 +361,11 @@ msgstr "E&special"
 msgid "&Taylor series"
 msgstr "Série de &Taylor"
 
-#: ../src/wxMaximaFrame.cpp:762
+#: ../src/wxMaximaFrame.cpp:761
 msgid "&Transpose Matrix"
 msgstr "&Transpor matriz"
 
-#: ../src/wxMaximaFrame.cpp:879
+#: ../src/wxMaximaFrame.cpp:878
 msgid "&Trigonometric Simplification"
 msgstr "Simplificação &trigonométrica"
 
@@ -383,7 +383,7 @@ msgstr "(Usar idioma padrão)"
 msgid "- Infinity"
 msgstr "- Infinito"
 
-#: ../src/wxMaxima.cpp:351
+#: ../src/wxMaxima.cpp:356
 msgid ""
 "... [suppressed additional lines since the output is longer than allowed in "
 "the configuration] "
@@ -393,16 +393,16 @@ msgstr ""
 msgid "1/2"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:103
+#: ../src/wxMaximaFrame.cpp:102
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4601
+#: ../src/wxMaxima.cpp:4613
 msgid "<br>Lisp: "
 msgstr "<br>Lisp: "
 
-#: ../src/wxMaxima.cpp:5487
+#: ../src/wxMaxima.cpp:5503
 msgid ""
 "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
@@ -434,11 +434,11 @@ msgid ""
 "\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1472
+#: ../src/wxMaximaFrame.cpp:1495
 msgid "A symbol from the configuration dialogue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:731
+#: ../src/wxMaximaFrame.cpp:730
 msgid "A&t Value..."
 msgstr "Valor no pon&to..."
 
@@ -446,12 +446,12 @@ msgstr "Valor no pon&to..."
 msgid "Abort evaluation on error"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaxima.cpp:4603
+#: ../src/wxMaxima.cpp:4615 ../src/wxMaximaFrame.cpp:985
 msgid "About"
 msgstr "Sobre"
 
-#: ../src/wxMaximaFrame.cpp:987 ../src/wxMaximaFrame.cpp:990
-#: ../src/wxMaximaFrame.cpp:991
+#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaximaFrame.cpp:989
+#: ../src/wxMaximaFrame.cpp:990
 msgid "About wxMaxima"
 msgstr "Sobre o wxMaxima"
 
@@ -459,23 +459,23 @@ msgstr "Sobre o wxMaxima"
 msgid "Active cell bracket"
 msgstr "Marcador da célula ativa"
 
-#: ../src/wxMaximaFrame.cpp:760
+#: ../src/wxMaximaFrame.cpp:759
 msgid "Ad&joint Matrix"
 msgstr "Matriz ad&junta"
 
-#: ../src/wxMaximaFrame.cpp:914
+#: ../src/wxMaximaFrame.cpp:913
 msgid "Add Algebraic E&quality..."
 msgstr "Adicionar &igualdade algébrica..."
 
-#: ../src/wxMaximaFrame.cpp:657
+#: ../src/wxMaximaFrame.cpp:656
 msgid "Add a directory to search path"
 msgstr "Adicionar um diretório ao caminho de busca"
 
-#: ../src/wxMaxima.cpp:3353
+#: ../src/wxMaxima.cpp:3365
 msgid "Add dir to path:"
 msgstr "Adicionar diretório ao caminho:"
 
-#: ../src/wxMaximaFrame.cpp:915
+#: ../src/wxMaximaFrame.cpp:914
 msgid "Add equality to the rational simplifier"
 msgstr "Adicionar igualdade ao simplificador racional"
 
@@ -483,7 +483,7 @@ msgstr "Adicionar igualdade ao simplificador racional"
 msgid "Add the .wxmx file to the HTML export"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:656
+#: ../src/wxMaximaFrame.cpp:655
 msgid "Add to &Path..."
 msgstr "Adicionar ao &caminho..."
 
@@ -524,27 +524,27 @@ msgstr "Variável antiga:"
 msgid "All|*"
 msgstr "Todos|*"
 
-#: ../src/wxMaximaFrame.cpp:1364
+#: ../src/wxMaximaFrame.cpp:1363
 msgid "Alpha"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3838
+#: ../src/wxMaxima.cpp:3850
 msgid "Apply"
 msgstr "Aplicar"
 
-#: ../src/wxMaximaFrame.cpp:768
+#: ../src/wxMaximaFrame.cpp:767
 msgid "Apply function to a list"
 msgstr "Aplicar função a uma lista"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Apropos"
 msgstr "Apropos"
 
-#: ../src/wxMaxima.cpp:3764
+#: ../src/wxMaxima.cpp:3776
 msgid "Array:"
 msgstr "Matriz:"
 
-#: ../src/wxMaxima.cpp:4462
+#: ../src/wxMaxima.cpp:4474
 msgid "Artwork by"
 msgstr "Arte por"
 
@@ -552,7 +552,7 @@ msgstr "Arte por"
 msgid "Ask to save untitled documents"
 msgstr "Pedir salvamento de documentos sem título"
 
-#: ../src/wxMaxima.cpp:3650
+#: ../src/wxMaxima.cpp:3662
 msgid "At value"
 msgstr "Valor no ponto"
 
@@ -573,11 +573,11 @@ msgstr ""
 msgid "Autosave interval (minutes, 0 means: off):"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3557
+#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3569
 msgid "BC2"
 msgstr "CC2"
 
-#: ../src/wxMaximaFrame.cpp:1272
+#: ../src/wxMaximaFrame.cpp:1271
 msgid "Barsplot..."
 msgstr "Gráfico de barras..."
 
@@ -585,7 +585,7 @@ msgstr "Gráfico de barras..."
 msgid "Bat files (*.bat)|*.bat|All|*"
 msgstr "Arquivos de lote (*.bat)|*.bat|Todos|*"
 
-#: ../src/wxMaxima.cpp:2943
+#: ../src/wxMaxima.cpp:2951
 msgid "Batch File"
 msgstr "Arquivo batch (de lote)"
 
@@ -598,7 +598,7 @@ msgid ""
 "cells."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1365
+#: ../src/wxMaximaFrame.cpp:1364
 msgid "Beta"
 msgstr ""
 
@@ -610,11 +610,11 @@ msgstr ""
 msgid "Bold"
 msgstr "Negrito"
 
-#: ../src/wxMaxima.cpp:2359
+#: ../src/wxMaxima.cpp:2366
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1274
+#: ../src/wxMaximaFrame.cpp:1273
 msgid "Boxplot..."
 msgstr "Gráfico de caixa..."
 
@@ -626,15 +626,15 @@ msgstr "Procurar"
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2080
+#: ../src/MathCtrl.cpp:2127
 msgid "Bug: Cell left but not entered."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1178
+#: ../src/wxMaxima.cpp:1183
 msgid "Bug: Found a math end marker without any start marker."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1222
+#: ../src/wxMaxima.cpp:1227
 msgid "Bug: Found the end of autocompletion symbols but no beginning"
 msgstr ""
 
@@ -646,22 +646,22 @@ msgstr ""
 msgid "Bug: Fraction without enumerator"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2312
+#: ../src/MathCtrl.cpp:2359
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5839
+#: ../src/MathCtrl.cpp:5891
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of "
 "the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5913
+#: ../src/MathCtrl.cpp:5965
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5882
+#: ../src/MathCtrl.cpp:5934
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
@@ -671,49 +671,49 @@ msgstr ""
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
 msgstr ""
 
-#: ../src/GroupCell.cpp:780 ../src/GroupCell.cpp:951
+#: ../src/GroupCell.cpp:781 ../src/GroupCell.cpp:952
 msgid "Bug: No image counter to write to!"
 msgstr ""
 
-#: ../src/AbsCell.cpp:193
+#: ../src/AbsCell.cpp:199
 msgid "Bug: No last cell in an absCell!"
 msgstr ""
 
-#: ../src/ConjugateCell.cpp:185
+#: ../src/ConjugateCell.cpp:194
 msgid "Bug: No last cell in an conjugateCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:471
+#: ../src/FracCell.cpp:472
 msgid "Bug: No last cell in an denominator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:267
+#: ../src/ExptCell.cpp:270
 msgid "Bug: No last cell in an exponent of an exptCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:459
+#: ../src/FracCell.cpp:460
 msgid "Bug: No last cell in an numerator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:257
+#: ../src/ExptCell.cpp:260
 msgid "Bug: No last cell in the base of an exptCell!"
 msgstr ""
 
-#: ../src/ParenCell.cpp:534
+#: ../src/ParenCell.cpp:535
 msgid "Bug: No last cell inside a parenthesis!"
 msgstr ""
 
-#: ../src/SqrtCell.cpp:312
+#: ../src/SqrtCell.cpp:317
 msgid "Bug: No last cell inside a square root!"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2123
+#: ../src/MathCtrl.cpp:2170
 msgid ""
 "Bug: Start or end of merging of subsequent editing actions was requested two "
 "times in a row."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2090
+#: ../src/MathCtrl.cpp:2137
 msgid "Bug: Text changed, but no active cell."
 msgstr ""
 
@@ -721,39 +721,39 @@ msgstr ""
 msgid "Bug: Trying to append NULL to a group cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:555
+#: ../src/MathCtrl.cpp:600
 msgid "Bug: Trying to append maxima's output to a cell outside the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2014
+#: ../src/MathCtrl.cpp:2061
 msgid ""
 "Bug: Trying to merge individual cell adds to a region in the undo buffer but "
 "there are other cells between them."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6522
+#: ../src/MathCtrl.cpp:6577
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2092
+#: ../src/MathCtrl.cpp:2139
 msgid "Bug: Trying to record a cell contents change without a cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1495
+#: ../src/MathCtrl.cpp:1540
 msgid "Bug: Trying to select inside a cell without having a current cell"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5883
+#: ../src/MathCtrl.cpp:5935
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5844 ../src/MathCtrl.cpp:5918 ../src/MathCtrl.cpp:5952
+#: ../src/MathCtrl.cpp:5896 ../src/MathCtrl.cpp:5970 ../src/MathCtrl.cpp:6004
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:973
+#: ../src/wxMaximaFrame.cpp:972
 msgid "Build &Info"
 msgstr "&Informações do build"
 
@@ -770,52 +770,52 @@ msgstr ""
 "'Editar->Configurações' marcando 'Enter calcula células'. Essa opção inverte "
 "as ações das duas teclas."
 
-#: ../src/wxMaximaFrame.cpp:782
+#: ../src/wxMaximaFrame.cpp:781
 msgid "C&hange Variable..."
 msgstr "&Mudar variável..."
 
-#: ../src/wxMaximaFrame.cpp:540
+#: ../src/wxMaximaFrame.cpp:539
 msgid "C&onfigure"
 msgstr "C&onfigurações"
 
-#: ../src/wxMaximaFrame.cpp:801
+#: ../src/wxMaximaFrame.cpp:800
 msgid "Calculate &Product..."
 msgstr "Calcular &produto..."
 
-#: ../src/wxMaximaFrame.cpp:799
+#: ../src/wxMaximaFrame.cpp:798
 msgid "Calculate Su&m..."
 msgstr "Calcular &soma..."
 
-#: ../src/wxMaximaFrame.cpp:939
+#: ../src/wxMaximaFrame.cpp:938
 msgid "Calculate bigfloat value of the last result"
 msgstr "Valor bigfloat do último resultado"
 
-#: ../src/wxMaximaFrame.cpp:936
+#: ../src/wxMaximaFrame.cpp:935
 msgid "Calculate float value of the last result"
 msgstr "Valor float do último resultado"
 
-#: ../src/wxMaxima.cpp:3971
+#: ../src/wxMaxima.cpp:3983
 msgid "Calculate modulus:"
 msgstr "Calcular módulo:"
 
-#: ../src/wxMaximaFrame.cpp:942
+#: ../src/wxMaximaFrame.cpp:941
 #, fuzzy
 msgid "Calculate numeric value of the last result"
 msgstr "Valor float do último resultado"
 
-#: ../src/wxMaximaFrame.cpp:802
+#: ../src/wxMaximaFrame.cpp:801
 msgid "Calculate products"
 msgstr "Calcular produtos"
 
-#: ../src/wxMaximaFrame.cpp:800
+#: ../src/wxMaximaFrame.cpp:799
 msgid "Calculate sums"
 msgstr "Calcular somas"
 
-#: ../src/wxMaxima.cpp:5830
+#: ../src/wxMaxima.cpp:5845
 msgid "Can not connect to the web server."
 msgstr "Não é possível se conectar com o servidor web."
 
-#: ../src/wxMaxima.cpp:5881
+#: ../src/wxMaxima.cpp:5896
 msgid "Can not download version info."
 msgstr "Não foi possível baixar informação de versão."
 
@@ -831,15 +831,15 @@ msgstr "Não foi possível baixar informação de versão."
 #: ../src/PlotFormatWiz.cpp:48 ../src/SeriesWiz.cpp:49 ../src/SeriesWiz.cpp:51
 #: ../src/SubstituteWiz.cpp:41 ../src/SubstituteWiz.cpp:43 ../src/SumWiz.cpp:44
 #: ../src/SumWiz.cpp:46 ../src/SystemWiz.cpp:38 ../src/SystemWiz.cpp:40
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: ../src/wxMaximaFrame.cpp:126 ../src/wxMaxima.cpp:932
+#: ../src/wxMaxima.cpp:937 ../src/wxMaximaFrame.cpp:125
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1217
+#: ../src/wxMaximaFrame.cpp:1216
 msgid "Canonical (tr)"
 msgstr "Forma canônica (tr)"
 
@@ -847,7 +847,7 @@ msgstr "Forma canônica (tr)"
 msgid "Catalan"
 msgstr "Catalão"
 
-#: ../src/wxMaximaFrame.cpp:638
+#: ../src/wxMaximaFrame.cpp:637
 msgid "Ce&ll"
 msgstr "Cé&lula"
 
@@ -855,40 +855,40 @@ msgstr "Cé&lula"
 msgid "Cell bracket"
 msgstr "Marcador da célula"
 
-#: ../src/wxMaxima.cpp:5261
+#: ../src/wxMaxima.cpp:5273
 msgid "Cell ends in a backslash"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:676
+#: ../src/wxMaximaFrame.cpp:675
 msgid "Change &2d Display"
 msgstr "Alterar exibição &2d"
 
-#: ../src/wxMaximaFrame.cpp:677
+#: ../src/wxMaximaFrame.cpp:676
 msgid "Change the 2d display algorithm used to display math output"
 msgstr ""
 "Alterar a algoritmo de exibição 2d usado para mostrar a saída matemática"
 
-#: ../src/wxMaxima.cpp:3995
+#: ../src/wxMaxima.cpp:4007
 msgid "Change variable"
 msgstr "Mudar variável"
 
-#: ../src/wxMaximaFrame.cpp:783
+#: ../src/wxMaximaFrame.cpp:782
 msgid "Change variable in integral or sum"
 msgstr "Mudar variável em integral ou soma"
 
-#: ../src/wxMaxima.cpp:3751
+#: ../src/wxMaxima.cpp:3763
 msgid "Char poly"
 msgstr "Polinômio característico"
 
-#: ../src/wxMaximaFrame.cpp:978
+#: ../src/wxMaximaFrame.cpp:977
 msgid "Check for Updates"
 msgstr "Procurar por atualizações"
 
-#: ../src/wxMaximaFrame.cpp:979
+#: ../src/wxMaximaFrame.cpp:978
 msgid "Check if a newer version of wxMaxima/Maxima exist."
 msgstr "Verificar se existe uma nova versão do wxMaxima/Maxima."
 
-#: ../src/wxMaximaFrame.cpp:1385
+#: ../src/wxMaximaFrame.cpp:1384
 msgid "Chi"
 msgstr ""
 
@@ -909,15 +909,15 @@ msgstr "Escolher fonte"
 msgid "Choose new plot format:"
 msgstr "Informe novo formato para gráficos:"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710
 msgid "Classes:"
 msgstr "Classes:"
 
-#: ../src/wxMaximaFrame.cpp:469
+#: ../src/wxMaximaFrame.cpp:468
 msgid "Close\tCtrl-W"
 msgstr "Fechar\tCtrl-W"
 
-#: ../src/wxMaximaFrame.cpp:470
+#: ../src/wxMaximaFrame.cpp:469
 msgid "Close window"
 msgstr "Fechar janela"
 
@@ -949,19 +949,19 @@ msgstr ""
 msgid "Code highlighting: Variables"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4806
+#: ../src/wxMaxima.cpp:4818
 msgid "Col. names:"
 msgstr "Nomes das colunas:"
 
-#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Columns:"
 msgstr "Colunas:"
 
-#: ../src/wxMaximaFrame.cpp:860
+#: ../src/wxMaximaFrame.cpp:859
 msgid "Combine factorials in an expression"
 msgstr "Combinar fatoriais numa expressão"
 
-#: ../src/wxMaxima.cpp:5293
+#: ../src/wxMaxima.cpp:5305
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
@@ -973,24 +973,24 @@ msgstr "Coordenadas x separadas por vírgulas."
 msgid "Comma separated y coordinates"
 msgstr "Coordenadas y separadas por vírgulas."
 
-#: ../src/MathCtrl.cpp:1030
+#: ../src/MathCtrl.cpp:1072
 msgid "Comment Selection"
 msgstr "Comentar seleção"
 
-#: ../src/wxMaximaFrame.cpp:533
+#: ../src/wxMaximaFrame.cpp:532
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:532
+#: ../src/wxMaximaFrame.cpp:531
 #, fuzzy
 msgid "Comment selection\tCtrl-/"
 msgstr "Comentar seleção"
 
-#: ../src/wxMaximaFrame.cpp:601
+#: ../src/wxMaximaFrame.cpp:600
 msgid "Complete Word\tCtrl-K"
 msgstr "Completar palavra\tCtrl-K"
 
-#: ../src/wxMaximaFrame.cpp:602
+#: ../src/wxMaximaFrame.cpp:601
 msgid "Complete word"
 msgstr "Completar palavra"
 
@@ -998,35 +998,35 @@ msgstr "Completar palavra"
 msgid "Completely stop maxima and restart it"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:823
+#: ../src/wxMaximaFrame.cpp:822
 msgid "Compute continued fraction of a value"
 msgstr "Calcular a fração contínua de um valor"
 
-#: ../src/wxMaximaFrame.cpp:761
+#: ../src/wxMaximaFrame.cpp:760
 msgid "Compute the adjoint matrix"
 msgstr "Calcular a matriz adjunta"
 
-#: ../src/wxMaximaFrame.cpp:750
+#: ../src/wxMaximaFrame.cpp:749
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr "Calcular o polinômio característico de uma matriz"
 
-#: ../src/wxMaximaFrame.cpp:753
+#: ../src/wxMaximaFrame.cpp:752
 msgid "Compute the determinant of a matrix"
 msgstr "Calcular o determinante de uma matriz"
 
-#: ../src/wxMaximaFrame.cpp:810
+#: ../src/wxMaximaFrame.cpp:809
 msgid "Compute the greatest common divisor"
 msgstr "Calcular o máximo divisor comum"
 
-#: ../src/wxMaximaFrame.cpp:747
+#: ../src/wxMaximaFrame.cpp:746
 msgid "Compute the inverse of a matrix"
 msgstr "Calcular a inversa de uma matriz"
 
-#: ../src/wxMaximaFrame.cpp:813
+#: ../src/wxMaximaFrame.cpp:812
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr "Calcular o mínimo múltiplo comum (faça load(functs) antes de usar)"
 
-#: ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4868
 msgid "Condition:"
 msgstr "Condição:"
 
@@ -1038,8 +1038,8 @@ msgstr "Arquivo de configuração (*.ini)|*.ini"
 msgid "Configuration warning"
 msgstr "Aviso da configuração"
 
-#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:538
-#: ../src/wxMaximaFrame.cpp:541
+#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:540
 msgid "Configure wxMaxima"
 msgstr "Configurar o wxMaxima"
 
@@ -1048,131 +1048,133 @@ msgstr "Configurar o wxMaxima"
 msgid "Constant"
 msgstr "Constante"
 
-#: ../src/wxMaximaFrame.cpp:844
+#: ../src/wxMaximaFrame.cpp:843
 msgid "Contract Logarithms"
 msgstr "Contrair logaritmos"
 
-#: ../src/wxMaximaFrame.cpp:851
+#: ../src/wxMaximaFrame.cpp:850
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr "Converter binômios e as funções beta e gama para fatoriais"
 
-#: ../src/wxMaximaFrame.cpp:854
+#: ../src/wxMaximaFrame.cpp:853
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr "Converter binômios, fatoriais e a função beta para a função gama"
 
-#: ../src/wxMaximaFrame.cpp:888
+#: ../src/wxMaximaFrame.cpp:887
 msgid "Convert complex expression to polar form"
 msgstr "Converter expressões complexas para a forma polar"
 
-#: ../src/wxMaximaFrame.cpp:885
+#: ../src/wxMaximaFrame.cpp:884
 msgid "Convert complex expression to rect form"
 msgstr "Converter expressões complexas para a forma retangular"
 
-#: ../src/wxMaximaFrame.cpp:897
+#: ../src/wxMaximaFrame.cpp:896
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
 "Converter função exponencial de argumento imaginário para a forma "
 "trigonométrica"
 
-#: ../src/wxMaximaFrame.cpp:842
+#: ../src/wxMaximaFrame.cpp:841
 msgid "Convert logarithm of product to sum of logarithms"
 msgstr "Converter logaritmo de um produto para soma de logaritmos"
 
-#: ../src/wxMaximaFrame.cpp:845
+#: ../src/wxMaximaFrame.cpp:844
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "Converter soma de logaritmos para logaritmos de um produto"
 
-#: ../src/wxMaximaFrame.cpp:850
+#: ../src/wxMaximaFrame.cpp:849
 msgid "Convert to &Factorials"
 msgstr "Converter para &fatoriais"
 
-#: ../src/wxMaximaFrame.cpp:853
+#: ../src/wxMaximaFrame.cpp:852
 msgid "Convert to &Gamma"
 msgstr "Converter para &gama"
 
-#: ../src/wxMaximaFrame.cpp:887
+#: ../src/wxMaximaFrame.cpp:886
 msgid "Convert to &Polarform"
 msgstr "Converter para forma &polar"
 
-#: ../src/wxMaximaFrame.cpp:884
+#: ../src/wxMaximaFrame.cpp:883
 msgid "Convert to &Rectform"
 msgstr "Converter para forma &retangular"
 
-#: ../src/wxMaximaFrame.cpp:877
+#: ../src/wxMaximaFrame.cpp:876
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr "Converter expressão trigonométrica para forma canônica quasilinear"
 
-#: ../src/wxMaximaFrame.cpp:900
+#: ../src/wxMaximaFrame.cpp:899
 msgid "Convert trigonometric functions to exponential form"
 msgstr "Converter funções trigonométricas para a forma exponencial"
 
-#: ../src/ToolBar.cpp:140 ../src/MathCtrl.cpp:918 ../src/MathCtrl.cpp:931
-#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1024
+#: ../src/MathCtrl.cpp:960 ../src/MathCtrl.cpp:973 ../src/MathCtrl.cpp:1019
+#: ../src/MathCtrl.cpp:1066 ../src/ToolBar.cpp:140
 msgid "Copy"
 msgstr "Copiar"
 
-#: ../src/wxMaximaFrame.cpp:597
+#: ../src/wxMaximaFrame.cpp:596
 msgid "Copy Previous Input\tCtrl-I"
 msgstr "Copiar entrada anterior\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:599
+#: ../src/wxMaximaFrame.cpp:598
 msgid "Copy Previous Output\tCtrl-U"
 msgstr "Copiar saída anterior\tCtrl-U"
 
-#: ../src/wxMaximaFrame.cpp:514 ../src/MathCtrl.cpp:936 ../src/MathCtrl.cpp:982
+#: ../src/MathCtrl.cpp:978 ../src/MathCtrl.cpp:1024
+#: ../src/wxMaximaFrame.cpp:513
 msgid "Copy as Image"
 msgstr "Copiar como imagem"
 
-#: ../src/wxMaximaFrame.cpp:507 ../src/MathCtrl.cpp:932 ../src/MathCtrl.cpp:978
+#: ../src/MathCtrl.cpp:974 ../src/MathCtrl.cpp:1020
+#: ../src/wxMaximaFrame.cpp:506
 msgid "Copy as LaTeX"
 msgstr "Copiar como LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:510
+#: ../src/wxMaximaFrame.cpp:509
 #, fuzzy
 msgid "Copy as MathML"
 msgstr "Copiar como imagem"
 
-#: ../src/MathCtrl.cpp:935 ../src/MathCtrl.cpp:980
+#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1022
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:504
+#: ../src/wxMaximaFrame.cpp:503
 msgid "Copy as Text\tCtrl-Shift-C"
 msgstr "&Copiar como texto\tCtrl-Shift-C"
 
-#: ../src/MathCtrl.cpp:933 ../src/MathCtrl.cpp:979
+#: ../src/MathCtrl.cpp:975 ../src/MathCtrl.cpp:1021
 #, fuzzy
 msgid "Copy as plain text"
 msgstr "Copiar como imagem"
 
-#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:503
+#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:502
 msgid "Copy selection"
 msgstr "Copiar seleção"
 
-#: ../src/wxMaximaFrame.cpp:515
+#: ../src/wxMaximaFrame.cpp:514
 msgid "Copy selection from document as an image"
 msgstr "Copiar seleção do documento como imagem"
 
-#: ../src/wxMaximaFrame.cpp:505
+#: ../src/wxMaximaFrame.cpp:504
 msgid "Copy selection from document as text"
 msgstr "Copiar seleção do documento como texto"
 
-#: ../src/wxMaximaFrame.cpp:508
+#: ../src/wxMaximaFrame.cpp:507
 msgid "Copy selection from document in LaTeX format"
 msgstr "Copiar seleção do documento no formato LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:511
+#: ../src/wxMaximaFrame.cpp:510
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:598
+#: ../src/wxMaximaFrame.cpp:597
 msgid "Create a new cell with previous input"
 msgstr "Cria uma nova célula com a entrada anterior"
 
-#: ../src/wxMaximaFrame.cpp:600
+#: ../src/wxMaximaFrame.cpp:599
 msgid "Create a new cell with previous output"
 msgstr "Cria uma nova célula com a saída anterior"
 
@@ -1180,15 +1182,15 @@ msgstr "Cria uma nova célula com a saída anterior"
 msgid "Cursor"
 msgstr "Cursor"
 
-#: ../src/ToolBar.cpp:137 ../src/MathCtrl.cpp:1023
+#: ../src/MathCtrl.cpp:1065 ../src/ToolBar.cpp:137
 msgid "Cut"
 msgstr "Recortar"
 
-#: ../src/wxMaximaFrame.cpp:499
+#: ../src/wxMaximaFrame.cpp:498
 msgid "Cut\tCtrl-X"
 msgstr "Cortar\tCtrl-X"
 
-#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:500
+#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:499
 msgid "Cut selection"
 msgstr "Cortar seleção"
 
@@ -1200,18 +1202,18 @@ msgstr "Tcheco"
 msgid "Danish"
 msgstr "Dinamarquês"
 
-#: ../src/wxMaxima.cpp:4799 ../src/wxMaxima.cpp:4806 ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4811 ../src/wxMaxima.cpp:4818 ../src/wxMaxima.cpp:4868
 msgid "Data Matrix:"
 msgstr "Matriz de dados:"
 
-#: ../src/wxMaxima.cpp:4826
+#: ../src/wxMaxima.cpp:4838
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr "Arquivo de dados (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698 ../src/wxMaxima.cpp:4712
-#: ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726 ../src/wxMaxima.cpp:4734
-#: ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748 ../src/wxMaxima.cpp:4755
-#: ../src/wxMaxima.cpp:4791
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710 ../src/wxMaxima.cpp:4724
+#: ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738 ../src/wxMaxima.cpp:4746
+#: ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760 ../src/wxMaxima.cpp:4767
+#: ../src/wxMaxima.cpp:4803
 msgid "Data:"
 msgstr "Dados:"
 
@@ -1219,7 +1221,7 @@ msgstr "Dados:"
 msgid "Debug: watch maxima's stdout stream"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:820
+#: ../src/wxMaximaFrame.cpp:819
 msgid "Decompose rational function to partial fractions"
 msgstr "Decompor função racional em frações parciais"
 
@@ -1250,47 +1252,47 @@ msgid ""
 "with."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3403 ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3415 ../src/wxMaxima.cpp:3424
 msgid "Delete"
 msgstr "Apagar"
 
-#: ../src/wxMaximaFrame.cpp:667
+#: ../src/wxMaximaFrame.cpp:666
 msgid "Delete F&unction..."
 msgstr "Apagar f&unção..."
 
-#: ../src/MathCtrl.cpp:939 ../src/MathCtrl.cpp:985
+#: ../src/MathCtrl.cpp:981 ../src/MathCtrl.cpp:1027
 msgid "Delete Selection"
 msgstr "Apagar seleção"
 
-#: ../src/wxMaximaFrame.cpp:669
+#: ../src/wxMaximaFrame.cpp:668
 msgid "Delete V&ariable..."
 msgstr "&Apagar variável..."
 
-#: ../src/wxMaximaFrame.cpp:668
+#: ../src/wxMaximaFrame.cpp:667
 msgid "Delete a function"
 msgstr "Apagar uma função"
 
-#: ../src/wxMaximaFrame.cpp:670
+#: ../src/wxMaximaFrame.cpp:669
 msgid "Delete a variable"
 msgstr "Apagar uma variável"
 
-#: ../src/wxMaximaFrame.cpp:655
+#: ../src/wxMaximaFrame.cpp:654
 msgid "Delete all values from memory"
 msgstr "Apagar todos os valores da memória"
 
-#: ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3424
 msgid "Delete function(s):"
 msgstr "Apagar função(ões):"
 
-#: ../src/wxMaxima.cpp:3403
+#: ../src/wxMaxima.cpp:3415
 msgid "Delete variable(s):"
 msgstr "Apagar variável(is):"
 
-#: ../src/wxMaximaFrame.cpp:1367
+#: ../src/wxMaximaFrame.cpp:1366
 msgid "Delta"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4011
+#: ../src/wxMaxima.cpp:4023
 msgid "Denom. deg:"
 msgstr "Grau denom.:"
 
@@ -1298,35 +1300,35 @@ msgstr "Grau denom.:"
 msgid "Depth:"
 msgstr "Grau máximo:"
 
-#: ../src/wxMaxima.cpp:3541
+#: ../src/wxMaxima.cpp:3553
 msgid "Derivative:"
 msgstr "Derivada:"
 
-#: ../src/wxMaximaFrame.cpp:1258
+#: ../src/wxMaximaFrame.cpp:1257
 msgid "Deviation..."
 msgstr "Desvio..."
 
-#: ../src/wxMaximaFrame.cpp:816
+#: ../src/wxMaximaFrame.cpp:815
 msgid "Di&vide Polynomials..."
 msgstr "Di&vidir polinômios..."
 
-#: ../src/wxMaximaFrame.cpp:1223
+#: ../src/wxMaximaFrame.cpp:1222
 msgid "Diff..."
 msgstr "Derivar..."
 
-#: ../src/wxMaxima.cpp:4154 ../src/wxMaxima.cpp:5066
+#: ../src/wxMaxima.cpp:4166 ../src/wxMaxima.cpp:5078
 msgid "Differentiate"
 msgstr "Diferenciar"
 
-#: ../src/wxMaximaFrame.cpp:786
+#: ../src/wxMaximaFrame.cpp:785
 msgid "Differentiate expression"
 msgstr "Diferenciar expressão"
 
-#: ../src/MathCtrl.cpp:1001
+#: ../src/MathCtrl.cpp:1043
 msgid "Differentiate..."
 msgstr "Diferenciar..."
 
-#: ../src/LimitWiz.cpp:37 ../src/FindReplacePane.cpp:76
+#: ../src/FindReplacePane.cpp:76 ../src/LimitWiz.cpp:37
 msgid "Direction:"
 msgstr "Direção:"
 
@@ -1334,48 +1336,49 @@ msgstr "Direção:"
 msgid "Discrete plot"
 msgstr "Gráfico discreto"
 
-#: ../src/wxMaximaFrame.cpp:679
+#: ../src/wxMaximaFrame.cpp:678
 msgid "Display Te&X Form"
 msgstr "Mostar forma Te&X"
 
-#: ../src/wxMaxima.cpp:3320
+#: ../src/wxMaxima.cpp:3332
 msgid "Display algorithm"
 msgstr "Algoritmo de exibição"
 
-#: ../src/wxMaximaFrame.cpp:680
+#: ../src/wxMaximaFrame.cpp:679
 msgid "Display last result in TeX form"
 msgstr "Exibir último resultado na forma Te&X"
 
-#: ../src/wxMaximaFrame.cpp:674
+#: ../src/wxMaximaFrame.cpp:673
 msgid "Display time used for evaluation"
 msgstr "Exibir tempo usado para execução"
 
-#: ../src/wxMaxima.cpp:4061
+#: ../src/wxMaxima.cpp:4073
 msgid "Divide"
 msgstr "Dividir"
 
-#: ../src/MathCtrl.cpp:1032
+#: ../src/MathCtrl.cpp:1074
 msgid "Divide Cell"
 msgstr "Dividir célula"
 
-#: ../src/wxMaximaFrame.cpp:635
+#: ../src/wxMaximaFrame.cpp:634
 #, fuzzy
 msgid "Divide Cell\tCtrl-D"
 msgstr "Dividir célula"
 
-#: ../src/wxMaximaFrame.cpp:817
+#: ../src/wxMaximaFrame.cpp:816
 msgid "Divide numbers or polynomials"
 msgstr "Dividir números ou polinômios"
 
-#: ../src/wxMaximaFrame.cpp:636
+#: ../src/wxMaximaFrame.cpp:635
 msgid "Divide this input cell into two cells"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5917
-msgid "Do you want to save the changes you made in the document \""
+#: ../src/wxMaxima.cpp:5932
+#, fuzzy, c-format
+msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr "Você quer salvar as mudanças feitas no documento \""
 
-#: ../src/wxMaxima.cpp:1664 ../src/wxMaxima.cpp:1672
+#: ../src/wxMaxima.cpp:1669 ../src/wxMaxima.cpp:1677
 msgid "Document "
 msgstr "Documento "
 
@@ -1394,7 +1397,7 @@ msgid ""
 "differences."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Don't save"
 msgstr "Não salvar"
 
@@ -1402,27 +1405,27 @@ msgstr "Não salvar"
 msgid "Down"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:734
+#: ../src/wxMaximaFrame.cpp:733
 msgid "E&quations"
 msgstr "E&quações"
 
-#: ../src/wxMaximaFrame.cpp:487
+#: ../src/wxMaximaFrame.cpp:486
 msgid "E&xit\tCtrl-Q"
 msgstr "Sai&r\tCtrl-Q"
 
-#: ../src/wxMaximaFrame.cpp:757
+#: ../src/wxMaximaFrame.cpp:756
 msgid "Eige&nvectors"
 msgstr "Autov&etores"
 
-#: ../src/wxMaximaFrame.cpp:755
+#: ../src/wxMaximaFrame.cpp:754
 msgid "Eigen&values"
 msgstr "Auto&valores"
 
-#: ../src/wxMaxima.cpp:3572
+#: ../src/wxMaxima.cpp:3584
 msgid "Eliminate"
 msgstr "Eliminar"
 
-#: ../src/wxMaximaFrame.cpp:710
+#: ../src/wxMaximaFrame.cpp:709
 msgid "Eliminate a variable from a system of equations"
 msgstr "Eliminar uma variável de um sistema de equações"
 
@@ -1434,21 +1437,21 @@ msgstr ""
 msgid "English"
 msgstr "Inglês"
 
-#: ../src/wxMaxima.cpp:4712 ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726
-#: ../src/wxMaxima.cpp:4734 ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748
-#: ../src/wxMaxima.cpp:4755 ../src/wxMaxima.cpp:4791 ../src/wxMaxima.cpp:4799
+#: ../src/wxMaxima.cpp:4724 ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738
+#: ../src/wxMaxima.cpp:4746 ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760
+#: ../src/wxMaxima.cpp:4767 ../src/wxMaxima.cpp:4803 ../src/wxMaxima.cpp:4811
 msgid "Enter Data"
 msgstr "Informe os dados"
 
-#: ../src/wxMaximaFrame.cpp:1279
+#: ../src/wxMaximaFrame.cpp:1278
 msgid "Enter Matrix..."
 msgstr "&Introduzir matriz..."
 
-#: ../src/wxMaximaFrame.cpp:745
+#: ../src/wxMaximaFrame.cpp:744
 msgid "Enter a matrix"
 msgstr "Introduza uma matriz"
 
-#: ../src/wxMaxima.cpp:3962
+#: ../src/wxMaxima.cpp:3974
 msgid "Enter an equation for rational simplification:"
 msgstr "Informe uma equação para simplificação racional:"
 
@@ -1460,11 +1463,11 @@ msgstr "Informa uma lista de variáveis separadas por vírgulas."
 msgid "Enter evaluates cells"
 msgstr "Enter calcula células"
 
-#: ../src/wxMaxima.cpp:3734
+#: ../src/wxMaxima.cpp:3746
 msgid "Enter matrix"
 msgstr "Informe uma matriz"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 #, fuzzy
 msgid "Enter new precision for bigfloats:"
 msgstr "Informe a nova precisão:"
@@ -1473,12 +1476,12 @@ msgstr "Informe a nova precisão:"
 msgid "Enter the path to the Maxima executable."
 msgstr "Informe o caminho para o executável Maxima."
 
-#: ../src/wxMaximaFrame.cpp:1368
+#: ../src/wxMaximaFrame.cpp:1367
 #, fuzzy
 msgid "Epsilon"
 msgstr "Epsilon:"
 
-#: ../src/wxMaxima.cpp:4208
+#: ../src/wxMaxima.cpp:4220
 msgid "Epsilon:"
 msgstr "Epsilon:"
 
@@ -1487,13 +1490,13 @@ msgstr "Epsilon:"
 msgid "Equation %d:"
 msgstr "Equação %d:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:3633
-#: ../src/wxMaxima.cpp:5019
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:3645
+#: ../src/wxMaxima.cpp:5031
 msgid "Equation(s):"
 msgstr "Equação(ões):"
 
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3993
-#: ../src/wxMaxima.cpp:4807 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:4005
+#: ../src/wxMaxima.cpp:4819 ../src/wxMaxima.cpp:5045
 msgid "Equation:"
 msgstr "Equação:"
 
@@ -1504,79 +1507,79 @@ msgid ""
 "be introduced one into another. Also they are always printed out as 2D maths."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3570
+#: ../src/wxMaxima.cpp:3582
 msgid "Equations:"
 msgstr "Equações:"
 
-#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1455
-#: ../src/wxMaxima.cpp:1469 ../src/wxMaxima.cpp:1620 ../src/wxMaxima.cpp:1633
-#: ../src/wxMaxima.cpp:1643 ../src/wxMaxima.cpp:1666 ../src/wxMaxima.cpp:2034
-#: ../src/wxMaxima.cpp:2206 ../src/wxMaxima.cpp:5381 ../src/wxMaxima.cpp:5830
-#: ../src/wxMaxima.cpp:5881
+#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1460
+#: ../src/wxMaxima.cpp:1474 ../src/wxMaxima.cpp:1625 ../src/wxMaxima.cpp:1638
+#: ../src/wxMaxima.cpp:1648 ../src/wxMaxima.cpp:1671 ../src/wxMaxima.cpp:2039
+#: ../src/wxMaxima.cpp:2211 ../src/wxMaxima.cpp:5397 ../src/wxMaxima.cpp:5845
+#: ../src/wxMaxima.cpp:5896
 msgid "Error"
 msgstr "Erro"
 
-#: ../src/wxMaxima.cpp:2886 ../src/wxMaxima.cpp:2900 ../src/wxMaxima.cpp:2913
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617 ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:2894 ../src/wxMaxima.cpp:2908 ../src/wxMaxima.cpp:2921
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629 ../src/wxMaxima.cpp:3740
 msgid "Error!"
 msgstr "Erro!"
 
-#: ../src/wxMaximaFrame.cpp:1370
+#: ../src/wxMaximaFrame.cpp:1369
 msgid "Eta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:909
+#: ../src/wxMaximaFrame.cpp:908
 msgid "Evaluate &Noun Forms"
 msgstr "Avaliar formas substa&ntivas"
 
-#: ../src/wxMaximaFrame.cpp:589
+#: ../src/wxMaximaFrame.cpp:588
 #, fuzzy
 msgid "Evaluate All Cells\tCtrl-Shift-R"
 msgstr "Avaliar todas as células\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:587
+#: ../src/wxMaximaFrame.cpp:586
 #, fuzzy
 msgid "Evaluate All Visible Cells\tCtrl-R"
 msgstr "Avaliar todas as células\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:585 ../src/MathCtrl.cpp:942
+#: ../src/MathCtrl.cpp:984 ../src/wxMaximaFrame.cpp:584
 msgid "Evaluate Cell(s)"
 msgstr "Avaliar célula(s)"
 
-#: ../src/wxMaximaFrame.cpp:591
+#: ../src/wxMaximaFrame.cpp:590
 #, fuzzy
 msgid "Evaluate Cells Above\tCtrl-Shift-P"
 msgstr "Avaliar todas as células\tCtrl-R"
 
-#: ../src/MathCtrl.cpp:956 ../src/MathCtrl.cpp:1051
+#: ../src/MathCtrl.cpp:998 ../src/MathCtrl.cpp:1093
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:961 ../src/MathCtrl.cpp:1053
+#: ../src/MathCtrl.cpp:1003 ../src/MathCtrl.cpp:1095
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:971 ../src/MathCtrl.cpp:1057
+#: ../src/MathCtrl.cpp:1013 ../src/MathCtrl.cpp:1099
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:966 ../src/MathCtrl.cpp:1055
+#: ../src/MathCtrl.cpp:1008 ../src/MathCtrl.cpp:1097
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:586
+#: ../src/wxMaximaFrame.cpp:585
 msgid "Evaluate active or selected cell(s)"
 msgstr "Avaliar célula ativa ou selecionada"
 
-#: ../src/wxMaximaFrame.cpp:590
+#: ../src/wxMaximaFrame.cpp:589
 msgid "Evaluate all cells in the document"
 msgstr "Avaliar todas as células no documento"
 
-#: ../src/wxMaximaFrame.cpp:910
+#: ../src/wxMaximaFrame.cpp:909
 msgid "Evaluate all noun forms in expression"
 msgstr "Avaliar todas as formas substa&ntivas na expressão"
 
-#: ../src/wxMaximaFrame.cpp:588
+#: ../src/wxMaximaFrame.cpp:587
 #, fuzzy
 msgid "Evaluate all visible cells in the document"
 msgstr "Avaliar todas as células no documento"
@@ -1590,7 +1593,7 @@ msgstr ""
 msgid "Evaluate to point"
 msgstr "Avaliar formas substa&ntivas"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Example"
 msgstr "Exemplo"
 
@@ -1603,31 +1606,31 @@ msgstr "Texto de exemplo"
 msgid "Examples:"
 msgstr "Exemplo"
 
-#: ../src/wxMaximaFrame.cpp:488
+#: ../src/wxMaximaFrame.cpp:487
 msgid "Exit wxMaxima"
 msgstr "Sair do wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:1214
+#: ../src/wxMaximaFrame.cpp:1213
 msgid "Expand"
 msgstr "Expandir"
 
-#: ../src/wxMaximaFrame.cpp:1219
+#: ../src/wxMaximaFrame.cpp:1218
 msgid "Expand (tr)"
 msgstr "Expandir (tr)"
 
-#: ../src/MathCtrl.cpp:997
+#: ../src/MathCtrl.cpp:1039
 msgid "Expand Expression"
 msgstr "Expandir expressão"
 
-#: ../src/wxMaximaFrame.cpp:841
+#: ../src/wxMaximaFrame.cpp:840
 msgid "Expand Logarithms"
 msgstr "Expandir logaritmos"
 
-#: ../src/wxMaximaFrame.cpp:840
+#: ../src/wxMaximaFrame.cpp:839
 msgid "Expand an expression"
 msgstr "Expandir uma expressão"
 
-#: ../src/wxMaximaFrame.cpp:874
+#: ../src/wxMaximaFrame.cpp:873
 msgid "Expand trigonometric expression"
 msgstr "Expandir expressão trigonométrica"
 
@@ -1635,7 +1638,7 @@ msgstr "Expandir expressão trigonométrica"
 msgid "Expected the icon files to be found at"
 msgstr ""
 
-#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2834
+#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2842
 msgid "Export"
 msgstr "Exportar"
 
@@ -1644,33 +1647,33 @@ msgid ""
 "Export animations to TeX (Images only move if the PDF viewer supports this)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:481
+#: ../src/wxMaximaFrame.cpp:480
 msgid "Export document to a HTML or pdfLaTeX file"
 msgstr "Exportar documento para o formato HTML ou pdfLaTeX"
 
-#: ../src/wxMaximaFrame.cpp:253
+#: ../src/wxMaximaFrame.cpp:252
 #, fuzzy
 msgid "Export failed."
 msgstr "Exportação para TeX falhou!"
 
-#: ../src/wxMaximaFrame.cpp:239
+#: ../src/wxMaximaFrame.cpp:238
 msgid "Export successful."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2913
+#: ../src/wxMaxima.cpp:2921
 msgid "Exporting to HTML failed!"
 msgstr "Exportação para HTML falhou!"
 
-#: ../src/wxMaxima.cpp:2886
+#: ../src/wxMaxima.cpp:2894
 msgid "Exporting to TeX failed!"
 msgstr "Exportação para TeX falhou!"
 
-#: ../src/wxMaxima.cpp:2900
+#: ../src/wxMaxima.cpp:2908
 #, fuzzy
 msgid "Exporting to maxima batch file failed!"
 msgstr "Exportação para TeX falhou!"
 
-#: ../src/wxMaximaFrame.cpp:229
+#: ../src/wxMaximaFrame.cpp:228
 #, fuzzy
 msgid "Exporting..."
 msgstr "&Exportar..."
@@ -1684,42 +1687,42 @@ msgid "Expression(s):"
 msgstr "Expressão(ões):"
 
 #: ../src/IntegrateWiz.cpp:30 ../src/LimitWiz.cpp:27 ../src/SeriesWiz.cpp:33
-#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3648
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:4205 ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5064
+#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3660
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:4217 ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5076
 msgid "Expression:"
 msgstr "Expressão:"
 
-#: ../src/wxMaximaFrame.cpp:1213
+#: ../src/wxMaximaFrame.cpp:1212
 msgid "Factor"
 msgstr "Fatorar"
 
-#: ../src/wxMaximaFrame.cpp:836
+#: ../src/wxMaximaFrame.cpp:835
 msgid "Factor Complex"
 msgstr "Fatorar complexo"
 
-#: ../src/MathCtrl.cpp:996
+#: ../src/MathCtrl.cpp:1038
 msgid "Factor Expression"
 msgstr "Fatorar expressão"
 
-#: ../src/wxMaximaFrame.cpp:835
+#: ../src/wxMaximaFrame.cpp:834
 msgid "Factor an expression"
 msgstr "Fatorar uma expressão"
 
-#: ../src/wxMaximaFrame.cpp:837
+#: ../src/wxMaximaFrame.cpp:836
 msgid "Factor an expression in Gaussian numbers"
 msgstr "Fatorar uma expressão em números gaussianos"
 
-#: ../src/wxMaximaFrame.cpp:862
+#: ../src/wxMaximaFrame.cpp:861
 msgid "Factorials and &Gamma"
 msgstr "Fatoriais e &gama"
 
-#: ../src/wxMaxima.cpp:285
+#: ../src/wxMaxima.cpp:286
 msgid "Fatal error"
 msgstr "Erro fatal"
 
-#: ../src/GroupCell.cpp:1571
+#: ../src/GroupCell.cpp:1572
 #, c-format
 msgid "Figure %d:"
 msgstr "Figura %d:"
@@ -1728,22 +1731,22 @@ msgstr "Figura %d:"
 msgid "File"
 msgstr "Arquivo"
 
-#: ../src/wxMaxima.cpp:1457 ../src/wxMaxima.cpp:1623 ../src/wxMaxima.cpp:1636
-#: ../src/wxMaxima.cpp:1646 ../src/wxMaxima.cpp:1668
+#: ../src/wxMaxima.cpp:1462 ../src/wxMaxima.cpp:1628 ../src/wxMaxima.cpp:1641
+#: ../src/wxMaxima.cpp:1651 ../src/wxMaxima.cpp:1673
 #, fuzzy
 msgid "File could not be opened"
 msgstr "Arquivo não encontrado"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File not found"
 msgstr "Arquivo não encontrado"
 
-#: ../src/wxMaxima.cpp:1511 ../src/wxMaxima.cpp:1729
+#: ../src/wxMaxima.cpp:1516 ../src/wxMaxima.cpp:1734
 #, fuzzy
 msgid "File opened"
 msgstr "Arquivo não encontrado"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File you tried to open does not exist."
 msgstr "O arquivo que você tentou abrir não existe."
 
@@ -1755,67 +1758,67 @@ msgstr "Arquivo:"
 msgid "Find"
 msgstr "Localizar"
 
-#: ../src/wxMaximaFrame.cpp:523
+#: ../src/wxMaximaFrame.cpp:522
 msgid "Find\tCtrl-F"
 msgstr "Localizar\tCtrl-F"
 
-#: ../src/wxMaximaFrame.cpp:787
+#: ../src/wxMaximaFrame.cpp:786
 msgid "Find &Limit..."
 msgstr "Encontrar &limite..."
 
-#: ../src/wxMaximaFrame.cpp:790
+#: ../src/wxMaximaFrame.cpp:789
 msgid "Find Minimum..."
 msgstr "Encontrar mínimo..."
 
-#: ../src/MathCtrl.cpp:993
+#: ../src/MathCtrl.cpp:1035
 msgid "Find Root..."
 msgstr "Encontrar raiz..."
 
-#: ../src/wxMaximaFrame.cpp:791
+#: ../src/wxMaximaFrame.cpp:790
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr "Encontrar um mínimo (sem restrição) de uma expressão"
 
-#: ../src/wxMaximaFrame.cpp:788
+#: ../src/wxMaximaFrame.cpp:787
 msgid "Find a limit of an expression"
 msgstr "Encontrar o limite de uma expressão"
 
-#: ../src/wxMaximaFrame.cpp:693
+#: ../src/wxMaximaFrame.cpp:692
 msgid "Find a root of an equation on an interval"
 msgstr "Encontrar uma raíz de uma equação num intervalo"
 
-#: ../src/wxMaximaFrame.cpp:695
+#: ../src/wxMaximaFrame.cpp:694
 msgid "Find all roots of a polynomial"
 msgstr "Encontrar todas as raízes de um polinômio"
 
-#: ../src/wxMaximaFrame.cpp:698
+#: ../src/wxMaximaFrame.cpp:697
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr "Encontrar todas as raízes de um polinômio (bfloat)"
 
-#: ../src/wxMaxima.cpp:3220
+#: ../src/wxMaxima.cpp:3215
 msgid "Find and Replace"
 msgstr "Localizar e substituir"
 
-#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:523
+#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:522
 msgid "Find and replace"
 msgstr "Localizar e substituir"
 
-#: ../src/wxMaximaFrame.cpp:756
+#: ../src/wxMaximaFrame.cpp:755
 msgid "Find eigenvalues of a matrix"
 msgstr "Encontrar os autovalores de uma matriz"
 
-#: ../src/wxMaximaFrame.cpp:758
+#: ../src/wxMaximaFrame.cpp:757
 msgid "Find eigenvectors of a matrix"
 msgstr "Encontrar os autovetores de uma matriz"
 
-#: ../src/wxMaxima.cpp:4210
+#: ../src/wxMaxima.cpp:4222
 msgid "Find minimum"
 msgstr "Encontrar mínimo"
 
-#: ../src/wxMaximaFrame.cpp:701
+#: ../src/wxMaximaFrame.cpp:700
 msgid "Find real roots of a polynomial"
 msgstr "Encontrar as raízes reais de um polinômio"
 
-#: ../src/wxMaxima.cpp:3493 ../src/wxMaxima.cpp:5036
+#: ../src/wxMaxima.cpp:3505 ../src/wxMaxima.cpp:5048
 msgid "Find root"
 msgstr "Encontrar raiz"
 
@@ -1838,12 +1841,12 @@ msgstr ""
 msgid "Fixed font in text controls"
 msgstr "Fonte monoespaçada nos controles de texto"
 
-#: ../src/wxMaximaFrame.cpp:623
+#: ../src/wxMaximaFrame.cpp:622
 #, fuzzy
 msgid "Fold All\tCtrl-Alt-["
 msgstr "Selecionar tudo\tCtrl-A"
 
-#: ../src/wxMaximaFrame.cpp:624
+#: ../src/wxMaximaFrame.cpp:623
 msgid "Fold all sections"
 msgstr ""
 
@@ -1851,25 +1854,25 @@ msgstr ""
 msgid "Follow"
 msgstr ""
 
-#: ../src/ParenCell.cpp:319
+#: ../src/ParenCell.cpp:320
 msgid "Font issue: The Parenthesis sign is too small!"
 msgstr ""
 
-#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:381
+#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:382
 msgid ""
 "Font issue: The char height is too small! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:199
+#: ../src/SqrtCell.cpp:202
 msgid ""
 "Font issue: The sqrt() sign has the size 0! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:198
+#: ../src/SqrtCell.cpp:201
 msgid "Font issue? The contents of a sqrt() has the size 0."
 msgstr ""
 
@@ -1900,15 +1903,15 @@ msgstr "Francês"
 
 #: ../src/IntegrateWiz.cpp:37 ../src/Plot2dWiz.cpp:37 ../src/Plot2dWiz.cpp:47
 #: ../src/Plot2dWiz.cpp:536 ../src/Plot3dWiz.cpp:36 ../src/Plot3dWiz.cpp:45
-#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4240
+#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4252
 msgid "From:"
 msgstr "De:"
 
-#: ../src/wxMaximaFrame.cpp:576
+#: ../src/wxMaximaFrame.cpp:575
 msgid "Full Screen\tAlt-Enter"
 msgstr "Tela cheia\tAlt-Enter"
 
-#: ../src/wxMaxima.cpp:3342
+#: ../src/wxMaxima.cpp:3354
 msgid "Function"
 msgstr "Função"
 
@@ -1916,32 +1919,32 @@ msgstr "Função"
 msgid "Function names"
 msgstr "Nomes de funções"
 
-#: ../src/wxMaxima.cpp:3633
+#: ../src/wxMaxima.cpp:3645
 msgid "Function(s):"
 msgstr "Função(ões):"
 
-#: ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3803
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3815
+#: ../src/wxMaxima.cpp:3848
 msgid "Function:"
 msgstr "Função:"
 
-#: ../src/wxMaximaFrame.cpp:904
+#: ../src/wxMaximaFrame.cpp:903
 msgid "Functions for complex simplification"
 msgstr "Funções para simplificação complexa"
 
-#: ../src/wxMaximaFrame.cpp:864
+#: ../src/wxMaximaFrame.cpp:863
 msgid "Functions for simplifying factorials and gamma function"
 msgstr "Funções para simplificar fatoriais e a função gama"
 
-#: ../src/wxMaximaFrame.cpp:881
+#: ../src/wxMaximaFrame.cpp:880
 msgid "Functions for simplifying trigonometric expressions"
 msgstr "Funções para simplificar expressões trigonométricas"
 
-#: ../src/wxMaxima.cpp:4046
+#: ../src/wxMaxima.cpp:4058
 msgid "GCD"
 msgstr "MDC"
 
-#: ../src/wxMaxima.cpp:5152
+#: ../src/wxMaxima.cpp:5164
 msgid "GIF image (*.gif)|*.gif"
 msgstr "Imagem GIF (*.gif)|*.gif"
 
@@ -1949,31 +1952,31 @@ msgstr "Imagem GIF (*.gif)|*.gif"
 msgid "Galician"
 msgstr "Galego"
 
-#: ../src/wxMaximaFrame.cpp:1366
+#: ../src/wxMaximaFrame.cpp:1365
 msgid "Gamma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:391
+#: ../src/wxMaximaFrame.cpp:390
 msgid "General Math"
 msgstr "Matemática Geral"
 
-#: ../src/wxMaximaFrame.cpp:549
+#: ../src/wxMaximaFrame.cpp:548
 msgid "General Math\tAlt-Shift-M"
 msgstr "Matemática Geral\tAlt-Shift-M"
 
-#: ../src/wxMaxima.cpp:3766 ../src/wxMaxima.cpp:3785
+#: ../src/wxMaxima.cpp:3778 ../src/wxMaxima.cpp:3797
 msgid "Generate Matrix"
 msgstr "Gerar matriz"
 
-#: ../src/wxMaximaFrame.cpp:741
+#: ../src/wxMaximaFrame.cpp:740
 msgid "Generate Matrix from Expression..."
 msgstr "Gerar matriz da expressão..."
 
-#: ../src/wxMaximaFrame.cpp:739
+#: ../src/wxMaximaFrame.cpp:738
 msgid "Generate a matrix from a 2-dimensional array"
 msgstr "Gerar uma matriz de uma array bidimensional"
 
-#: ../src/wxMaximaFrame.cpp:742
+#: ../src/wxMaximaFrame.cpp:741
 msgid "Generate a matrix from a lambda expression"
 msgstr "Gerar uma matriz de uma expressão lambda"
 
@@ -1981,39 +1984,39 @@ msgstr "Gerar uma matriz de uma expressão lambda"
 msgid "German"
 msgstr "Alemão"
 
-#: ../src/wxMaximaFrame.cpp:893
+#: ../src/wxMaximaFrame.cpp:892
 msgid "Get &Imaginary Part"
 msgstr "Obter parte &imaginária"
 
-#: ../src/wxMaximaFrame.cpp:793
+#: ../src/wxMaximaFrame.cpp:792
 msgid "Get &Series..."
 msgstr "Obter &série..."
 
-#: ../src/wxMaximaFrame.cpp:804
+#: ../src/wxMaximaFrame.cpp:803
 msgid "Get Laplace transformation of an expression"
 msgstr "Obter transformada de Laplace de uma expressão"
 
-#: ../src/wxMaximaFrame.cpp:890
+#: ../src/wxMaximaFrame.cpp:889
 msgid "Get Real P&art"
 msgstr "Obter parte re&al"
 
-#: ../src/wxMaximaFrame.cpp:807
+#: ../src/wxMaximaFrame.cpp:806
 msgid "Get inverse Laplace transformation of an expression"
 msgstr "Obter transformada inversa de Laplace de uma expressão"
 
-#: ../src/wxMaximaFrame.cpp:794
+#: ../src/wxMaximaFrame.cpp:793
 msgid "Get the Taylor or power series of expression"
 msgstr "Obter série de Taylor ou de potências de uma expressão"
 
-#: ../src/wxMaximaFrame.cpp:894
+#: ../src/wxMaximaFrame.cpp:893
 msgid "Get the imaginary part of complex expression"
 msgstr "Obter a parte imaginária de uma expressão complexa"
 
-#: ../src/wxMaximaFrame.cpp:891
+#: ../src/wxMaximaFrame.cpp:890
 msgid "Get the real part of complex expression"
 msgstr "Obter a parte eral de uma expressão complexa"
 
-#: ../src/MathCtrl.cpp:5932
+#: ../src/MathCtrl.cpp:5984
 msgid ""
 "Got a request to undo an action that involves an delete which isn't possible "
 "at this moment."
@@ -2023,12 +2026,12 @@ msgstr ""
 msgid "Greek"
 msgstr "Grego"
 
-#: ../src/wxMaximaFrame.cpp:356
+#: ../src/wxMaximaFrame.cpp:355
 #, fuzzy
 msgid "Greek Letters"
 msgstr "Constantes gregas"
 
-#: ../src/wxMaximaFrame.cpp:552
+#: ../src/wxMaximaFrame.cpp:551
 #, fuzzy
 msgid "Greek Letters\tAlt-Shift-G"
 msgstr "Matemática Geral\tAlt-Shift-M"
@@ -2041,7 +2044,7 @@ msgstr "Constantes gregas"
 msgid "Grid:"
 msgstr "Grade:"
 
-#: ../src/wxMaxima.cpp:2836
+#: ../src/wxMaxima.cpp:2844
 #, fuzzy
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|pdfLaTeX file (*."
@@ -2056,12 +2059,12 @@ msgstr ""
 msgid "Help"
 msgstr "Ajuda"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 #, fuzzy
 msgid "Hide All Toolbars\tAlt-Shift--"
 msgstr "Esconder todos\tAlt-Shift--"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide all panes"
 msgstr "Esconder todos os painéis"
 
@@ -2069,19 +2072,19 @@ msgstr "Esconder todos os painéis"
 msgid "Highlight (dpart)"
 msgstr "Destaque (dpart)"
 
-#: ../src/wxMaxima.cpp:4685
+#: ../src/wxMaxima.cpp:4697
 msgid "Histogram"
 msgstr "Histograma"
 
-#: ../src/wxMaximaFrame.cpp:1270
+#: ../src/wxMaximaFrame.cpp:1269
 msgid "Histogram..."
 msgstr "Histograma..."
 
-#: ../src/wxMaximaFrame.cpp:309
+#: ../src/wxMaximaFrame.cpp:308
 msgid "History"
 msgstr "Histórico"
 
-#: ../src/wxMaximaFrame.cpp:555
+#: ../src/wxMaximaFrame.cpp:554
 #, fuzzy
 msgid "History\tAlt-Shift-I"
 msgstr "Histórico\tAlt-Shift-H"
@@ -2102,11 +2105,11 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Húngaro"
 
-#: ../src/wxMaxima.cpp:3527
+#: ../src/wxMaxima.cpp:3539
 msgid "IC1"
 msgstr "CI1"
 
-#: ../src/wxMaxima.cpp:3543
+#: ../src/wxMaxima.cpp:3555
 msgid "IC2"
 msgstr "CI2"
 
@@ -2122,7 +2125,7 @@ msgid ""
 "same output cell."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:683
+#: ../src/wxMaximaFrame.cpp:682
 msgid ""
 "If maxima ever finishes evaluating without wxMaxima realizing this this menu "
 "item can force wxMaxima to try to send commands to maxima again."
@@ -2184,11 +2187,11 @@ msgstr ""
 "Se seu cálculo está demorando de mais para executar, você pode tentar os "
 "menus 'Maxima->Interromper' ou 'Maxima->Reiniciar o Maxima'."
 
-#: ../src/wxMaximaFrame.cpp:1499
+#: ../src/wxMaximaFrame.cpp:1518
 msgid "Image"
 msgstr "Imagem"
 
-#: ../src/wxMaxima.cpp:5644
+#: ../src/wxMaxima.cpp:5659
 msgid "Image files (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 msgstr "Imagens (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 
@@ -2215,7 +2218,7 @@ msgid ""
 "above it. Might increase readability for some fonts and short subscripts."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Include columns:"
 msgstr "Incluir colunas:"
 
@@ -2234,19 +2237,19 @@ msgstr ""
 msgid "Infinity"
 msgstr "Infinito"
 
-#: ../src/wxMaximaFrame.cpp:974
+#: ../src/wxMaximaFrame.cpp:973
 msgid "Info about Maxima build"
 msgstr "Informações sobre a versão do maxima"
 
-#: ../src/wxMaxima.cpp:4207
+#: ../src/wxMaxima.cpp:4219
 msgid "Initial Estimates:"
 msgstr "Estimativas iniciais:"
 
-#: ../src/wxMaximaFrame.cpp:718
+#: ../src/wxMaximaFrame.cpp:717
 msgid "Initial Value Problem (&1)..."
 msgstr "Problema de valor inicial (&1)..."
 
-#: ../src/wxMaximaFrame.cpp:721
+#: ../src/wxMaximaFrame.cpp:720
 msgid "Initial Value Problem (&2)..."
 msgstr "Problema de valor inicial (&2)..."
 
@@ -2254,7 +2257,7 @@ msgstr "Problema de valor inicial (&2)..."
 msgid "Input labels"
 msgstr "Rótulos de entrada"
 
-#: ../src/wxMaximaFrame.cpp:403
+#: ../src/wxMaximaFrame.cpp:402
 msgid "Insert"
 msgstr "Inserir"
 
@@ -2262,98 +2265,98 @@ msgstr "Inserir"
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:612
+#: ../src/wxMaximaFrame.cpp:611
 msgid "Insert &Section Cell\tCtrl-3"
 msgstr "Inserir célula de &seleção\tCtrl-3"
 
-#: ../src/wxMaximaFrame.cpp:608
+#: ../src/wxMaximaFrame.cpp:607
 msgid "Insert &Text Cell\tCtrl-1"
 msgstr "Inserir célula de &texto\tCtrl-1"
 
-#: ../src/wxMaximaFrame.cpp:558
+#: ../src/wxMaximaFrame.cpp:557
 msgid "Insert Cell\tAlt-Shift-C"
 msgstr "Inserir Célula\tAlt-Shift-C"
 
-#: ../src/wxMaxima.cpp:5642
+#: ../src/wxMaxima.cpp:5657
 msgid "Insert Image"
 msgstr "Inserir imagem"
 
-#: ../src/wxMaximaFrame.cpp:620
+#: ../src/wxMaximaFrame.cpp:619
 msgid "Insert Image..."
 msgstr "Inserir imagem..."
 
-#: ../src/wxMaximaFrame.cpp:606
+#: ../src/wxMaximaFrame.cpp:605
 msgid "Insert Input &Cell"
 msgstr "Nova &célula de entrada"
 
-#: ../src/wxMaximaFrame.cpp:618
+#: ../src/wxMaximaFrame.cpp:617
 msgid "Insert Page Break"
 msgstr "Inserir quebra de página"
 
-#: ../src/wxMaximaFrame.cpp:614
+#: ../src/wxMaximaFrame.cpp:613
 msgid "Insert S&ubsection Cell\tCtrl-4"
 msgstr "Inserir célula de s&ubseção\tCtrl-4"
 
-#: ../src/wxMaximaFrame.cpp:616
+#: ../src/wxMaximaFrame.cpp:615
 #, fuzzy
 msgid "Insert S&ubsubsection Cell\tCtrl-5"
 msgstr "Inserir célula de s&ubseção\tCtrl-4"
 
-#: ../src/MathCtrl.cpp:1015
+#: ../src/MathCtrl.cpp:1057
 msgid "Insert Section Cell"
 msgstr "Inserir célula de seleção"
 
-#: ../src/MathCtrl.cpp:1016
+#: ../src/MathCtrl.cpp:1058
 msgid "Insert Subsection Cell"
 msgstr "Inserir célula de subseção"
 
-#: ../src/MathCtrl.cpp:1017
+#: ../src/MathCtrl.cpp:1059
 #, fuzzy
 msgid "Insert Subsubsection Cell"
 msgstr "Inserir célula de subseção"
 
-#: ../src/wxMaximaFrame.cpp:610
+#: ../src/wxMaximaFrame.cpp:609
 msgid "Insert T&itle Cell\tCtrl-2"
 msgstr "Inserir célula de tít&ulo\tCtrl-2"
 
-#: ../src/MathCtrl.cpp:1013
+#: ../src/MathCtrl.cpp:1055
 msgid "Insert Text Cell"
 msgstr "Inserir célula de texto"
 
-#: ../src/MathCtrl.cpp:1014
+#: ../src/MathCtrl.cpp:1056
 msgid "Insert Title Cell"
 msgstr "Inserir célula de título"
 
-#: ../src/wxMaximaFrame.cpp:607
+#: ../src/wxMaximaFrame.cpp:606
 msgid "Insert a new input cell"
 msgstr "Inserir nova célula de entrada"
 
-#: ../src/wxMaximaFrame.cpp:613
+#: ../src/wxMaximaFrame.cpp:612
 msgid "Insert a new section cell"
 msgstr "Inserir nova célula de seleção"
 
-#: ../src/wxMaximaFrame.cpp:615
+#: ../src/wxMaximaFrame.cpp:614
 msgid "Insert a new subsection cell"
 msgstr "Inserir nova célula de subseção"
 
-#: ../src/wxMaximaFrame.cpp:617
+#: ../src/wxMaximaFrame.cpp:616
 #, fuzzy
 msgid "Insert a new subsubsection cell"
 msgstr "Inserir nova célula de subseção"
 
-#: ../src/wxMaximaFrame.cpp:609
+#: ../src/wxMaximaFrame.cpp:608
 msgid "Insert a new text cell"
 msgstr "Inserir nova célula de texto"
 
-#: ../src/wxMaximaFrame.cpp:611
+#: ../src/wxMaximaFrame.cpp:610
 msgid "Insert a new title cell"
 msgstr "Inserir nova célula de título"
 
-#: ../src/wxMaximaFrame.cpp:619
+#: ../src/wxMaximaFrame.cpp:618
 msgid "Insert a page break"
 msgstr "Inserir uma quebra de página"
 
-#: ../src/wxMaximaFrame.cpp:621
+#: ../src/wxMaximaFrame.cpp:620
 msgid "Insert image"
 msgstr "Inserir imagem"
 
@@ -2366,27 +2369,27 @@ msgstr ""
 msgid "Integral sign"
 msgstr "Integrar expressão"
 
-#: ../src/wxMaxima.cpp:3992
+#: ../src/wxMaxima.cpp:4004
 msgid "Integral/Sum:"
 msgstr "Integral/soma:"
 
-#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4105 ../src/wxMaxima.cpp:5051
+#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4117 ../src/wxMaxima.cpp:5063
 msgid "Integrate"
 msgstr "Integrar"
 
-#: ../src/wxMaxima.cpp:4091
+#: ../src/wxMaxima.cpp:4103
 msgid "Integrate (risch)"
 msgstr "Integrar (risch)"
 
-#: ../src/wxMaximaFrame.cpp:778
+#: ../src/wxMaximaFrame.cpp:777
 msgid "Integrate expression"
 msgstr "Integrar expressão"
 
-#: ../src/wxMaximaFrame.cpp:780
+#: ../src/wxMaximaFrame.cpp:779
 msgid "Integrate expression with Risch algorithm"
 msgstr "Integrar expressão com o algoritmo Risch"
 
-#: ../src/wxMaximaFrame.cpp:1224 ../src/MathCtrl.cpp:1000
+#: ../src/MathCtrl.cpp:1042 ../src/wxMaximaFrame.cpp:1223
 msgid "Integrate..."
 msgstr "Integrar..."
 
@@ -2394,7 +2397,7 @@ msgstr "Integrar..."
 msgid "Interrupt"
 msgstr "Interromper"
 
-#: ../src/wxMaximaFrame.cpp:646 ../src/wxMaximaFrame.cpp:650
+#: ../src/wxMaximaFrame.cpp:645 ../src/wxMaximaFrame.cpp:649
 msgid "Interrupt current computation"
 msgstr "Interromper cálculo atual"
 
@@ -2414,15 +2417,15 @@ msgstr ""
 "\n"
 "Por favor informe o caminho do programa Maxima novamente."
 
-#: ../src/wxMaxima.cpp:4137
+#: ../src/wxMaxima.cpp:4149
 msgid "Inverse Laplace"
 msgstr "Inversa de Laplace"
 
-#: ../src/wxMaximaFrame.cpp:806
+#: ../src/wxMaximaFrame.cpp:805
 msgid "Inverse Laplace T&ransform..."
 msgstr "T&ransformada inversa de Laplace..."
 
-#: ../src/wxMaximaFrame.cpp:1372
+#: ../src/wxMaximaFrame.cpp:1371
 msgid "Iota"
 msgstr ""
 
@@ -2456,7 +2459,7 @@ msgstr "Japonês"
 msgid "Kabyle"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1373
+#: ../src/wxMaximaFrame.cpp:1372
 msgid "Kappa"
 msgstr ""
 
@@ -2465,7 +2468,7 @@ msgstr ""
 msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr "Manter símbolo de percentual com símbolos especiais: %e, %i, etc."
 
-#: ../src/wxMaxima.cpp:4031
+#: ../src/wxMaxima.cpp:4043
 msgid "LCM"
 msgstr "MMC"
 
@@ -2481,7 +2484,7 @@ msgstr ""
 msgid "Label width:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1374
+#: ../src/wxMaximaFrame.cpp:1373
 msgid "Lambda"
 msgstr ""
 
@@ -2493,11 +2496,11 @@ msgstr "Idioma usada para a interface do wxMaxima."
 msgid "Language:"
 msgstr "Idioma:"
 
-#: ../src/wxMaxima.cpp:4120
+#: ../src/wxMaxima.cpp:4132
 msgid "Laplace"
 msgstr "Laplace"
 
-#: ../src/wxMaximaFrame.cpp:803
+#: ../src/wxMaximaFrame.cpp:802
 msgid "Laplace &Transform..."
 msgstr "&Transformada de Laplace..."
 
@@ -2505,15 +2508,15 @@ msgstr "&Transformada de Laplace..."
 msgid "Leads to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:812
+#: ../src/wxMaximaFrame.cpp:811
 msgid "Least Common Multiple..."
 msgstr "Mínimo múltiplo comum..."
 
-#: ../src/wxMaxima.cpp:4809
+#: ../src/wxMaxima.cpp:4821
 msgid "Least Squares Fit"
 msgstr "Mínimos quadrados"
 
-#: ../src/wxMaximaFrame.cpp:1266
+#: ../src/wxMaximaFrame.cpp:1265
 msgid "Least Squares Fit..."
 msgstr "Mínimos quadrados..."
 
@@ -2524,24 +2527,24 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4192
+#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4204
 msgid "Limit"
 msgstr "Limite"
 
-#: ../src/wxMaximaFrame.cpp:1225
+#: ../src/wxMaximaFrame.cpp:1224
 msgid "Limit..."
 msgstr "Limite..."
 
-#: ../src/wxMaximaFrame.cpp:1265
+#: ../src/wxMaximaFrame.cpp:1264
 msgid "Linear Regression..."
 msgstr "Regressão linear..."
 
-#: ../src/wxMaxima.cpp:3803
+#: ../src/wxMaxima.cpp:3815
 #, fuzzy
 msgid "List(s):"
 msgstr "Lista:"
 
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3848
 msgid "List:"
 msgstr "Lista:"
 
@@ -2549,15 +2552,15 @@ msgstr "Lista:"
 msgid "Load"
 msgstr "Carregar"
 
-#: ../src/wxMaxima.cpp:2932
+#: ../src/wxMaxima.cpp:2940
 msgid "Load Package"
 msgstr "Carregar pacote"
 
-#: ../src/wxMaximaFrame.cpp:479
+#: ../src/wxMaximaFrame.cpp:478
 msgid "Load a Maxima file using the batch command"
 msgstr "Carregar um arquivo do Maxima usando o comando batch"
 
-#: ../src/wxMaximaFrame.cpp:477
+#: ../src/wxMaximaFrame.cpp:476
 msgid "Load a Maxima package file"
 msgstr "Carregar um arquivo de pacote Maxima"
 
@@ -2569,49 +2572,49 @@ msgstr "Ler estilo de um arquivo"
 msgid "Long Right arrow"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Lower bound:"
 msgstr "Limite inferior:"
 
-#: ../src/wxMaximaFrame.cpp:771
+#: ../src/wxMaximaFrame.cpp:770
 msgid "Ma&p to Matrix..."
 msgstr "Ma&pear a uma matriz..."
 
-#: ../src/wxMaximaFrame.cpp:547
+#: ../src/wxMaximaFrame.cpp:546
 #, fuzzy
 msgid "Main Toolbar\tAlt-Shift-B"
 msgstr "Barra de ferramentas\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:765
+#: ../src/wxMaximaFrame.cpp:764
 msgid "Make &List..."
 msgstr "Criar &lista..."
 
-#: ../src/wxMaxima.cpp:3821
+#: ../src/wxMaxima.cpp:3833
 msgid "Make list"
 msgstr "Criar lista"
 
-#: ../src/wxMaximaFrame.cpp:766
+#: ../src/wxMaximaFrame.cpp:765
 msgid "Make list from expression"
 msgstr "Criar lista de uma expressão"
 
-#: ../src/wxMaximaFrame.cpp:907
+#: ../src/wxMaximaFrame.cpp:906
 msgid "Make substitution in expression"
 msgstr "Fazer substituição numa expressão"
 
-#: ../src/wxMaximaFrame.cpp:682
+#: ../src/wxMaximaFrame.cpp:681
 #, fuzzy
 msgid "Manually Trigger Evaluation"
 msgstr "Exibir tempo usado para execução"
 
-#: ../src/wxMaxima.cpp:3805
+#: ../src/wxMaxima.cpp:3817
 msgid "Map"
 msgstr "Mapear"
 
-#: ../src/wxMaximaFrame.cpp:770
+#: ../src/wxMaximaFrame.cpp:769
 msgid "Map function to a list"
 msgstr "Mapear função a uma lista"
 
-#: ../src/wxMaximaFrame.cpp:772
+#: ../src/wxMaximaFrame.cpp:771
 msgid "Map function to a matrix"
 msgstr "Mapear função a uma matriz"
 
@@ -2628,23 +2631,23 @@ msgstr "Parêntesis aos pares nos controles de texto"
 msgid "Math font:"
 msgstr "Fonte matemática:"
 
-#: ../src/wxMaximaFrame.cpp:374
+#: ../src/wxMaximaFrame.cpp:373
 msgid "Mathematical Symbols"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3716
+#: ../src/wxMaxima.cpp:3728
 msgid "Matrix"
 msgstr "Matriz"
 
-#: ../src/wxMaxima.cpp:3702
+#: ../src/wxMaxima.cpp:3714
 msgid "Matrix map"
 msgstr "Mapear a matriz"
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Matrix name:"
 msgstr "Nome da matriz:"
 
-#: ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3749
+#: ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3761
 msgid "Matrix:"
 msgstr "Matriz:"
 
@@ -2652,7 +2655,7 @@ msgstr "Matriz:"
 msgid "Maxima"
 msgstr "Maxima"
 
-#: ../src/wxMaximaFrame.cpp:137
+#: ../src/wxMaximaFrame.cpp:136
 #, fuzzy
 msgid "Maxima has a question"
 msgstr "Questões do Maxima"
@@ -2661,24 +2664,24 @@ msgstr "Questões do Maxima"
 msgid "Maxima input"
 msgstr "Entrada do Maxima"
 
-#: ../src/wxMaximaFrame.cpp:166
+#: ../src/wxMaximaFrame.cpp:165
 msgid "Maxima is calculating"
 msgstr "Maxima está calculando"
 
-#: ../src/wxMaximaFrame.cpp:111
+#: ../src/wxMaximaFrame.cpp:110
 #, fuzzy
 msgid "Maxima is ready for input."
 msgstr "Entrada do Maxima"
 
-#: ../src/wxMaxima.cpp:2945
+#: ../src/wxMaxima.cpp:2953
 msgid "Maxima package (*.mac)|*.mac"
 msgstr "Pacote Maxima (*.mac)|*.mac"
 
-#: ../src/wxMaxima.cpp:2934
+#: ../src/wxMaxima.cpp:2942
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr "Pacote Maxima (*.mac)|*.mac|Pacote Lisp (*.lisp)|*.lisp|Todos|*"
 
-#: ../src/wxMaxima.cpp:1014
+#: ../src/wxMaxima.cpp:1019
 msgid "Maxima process terminated."
 msgstr "Maxima terminado."
 
@@ -2690,7 +2693,7 @@ msgstr "Programa Maxima:"
 msgid "Maxima questions"
 msgstr "Questões do Maxima"
 
-#: ../src/wxMaxima.cpp:942
+#: ../src/wxMaxima.cpp:947
 msgid "Maxima started. Waiting for connection..."
 msgstr "Maxima iniciado. Aguardando conexão..."
 
@@ -2714,7 +2717,7 @@ msgstr ""
 "O Maxima usa ':' para atribuir valores ('a : 3;') e ':=' para definir "
 "funções ('f(x) := x^2;')."
 
-#: ../src/wxMaxima.cpp:4597
+#: ../src/wxMaxima.cpp:4609
 msgid "Maxima version: "
 msgstr "Versão do Maxima: "
 
@@ -2751,40 +2754,40 @@ msgstr ""
 msgid "Maximum displayed number of digits:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1263
+#: ../src/wxMaximaFrame.cpp:1262
 msgid "Mean Difference Test..."
 msgstr "Teste de diferença entre médias..."
 
-#: ../src/wxMaximaFrame.cpp:1262
+#: ../src/wxMaximaFrame.cpp:1261
 msgid "Mean Test..."
 msgstr "Teste de média..."
 
-#: ../src/wxMaximaFrame.cpp:1255
+#: ../src/wxMaximaFrame.cpp:1254
 msgid "Mean..."
 msgstr "Média..."
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Mean:"
 msgstr "Média:"
 
-#: ../src/wxMaximaFrame.cpp:1256
+#: ../src/wxMaximaFrame.cpp:1255
 msgid "Median..."
 msgstr "Mediana..."
 
-#: ../src/MathCtrl.cpp:945
+#: ../src/MathCtrl.cpp:987
 msgid "Merge Cells"
 msgstr "Mesclar células"
 
-#: ../src/wxMaximaFrame.cpp:633
+#: ../src/wxMaximaFrame.cpp:632
 #, fuzzy
 msgid "Merge Cells\tCtrl-M"
 msgstr "Mesclar células"
 
-#: ../src/wxMaximaFrame.cpp:634
+#: ../src/wxMaximaFrame.cpp:633
 msgid "Merge the text from two input cells into one"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2668
+#: ../src/wxMaxima.cpp:2676
 msgid "Message from the stdout of Maxima: "
 msgstr ""
 
@@ -2792,20 +2795,20 @@ msgstr ""
 msgid "Method:"
 msgstr "Método:"
 
-#: ../src/wxMaxima.cpp:5289
+#: ../src/wxMaxima.cpp:5301
 #, fuzzy
 msgid "Mismatched parenthesis"
 msgstr "Parêntesis aos pares nos controles de texto"
 
-#: ../src/wxMaxima.cpp:3972
+#: ../src/wxMaxima.cpp:3984
 msgid "Modulus"
 msgstr "Módulo"
 
-#: ../src/wxMaximaFrame.cpp:1375
+#: ../src/wxMaximaFrame.cpp:1374
 msgid "Mu"
 msgstr ""
 
-#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Name:"
 msgstr "Nome:"
 
@@ -2813,7 +2816,7 @@ msgstr "Nome:"
 msgid "New"
 msgstr "Novo"
 
-#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
+#: ../src/wxMaximaFrame.cpp:456 ../src/wxMaximaFrame.cpp:459
 msgid "New\tCtrl-N"
 msgstr "Novo\tCtrl-N"
 
@@ -2829,11 +2832,11 @@ msgstr ""
 msgid "New value:"
 msgstr "Valor novo:"
 
-#: ../src/wxMaxima.cpp:3993 ../src/wxMaxima.cpp:4119 ../src/wxMaxima.cpp:4136
+#: ../src/wxMaxima.cpp:4005 ../src/wxMaxima.cpp:4131 ../src/wxMaxima.cpp:4148
 msgid "New variable:"
 msgstr "Nova variável:"
 
-#: ../src/wxMaximaFrame.cpp:630
+#: ../src/wxMaximaFrame.cpp:629
 msgid "Next Command\tAlt-Down"
 msgstr "Próximo comando\tAlt-Down"
 
@@ -2841,15 +2844,15 @@ msgstr "Próximo comando\tAlt-Down"
 msgid "No"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5362
+#: ../src/wxMaxima.cpp:5378
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3249 ../src/wxMaxima.cpp:3271
+#: ../src/wxMaxima.cpp:3260 ../src/wxMaxima.cpp:3283
 msgid "No matches found!"
 msgstr "Nenhuma correspondência encontrada!"
 
-#: ../src/wxMaximaFrame.cpp:1264
+#: ../src/wxMaximaFrame.cpp:1263
 msgid "Normality Test..."
 msgstr "Teste de normalidade..."
 
@@ -2872,34 +2875,34 @@ msgstr ""
 msgid "Norwegian"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:3740
 msgid "Not a valid matrix dimension!"
 msgstr "Dimensão inválida para matriz!"
 
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629
 msgid "Not a valid number of equations!"
 msgstr "Número de equações inválido!"
 
-#: ../src/wxMaximaFrame.cpp:197
+#: ../src/wxMaximaFrame.cpp:196
 #, fuzzy
 msgid "Not connected to maxima"
 msgstr ""
 "\n"
 "Não conectado ao Maxima!\n"
 
-#: ../src/wxMaxima.cpp:4599
+#: ../src/wxMaxima.cpp:4611
 msgid "Not connected."
 msgstr "Não conectado."
 
-#: ../src/wxMaximaFrame.cpp:1376
+#: ../src/wxMaximaFrame.cpp:1375
 msgid "Nu"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Num. deg:"
 msgstr "Grau num.:"
 
-#: ../src/wxMaxima.cpp:3585 ../src/wxMaxima.cpp:3609
+#: ../src/wxMaxima.cpp:3597 ../src/wxMaxima.cpp:3621
 msgid "Number of equations:"
 msgstr "Número de equações:"
 
@@ -2926,15 +2929,15 @@ msgstr "OK"
 msgid "Old value:"
 msgstr "Valor antigo:"
 
-#: ../src/wxMaxima.cpp:3992 ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135
+#: ../src/wxMaxima.cpp:4004 ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147
 msgid "Old variable:"
 msgstr "Variável antiga:"
 
-#: ../src/wxMaximaFrame.cpp:1387
+#: ../src/wxMaximaFrame.cpp:1386
 msgid "Omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1378
+#: ../src/wxMaximaFrame.cpp:1377
 msgid "Omicron"
 msgstr ""
 
@@ -2948,20 +2951,20 @@ msgid ""
 "stream for messages."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4763
+#: ../src/wxMaxima.cpp:4775
 msgid "One sample t-test"
 msgstr "Teste t com uma amostra"
 
-#: ../src/wxMaximaFrame.cpp:971
+#: ../src/wxMaximaFrame.cpp:970
 msgid "Online tutorials"
 msgstr "Tutoriais online"
 
 #: ../src/ConfigDialogue.cpp:656 ../src/main.cpp:347 ../src/ToolBar.cpp:119
-#: ../src/wxMaxima.cpp:2797
+#: ../src/wxMaxima.cpp:2805
 msgid "Open"
 msgstr "Abrir"
 
-#: ../src/wxMaximaFrame.cpp:466
+#: ../src/wxMaximaFrame.cpp:465
 msgid "Open Recent"
 msgstr "Abrir recente"
 
@@ -2969,11 +2972,11 @@ msgstr "Abrir recente"
 msgid "Open a cell when Maxima expects input"
 msgstr "Abrir uma célula quando o Maxima espera entrada"
 
-#: ../src/wxMaximaFrame.cpp:464
+#: ../src/wxMaximaFrame.cpp:463
 msgid "Open a document"
 msgstr "Abrir um documento"
 
-#: ../src/wxMaximaFrame.cpp:458 ../src/wxMaximaFrame.cpp:461
+#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
 msgid "Open a new window"
 msgstr "Abrir uma nova janela"
 
@@ -2981,11 +2984,11 @@ msgstr "Abrir uma nova janela"
 msgid "Open document"
 msgstr "Abrir documento"
 
-#: ../src/wxMaxima.cpp:4824
+#: ../src/wxMaxima.cpp:4836
 msgid "Open matrix"
 msgstr "Abrir matriz"
 
-#: ../src/wxMaxima.cpp:1446 ../src/wxMaxima.cpp:1518
+#: ../src/wxMaxima.cpp:1451 ../src/wxMaxima.cpp:1523
 msgid "Opening file"
 msgstr "Abrindo arquivo"
 
@@ -3009,11 +3012,11 @@ msgstr "Células desatualizadas"
 msgid "Output labels"
 msgstr "Rótulos de saída"
 
-#: ../src/wxMaximaFrame.cpp:796
+#: ../src/wxMaximaFrame.cpp:795
 msgid "P&ade Approximation..."
 msgstr "Aproximação de P&adé..."
 
-#: ../src/wxMaxima.cpp:3132 ../src/wxMaxima.cpp:5133
+#: ../src/wxMaxima.cpp:3141 ../src/wxMaxima.cpp:5145
 #, fuzzy
 msgid ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
@@ -3023,15 +3026,15 @@ msgstr ""
 "Imagem PNG (*.png)|*.png|Imagem JPEG (*.jpg)|*.jpg|Bitmap do Windows (*.bmp)|"
 "*.bmp|Pixmap X (*.xpm)|*.xpm"
 
-#: ../src/wxMaxima.cpp:4012
+#: ../src/wxMaxima.cpp:4024
 msgid "Pade approximation"
 msgstr "Aproximação de Padé"
 
-#: ../src/wxMaximaFrame.cpp:797
+#: ../src/wxMaximaFrame.cpp:796
 msgid "Pade approximation of a Taylor series"
 msgstr "Aproximação de Padé de uma série de Taylor"
 
-#: ../src/wxMaximaFrame.cpp:1500
+#: ../src/wxMaximaFrame.cpp:1519
 msgid "Pagebreak"
 msgstr "Quebra de página"
 
@@ -3043,19 +3046,19 @@ msgstr ""
 msgid "Parametric plot"
 msgstr "Gráfico paramétrico"
 
-#: ../src/wxMaximaFrame.cpp:188
+#: ../src/wxMaximaFrame.cpp:187
 msgid "Parsing output"
 msgstr "Interpretando saída"
 
-#: ../src/wxMaximaFrame.cpp:819
+#: ../src/wxMaximaFrame.cpp:818
 msgid "Partial &Fractions..."
 msgstr "&Frações parciais..."
 
-#: ../src/wxMaxima.cpp:4076
+#: ../src/wxMaxima.cpp:4088
 msgid "Partial fractions"
 msgstr "Frações parciais"
 
-#: ../src/wxMaxima.cpp:1769
+#: ../src/wxMaxima.cpp:1774
 msgid "Parts of the document will not be loaded correctly!"
 msgstr "Partes do documento não serão carregadas corretamente!"
 
@@ -3066,11 +3069,11 @@ msgid ""
 "Found unknown XML Tag name "
 msgstr "Partes do documento não serão carregadas corretamente!"
 
-#: ../src/ToolBar.cpp:143 ../src/MathCtrl.cpp:1010 ../src/MathCtrl.cpp:1025
+#: ../src/MathCtrl.cpp:1052 ../src/MathCtrl.cpp:1067 ../src/ToolBar.cpp:143
 msgid "Paste"
 msgstr "Colar"
 
-#: ../src/wxMaximaFrame.cpp:518
+#: ../src/wxMaximaFrame.cpp:517
 msgid "Paste\tCtrl-V"
 msgstr "Colar\tCtrl-V"
 
@@ -3078,7 +3081,7 @@ msgstr "Colar\tCtrl-V"
 msgid "Paste from clipboard"
 msgstr "Colar da área de transferência"
 
-#: ../src/wxMaximaFrame.cpp:519
+#: ../src/wxMaximaFrame.cpp:518
 msgid "Paste text from clipboard"
 msgstr "Colar texto da área de transferência"
 
@@ -3086,19 +3089,19 @@ msgstr "Colar texto da área de transferência"
 msgid "Perpendicular to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1384
+#: ../src/wxMaximaFrame.cpp:1383
 msgid "Phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1379
+#: ../src/wxMaximaFrame.cpp:1378
 msgid "Pi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1273
+#: ../src/wxMaximaFrame.cpp:1272
 msgid "Piechart..."
 msgstr "Gráfico de torta..."
 
-#: ../src/wxMaxima.cpp:1952
+#: ../src/wxMaxima.cpp:1957
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr "Queira configurar o wxMaxima com 'Editar->Configurações'."
 
@@ -3106,52 +3109,52 @@ msgstr "Queira configurar o wxMaxima com 'Editar->Configurações'."
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr "Queira reiniciar o wxMaxima para as mudanças terem efeito!"
 
-#: ../src/wxMaximaFrame.cpp:923
+#: ../src/wxMaximaFrame.cpp:922
 msgid "Plot &2d..."
 msgstr "Gráfico &2d..."
 
-#: ../src/wxMaximaFrame.cpp:925
+#: ../src/wxMaximaFrame.cpp:924
 msgid "Plot &3d..."
 msgstr "Gráfico &3d..."
 
-#: ../src/wxMaximaFrame.cpp:927
+#: ../src/wxMaximaFrame.cpp:926
 msgid "Plot &Format..."
 msgstr "&Formato do gráfico..."
 
 #: ../src/Plot2dWiz.cpp:104 ../src/Plot2dWiz.cpp:450 ../src/Plot2dWiz.cpp:464
-#: ../src/wxMaxima.cpp:4283 ../src/wxMaxima.cpp:5102
+#: ../src/wxMaxima.cpp:4295 ../src/wxMaxima.cpp:5114
 msgid "Plot 2D"
 msgstr "Gráfico 2D"
 
-#: ../src/wxMaximaFrame.cpp:1227
+#: ../src/wxMaximaFrame.cpp:1226
 msgid "Plot 2D..."
 msgstr "Gráfico 2D..."
 
-#: ../src/MathCtrl.cpp:1003
+#: ../src/MathCtrl.cpp:1045
 msgid "Plot 2d..."
 msgstr "Gráfico 2d..."
 
-#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4269 ../src/wxMaxima.cpp:5115
+#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4281 ../src/wxMaxima.cpp:5127
 msgid "Plot 3D"
 msgstr "Gráfico 3D"
 
-#: ../src/wxMaximaFrame.cpp:1228
+#: ../src/wxMaximaFrame.cpp:1227
 msgid "Plot 3D..."
 msgstr "Gráfico 3D..."
 
-#: ../src/MathCtrl.cpp:1004
+#: ../src/MathCtrl.cpp:1046
 msgid "Plot 3d..."
 msgstr "Gráfico 3d..."
 
-#: ../src/wxMaxima.cpp:4296
+#: ../src/wxMaxima.cpp:4308
 msgid "Plot format"
 msgstr "Formato do gráfico"
 
-#: ../src/wxMaximaFrame.cpp:924
+#: ../src/wxMaximaFrame.cpp:923
 msgid "Plot in 2 dimensions"
 msgstr "Gráfico bidimensional"
 
-#: ../src/wxMaximaFrame.cpp:926
+#: ../src/wxMaximaFrame.cpp:925
 msgid "Plot in 3 dimensions"
 msgstr "Gráfico tridimensional"
 
@@ -3160,8 +3163,8 @@ msgid "Plot to file:"
 msgstr "Gráfico para arquivo:"
 
 #: ../src/BC2Wiz.cpp:30 ../src/BC2Wiz.cpp:36 ../src/LimitWiz.cpp:33
-#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
-#: ../src/wxMaxima.cpp:3648
+#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
+#: ../src/wxMaxima.cpp:3660
 msgid "Point:"
 msgstr "Ponto:"
 
@@ -3169,11 +3172,11 @@ msgstr "Ponto:"
 msgid "Polish"
 msgstr "Polonês"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 1:"
 msgstr "Polinômio 1:"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 2:"
 msgstr "Polinômio 2:"
 
@@ -3185,11 +3188,11 @@ msgstr "Português (Brasileiro)"
 msgid "Postscript file (*.eps)|*.eps|All|*"
 msgstr "Arquivo Postscript (*.eps)|*.eps|Todos|*"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Precision"
 msgstr "Precisão"
 
-#: ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:536
 #, fuzzy
 msgid "Preferences...\tCtrl+,"
 msgstr "Preferências...\tCTRL+,"
@@ -3202,7 +3205,7 @@ msgid ""
 "packages and from functions that are defined in the current file."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:628
+#: ../src/wxMaximaFrame.cpp:627
 msgid "Previous Command\tAlt-Up"
 msgstr "Comando anterior\tAlt-Up"
 
@@ -3210,11 +3213,11 @@ msgstr "Comando anterior\tAlt-Up"
 msgid "Print"
 msgstr "Imprimir"
 
-#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:484
+#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:483
 msgid "Print document"
 msgstr "Imprimir documento"
 
-#: ../src/wxMaxima.cpp:4242
+#: ../src/wxMaxima.cpp:4254
 msgid "Product"
 msgstr "Produto"
 
@@ -3223,36 +3226,36 @@ msgstr "Produto"
 msgid "Product sign"
 msgstr "Produto"
 
-#: ../src/wxMaximaFrame.cpp:1386
+#: ../src/wxMaximaFrame.cpp:1385
 msgid "Psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:331
+#: ../src/wxMaximaFrame.cpp:330
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:592
+#: ../src/wxMaximaFrame.cpp:591
 #, fuzzy
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr "Avaliar todas as células no documento"
 
-#: ../src/wxMaximaFrame.cpp:1278
+#: ../src/wxMaximaFrame.cpp:1277
 msgid "Read Matrix..."
 msgstr "Ler matriz..."
 
-#: ../src/wxMaximaFrame.cpp:177
+#: ../src/wxMaximaFrame.cpp:176
 msgid "Reading Maxima output"
 msgstr "Lendo saída do Maxima"
 
-#: ../src/wxMaximaFrame.cpp:153
+#: ../src/wxMaximaFrame.cpp:152
 msgid "Ready for user input"
 msgstr "Pronto para entrada do usuário"
 
-#: ../src/wxMaximaFrame.cpp:631
+#: ../src/wxMaximaFrame.cpp:630
 msgid "Recall next command from history"
 msgstr "Recuperar o próximo comando do histórico"
 
-#: ../src/wxMaximaFrame.cpp:629
+#: ../src/wxMaximaFrame.cpp:628
 msgid "Recall previous command from history"
 msgstr "Recuperar o comando anterior do histórico"
 
@@ -3260,36 +3263,36 @@ msgstr "Recuperar o comando anterior do histórico"
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1215
+#: ../src/wxMaximaFrame.cpp:1214
 msgid "Rectform"
 msgstr "Forma ret"
 
-#: ../src/wxMaximaFrame.cpp:495
+#: ../src/wxMaximaFrame.cpp:494
 #, fuzzy
 msgid "Redo\tCtrl-Y"
 msgstr "&Desfazer\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:496
+#: ../src/wxMaximaFrame.cpp:495
 msgid "Redo last change"
 msgstr "Desfazer última alteração"
 
-#: ../src/wxMaximaFrame.cpp:1220
+#: ../src/wxMaximaFrame.cpp:1219
 msgid "Reduce (tr)"
 msgstr "Reduzir (tr)"
 
-#: ../src/wxMaximaFrame.cpp:871
+#: ../src/wxMaximaFrame.cpp:870
 msgid "Reduce trigonometric expression"
 msgstr "Reduzir expressão trigonométrica"
 
-#: ../src/wxMaxima.cpp:622 ../src/wxMaxima.cpp:5495
+#: ../src/wxMaxima.cpp:627 ../src/wxMaxima.cpp:5511
 msgid "Refusing to send cell to maxima: "
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:594
+#: ../src/wxMaximaFrame.cpp:593
 msgid "Remove All Output"
 msgstr "Remover todas as saídas"
 
-#: ../src/wxMaximaFrame.cpp:595
+#: ../src/wxMaximaFrame.cpp:594
 msgid "Remove output from input cells"
 msgstr "Remover saídas das células de entrada"
 
@@ -3298,7 +3301,7 @@ msgstr "Remover saídas das células de entrada"
 msgid "Replace All"
 msgstr "Selecionar tudo"
 
-#: ../src/wxMaxima.cpp:3282
+#: ../src/wxMaxima.cpp:3294
 #, c-format
 msgid "Replaced %d occurrences."
 msgstr "Substituídas %d ocorrências."
@@ -3307,11 +3310,11 @@ msgstr "Substituídas %d ocorrências."
 msgid "Replacement:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:976
+#: ../src/wxMaximaFrame.cpp:975
 msgid "Report bug"
 msgstr "Relatar bug"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "Restart Maxima"
 msgstr "Reiniciar Maxima"
 
@@ -3320,7 +3323,7 @@ msgstr "Reiniciar Maxima"
 msgid "Restart maxima"
 msgstr "Reiniciar Maxima"
 
-#: ../src/MathCtrl.cpp:4442
+#: ../src/MathCtrl.cpp:4497
 msgid "Result"
 msgstr ""
 
@@ -3328,7 +3331,7 @@ msgstr ""
 msgid "Return to the cell that is currently being evaluated"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1380
+#: ../src/wxMaximaFrame.cpp:1379
 msgid "Rho"
 msgstr ""
 
@@ -3336,19 +3339,19 @@ msgstr ""
 msgid "Right arrow"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:779
+#: ../src/wxMaximaFrame.cpp:778
 msgid "Risch Integration..."
 msgstr "Integração Risch..."
 
-#: ../src/wxMaximaFrame.cpp:694
+#: ../src/wxMaximaFrame.cpp:693
 msgid "Roots of &Polynomial"
 msgstr "Raízes de &polinômio"
 
-#: ../src/wxMaximaFrame.cpp:697
+#: ../src/wxMaximaFrame.cpp:696
 msgid "Roots of Polynomial (bfloat)"
 msgstr "Raízes do polinômio (bfloat)"
 
-#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Rows:"
 msgstr "Linas:"
 
@@ -3356,56 +3359,56 @@ msgstr "Linas:"
 msgid "Russian"
 msgstr "Russo"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 1:"
 msgstr "Amostra 1:"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 2:"
 msgstr "Amostra 2:"
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Sample:"
 msgstr "Amostra:"
 
 #: ../src/ConfigDialogue.cpp:781 ../src/ToolBar.cpp:122
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Save"
 msgstr "Salvar"
 
-#: ../src/MathCtrl.cpp:921
+#: ../src/MathCtrl.cpp:963
 msgid "Save Animation..."
 msgstr "Salvar animação..."
 
-#: ../src/wxMaxima.cpp:2565
+#: ../src/wxMaxima.cpp:2572
 msgid "Save As"
 msgstr "Salvar como"
 
-#: ../src/wxMaximaFrame.cpp:474
+#: ../src/wxMaximaFrame.cpp:473
 msgid "Save As...\tShift-Ctrl-S"
 msgstr "Salvar como...\tShift-Ctrl-S"
 
-#: ../src/MathCtrl.cpp:919
+#: ../src/MathCtrl.cpp:961
 msgid "Save Image..."
 msgstr "Salvar imagem..."
 
-#: ../src/wxMaxima.cpp:3130
+#: ../src/wxMaxima.cpp:3139
 msgid "Save Selection to Image"
 msgstr "Salvar seleção para imagem"
 
-#: ../src/wxMaximaFrame.cpp:528
+#: ../src/wxMaximaFrame.cpp:527
 msgid "Save Selection to Image..."
 msgstr "Salvar seleção para imagem..."
 
-#: ../src/wxMaxima.cpp:5150
+#: ../src/wxMaxima.cpp:5162
 msgid "Save animation to file"
 msgstr "Salvar animação para arquivo"
 
-#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:473
+#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:472
 msgid "Save document"
 msgstr "Salvar documento"
 
-#: ../src/wxMaximaFrame.cpp:475
+#: ../src/wxMaximaFrame.cpp:474
 msgid "Save document as"
 msgstr "Salvar documento como"
 
@@ -3427,11 +3430,11 @@ msgstr "Salvar layout dos painéis entre sessões."
 msgid "Save plot to file"
 msgstr "Salvar gráfico para um arquivo"
 
-#: ../src/wxMaximaFrame.cpp:529
+#: ../src/wxMaximaFrame.cpp:528
 msgid "Save selection from document to an image file"
 msgstr "Salvar seleção do documento para uma imagem"
 
-#: ../src/wxMaxima.cpp:5131
+#: ../src/wxMaxima.cpp:5143
 msgid "Save selection to file"
 msgstr "Salvar seleção para arquivo"
 
@@ -3447,28 +3450,28 @@ msgstr "Salvar posição/tamanho da janela do wxMaxima"
 msgid "Save wxMaxima window size/position between sessions."
 msgstr "Salvar posição/tamanho da janela do wxMaxima entre sessões."
 
-#: ../src/wxMaximaFrame.cpp:246
+#: ../src/wxMaximaFrame.cpp:245
 #, fuzzy
 msgid "Saving failed."
 msgstr "Falha ao iniciar o servidor"
 
-#: ../src/wxMaximaFrame.cpp:222
+#: ../src/wxMaximaFrame.cpp:221
 msgid "Saving successful."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:212
+#: ../src/wxMaximaFrame.cpp:211
 msgid "Saving..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4699
+#: ../src/wxMaxima.cpp:4711
 msgid "Scatterplot"
 msgstr "Gráfico de dispersão"
 
-#: ../src/wxMaximaFrame.cpp:1271
+#: ../src/wxMaximaFrame.cpp:1270
 msgid "Scatterplot..."
 msgstr "Gráfico de dispersão..."
 
-#: ../src/wxMaximaFrame.cpp:1498
+#: ../src/wxMaximaFrame.cpp:1517
 msgid "Section"
 msgstr "Seção"
 
@@ -3476,26 +3479,26 @@ msgstr "Seção"
 msgid "Section cell"
 msgstr "Selecionar célula"
 
-#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:292 ../src/TextCell.cpp:306
-#: ../src/TextCell.cpp:322 ../src/TextCell.cpp:334
+#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:290 ../src/TextCell.cpp:304
+#: ../src/TextCell.cpp:320 ../src/TextCell.cpp:332
 msgid ""
 "Seems like something is broken with a font. Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/TextCell.cpp:139
+#: ../src/TextCell.cpp:137
 msgid ""
 "Seems like something is broken with the maths font. Installing http://www."
 "math.union.edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use "
 "JSmath fonts\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1011 ../src/MathCtrl.cpp:1027
+#: ../src/MathCtrl.cpp:1053 ../src/MathCtrl.cpp:1069
 msgid "Select All"
 msgstr "Selecionar tudo"
 
-#: ../src/wxMaximaFrame.cpp:525
+#: ../src/wxMaximaFrame.cpp:524
 msgid "Select All\tCtrl-A"
 msgstr "Selecionar tudo\tCtrl-A"
 
@@ -3503,7 +3506,7 @@ msgstr "Selecionar tudo\tCtrl-A"
 msgid "Select Maxima program"
 msgstr "Selecione o programa Maxima"
 
-#: ../src/wxMaxima.cpp:4860
+#: ../src/wxMaxima.cpp:4872
 msgid "Select Subsample"
 msgstr "Selecione a subamostra"
 
@@ -3512,11 +3515,11 @@ msgstr "Selecione a subamostra"
 msgid "Select a constant"
 msgstr "Selecione uma constante"
 
-#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:526
+#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:525
 msgid "Select all"
 msgstr "Selecionar tudo"
 
-#: ../src/wxMaxima.cpp:3319
+#: ../src/wxMaxima.cpp:3331
 msgid "Select math display algorithm"
 msgstr "Selecione o algoritmo de exibição de fórmulas"
 
@@ -3533,23 +3536,23 @@ msgstr ""
 msgid "Selection"
 msgstr "Seleção"
 
-#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4178
+#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4190
 msgid "Series"
 msgstr "Série"
 
-#: ../src/wxMaximaFrame.cpp:1226
+#: ../src/wxMaximaFrame.cpp:1225
 msgid "Series..."
 msgstr "Série..."
 
-#: ../src/wxMaxima.cpp:863
+#: ../src/wxMaxima.cpp:868
 msgid "Server started"
 msgstr "Servidor iniciado"
 
-#: ../src/wxMaximaFrame.cpp:575
+#: ../src/wxMaximaFrame.cpp:574
 msgid "Set Zoom"
 msgstr "Ajustar zoom"
 
-#: ../src/wxMaximaFrame.cpp:944
+#: ../src/wxMaximaFrame.cpp:943
 #, fuzzy
 msgid "Set bigfloat &Precision..."
 msgstr "Ajustar a precisão de ponto flutuante"
@@ -3558,62 +3561,62 @@ msgstr "Ajustar a precisão de ponto flutuante"
 msgid "Set fixed font in text controls."
 msgstr "Usa fonte monoespaçada nos controles de texto."
 
-#: ../src/wxMaximaFrame.cpp:928
+#: ../src/wxMaximaFrame.cpp:927
 msgid "Set plot format"
 msgstr "Ajustar formato do gráfico"
 
-#: ../src/wxMaximaFrame.cpp:945
+#: ../src/wxMaximaFrame.cpp:944
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can "
 "be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:569
+#: ../src/wxMaximaFrame.cpp:568
 msgid "Set zoom to 100%"
 msgstr "Definir zoom em 100%"
 
-#: ../src/wxMaximaFrame.cpp:570
+#: ../src/wxMaximaFrame.cpp:569
 msgid "Set zoom to 120%"
 msgstr "Definir zoom em 120%"
 
-#: ../src/wxMaximaFrame.cpp:571
+#: ../src/wxMaximaFrame.cpp:570
 msgid "Set zoom to 150%"
 msgstr "Definir zoom em 150%"
 
-#: ../src/wxMaximaFrame.cpp:572
+#: ../src/wxMaximaFrame.cpp:571
 msgid "Set zoom to 200%"
 msgstr "Definir zoom em 200%"
 
-#: ../src/wxMaximaFrame.cpp:573
+#: ../src/wxMaximaFrame.cpp:572
 msgid "Set zoom to 300%"
 msgstr "Definir zoom em 300%"
 
-#: ../src/wxMaximaFrame.cpp:568
+#: ../src/wxMaximaFrame.cpp:567
 msgid "Set zoom to 80%"
 msgstr "Definir zoom em 80%"
 
-#: ../src/wxMaximaFrame.cpp:732
+#: ../src/wxMaximaFrame.cpp:731
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
 "Configurar valores em pontos para resolver EDO com transformada de Laplace"
 
-#: ../src/wxMaximaFrame.cpp:918
+#: ../src/wxMaximaFrame.cpp:917
 msgid "Setup modulus computation"
 msgstr "Configurar cálculos com módulo"
 
-#: ../src/wxMaximaFrame.cpp:662
+#: ../src/wxMaximaFrame.cpp:661
 msgid "Show &Definition..."
 msgstr "Mostar &definição..."
 
-#: ../src/wxMaximaFrame.cpp:660
+#: ../src/wxMaximaFrame.cpp:659
 msgid "Show &Functions"
 msgstr "Mostrar &funções"
 
-#: ../src/wxMaximaFrame.cpp:967
+#: ../src/wxMaximaFrame.cpp:966
 msgid "Show &Tips..."
 msgstr "&Mostar dicas..."
 
-#: ../src/wxMaximaFrame.cpp:665
+#: ../src/wxMaximaFrame.cpp:664
 msgid "Show &Variables"
 msgstr "Mostrar &variáveis"
 
@@ -3621,43 +3624,43 @@ msgstr "Mostrar &variáveis"
 msgid "Show Maxima help"
 msgstr "Mostrar ajuda do Maxima"
 
-#: ../src/wxMaximaFrame.cpp:603
+#: ../src/wxMaximaFrame.cpp:602
 msgid "Show Template\tCtrl-Shift-K"
 msgstr "Exibir modelo\tCtrl-Shift-K"
 
-#: ../src/wxMaximaFrame.cpp:968
+#: ../src/wxMaximaFrame.cpp:967
 msgid "Show a tip"
 msgstr "Mostrar uma dica"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Show all commands similar to:"
 msgstr "Mostrar todos os comandos semelhantes a:"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Show an example for the command:"
 msgstr "Mostrar um exemplo para o comando:"
 
-#: ../src/wxMaximaFrame.cpp:962
+#: ../src/wxMaximaFrame.cpp:961
 msgid "Show an example of usage"
 msgstr "Mostrar um exemplo de uso"
 
-#: ../src/wxMaximaFrame.cpp:965
+#: ../src/wxMaximaFrame.cpp:964
 msgid "Show commands similar to"
 msgstr "Mostrar os comandos semelhantes a"
 
-#: ../src/wxMaximaFrame.cpp:661
+#: ../src/wxMaximaFrame.cpp:660
 msgid "Show defined functions"
 msgstr "Mostrar funções definidas"
 
-#: ../src/wxMaximaFrame.cpp:666
+#: ../src/wxMaximaFrame.cpp:665
 msgid "Show defined variables"
 msgstr "Mostrar variáveis definidas"
 
-#: ../src/wxMaximaFrame.cpp:663
+#: ../src/wxMaximaFrame.cpp:662
 msgid "Show definition of a function"
 msgstr "Mostrar definição de uma função"
 
-#: ../src/wxMaximaFrame.cpp:604
+#: ../src/wxMaximaFrame.cpp:603
 msgid "Show function template"
 msgstr "Mostrar modelo de função"
 
@@ -3670,7 +3673,7 @@ msgstr "Mostrar expressões grandes no documento do wxMaxima."
 msgid "Show long expressions:"
 msgstr "Mostrar expressões longas"
 
-#: ../src/wxMaxima.cpp:3341
+#: ../src/wxMaxima.cpp:3353
 msgid "Show the definition of function:"
 msgstr "Mostrar a definição da função:"
 
@@ -3679,44 +3682,44 @@ msgstr "Mostrar a definição da função:"
 msgid "Show user-defined labels instead of (%oxx)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:953 ../src/wxMaximaFrame.cpp:956
+#: ../src/wxMaximaFrame.cpp:952 ../src/wxMaximaFrame.cpp:955
 #, fuzzy
 msgid "Show wxMaxima help"
 msgstr "Mostrar ajuda do Maxima"
 
-#: ../src/wxMaximaFrame.cpp:1381
+#: ../src/wxMaximaFrame.cpp:1380
 msgid "Sigma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1211
+#: ../src/wxMaximaFrame.cpp:1210
 msgid "Simplify"
 msgstr "Simplificar"
 
-#: ../src/wxMaximaFrame.cpp:831
+#: ../src/wxMaximaFrame.cpp:830
 msgid "Simplify &Radicals"
 msgstr "Simplificar &radicais"
 
-#: ../src/wxMaximaFrame.cpp:1212
+#: ../src/wxMaximaFrame.cpp:1211
 msgid "Simplify (r)"
 msgstr "Simplificar (r)"
 
-#: ../src/wxMaximaFrame.cpp:1218
+#: ../src/wxMaximaFrame.cpp:1217
 msgid "Simplify (tr)"
 msgstr "Simplificar (tr)"
 
-#: ../src/MathCtrl.cpp:995
+#: ../src/MathCtrl.cpp:1037
 msgid "Simplify Expression"
 msgstr "Simplificar expressão"
 
-#: ../src/wxMaximaFrame.cpp:857
+#: ../src/wxMaximaFrame.cpp:856
 msgid "Simplify an expression containing factorials"
 msgstr "Simplificar uma expressão envolvendo fatoriais"
 
-#: ../src/wxMaximaFrame.cpp:832
+#: ../src/wxMaximaFrame.cpp:831
 msgid "Simplify expression containing radicals"
 msgstr "Simplificar uma expressão envolvendo radicais"
 
-#: ../src/wxMaximaFrame.cpp:830
+#: ../src/wxMaximaFrame.cpp:829
 msgid "Simplify rational expression"
 msgstr "Simplificar uma expressão racional"
 
@@ -3724,7 +3727,7 @@ msgstr "Simplificar uma expressão racional"
 msgid "Simplify the sum"
 msgstr "Simplificar a soma"
 
-#: ../src/wxMaximaFrame.cpp:868
+#: ../src/wxMaximaFrame.cpp:867
 msgid "Simplify trigonometric expression"
 msgstr "Simplificar uma expressão trigonométrica"
 
@@ -3740,87 +3743,87 @@ msgstr ""
 "formato 'Documento XML do wxMaxima' para que a imagem seja salva junto com o "
 "documento."
 
-#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
+#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
 msgid "Solution:"
 msgstr "Solução:"
 
-#: ../src/wxMaxima.cpp:3461 ../src/wxMaxima.cpp:3475 ../src/wxMaxima.cpp:5020
+#: ../src/wxMaxima.cpp:3473 ../src/wxMaxima.cpp:3487 ../src/wxMaxima.cpp:5032
 msgid "Solve"
 msgstr "Resolver"
 
-#: ../src/wxMaximaFrame.cpp:706
+#: ../src/wxMaximaFrame.cpp:705
 msgid "Solve &Algebraic System..."
 msgstr "Resolver sistema &algébrico..."
 
-#: ../src/wxMaximaFrame.cpp:703
+#: ../src/wxMaximaFrame.cpp:702
 msgid "Solve &Linear System..."
 msgstr "Resolver sistema &linear..."
 
-#: ../src/wxMaximaFrame.cpp:714
+#: ../src/wxMaximaFrame.cpp:713
 msgid "Solve &ODE..."
 msgstr "Resolver ED&O..."
 
-#: ../src/wxMaximaFrame.cpp:690
+#: ../src/wxMaximaFrame.cpp:689
 msgid "Solve (to_poly)..."
 msgstr "Resolver (to_poly)..."
 
-#: ../src/wxMaxima.cpp:3511 ../src/wxMaxima.cpp:3635
+#: ../src/wxMaxima.cpp:3523 ../src/wxMaxima.cpp:3647
 msgid "Solve ODE"
 msgstr "Resolver EDO ..."
 
-#: ../src/wxMaximaFrame.cpp:728
+#: ../src/wxMaximaFrame.cpp:727
 msgid "Solve ODE with Lapla&ce..."
 msgstr "Resolver EDO com Laplace..."
 
-#: ../src/wxMaximaFrame.cpp:1222
+#: ../src/wxMaximaFrame.cpp:1221
 msgid "Solve ODE..."
 msgstr "Resolver EDO..."
 
-#: ../src/wxMaxima.cpp:3586 ../src/wxMaxima.cpp:3597
+#: ../src/wxMaxima.cpp:3598 ../src/wxMaxima.cpp:3609
 msgid "Solve algebraic system"
 msgstr "Resolver sistema algébrico"
 
-#: ../src/wxMaximaFrame.cpp:707
+#: ../src/wxMaximaFrame.cpp:706
 msgid "Solve algebraic system of equations"
 msgstr "Resolver sistema de equações algébricas"
 
-#: ../src/wxMaximaFrame.cpp:725
+#: ../src/wxMaximaFrame.cpp:724
 msgid "Solve boundary value problem for second degree ODE"
 msgstr "Resolver problema de contorno para EDO de segunda ordem"
 
-#: ../src/wxMaximaFrame.cpp:689
+#: ../src/wxMaximaFrame.cpp:688
 msgid "Solve equation(s)"
 msgstr "Resolver equação(ões)"
 
-#: ../src/wxMaximaFrame.cpp:691
+#: ../src/wxMaximaFrame.cpp:690
 msgid "Solve equation(s) with to_poly_solve"
 msgstr "Resolver equação(ões) como to_poly_solve"
 
-#: ../src/wxMaximaFrame.cpp:719
+#: ../src/wxMaximaFrame.cpp:718
 msgid "Solve initial value problem for first degree ODE"
 msgstr "Resolver problema de valor inicial para EDO de primeira ordem"
 
-#: ../src/wxMaximaFrame.cpp:722
+#: ../src/wxMaximaFrame.cpp:721
 msgid "Solve initial value problem for second degree ODE"
 msgstr "Resolver problema de valor inicial para EDO de segunda ordem"
 
-#: ../src/wxMaxima.cpp:3610 ../src/wxMaxima.cpp:3621
+#: ../src/wxMaxima.cpp:3622 ../src/wxMaxima.cpp:3633
 msgid "Solve linear system"
 msgstr "Resolver sistema linear"
 
-#: ../src/wxMaximaFrame.cpp:704
+#: ../src/wxMaximaFrame.cpp:703
 msgid "Solve linear system of equations"
 msgstr "Resolver sistema de equações lineares"
 
-#: ../src/wxMaximaFrame.cpp:715
+#: ../src/wxMaximaFrame.cpp:714
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr "Resolver equação diferencial ordinário de grau máximo 2"
 
-#: ../src/wxMaximaFrame.cpp:729
+#: ../src/wxMaximaFrame.cpp:728
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr "Resolver equação diferencial ordinário com transformada de Laplace"
 
-#: ../src/wxMaximaFrame.cpp:1221 ../src/MathCtrl.cpp:992
+#: ../src/MathCtrl.cpp:1034 ../src/wxMaximaFrame.cpp:1220
 msgid "Solve..."
 msgstr "Resolver..."
 
@@ -3844,7 +3847,7 @@ msgstr "Especial"
 msgid "Special constants"
 msgstr "Constantes especiais"
 
-#: ../src/MathCtrl.cpp:922
+#: ../src/MathCtrl.cpp:964
 msgid "Start Animation"
 msgstr "Iniciar animação"
 
@@ -3863,28 +3866,28 @@ msgstr ""
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:294
+#: ../src/wxMaxima.cpp:295
 msgid "Starting Maxima process failed"
 msgstr "Falha ao iniciar o Maxima"
 
-#: ../src/wxMaxima.cpp:928
+#: ../src/wxMaxima.cpp:933
 msgid "Starting Maxima..."
 msgstr "Iniciando Maxima..."
 
-#: ../src/wxMaxima.cpp:292 ../src/wxMaxima.cpp:860
+#: ../src/wxMaxima.cpp:293 ../src/wxMaxima.cpp:865
 msgid "Starting server failed"
 msgstr "Falha ao iniciar o servidor"
 
-#: ../src/wxMaxima.cpp:841
+#: ../src/wxMaxima.cpp:846
 #, c-format
 msgid "Starting server on port %d"
 msgstr "Iniciando servidor na porta %d"
 
-#: ../src/wxMaximaFrame.cpp:342
+#: ../src/wxMaximaFrame.cpp:341
 msgid "Statistics"
 msgstr "Estatísticas"
 
-#: ../src/wxMaximaFrame.cpp:550
+#: ../src/wxMaximaFrame.cpp:549
 msgid "Statistics\tAlt-Shift-S"
 msgstr "Estatísticas\tAlt-Shift-S"
 
@@ -3900,11 +3903,11 @@ msgstr "Estilo"
 msgid "Styles"
 msgstr "Estilos"
 
-#: ../src/wxMaximaFrame.cpp:1283
+#: ../src/wxMaximaFrame.cpp:1282
 msgid "Subsample..."
 msgstr "Subamostra..."
 
-#: ../src/wxMaximaFrame.cpp:1496
+#: ../src/wxMaximaFrame.cpp:1515
 msgid "Subsection"
 msgstr "Subseção"
 
@@ -3912,20 +3915,20 @@ msgstr "Subseção"
 msgid "Subsection cell"
 msgstr "Célula de subseção"
 
-#: ../src/wxMaximaFrame.cpp:1216
+#: ../src/wxMaximaFrame.cpp:1215
 msgid "Subst..."
 msgstr "Substituir..."
 
-#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3423
-#: ../src/wxMaxima.cpp:5089
+#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3435
+#: ../src/wxMaxima.cpp:5101
 msgid "Substitute"
 msgstr "Substituir"
 
-#: ../src/wxMaximaFrame.cpp:906 ../src/MathCtrl.cpp:998
+#: ../src/MathCtrl.cpp:1040 ../src/wxMaximaFrame.cpp:905
 msgid "Substitute..."
 msgstr "Substituir..."
 
-#: ../src/wxMaximaFrame.cpp:1497
+#: ../src/wxMaximaFrame.cpp:1516
 #, fuzzy
 msgid "Subsubsection"
 msgstr "Subseção"
@@ -3935,7 +3938,7 @@ msgstr "Subseção"
 msgid "Subsubsection cell"
 msgstr "Célula de subseção"
 
-#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4226
+#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4238
 msgid "Sum"
 msgstr "Soma"
 
@@ -3943,37 +3946,37 @@ msgstr "Soma"
 msgid "Sum sign"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:553
+#: ../src/wxMaximaFrame.cpp:552
 #, fuzzy
 msgid "Symbols\tAlt-Shift-Y"
 msgstr "Estatísticas\tAlt-Shift-S"
 
-#: ../src/wxMaxima.cpp:4456
+#: ../src/wxMaxima.cpp:4468
 msgid "System info"
 msgstr "Informações de sistema"
 
-#: ../src/wxMaximaFrame.cpp:320
+#: ../src/wxMaximaFrame.cpp:319
 msgid "Table of Contents"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:556
+#: ../src/wxMaximaFrame.cpp:555
 #, fuzzy
 msgid "Table of Contents\tAlt-Shift-T"
 msgstr "Barra de ferramentas\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:1382
+#: ../src/wxMaximaFrame.cpp:1381
 msgid "Tau"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Taylor series:"
 msgstr "Série de Taylor:"
 
-#: ../src/wxMaxima.cpp:3963
+#: ../src/wxMaxima.cpp:3975
 msgid "Tellrat"
 msgstr "Tellrat"
 
-#: ../src/wxMaximaFrame.cpp:1494
+#: ../src/wxMaximaFrame.cpp:1513
 msgid "Text"
 msgstr "Texto"
 
@@ -4019,7 +4022,7 @@ msgstr ""
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr ""
 
-#: ../src/TextCell.cpp:136
+#: ../src/TextCell.cpp:134
 msgid ""
 "The letter \"X\" is of width zero. Installing http://www.math.union.edu/"
 "~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts\" in "
@@ -4036,7 +4039,7 @@ msgstr ""
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:959
+#: ../src/wxMaximaFrame.cpp:958
 msgid "The offline manual of maxima"
 msgstr ""
 
@@ -4074,7 +4077,7 @@ msgstr ""
 "wxmaxima.sourceforge.net/wiki/index.php/Tutorials para mais informações "
 "sobre o uso do wxMaxima e do Maxima."
 
-#: ../src/SlideShowCell.cpp:332
+#: ../src/SlideShowCell.cpp:336
 msgid ""
 "There was an error during GIF export!\n"
 "\n"
@@ -4085,7 +4088,7 @@ msgstr ""
 "Certifique-se de que o ImageMagick está instalado e o wxMaxima pode "
 "encontrar o programa \"convert\"."
 
-#: ../src/wxMaxima.cpp:442
+#: ../src/wxMaxima.cpp:447
 msgid ""
 "There was an error in generated XML!\n"
 "\n"
@@ -4095,7 +4098,7 @@ msgstr ""
 "\n"
 "Favor relatar isso como um bug."
 
-#: ../src/wxMaximaFrame.cpp:1371
+#: ../src/wxMaximaFrame.cpp:1370
 msgid "Theta"
 msgstr ""
 
@@ -4103,7 +4106,7 @@ msgstr ""
 msgid "Ticks:"
 msgstr "Marcações:"
 
-#: ../src/wxMaxima.cpp:4153 ../src/wxMaxima.cpp:5065
+#: ../src/wxMaxima.cpp:4165 ../src/wxMaxima.cpp:5077
 msgid "Times:"
 msgstr "Vezes:"
 
@@ -4111,7 +4114,7 @@ msgstr "Vezes:"
 msgid "Tips not available, sorry!"
 msgstr "Dicas não disponíveis, desculpe!"
 
-#: ../src/wxMaximaFrame.cpp:1495
+#: ../src/wxMaximaFrame.cpp:1514
 msgid "Title"
 msgstr "Título"
 
@@ -4130,19 +4133,19 @@ msgstr ""
 "você segurar Shift enquanto clica, todos os subníveis daquela célula também "
 "serão recolhidos/expandidos."
 
-#: ../src/wxMaximaFrame.cpp:938
+#: ../src/wxMaximaFrame.cpp:937
 msgid "To &Bigfloat"
 msgstr "Para &bigfloat"
 
-#: ../src/wxMaximaFrame.cpp:935
+#: ../src/wxMaximaFrame.cpp:934
 msgid "To &Float"
 msgstr "Para &float"
 
-#: ../src/MathCtrl.cpp:990
+#: ../src/MathCtrl.cpp:1032
 msgid "To Float"
 msgstr "Para float"
 
-#: ../src/wxMaximaFrame.cpp:941
+#: ../src/wxMaximaFrame.cpp:940
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr ""
 
@@ -4183,51 +4186,51 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:41 ../src/Plot2dWiz.cpp:40 ../src/Plot2dWiz.cpp:50
 #: ../src/Plot2dWiz.cpp:539 ../src/Plot3dWiz.cpp:39 ../src/Plot3dWiz.cpp:48
-#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4241
+#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4253
 msgid "To:"
 msgstr "Até:"
 
-#: ../src/wxMaximaFrame.cpp:912
+#: ../src/wxMaximaFrame.cpp:911
 msgid "Toggle &Algebraic Flag"
 msgstr "Alternar flag &algébrico"
 
-#: ../src/wxMaximaFrame.cpp:933
+#: ../src/wxMaximaFrame.cpp:932
 msgid "Toggle &Numeric Output"
 msgstr "Alternar saída &numérica"
 
-#: ../src/wxMaximaFrame.cpp:673
+#: ../src/wxMaximaFrame.cpp:672
 msgid "Toggle &Time Display"
 msgstr "Alternar exibição do &tempo"
 
-#: ../src/wxMaximaFrame.cpp:913
+#: ../src/wxMaximaFrame.cpp:912
 msgid "Toggle algebraic flag"
 msgstr "Alternar flag algébrico"
 
-#: ../src/wxMaximaFrame.cpp:577
+#: ../src/wxMaximaFrame.cpp:576
 msgid "Toggle full screen editing"
 msgstr "Alternar edição em tela cheia"
 
-#: ../src/wxMaximaFrame.cpp:934
+#: ../src/wxMaximaFrame.cpp:933
 msgid "Toggle numeric output"
 msgstr "Alternar saída numérica"
 
-#: ../src/wxMaxima.cpp:4464
+#: ../src/wxMaxima.cpp:4476
 msgid "Toolbar icons"
 msgstr "Ícones da barra de ferramentas"
 
-#: ../src/wxMaxima.cpp:4465
+#: ../src/wxMaxima.cpp:4477
 msgid "Translated by"
 msgstr "Traduzido por"
 
-#: ../src/wxMaximaFrame.cpp:763
+#: ../src/wxMaximaFrame.cpp:762
 msgid "Transpose a matrix"
 msgstr "Transposta de uma matriz"
 
-#: ../src/MathCtrl.cpp:5834
+#: ../src/MathCtrl.cpp:5886
 msgid "Trying to undo an action without starting cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5901
+#: ../src/MathCtrl.cpp:5953
 msgid "Trying to undo something but the undo action is empty."
 msgstr ""
 
@@ -4235,11 +4238,11 @@ msgstr ""
 msgid "Turkish"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:970
+#: ../src/wxMaximaFrame.cpp:969
 msgid "Tutorials"
 msgstr "Tutoriais"
 
-#: ../src/wxMaxima.cpp:4778
+#: ../src/wxMaxima.cpp:4790
 msgid "Two sample t-test"
 msgstr "Teste t com duas amostras"
 
@@ -4251,15 +4254,15 @@ msgstr "Tipo:"
 msgid "Ukrainian"
 msgstr "Ucraniano"
 
-#: ../src/wxMaxima.cpp:5356
+#: ../src/wxMaxima.cpp:5372
 msgid "Un-closed parenthesis"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5323
+#: ../src/wxMaxima.cpp:5335
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5889
 msgid ""
 "Unable to interpret the version info I got from http://andrejv.github.io//"
 "wxmaxima/version.txt: "
@@ -4273,11 +4276,11 @@ msgstr "Sublinhado"
 msgid "Underscore converts to subscripts:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:492
+#: ../src/wxMaximaFrame.cpp:491
 msgid "Undo\tCtrl-Z"
 msgstr "&Desfazer\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:493
+#: ../src/wxMaximaFrame.cpp:492
 msgid "Undo last change"
 msgstr "Desfazer última alteração"
 
@@ -4285,24 +4288,24 @@ msgstr "Desfazer última alteração"
 msgid "Undo limit (0 for none):"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:625
+#: ../src/wxMaximaFrame.cpp:624
 #, fuzzy
 msgid "Unfold All\tCtrl-Alt-]"
 msgstr "Selecionar tudo\tCtrl-A"
 
-#: ../src/wxMaximaFrame.cpp:626
+#: ../src/wxMaximaFrame.cpp:625
 msgid "Unfold all folded sections"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4458
+#: ../src/wxMaxima.cpp:4470
 msgid "Unicode Support"
 msgstr "Suporte Unicode"
 
-#: ../src/wxMaxima.cpp:5335
+#: ../src/wxMaxima.cpp:5347
 msgid "Unterminated comment."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5309
+#: ../src/wxMaxima.cpp:5321
 msgid "Unterminated string."
 msgstr ""
 
@@ -4310,15 +4313,15 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5859 ../src/wxMaxima.cpp:5866 ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5874 ../src/wxMaxima.cpp:5881 ../src/wxMaxima.cpp:5889
 msgid "Upgrade"
 msgstr "Atualizar"
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Upper bound:"
 msgstr "Limite superior:"
 
-#: ../src/wxMaximaFrame.cpp:1383
+#: ../src/wxMaximaFrame.cpp:1382
 #, fuzzy
 msgid "Upsilon"
 msgstr "Epsilon:"
@@ -4363,22 +4366,22 @@ msgstr ""
 msgid "User-defined labels"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3525
-#: ../src/wxMaxima.cpp:3541 ../src/wxMaxima.cpp:3649
+#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3537
+#: ../src/wxMaxima.cpp:3553 ../src/wxMaxima.cpp:3661
 msgid "Value:"
 msgstr "Valor:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:5019 ../src/wxMaxima.cpp:5064
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:5031 ../src/wxMaxima.cpp:5076
 msgid "Variable(s):"
 msgstr "Variável(is):"
 
 #: ../src/IntegrateWiz.cpp:33 ../src/LimitWiz.cpp:30 ../src/Plot2dWiz.cpp:34
 #: ../src/Plot2dWiz.cpp:44 ../src/Plot2dWiz.cpp:533 ../src/Plot3dWiz.cpp:33
 #: ../src/Plot3dWiz.cpp:42 ../src/SeriesWiz.cpp:36 ../src/SumWiz.cpp:30
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3749
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3761
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5045
 msgid "Variable:"
 msgstr "Variável:"
 
@@ -4386,25 +4389,25 @@ msgstr "Variável:"
 msgid "Variables"
 msgstr "Variáveis"
 
-#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3571 ../src/wxMaxima.cpp:4206
-#: ../src/wxMaxima.cpp:4807
+#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3583 ../src/wxMaxima.cpp:4218
+#: ../src/wxMaxima.cpp:4819
 msgid "Variables:"
 msgstr "Variáveis:"
 
-#: ../src/wxMaximaFrame.cpp:1257
+#: ../src/wxMaximaFrame.cpp:1256
 msgid "Variance..."
 msgstr "Variância..."
 
-#: ../src/wxMaximaFrame.cpp:580
+#: ../src/wxMaximaFrame.cpp:579
 msgid "View"
 msgstr ""
 
-#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1674 ../src/wxMaxima.cpp:1769
-#: ../src/wxMaxima.cpp:1950
+#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1679 ../src/wxMaxima.cpp:1774
+#: ../src/wxMaxima.cpp:1955
 msgid "Warning"
 msgstr "Aviso"
 
-#: ../src/wxMaximaFrame.cpp:109 ../src/wxMaximaFrame.cpp:295
+#: ../src/wxMaximaFrame.cpp:108 ../src/wxMaximaFrame.cpp:294
 msgid "Welcome to wxMaxima"
 msgstr "Bem-vindo ao wxMaxima"
 
@@ -4427,7 +4430,7 @@ msgid ""
 "introducing an empty line."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2567
+#: ../src/wxMaxima.cpp:2574
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) "
 "(*.wxm)|*.wxm"
@@ -4443,7 +4446,7 @@ msgid ""
 "as equation markers"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6798
+#: ../src/MathCtrl.cpp:6856
 msgid "Wrapped search"
 msgstr ""
 
@@ -4451,15 +4454,15 @@ msgstr ""
 msgid "Write matching parenthesis in text controls."
 msgstr "Escrever parêntesis aos pares nos controles de texto."
 
-#: ../src/wxMaxima.cpp:4461
+#: ../src/wxMaxima.cpp:4473
 msgid "Written by"
 msgstr "Escrito por"
 
-#: ../src/wxMaximaFrame.cpp:557
+#: ../src/wxMaximaFrame.cpp:556
 msgid "XML Inspector"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1377
+#: ../src/wxMaximaFrame.cpp:1376
 msgid "Xi"
 msgstr ""
 
@@ -4530,7 +4533,7 @@ msgstr ""
 "segure Shift enquanto move o cursor horizontal - e então operar na seleção. "
 "Isso é útil quando você quer apagar ou calcular múltiplas células."
 
-#: ../src/wxMaxima.cpp:5856
+#: ../src/wxMaxima.cpp:5871
 #, c-format
 msgid ""
 "You have version %s. Current version is %s.\n"
@@ -4541,41 +4544,41 @@ msgstr ""
 "\n"
 "Selecione OK para visitar a página do wxMaxima."
 
-#: ../src/wxMaxima.cpp:5921
+#: ../src/wxMaxima.cpp:5936
 msgid "Your changes will be lost if you don't save them."
 msgstr "Suas mudanças serão perdidas se você não as salvar."
 
-#: ../src/wxMaxima.cpp:5866
+#: ../src/wxMaxima.cpp:5881
 msgid "Your version of wxMaxima is up to date."
 msgstr "Sua versão do wxMaxima está atualizada."
 
-#: ../src/wxMaximaFrame.cpp:1369
+#: ../src/wxMaximaFrame.cpp:1368
 msgid "Zeta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:562
+#: ../src/wxMaximaFrame.cpp:561
 #, fuzzy
 msgid "Zoom &In\tCtrl-+"
 msgstr "Aprox&imar\tAlt-I"
 
-#: ../src/wxMaximaFrame.cpp:564
+#: ../src/wxMaximaFrame.cpp:563
 #, fuzzy
 msgid "Zoom Ou&t\tCtrl--"
 msgstr "Afas&tar\tAlt-O"
 
-#: ../src/wxMaximaFrame.cpp:563
+#: ../src/wxMaximaFrame.cpp:562
 msgid "Zoom in 10%"
 msgstr "Aproximar em 10%"
 
-#: ../src/wxMaximaFrame.cpp:565
+#: ../src/wxMaximaFrame.cpp:564
 msgid "Zoom out 10%"
 msgstr "Afastar em 10%"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaximaFrame.cpp:287
 msgid "[ unsaved ]"
 msgstr "[ não salvo ]"
 
-#: ../src/wxMaxima.cpp:5700
+#: ../src/wxMaxima.cpp:5715
 msgid "[ unsaved* ]"
 msgstr "[ não salvo* ]"
 
@@ -4584,17 +4587,17 @@ msgstr "[ não salvo* ]"
 msgid "[%i digits]"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4392
+#: ../src/MathCtrl.cpp:4447
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" style=\"max-width:90%%;\" >\n"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4517
+#: ../src/MathCtrl.cpp:4572
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" >"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1333
+#: ../src/wxMaximaFrame.cpp:1332
 msgid "alpha"
 msgstr ""
 
@@ -4607,7 +4610,7 @@ msgstr "Expandir"
 msgid "antisymmetric"
 msgstr "antisimétrica"
 
-#: ../src/wxMaximaFrame.cpp:1334
+#: ../src/wxMaximaFrame.cpp:1333
 msgid "beta"
 msgstr ""
 
@@ -4651,7 +4654,7 @@ msgstr ""
 msgid "bug:Invalid sup tag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1354
+#: ../src/wxMaximaFrame.cpp:1353
 msgid "chi"
 msgstr ""
 
@@ -4664,7 +4667,7 @@ msgstr ""
 msgid "default"
 msgstr "padrão"
 
-#: ../src/wxMaximaFrame.cpp:1336
+#: ../src/wxMaximaFrame.cpp:1335
 msgid "delta"
 msgstr ""
 
@@ -4676,7 +4679,7 @@ msgstr "diagonal"
 msgid "empty"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1337
+#: ../src/wxMaximaFrame.cpp:1336
 #, fuzzy
 msgid "epsilon"
 msgstr "Epsilon:"
@@ -4685,7 +4688,7 @@ msgstr "Epsilon:"
 msgid "equivalent"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1339
+#: ../src/wxMaximaFrame.cpp:1338
 msgid "eta"
 msgstr ""
 
@@ -4701,7 +4704,7 @@ msgid ""
 "all=_ marks subscripts."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1335
+#: ../src/wxMaximaFrame.cpp:1334
 msgid "gamma"
 msgstr ""
 
@@ -4730,15 +4733,15 @@ msgstr "embutido"
 msgid "intersection"
 msgstr "Direção:"
 
-#: ../src/wxMaximaFrame.cpp:1341
+#: ../src/wxMaximaFrame.cpp:1340
 msgid "iota"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1342
+#: ../src/wxMaximaFrame.cpp:1341
 msgid "kappa"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1343
+#: ../src/wxMaximaFrame.cpp:1342
 msgid "lambda"
 msgstr ""
 
@@ -4755,7 +4758,7 @@ msgstr "Célula de subseção"
 msgid "logscale"
 msgstr "escala logarítmica"
 
-#: ../src/wxMaxima.cpp:3783
+#: ../src/wxMaxima.cpp:3795
 msgid "matrix[i,j]:"
 msgstr "matriz[i,j]:"
 
@@ -4763,7 +4766,7 @@ msgstr "matriz[i,j]:"
 msgid "maxima's pwd is path to document"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1344
+#: ../src/wxMaximaFrame.cpp:1343
 msgid "mu"
 msgstr ""
 
@@ -4780,7 +4783,7 @@ msgstr ""
 msgid "nand"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4524
+#: ../src/wxMaxima.cpp:4536
 msgid "no"
 msgstr "não"
 
@@ -4806,15 +4809,15 @@ msgstr ""
 msgid "not subset or equal"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1345
+#: ../src/wxMaximaFrame.cpp:1344
 msgid "nu"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1356
+#: ../src/wxMaximaFrame.cpp:1355
 msgid "omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1347
+#: ../src/wxMaximaFrame.cpp:1346
 msgid "omicron"
 msgstr ""
 
@@ -4827,11 +4830,11 @@ msgstr ""
 msgid "partial sign"
 msgstr "Frações parciais"
 
-#: ../src/wxMaximaFrame.cpp:1353
+#: ../src/wxMaximaFrame.cpp:1352
 msgid "phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1348
+#: ../src/wxMaximaFrame.cpp:1347
 msgid "pi"
 msgstr ""
 
@@ -4843,11 +4846,11 @@ msgstr ""
 msgid "proportional to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1355
+#: ../src/wxMaximaFrame.cpp:1354
 msgid "psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1349
+#: ../src/wxMaximaFrame.cpp:1348
 msgid "rho"
 msgstr ""
 
@@ -4855,7 +4858,7 @@ msgstr ""
 msgid "right"
 msgstr "direita"
 
-#: ../src/wxMaximaFrame.cpp:1350
+#: ../src/wxMaximaFrame.cpp:1349
 msgid "sigma"
 msgstr ""
 
@@ -4877,7 +4880,7 @@ msgstr "Célula de subseção"
 msgid "symmetric"
 msgstr "simétrica"
 
-#: ../src/wxMaximaFrame.cpp:1351
+#: ../src/wxMaximaFrame.cpp:1350
 msgid "tau"
 msgstr ""
 
@@ -4889,7 +4892,7 @@ msgstr ""
 msgid "there is no"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1340
+#: ../src/wxMaximaFrame.cpp:1339
 msgid "theta"
 msgstr ""
 
@@ -4905,12 +4908,12 @@ msgstr ""
 msgid "union"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5903
+#: ../src/wxMaxima.cpp:5918
 msgid "unsaved"
 msgstr "não salvo"
 
-#: ../src/wxMaximaFrame.cpp:290 ../src/wxMaxima.cpp:2559
-#: ../src/wxMaxima.cpp:2826
+#: ../src/wxMaxima.cpp:2566 ../src/wxMaxima.cpp:2834
+#: ../src/wxMaximaFrame.cpp:289
 msgid "untitled"
 msgstr "sem título"
 
@@ -4919,27 +4922,27 @@ msgstr "sem título"
 msgid "untitled %d"
 msgstr "sem título %d"
 
-#: ../src/wxMaximaFrame.cpp:1352
+#: ../src/wxMaximaFrame.cpp:1351
 #, fuzzy
 msgid "upsilon"
 msgstr "Epsilon:"
 
-#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4538
+#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4550
 msgid "wxMaxima"
 msgstr "wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
-#: ../src/wxMaxima.cpp:5700 ../src/wxMaxima.cpp:5709 ../src/wxMaxima.cpp:5712
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaxima.cpp:5715 ../src/wxMaxima.cpp:5724
+#: ../src/wxMaxima.cpp:5727 ../src/wxMaximaFrame.cpp:287
 #, c-format
 msgid "wxMaxima %s "
 msgstr "wxMaxima %s "
 
-#: ../src/wxMaximaFrame.cpp:952
+#: ../src/wxMaximaFrame.cpp:951
 #, fuzzy
 msgid "wxMaxima &Help\tCtrl+?"
 msgstr "&Ajuda do Maxima\tCTRL+?"
 
-#: ../src/wxMaximaFrame.cpp:955
+#: ../src/wxMaximaFrame.cpp:954
 #, fuzzy
 msgid "wxMaxima &Help\tF1"
 msgstr "&Ajuda do Maxima\tF1"
@@ -4951,11 +4954,11 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1619
+#: ../src/wxMaxima.cpp:1624
 msgid "wxMaxima cannot open content.xml in the .wxmx zip archive "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1633
+#: ../src/wxMaxima.cpp:1638
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
@@ -4963,7 +4966,7 @@ msgstr ""
 msgid "wxMaxima configuration"
 msgstr "Configuração do wxMaxima"
 
-#: ../src/wxMaxima.cpp:1947
+#: ../src/wxMaxima.cpp:1952
 msgid ""
 "wxMaxima could not find Maxima!\n"
 "\n"
@@ -4975,7 +4978,7 @@ msgstr ""
 "Queira configurar o wxMaxima com 'Editar->Configurações.\n"
 "Então inicie o Maxima com 'Maxima->Reiniciar maxima'."
 
-#: ../src/wxMaxima.cpp:2204
+#: ../src/wxMaxima.cpp:2209
 msgid ""
 "wxMaxima could not find help files.\n"
 "\n"
@@ -4985,7 +4988,7 @@ msgstr ""
 "\n"
 "Queira verificar sua instalação."
 
-#: ../src/wxMaxima.cpp:2032
+#: ../src/wxMaxima.cpp:2037
 msgid ""
 "wxMaxima could not find tip files.\n"
 "\n"
@@ -4995,7 +4998,7 @@ msgstr ""
 "\n"
 "Queira verificar sua instalação."
 
-#: ../src/wxMaxima.cpp:282
+#: ../src/wxMaxima.cpp:283
 msgid ""
 "wxMaxima could not start the server.\n"
 "\n"
@@ -5017,23 +5020,23 @@ msgstr ""
 "'%'. Se você selecionou algo no documento, a seleção será usada no lugar de "
 "'%'."
 
-#: ../src/wxMaxima.cpp:2330
+#: ../src/wxMaxima.cpp:2336
 msgid "wxMaxima document"
 msgstr "Documento do wxMaxima"
 
-#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2799
+#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2807
 msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 msgstr "Documento do wxMaxima (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 
-#: ../src/wxMaxima.cpp:1455 ../src/wxMaxima.cpp:1469
+#: ../src/wxMaxima.cpp:1460 ../src/wxMaxima.cpp:1474
 msgid "wxMaxima encountered an error loading "
 msgstr "o wxMaxima encontrou um erro carregando "
 
-#: ../src/wxMaxima.cpp:4463
+#: ../src/wxMaxima.cpp:4475
 msgid "wxMaxima icon"
 msgstr "Ícone do wxMaxima"
 
-#: ../src/wxMaxima.cpp:4455
+#: ../src/wxMaxima.cpp:4467
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "MAXIMA based on wxWidgets."
@@ -5041,7 +5044,7 @@ msgstr ""
 "O wxMaxima é uma interface para o sistema de álgebra computacional MAXIMA "
 "baseada no wxWidgets."
 
-#: ../src/wxMaxima.cpp:4516
+#: ../src/wxMaxima.cpp:4528
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "Maxima based on wxWidgets."
@@ -5061,11 +5064,11 @@ msgstr ""
 msgid "x"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1346
+#: ../src/wxMaximaFrame.cpp:1345
 msgid "xi"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1643
+#: ../src/wxMaxima.cpp:1648
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
@@ -5074,11 +5077,11 @@ msgstr ""
 msgid "xor"
 msgstr "Exportar"
 
-#: ../src/wxMaxima.cpp:4522
+#: ../src/wxMaxima.cpp:4534
 msgid "yes"
 msgstr "sim"
 
-#: ../src/wxMaximaFrame.cpp:1338
+#: ../src/wxMaximaFrame.cpp:1337
 msgid "zeta"
 msgstr ""
 

--- a/locales/ru.po
+++ b/locales/ru.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxMaxima\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-07 21:42+0200\n"
+"POT-Creation-Date: 2016-10-16 17:47+0900\n"
 "PO-Revision-Date: 2013-03-13 11:01+0300\n"
 "Last-Translator: Max Musatov <m1kc@yandex.ru>\n"
 "Language-Team: \n"
@@ -21,7 +21,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.5.4\n"
 
-#: ../src/wxMaxima.cpp:4519
+#: ../src/wxMaxima.cpp:4531
 #, c-format
 msgid ""
 "\n"
@@ -34,7 +34,7 @@ msgstr ""
 "wxWidgets: %d.%d.%d\n"
 "Поддержка Unicode: %s"
 
-#: ../src/wxMaxima.cpp:4532
+#: ../src/wxMaxima.cpp:4544
 msgid ""
 "\n"
 "Lisp: "
@@ -42,7 +42,7 @@ msgstr ""
 "\n"
 "Lisp: "
 
-#: ../src/wxMaxima.cpp:4528
+#: ../src/wxMaxima.cpp:4540
 msgid ""
 "\n"
 "Maxima version: "
@@ -50,7 +50,7 @@ msgstr ""
 "\n"
 "Версия Maxima: "
 
-#: ../src/wxMaxima.cpp:5381
+#: ../src/wxMaxima.cpp:5397
 msgid ""
 "\n"
 "Not connected to Maxima!\n"
@@ -58,7 +58,7 @@ msgstr ""
 "\n"
 "Нет подключения к Maxima!\n"
 
-#: ../src/wxMaxima.cpp:4530
+#: ../src/wxMaxima.cpp:4542
 msgid ""
 "\n"
 "Not connected."
@@ -78,7 +78,7 @@ msgstr ""
 msgid " (Graphics) "
 msgstr ""
 
-#: ../src/EditorCell.cpp:3045 ../src/EditorCell.cpp:3227
+#: ../src/EditorCell.cpp:3088 ../src/EditorCell.cpp:3270
 #, c-format
 msgid " ... + %i hidden lines"
 msgstr ""
@@ -87,7 +87,7 @@ msgstr ""
 msgid " << Expression longer than allowed by the configuration setting! >>"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1673
+#: ../src/wxMaxima.cpp:1678
 msgid ""
 " was saved using a newer version of wxMaxima so it may not load correctly. "
 "Please update your wxMaxima."
@@ -95,7 +95,7 @@ msgstr ""
 " был сохранён более новой версией wxMaxima и может не загрузиться корректно. "
 "Пожалуйста, обновите wxMaxima."
 
-#: ../src/wxMaxima.cpp:1665
+#: ../src/wxMaxima.cpp:1670
 msgid ""
 " was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr ""
@@ -109,68 +109,68 @@ msgstr ""
 msgid "\"implies\" symbol"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:101
+#: ../src/wxMaximaFrame.cpp:100
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:773
+#: ../src/wxMaximaFrame.cpp:772
 msgid "&Algebra"
 msgstr "А&лгебра"
 
-#: ../src/wxMaximaFrame.cpp:767
+#: ../src/wxMaximaFrame.cpp:766
 #, fuzzy
 msgid "&Apply to List..."
 msgstr "Применить к списку..."
 
-#: ../src/wxMaximaFrame.cpp:964
+#: ../src/wxMaximaFrame.cpp:963
 msgid "&Apropos..."
 msgstr "&Поиск"
 
-#: ../src/wxMaximaFrame.cpp:478
+#: ../src/wxMaximaFrame.cpp:477
 msgid "&Batch File...\tCtrl-B"
 msgstr "Пакетный файл...\tCtrl-B"
 
-#: ../src/wxMaximaFrame.cpp:724
+#: ../src/wxMaximaFrame.cpp:723
 msgid "&Boundary Value Problem..."
 msgstr "&Краевая задача..."
 
-#: ../src/wxMaximaFrame.cpp:975
+#: ../src/wxMaximaFrame.cpp:974
 msgid "&Bug Report"
 msgstr "&Сообщить об ошибке"
 
-#: ../src/wxMaximaFrame.cpp:825
+#: ../src/wxMaximaFrame.cpp:824
 msgid "&Calculus"
 msgstr "&Анализ"
 
-#: ../src/wxMaximaFrame.cpp:876
+#: ../src/wxMaximaFrame.cpp:875
 msgid "&Canonical Form"
 msgstr "&Каноническая форма"
 
-#: ../src/wxMaximaFrame.cpp:749
+#: ../src/wxMaximaFrame.cpp:748
 msgid "&Characteristic Polynomial..."
 msgstr "&Характеристический полином..."
 
-#: ../src/wxMaximaFrame.cpp:654
+#: ../src/wxMaximaFrame.cpp:653
 msgid "&Clear Memory"
 msgstr "&Очистить память"
 
-#: ../src/wxMaximaFrame.cpp:859
+#: ../src/wxMaximaFrame.cpp:858
 #, fuzzy
 msgid "&Combine Factorials"
 msgstr "Объединить факториалы"
 
-#: ../src/wxMaximaFrame.cpp:902
+#: ../src/wxMaximaFrame.cpp:901
 #, fuzzy
 msgid "&Complex Simplification"
 msgstr "Комплексное упрощение"
 
-#: ../src/wxMaximaFrame.cpp:822
+#: ../src/wxMaximaFrame.cpp:821
 #, fuzzy
 msgid "&Continued Fraction"
 msgstr "Цепная дробь"
 
-#: ../src/wxMaximaFrame.cpp:502
+#: ../src/wxMaximaFrame.cpp:501
 msgid "&Copy\tCtrl-C"
 msgstr "Копировать\tCtrl-C"
 
@@ -178,112 +178,112 @@ msgstr "Копировать\tCtrl-C"
 msgid "&Definite integration"
 msgstr "Определенное интегрирование"
 
-#: ../src/wxMaximaFrame.cpp:896
+#: ../src/wxMaximaFrame.cpp:895
 msgid "&Demoivre"
 msgstr "В тригонометрическую форму"
 
-#: ../src/wxMaximaFrame.cpp:752
+#: ../src/wxMaximaFrame.cpp:751
 msgid "&Determinant"
 msgstr "Определитель"
 
-#: ../src/wxMaximaFrame.cpp:785
+#: ../src/wxMaximaFrame.cpp:784
 msgid "&Differentiate..."
 msgstr "&Дифференцировать..."
 
-#: ../src/wxMaximaFrame.cpp:543
+#: ../src/wxMaximaFrame.cpp:542
 msgid "&Edit"
 msgstr "&Правка"
 
-#: ../src/wxMaximaFrame.cpp:709
+#: ../src/wxMaximaFrame.cpp:708
 msgid "&Eliminate Variable..."
 msgstr "&Исключить переменную..."
 
-#: ../src/wxMaximaFrame.cpp:744
+#: ../src/wxMaximaFrame.cpp:743
 msgid "&Enter Matrix..."
 msgstr "&Ввести матрицу..."
 
-#: ../src/wxMaximaFrame.cpp:961
+#: ../src/wxMaximaFrame.cpp:960
 msgid "&Example..."
 msgstr "&Пример..."
 
-#: ../src/wxMaximaFrame.cpp:839
+#: ../src/wxMaximaFrame.cpp:838
 #, fuzzy
 msgid "&Expand Expression"
 msgstr "Раскрыть выражение"
 
-#: ../src/wxMaximaFrame.cpp:873
+#: ../src/wxMaximaFrame.cpp:872
 #, fuzzy
 msgid "&Expand Trigonometric"
 msgstr "Раскрыть тригонометрически"
 
-#: ../src/wxMaximaFrame.cpp:899
+#: ../src/wxMaximaFrame.cpp:898
 msgid "&Exponentialize"
 msgstr "В экспоненциальное представление"
 
-#: ../src/wxMaximaFrame.cpp:480
+#: ../src/wxMaximaFrame.cpp:479
 msgid "&Export..."
 msgstr "&Экспортировать..."
 
-#: ../src/wxMaximaFrame.cpp:834
+#: ../src/wxMaximaFrame.cpp:833
 #, fuzzy
 msgid "&Factor Expression"
 msgstr "Факторизовать выражение"
 
-#: ../src/wxMaximaFrame.cpp:489
+#: ../src/wxMaximaFrame.cpp:488
 msgid "&File"
 msgstr "&Файл"
 
-#: ../src/wxMaximaFrame.cpp:692
+#: ../src/wxMaximaFrame.cpp:691
 msgid "&Find Root..."
 msgstr "Найти &корень..."
 
-#: ../src/wxMaximaFrame.cpp:738
+#: ../src/wxMaximaFrame.cpp:737
 msgid "&Generate Matrix..."
 msgstr "Создать &матрицу..."
 
-#: ../src/wxMaximaFrame.cpp:809
+#: ../src/wxMaximaFrame.cpp:808
 msgid "&Greatest Common Divisor..."
 msgstr "&Наибольший общий делитель..."
 
-#: ../src/wxMaximaFrame.cpp:994
+#: ../src/wxMaximaFrame.cpp:993
 msgid "&Help"
 msgstr "&Справка"
 
-#: ../src/wxMaximaFrame.cpp:777
+#: ../src/wxMaximaFrame.cpp:776
 msgid "&Integrate..."
 msgstr "&Интегрировать..."
 
-#: ../src/wxMaximaFrame.cpp:645
+#: ../src/wxMaximaFrame.cpp:644
 msgid "&Interrupt\tCtrl-."
 msgstr "Прервать\tCtrl- "
 
-#: ../src/wxMaximaFrame.cpp:649
+#: ../src/wxMaximaFrame.cpp:648
 msgid "&Interrupt\tCtrl-G"
 msgstr "Прервать\tCtrl-"
 
-#: ../src/wxMaximaFrame.cpp:746
+#: ../src/wxMaximaFrame.cpp:745
 msgid "&Invert Matrix"
 msgstr "&Обратить матрицу"
 
-#: ../src/wxMaximaFrame.cpp:476
+#: ../src/wxMaximaFrame.cpp:475
 msgid "&Load Package...\tCtrl-L"
 msgstr "Загрузить &пакет\tCtrl-L"
 
-#: ../src/wxMaximaFrame.cpp:769
+#: ../src/wxMaximaFrame.cpp:768
 #, fuzzy
 msgid "&Map to List(s)..."
 msgstr "&Применить к элементам списка..."
 
-#: ../src/wxMaximaFrame.cpp:684
+#: ../src/wxMaximaFrame.cpp:683
 msgid "&Maxima"
 msgstr "&Maxima"
 
-#: ../src/wxMaximaFrame.cpp:958
+#: ../src/wxMaximaFrame.cpp:957
 #, fuzzy
 msgid "&Maxima help"
 msgstr "Показать справку по Maxima"
 
-#: ../src/wxMaximaFrame.cpp:917
+#: ../src/wxMaximaFrame.cpp:916
 #, fuzzy
 msgid "&Modulus Computation..."
 msgstr "Вычисления по &модулю..."
@@ -292,7 +292,7 @@ msgstr "Вычисления по &модулю..."
 msgid "&New\tCtrl-N"
 msgstr "Новый\tCtrl-N "
 
-#: ../src/wxMaximaFrame.cpp:947
+#: ../src/wxMaximaFrame.cpp:946
 msgid "&Numeric"
 msgstr "&Численные расчёты"
 
@@ -308,11 +308,11 @@ msgstr "Суммирование (nusum)"
 msgid "&Open\tCtrl-O"
 msgstr "Открыть\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:463
+#: ../src/wxMaximaFrame.cpp:462
 msgid "&Open...\tCtrl-O"
 msgstr "&Открыть...\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:929
+#: ../src/wxMaximaFrame.cpp:928
 msgid "&Plot"
 msgstr "&Графики"
 
@@ -320,7 +320,7 @@ msgstr "&Графики"
 msgid "&Power series"
 msgstr "Степенной ряд"
 
-#: ../src/wxMaximaFrame.cpp:483
+#: ../src/wxMaximaFrame.cpp:482
 msgid "&Print...\tCtrl-P"
 msgstr "&Печать...\tCtrl-P"
 
@@ -328,43 +328,43 @@ msgstr "&Печать...\tCtrl-P"
 msgid "&Rational"
 msgstr "Рациональное выражение"
 
-#: ../src/wxMaximaFrame.cpp:870
+#: ../src/wxMaximaFrame.cpp:869
 #, fuzzy
 msgid "&Reduce Trigonometric"
 msgstr "Тригонометрическое приведение"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "&Restart Maxima"
 msgstr "Пере&запустить Maxima"
 
-#: ../src/wxMaximaFrame.cpp:700
+#: ../src/wxMaximaFrame.cpp:699
 #, fuzzy
 msgid "&Roots of Polynomial (Real)"
 msgstr "Корни полинома (вещественные)"
 
-#: ../src/wxMaximaFrame.cpp:472
+#: ../src/wxMaximaFrame.cpp:471
 msgid "&Save\tCtrl-S"
 msgstr "Сохранить\tCtrl-S"
 
-#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:919
+#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:918
 msgid "&Simplify"
 msgstr "Упрост&ить"
 
-#: ../src/wxMaximaFrame.cpp:829
+#: ../src/wxMaximaFrame.cpp:828
 msgid "&Simplify Expression"
 msgstr "Упростить &выражение"
 
-#: ../src/wxMaximaFrame.cpp:856
+#: ../src/wxMaximaFrame.cpp:855
 #, fuzzy
 msgid "&Simplify Factorials"
 msgstr "Упростить факториалы"
 
-#: ../src/wxMaximaFrame.cpp:867
+#: ../src/wxMaximaFrame.cpp:866
 #, fuzzy
 msgid "&Simplify Trigonometric"
 msgstr "Упростить тригонометрически"
 
-#: ../src/wxMaximaFrame.cpp:688
+#: ../src/wxMaximaFrame.cpp:687
 msgid "&Solve..."
 msgstr "&Решить..."
 
@@ -376,11 +376,11 @@ msgstr "Дополнительно"
 msgid "&Taylor series"
 msgstr "Ряд Тейлора"
 
-#: ../src/wxMaximaFrame.cpp:762
+#: ../src/wxMaximaFrame.cpp:761
 msgid "&Transpose Matrix"
 msgstr "&Транспонировать матрицу"
 
-#: ../src/wxMaximaFrame.cpp:879
+#: ../src/wxMaximaFrame.cpp:878
 #, fuzzy
 msgid "&Trigonometric Simplification"
 msgstr "Тригонометрическое упрощение"
@@ -399,7 +399,7 @@ msgstr "(Использовать язык по умолчанию)"
 msgid "- Infinity"
 msgstr "- Бесконечность"
 
-#: ../src/wxMaxima.cpp:351
+#: ../src/wxMaxima.cpp:356
 msgid ""
 "... [suppressed additional lines since the output is longer than allowed in "
 "the configuration] "
@@ -409,16 +409,16 @@ msgstr ""
 msgid "1/2"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:103
+#: ../src/wxMaximaFrame.cpp:102
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4601
+#: ../src/wxMaxima.cpp:4613
 msgid "<br>Lisp: "
 msgstr "<br>Lisp: "
 
-#: ../src/wxMaxima.cpp:5487
+#: ../src/wxMaxima.cpp:5503
 msgid ""
 "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
@@ -447,11 +447,11 @@ msgid ""
 "\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1472
+#: ../src/wxMaximaFrame.cpp:1495
 msgid "A symbol from the configuration dialogue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:731
+#: ../src/wxMaximaFrame.cpp:730
 #, fuzzy
 msgid "A&t Value..."
 msgstr "Значение в &точке..."
@@ -460,12 +460,12 @@ msgstr "Значение в &точке..."
 msgid "Abort evaluation on error"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaxima.cpp:4603
+#: ../src/wxMaxima.cpp:4615 ../src/wxMaximaFrame.cpp:985
 msgid "About"
 msgstr "О программе"
 
-#: ../src/wxMaximaFrame.cpp:987 ../src/wxMaximaFrame.cpp:990
-#: ../src/wxMaximaFrame.cpp:991
+#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaximaFrame.cpp:989
+#: ../src/wxMaximaFrame.cpp:990
 msgid "About wxMaxima"
 msgstr "О wxMaxima"
 
@@ -473,24 +473,24 @@ msgstr "О wxMaxima"
 msgid "Active cell bracket"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:760
+#: ../src/wxMaximaFrame.cpp:759
 msgid "Ad&joint Matrix"
 msgstr "Сопря&женная матрица"
 
-#: ../src/wxMaximaFrame.cpp:914
+#: ../src/wxMaximaFrame.cpp:913
 #, fuzzy
 msgid "Add Algebraic E&quality..."
 msgstr "Добавить &алгебраическое равенство..."
 
-#: ../src/wxMaximaFrame.cpp:657
+#: ../src/wxMaximaFrame.cpp:656
 msgid "Add a directory to search path"
 msgstr "Добавить директорию к пути поиска"
 
-#: ../src/wxMaxima.cpp:3353
+#: ../src/wxMaxima.cpp:3365
 msgid "Add dir to path:"
 msgstr "Добавить директорию к пути:"
 
-#: ../src/wxMaximaFrame.cpp:915
+#: ../src/wxMaximaFrame.cpp:914
 msgid "Add equality to the rational simplifier"
 msgstr "Добавить равенство к упрощателю рациональных выражений"
 
@@ -498,7 +498,7 @@ msgstr "Добавить равенство к упрощателю рацион
 msgid "Add the .wxmx file to the HTML export"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:656
+#: ../src/wxMaximaFrame.cpp:655
 msgid "Add to &Path..."
 msgstr "До&бавить к пути поиска..."
 
@@ -539,27 +539,27 @@ msgstr "Старая переменная:"
 msgid "All|*"
 msgstr "Все|*"
 
-#: ../src/wxMaximaFrame.cpp:1364
+#: ../src/wxMaximaFrame.cpp:1363
 msgid "Alpha"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3838
+#: ../src/wxMaxima.cpp:3850
 msgid "Apply"
 msgstr "Применить"
 
-#: ../src/wxMaximaFrame.cpp:768
+#: ../src/wxMaximaFrame.cpp:767
 msgid "Apply function to a list"
 msgstr "Применить функцию к списку"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Apropos"
 msgstr "По поводу"
 
-#: ../src/wxMaxima.cpp:3764
+#: ../src/wxMaxima.cpp:3776
 msgid "Array:"
 msgstr "Массив:"
 
-#: ../src/wxMaxima.cpp:4462
+#: ../src/wxMaxima.cpp:4474
 msgid "Artwork by"
 msgstr "Изображения"
 
@@ -567,7 +567,7 @@ msgstr "Изображения"
 msgid "Ask to save untitled documents"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3650
+#: ../src/wxMaxima.cpp:3662
 msgid "At value"
 msgstr "Значение в точке"
 
@@ -588,11 +588,11 @@ msgstr ""
 msgid "Autosave interval (minutes, 0 means: off):"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3557
+#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3569
 msgid "BC2"
 msgstr "BC2"
 
-#: ../src/wxMaximaFrame.cpp:1272
+#: ../src/wxMaximaFrame.cpp:1271
 msgid "Barsplot..."
 msgstr ""
 
@@ -600,7 +600,7 @@ msgstr ""
 msgid "Bat files (*.bat)|*.bat|All|*"
 msgstr "Пакетные файлы (*.bat)|*.bat|Все|*"
 
-#: ../src/wxMaxima.cpp:2943
+#: ../src/wxMaxima.cpp:2951
 msgid "Batch File"
 msgstr "Пакетный файл"
 
@@ -613,7 +613,7 @@ msgid ""
 "cells."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1365
+#: ../src/wxMaximaFrame.cpp:1364
 msgid "Beta"
 msgstr ""
 
@@ -625,11 +625,11 @@ msgstr ""
 msgid "Bold"
 msgstr "Жирный"
 
-#: ../src/wxMaxima.cpp:2359
+#: ../src/wxMaxima.cpp:2366
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1274
+#: ../src/wxMaximaFrame.cpp:1273
 #, fuzzy
 msgid "Boxplot..."
 msgstr "Экспорт"
@@ -642,15 +642,15 @@ msgstr "Просмотр"
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2080
+#: ../src/MathCtrl.cpp:2127
 msgid "Bug: Cell left but not entered."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1178
+#: ../src/wxMaxima.cpp:1183
 msgid "Bug: Found a math end marker without any start marker."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1222
+#: ../src/wxMaxima.cpp:1227
 msgid "Bug: Found the end of autocompletion symbols but no beginning"
 msgstr ""
 
@@ -662,22 +662,22 @@ msgstr ""
 msgid "Bug: Fraction without enumerator"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2312
+#: ../src/MathCtrl.cpp:2359
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5839
+#: ../src/MathCtrl.cpp:5891
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of "
 "the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5913
+#: ../src/MathCtrl.cpp:5965
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5882
+#: ../src/MathCtrl.cpp:5934
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
@@ -687,49 +687,49 @@ msgstr ""
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
 msgstr ""
 
-#: ../src/GroupCell.cpp:780 ../src/GroupCell.cpp:951
+#: ../src/GroupCell.cpp:781 ../src/GroupCell.cpp:952
 msgid "Bug: No image counter to write to!"
 msgstr ""
 
-#: ../src/AbsCell.cpp:193
+#: ../src/AbsCell.cpp:199
 msgid "Bug: No last cell in an absCell!"
 msgstr ""
 
-#: ../src/ConjugateCell.cpp:185
+#: ../src/ConjugateCell.cpp:194
 msgid "Bug: No last cell in an conjugateCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:471
+#: ../src/FracCell.cpp:472
 msgid "Bug: No last cell in an denominator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:267
+#: ../src/ExptCell.cpp:270
 msgid "Bug: No last cell in an exponent of an exptCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:459
+#: ../src/FracCell.cpp:460
 msgid "Bug: No last cell in an numerator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:257
+#: ../src/ExptCell.cpp:260
 msgid "Bug: No last cell in the base of an exptCell!"
 msgstr ""
 
-#: ../src/ParenCell.cpp:534
+#: ../src/ParenCell.cpp:535
 msgid "Bug: No last cell inside a parenthesis!"
 msgstr ""
 
-#: ../src/SqrtCell.cpp:312
+#: ../src/SqrtCell.cpp:317
 msgid "Bug: No last cell inside a square root!"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2123
+#: ../src/MathCtrl.cpp:2170
 msgid ""
 "Bug: Start or end of merging of subsequent editing actions was requested two "
 "times in a row."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2090
+#: ../src/MathCtrl.cpp:2137
 msgid "Bug: Text changed, but no active cell."
 msgstr ""
 
@@ -737,39 +737,39 @@ msgstr ""
 msgid "Bug: Trying to append NULL to a group cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:555
+#: ../src/MathCtrl.cpp:600
 msgid "Bug: Trying to append maxima's output to a cell outside the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2014
+#: ../src/MathCtrl.cpp:2061
 msgid ""
 "Bug: Trying to merge individual cell adds to a region in the undo buffer but "
 "there are other cells between them."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6522
+#: ../src/MathCtrl.cpp:6577
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2092
+#: ../src/MathCtrl.cpp:2139
 msgid "Bug: Trying to record a cell contents change without a cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1495
+#: ../src/MathCtrl.cpp:1540
 msgid "Bug: Trying to select inside a cell without having a current cell"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5883
+#: ../src/MathCtrl.cpp:5935
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5844 ../src/MathCtrl.cpp:5918 ../src/MathCtrl.cpp:5952
+#: ../src/MathCtrl.cpp:5896 ../src/MathCtrl.cpp:5970 ../src/MathCtrl.cpp:6004
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:973
+#: ../src/wxMaximaFrame.cpp:972
 msgid "Build &Info"
 msgstr "Ин&формация о сборке"
 
@@ -781,54 +781,54 @@ msgid ""
 "two key commands."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:782
+#: ../src/wxMaximaFrame.cpp:781
 msgid "C&hange Variable..."
 msgstr "&Заменить переменную..."
 
-#: ../src/wxMaximaFrame.cpp:540
+#: ../src/wxMaximaFrame.cpp:539
 msgid "C&onfigure"
 msgstr "Настройка"
 
-#: ../src/wxMaximaFrame.cpp:801
+#: ../src/wxMaximaFrame.cpp:800
 msgid "Calculate &Product..."
 msgstr "Вычислить &произведение..."
 
-#: ../src/wxMaximaFrame.cpp:799
+#: ../src/wxMaximaFrame.cpp:798
 msgid "Calculate Su&m..."
 msgstr "Вычислить &сумму..."
 
-#: ../src/wxMaximaFrame.cpp:939
+#: ../src/wxMaximaFrame.cpp:938
 #, fuzzy
 msgid "Calculate bigfloat value of the last result"
 msgstr "Численное значение выражения с повышенной точностью"
 
-#: ../src/wxMaximaFrame.cpp:936
+#: ../src/wxMaximaFrame.cpp:935
 #, fuzzy
 msgid "Calculate float value of the last result"
 msgstr "Численное значение выражения"
 
-#: ../src/wxMaxima.cpp:3971
+#: ../src/wxMaxima.cpp:3983
 msgid "Calculate modulus:"
 msgstr "Вычислить модуль:"
 
-#: ../src/wxMaximaFrame.cpp:942
+#: ../src/wxMaximaFrame.cpp:941
 #, fuzzy
 msgid "Calculate numeric value of the last result"
 msgstr "Численное значение выражения"
 
-#: ../src/wxMaximaFrame.cpp:802
+#: ../src/wxMaximaFrame.cpp:801
 msgid "Calculate products"
 msgstr "Вычислить произведения"
 
-#: ../src/wxMaximaFrame.cpp:800
+#: ../src/wxMaximaFrame.cpp:799
 msgid "Calculate sums"
 msgstr "Вычислить суммы"
 
-#: ../src/wxMaxima.cpp:5830
+#: ../src/wxMaxima.cpp:5845
 msgid "Can not connect to the web server."
 msgstr "Не удалось соединиться с сервером."
 
-#: ../src/wxMaxima.cpp:5881
+#: ../src/wxMaxima.cpp:5896
 msgid "Can not download version info."
 msgstr "Не удалось загрузить информацию об обновлениях."
 
@@ -844,15 +844,15 @@ msgstr "Не удалось загрузить информацию об обн�
 #: ../src/PlotFormatWiz.cpp:48 ../src/SeriesWiz.cpp:49 ../src/SeriesWiz.cpp:51
 #: ../src/SubstituteWiz.cpp:41 ../src/SubstituteWiz.cpp:43 ../src/SumWiz.cpp:44
 #: ../src/SumWiz.cpp:46 ../src/SystemWiz.cpp:38 ../src/SystemWiz.cpp:40
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Cancel"
 msgstr "Отменить"
 
-#: ../src/wxMaximaFrame.cpp:126 ../src/wxMaxima.cpp:932
+#: ../src/wxMaxima.cpp:937 ../src/wxMaximaFrame.cpp:125
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1217
+#: ../src/wxMaximaFrame.cpp:1216
 msgid "Canonical (tr)"
 msgstr "Каноническая форма (триг.)"
 
@@ -860,7 +860,7 @@ msgstr "Каноническая форма (триг.)"
 msgid "Catalan"
 msgstr "Каталанский"
 
-#: ../src/wxMaximaFrame.cpp:638
+#: ../src/wxMaximaFrame.cpp:637
 msgid "Ce&ll"
 msgstr "&Ячейка"
 
@@ -869,41 +869,41 @@ msgstr "&Ячейка"
 msgid "Cell bracket"
 msgstr "Tellrat"
 
-#: ../src/wxMaxima.cpp:5261
+#: ../src/wxMaxima.cpp:5273
 msgid "Cell ends in a backslash"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:676
+#: ../src/wxMaximaFrame.cpp:675
 #, fuzzy
 msgid "Change &2d Display"
 msgstr "Изменить способ отображения выражений"
 
-#: ../src/wxMaximaFrame.cpp:677
+#: ../src/wxMaximaFrame.cpp:676
 #, fuzzy
 msgid "Change the 2d display algorithm used to display math output"
 msgstr "Изменить способ, применяемый для отображения математических выражений."
 
-#: ../src/wxMaxima.cpp:3995
+#: ../src/wxMaxima.cpp:4007
 msgid "Change variable"
 msgstr "Заменить переменную"
 
-#: ../src/wxMaximaFrame.cpp:783
+#: ../src/wxMaximaFrame.cpp:782
 msgid "Change variable in integral or sum"
 msgstr "Заменить переменную в интеграле или сумме"
 
-#: ../src/wxMaxima.cpp:3751
+#: ../src/wxMaxima.cpp:3763
 msgid "Char poly"
 msgstr "Характеристический полином"
 
-#: ../src/wxMaximaFrame.cpp:978
+#: ../src/wxMaximaFrame.cpp:977
 msgid "Check for Updates"
 msgstr "Проверить наличие обновлений"
 
-#: ../src/wxMaximaFrame.cpp:979
+#: ../src/wxMaximaFrame.cpp:978
 msgid "Check if a newer version of wxMaxima/Maxima exist."
 msgstr "Проверить, не вышла ли новая версия wxMaxima/Maxima."
 
-#: ../src/wxMaximaFrame.cpp:1385
+#: ../src/wxMaximaFrame.cpp:1384
 msgid "Chi"
 msgstr ""
 
@@ -924,15 +924,15 @@ msgstr "Выбор шрифта"
 msgid "Choose new plot format:"
 msgstr "Выберите новый формат графиков:"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710
 msgid "Classes:"
 msgstr "Классы:"
 
-#: ../src/wxMaximaFrame.cpp:469
+#: ../src/wxMaximaFrame.cpp:468
 msgid "Close\tCtrl-W"
 msgstr "Закрыть\tCtrl-W"
 
-#: ../src/wxMaximaFrame.cpp:470
+#: ../src/wxMaximaFrame.cpp:469
 msgid "Close window"
 msgstr "Закрыть окно"
 
@@ -964,20 +964,20 @@ msgstr ""
 msgid "Code highlighting: Variables"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4806
+#: ../src/wxMaxima.cpp:4818
 #, fuzzy
 msgid "Col. names:"
 msgstr "Имена столбцов:"
 
-#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Columns:"
 msgstr "Столбцы:"
 
-#: ../src/wxMaximaFrame.cpp:860
+#: ../src/wxMaximaFrame.cpp:859
 msgid "Combine factorials in an expression"
 msgstr "Объединить факториалы в выражении"
 
-#: ../src/wxMaxima.cpp:5293
+#: ../src/wxMaxima.cpp:5305
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
@@ -989,25 +989,25 @@ msgstr "Введите список x-координат, разделенных
 msgid "Comma separated y coordinates"
 msgstr "Введите список y-координат, разделенных запятыми"
 
-#: ../src/MathCtrl.cpp:1030
+#: ../src/MathCtrl.cpp:1072
 #, fuzzy
 msgid "Comment Selection"
 msgstr "Копировать выделение"
 
-#: ../src/wxMaximaFrame.cpp:533
+#: ../src/wxMaximaFrame.cpp:532
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:532
+#: ../src/wxMaximaFrame.cpp:531
 #, fuzzy
 msgid "Comment selection\tCtrl-/"
 msgstr "Копировать выделение"
 
-#: ../src/wxMaximaFrame.cpp:601
+#: ../src/wxMaximaFrame.cpp:600
 msgid "Complete Word\tCtrl-K"
 msgstr "Завершить слово\tCtrl-K"
 
-#: ../src/wxMaximaFrame.cpp:602
+#: ../src/wxMaximaFrame.cpp:601
 msgid "Complete word"
 msgstr "Завершить слово"
 
@@ -1015,37 +1015,37 @@ msgstr "Завершить слово"
 msgid "Completely stop maxima and restart it"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:823
+#: ../src/wxMaximaFrame.cpp:822
 msgid "Compute continued fraction of a value"
 msgstr "Вычислить цепную дробь значения"
 
-#: ../src/wxMaximaFrame.cpp:761
+#: ../src/wxMaximaFrame.cpp:760
 msgid "Compute the adjoint matrix"
 msgstr "Вычислить сопряжённую матрицу"
 
-#: ../src/wxMaximaFrame.cpp:750
+#: ../src/wxMaximaFrame.cpp:749
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr "Вычислить характеристический полином матрицы"
 
-#: ../src/wxMaximaFrame.cpp:753
+#: ../src/wxMaximaFrame.cpp:752
 msgid "Compute the determinant of a matrix"
 msgstr "Вычислить определитель матрицы"
 
-#: ../src/wxMaximaFrame.cpp:810
+#: ../src/wxMaximaFrame.cpp:809
 msgid "Compute the greatest common divisor"
 msgstr "Вычислить наибольший общий делитель"
 
-#: ../src/wxMaximaFrame.cpp:747
+#: ../src/wxMaximaFrame.cpp:746
 msgid "Compute the inverse of a matrix"
 msgstr "Вычислить обратную матрицу"
 
-#: ../src/wxMaximaFrame.cpp:813
+#: ../src/wxMaximaFrame.cpp:812
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
 "Вычислить наменьший общий множитель (выполните load(functs) перед "
 "использованием)"
 
-#: ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4868
 msgid "Condition:"
 msgstr "Условие:"
 
@@ -1057,8 +1057,8 @@ msgstr "Файл настроек (*.ini)|*.ini"
 msgid "Configuration warning"
 msgstr "Предупреждение о настройке"
 
-#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:538
-#: ../src/wxMaximaFrame.cpp:541
+#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:540
 msgid "Configure wxMaxima"
 msgstr "Настроить wxMaxima"
 
@@ -1067,143 +1067,145 @@ msgstr "Настроить wxMaxima"
 msgid "Constant"
 msgstr "Константа"
 
-#: ../src/wxMaximaFrame.cpp:844
+#: ../src/wxMaximaFrame.cpp:843
 #, fuzzy
 msgid "Contract Logarithms"
 msgstr "Объединить логарифмы"
 
-#: ../src/wxMaximaFrame.cpp:851
+#: ../src/wxMaximaFrame.cpp:850
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr ""
 "Преобразовать биномиальные коэффициенты, бета- и гамма-функции в факториалы"
 
-#: ../src/wxMaximaFrame.cpp:854
+#: ../src/wxMaximaFrame.cpp:853
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr ""
 "Преобразовать биномиальные коэффициенты, факториалы и бета-функции в гамма-"
 "функции"
 
-#: ../src/wxMaximaFrame.cpp:888
+#: ../src/wxMaximaFrame.cpp:887
 msgid "Convert complex expression to polar form"
 msgstr "Преобразовать комплексное выражение в полярную форму"
 
-#: ../src/wxMaximaFrame.cpp:885
+#: ../src/wxMaximaFrame.cpp:884
 msgid "Convert complex expression to rect form"
 msgstr "Преобразовать комплексное выражение в стандатную форму"
 
-#: ../src/wxMaximaFrame.cpp:897
+#: ../src/wxMaximaFrame.cpp:896
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
 "Преобразовать экспоненциальную функцию мнимого аргумента в "
 "тригонометрическую форму"
 
-#: ../src/wxMaximaFrame.cpp:842
+#: ../src/wxMaximaFrame.cpp:841
 msgid "Convert logarithm of product to sum of logarithms"
 msgstr "Преобразовать логарифм произведения в сумму логарифмов"
 
-#: ../src/wxMaximaFrame.cpp:845
+#: ../src/wxMaximaFrame.cpp:844
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "Преобразовать сумму логарифмов в логарифм произведения"
 
-#: ../src/wxMaximaFrame.cpp:850
+#: ../src/wxMaximaFrame.cpp:849
 #, fuzzy
 msgid "Convert to &Factorials"
 msgstr "Преобразовать в факториалы"
 
-#: ../src/wxMaximaFrame.cpp:853
+#: ../src/wxMaximaFrame.cpp:852
 #, fuzzy
 msgid "Convert to &Gamma"
 msgstr "Преобразовать в гамма-функцию"
 
-#: ../src/wxMaximaFrame.cpp:887
+#: ../src/wxMaximaFrame.cpp:886
 #, fuzzy
 msgid "Convert to &Polarform"
 msgstr "Преобразовать в полярную форму"
 
-#: ../src/wxMaximaFrame.cpp:884
+#: ../src/wxMaximaFrame.cpp:883
 #, fuzzy
 msgid "Convert to &Rectform"
 msgstr "Преобразовать в стандартную форму"
 
-#: ../src/wxMaximaFrame.cpp:877
+#: ../src/wxMaximaFrame.cpp:876
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr ""
 "Преобразовать тригонометрическое выражение в каноническую квазилинейную форму"
 
-#: ../src/wxMaximaFrame.cpp:900
+#: ../src/wxMaximaFrame.cpp:899
 #, fuzzy
 msgid "Convert trigonometric functions to exponential form"
 msgstr ""
 "Преобразовать тригонометрические функции в экспоненциальное представление"
 
-#: ../src/ToolBar.cpp:140 ../src/MathCtrl.cpp:918 ../src/MathCtrl.cpp:931
-#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1024
+#: ../src/MathCtrl.cpp:960 ../src/MathCtrl.cpp:973 ../src/MathCtrl.cpp:1019
+#: ../src/MathCtrl.cpp:1066 ../src/ToolBar.cpp:140
 msgid "Copy"
 msgstr "Копировать"
 
-#: ../src/wxMaximaFrame.cpp:597
+#: ../src/wxMaximaFrame.cpp:596
 msgid "Copy Previous Input\tCtrl-I"
 msgstr "Скопировать предыдущий ввод\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:599
+#: ../src/wxMaximaFrame.cpp:598
 #, fuzzy
 msgid "Copy Previous Output\tCtrl-U"
 msgstr "Скопировать предыдущий ввод\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:514 ../src/MathCtrl.cpp:936 ../src/MathCtrl.cpp:982
+#: ../src/MathCtrl.cpp:978 ../src/MathCtrl.cpp:1024
+#: ../src/wxMaximaFrame.cpp:513
 msgid "Copy as Image"
 msgstr "Скопировать изображение"
 
-#: ../src/wxMaximaFrame.cpp:507 ../src/MathCtrl.cpp:932 ../src/MathCtrl.cpp:978
+#: ../src/MathCtrl.cpp:974 ../src/MathCtrl.cpp:1020
+#: ../src/wxMaximaFrame.cpp:506
 msgid "Copy as LaTeX"
 msgstr "Скопировать LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:510
+#: ../src/wxMaximaFrame.cpp:509
 #, fuzzy
 msgid "Copy as MathML"
 msgstr "Скопировать изображение"
 
-#: ../src/MathCtrl.cpp:935 ../src/MathCtrl.cpp:980
+#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1022
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:504
+#: ../src/wxMaximaFrame.cpp:503
 msgid "Copy as Text\tCtrl-Shift-C"
 msgstr "Скопировать текст\tCtrl-Shift-C"
 
-#: ../src/MathCtrl.cpp:933 ../src/MathCtrl.cpp:979
+#: ../src/MathCtrl.cpp:975 ../src/MathCtrl.cpp:1021
 #, fuzzy
 msgid "Copy as plain text"
 msgstr "Скопировать изображение"
 
-#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:503
+#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:502
 msgid "Copy selection"
 msgstr "Копировать выделение"
 
-#: ../src/wxMaximaFrame.cpp:515
+#: ../src/wxMaximaFrame.cpp:514
 msgid "Copy selection from document as an image"
 msgstr "Копировать выделение в документе как изображение"
 
-#: ../src/wxMaximaFrame.cpp:505
+#: ../src/wxMaximaFrame.cpp:504
 msgid "Copy selection from document as text"
 msgstr "Копировать выделение в документе как текст"
 
-#: ../src/wxMaximaFrame.cpp:508
+#: ../src/wxMaximaFrame.cpp:507
 msgid "Copy selection from document in LaTeX format"
 msgstr "Копировать выделение из документа в формате LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:511
+#: ../src/wxMaximaFrame.cpp:510
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:598
+#: ../src/wxMaximaFrame.cpp:597
 msgid "Create a new cell with previous input"
 msgstr "Создать новую ячейку с такими же входными данными"
 
-#: ../src/wxMaximaFrame.cpp:600
+#: ../src/wxMaximaFrame.cpp:599
 #, fuzzy
 msgid "Create a new cell with previous output"
 msgstr "Создать новую ячейку с такими же входными данными"
@@ -1212,15 +1214,15 @@ msgstr "Создать новую ячейку с такими же входны
 msgid "Cursor"
 msgstr "Курсор"
 
-#: ../src/ToolBar.cpp:137 ../src/MathCtrl.cpp:1023
+#: ../src/MathCtrl.cpp:1065 ../src/ToolBar.cpp:137
 msgid "Cut"
 msgstr "Вырезать"
 
-#: ../src/wxMaximaFrame.cpp:499
+#: ../src/wxMaximaFrame.cpp:498
 msgid "Cut\tCtrl-X"
 msgstr "Вырезать\tCtrl-X"
 
-#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:500
+#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:499
 msgid "Cut selection"
 msgstr "Вырезать выделение"
 
@@ -1232,19 +1234,19 @@ msgstr "Чешский"
 msgid "Danish"
 msgstr "Датский"
 
-#: ../src/wxMaxima.cpp:4799 ../src/wxMaxima.cpp:4806 ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4811 ../src/wxMaxima.cpp:4818 ../src/wxMaxima.cpp:4868
 #, fuzzy
 msgid "Data Matrix:"
 msgstr "Матрица:"
 
-#: ../src/wxMaxima.cpp:4826
+#: ../src/wxMaxima.cpp:4838
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr "Файл с данными (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698 ../src/wxMaxima.cpp:4712
-#: ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726 ../src/wxMaxima.cpp:4734
-#: ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748 ../src/wxMaxima.cpp:4755
-#: ../src/wxMaxima.cpp:4791
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710 ../src/wxMaxima.cpp:4724
+#: ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738 ../src/wxMaxima.cpp:4746
+#: ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760 ../src/wxMaxima.cpp:4767
+#: ../src/wxMaxima.cpp:4803
 msgid "Data:"
 msgstr "Данные:"
 
@@ -1252,7 +1254,7 @@ msgstr "Данные:"
 msgid "Debug: watch maxima's stdout stream"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:820
+#: ../src/wxMaximaFrame.cpp:819
 msgid "Decompose rational function to partial fractions"
 msgstr "Разложить рациональную функцию на простые дроби"
 
@@ -1283,47 +1285,47 @@ msgid ""
 "with."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3403 ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3415 ../src/wxMaxima.cpp:3424
 msgid "Delete"
 msgstr "Удалить"
 
-#: ../src/wxMaximaFrame.cpp:667
+#: ../src/wxMaximaFrame.cpp:666
 msgid "Delete F&unction..."
 msgstr "Удалить &функцию"
 
-#: ../src/MathCtrl.cpp:939 ../src/MathCtrl.cpp:985
+#: ../src/MathCtrl.cpp:981 ../src/MathCtrl.cpp:1027
 msgid "Delete Selection"
 msgstr "Удалить &выделение"
 
-#: ../src/wxMaximaFrame.cpp:669
+#: ../src/wxMaximaFrame.cpp:668
 msgid "Delete V&ariable..."
 msgstr "Удалить &переменную"
 
-#: ../src/wxMaximaFrame.cpp:668
+#: ../src/wxMaximaFrame.cpp:667
 msgid "Delete a function"
 msgstr "Удалить функцию"
 
-#: ../src/wxMaximaFrame.cpp:670
+#: ../src/wxMaximaFrame.cpp:669
 msgid "Delete a variable"
 msgstr "Удалить переменную"
 
-#: ../src/wxMaximaFrame.cpp:655
+#: ../src/wxMaximaFrame.cpp:654
 msgid "Delete all values from memory"
 msgstr "Удалить все значения из памяти"
 
-#: ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3424
 msgid "Delete function(s):"
 msgstr "Удалить функцию(ции)"
 
-#: ../src/wxMaxima.cpp:3403
+#: ../src/wxMaxima.cpp:3415
 msgid "Delete variable(s):"
 msgstr "Удалить переменную(ные):"
 
-#: ../src/wxMaximaFrame.cpp:1367
+#: ../src/wxMaximaFrame.cpp:1366
 msgid "Delta"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4011
+#: ../src/wxMaxima.cpp:4023
 msgid "Denom. deg:"
 msgstr "Степень знаменателя:"
 
@@ -1331,37 +1333,37 @@ msgstr "Степень знаменателя:"
 msgid "Depth:"
 msgstr "Глубина:"
 
-#: ../src/wxMaxima.cpp:3541
+#: ../src/wxMaxima.cpp:3553
 msgid "Derivative:"
 msgstr "Производная:"
 
-#: ../src/wxMaximaFrame.cpp:1258
+#: ../src/wxMaximaFrame.cpp:1257
 #, fuzzy
 msgid "Deviation..."
 msgstr "Анимация"
 
-#: ../src/wxMaximaFrame.cpp:816
+#: ../src/wxMaximaFrame.cpp:815
 #, fuzzy
 msgid "Di&vide Polynomials..."
 msgstr "Делить полиномы..."
 
-#: ../src/wxMaximaFrame.cpp:1223
+#: ../src/wxMaximaFrame.cpp:1222
 msgid "Diff..."
 msgstr "Дифференцировать..."
 
-#: ../src/wxMaxima.cpp:4154 ../src/wxMaxima.cpp:5066
+#: ../src/wxMaxima.cpp:4166 ../src/wxMaxima.cpp:5078
 msgid "Differentiate"
 msgstr "Дифференцировать"
 
-#: ../src/wxMaximaFrame.cpp:786
+#: ../src/wxMaximaFrame.cpp:785
 msgid "Differentiate expression"
 msgstr "Дифференцировать выражение"
 
-#: ../src/MathCtrl.cpp:1001
+#: ../src/MathCtrl.cpp:1043
 msgid "Differentiate..."
 msgstr "Дифференцировать..."
 
-#: ../src/LimitWiz.cpp:37 ../src/FindReplacePane.cpp:76
+#: ../src/FindReplacePane.cpp:76 ../src/LimitWiz.cpp:37
 msgid "Direction:"
 msgstr "Направление:"
 
@@ -1369,49 +1371,50 @@ msgstr "Направление:"
 msgid "Discrete plot"
 msgstr "Дискретный график"
 
-#: ../src/wxMaximaFrame.cpp:679
+#: ../src/wxMaximaFrame.cpp:678
 msgid "Display Te&X Form"
 msgstr "Вывести в формате &TeX"
 
-#: ../src/wxMaxima.cpp:3320
+#: ../src/wxMaxima.cpp:3332
 msgid "Display algorithm"
 msgstr "Способ вывода"
 
-#: ../src/wxMaximaFrame.cpp:680
+#: ../src/wxMaximaFrame.cpp:679
 msgid "Display last result in TeX form"
 msgstr "Вывести выражение в формате TeX"
 
-#: ../src/wxMaximaFrame.cpp:674
+#: ../src/wxMaximaFrame.cpp:673
 msgid "Display time used for evaluation"
 msgstr "Отображать время выполнения команд"
 
-#: ../src/wxMaxima.cpp:4061
+#: ../src/wxMaxima.cpp:4073
 msgid "Divide"
 msgstr "Делить"
 
-#: ../src/MathCtrl.cpp:1032
+#: ../src/MathCtrl.cpp:1074
 #, fuzzy
 msgid "Divide Cell"
 msgstr "Делить"
 
-#: ../src/wxMaximaFrame.cpp:635
+#: ../src/wxMaximaFrame.cpp:634
 #, fuzzy
 msgid "Divide Cell\tCtrl-D"
 msgstr "Делить"
 
-#: ../src/wxMaximaFrame.cpp:817
+#: ../src/wxMaximaFrame.cpp:816
 msgid "Divide numbers or polynomials"
 msgstr "Делить числа или полиномы"
 
-#: ../src/wxMaximaFrame.cpp:636
+#: ../src/wxMaximaFrame.cpp:635
 msgid "Divide this input cell into two cells"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5917
-msgid "Do you want to save the changes you made in the document \""
+#: ../src/wxMaxima.cpp:5932
+#, fuzzy, c-format
+msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr "Сохранить изменения в документе \""
 
-#: ../src/wxMaxima.cpp:1664 ../src/wxMaxima.cpp:1672
+#: ../src/wxMaxima.cpp:1669 ../src/wxMaxima.cpp:1677
 msgid "Document "
 msgstr "Документ"
 
@@ -1430,7 +1433,7 @@ msgid ""
 "differences."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Don't save"
 msgstr "Не сохранять"
 
@@ -1438,27 +1441,27 @@ msgstr "Не сохранять"
 msgid "Down"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:734
+#: ../src/wxMaximaFrame.cpp:733
 msgid "E&quations"
 msgstr "&Уравнения"
 
-#: ../src/wxMaximaFrame.cpp:487
+#: ../src/wxMaximaFrame.cpp:486
 msgid "E&xit\tCtrl-Q"
 msgstr "Выход\tCtrl-Q"
 
-#: ../src/wxMaximaFrame.cpp:757
+#: ../src/wxMaximaFrame.cpp:756
 msgid "Eige&nvectors"
 msgstr "Собственные векторы"
 
-#: ../src/wxMaximaFrame.cpp:755
+#: ../src/wxMaximaFrame.cpp:754
 msgid "Eigen&values"
 msgstr "Собственные значения"
 
-#: ../src/wxMaxima.cpp:3572
+#: ../src/wxMaxima.cpp:3584
 msgid "Eliminate"
 msgstr "Исключить"
 
-#: ../src/wxMaximaFrame.cpp:710
+#: ../src/wxMaximaFrame.cpp:709
 msgid "Eliminate a variable from a system of equations"
 msgstr "Исключить переменную из системы уравнений"
 
@@ -1470,21 +1473,21 @@ msgstr ""
 msgid "English"
 msgstr "Английский"
 
-#: ../src/wxMaxima.cpp:4712 ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726
-#: ../src/wxMaxima.cpp:4734 ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748
-#: ../src/wxMaxima.cpp:4755 ../src/wxMaxima.cpp:4791 ../src/wxMaxima.cpp:4799
+#: ../src/wxMaxima.cpp:4724 ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738
+#: ../src/wxMaxima.cpp:4746 ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760
+#: ../src/wxMaxima.cpp:4767 ../src/wxMaxima.cpp:4803 ../src/wxMaxima.cpp:4811
 msgid "Enter Data"
 msgstr "Введите данные"
 
-#: ../src/wxMaximaFrame.cpp:1279
+#: ../src/wxMaximaFrame.cpp:1278
 msgid "Enter Matrix..."
 msgstr "Ввести матрицу..."
 
-#: ../src/wxMaximaFrame.cpp:745
+#: ../src/wxMaximaFrame.cpp:744
 msgid "Enter a matrix"
 msgstr "Ввод матрицы"
 
-#: ../src/wxMaxima.cpp:3962
+#: ../src/wxMaxima.cpp:3974
 msgid "Enter an equation for rational simplification:"
 msgstr "Введите уравнение для рационального упрощения"
 
@@ -1496,11 +1499,11 @@ msgstr "Введите список переменных, разделенных
 msgid "Enter evaluates cells"
 msgstr "Enter отправляет ячейку на вычисление"
 
-#: ../src/wxMaxima.cpp:3734
+#: ../src/wxMaxima.cpp:3746
 msgid "Enter matrix"
 msgstr "Ввести матрицу"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 #, fuzzy
 msgid "Enter new precision for bigfloats:"
 msgstr "Введите новую точность:"
@@ -1509,12 +1512,12 @@ msgstr "Введите новую точность:"
 msgid "Enter the path to the Maxima executable."
 msgstr "Введите путь к исполняемому файлу Maxima."
 
-#: ../src/wxMaximaFrame.cpp:1368
+#: ../src/wxMaximaFrame.cpp:1367
 #, fuzzy
 msgid "Epsilon"
 msgstr "Выражение:"
 
-#: ../src/wxMaxima.cpp:4208
+#: ../src/wxMaxima.cpp:4220
 #, fuzzy
 msgid "Epsilon:"
 msgstr "Выражение:"
@@ -1524,13 +1527,13 @@ msgstr "Выражение:"
 msgid "Equation %d:"
 msgstr "Уравнение %d:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:3633
-#: ../src/wxMaxima.cpp:5019
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:3645
+#: ../src/wxMaxima.cpp:5031
 msgid "Equation(s):"
 msgstr "Уравнения:"
 
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3993
-#: ../src/wxMaxima.cpp:4807 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:4005
+#: ../src/wxMaxima.cpp:4819 ../src/wxMaxima.cpp:5045
 msgid "Equation:"
 msgstr "Уравнение:"
 
@@ -1541,84 +1544,84 @@ msgid ""
 "be introduced one into another. Also they are always printed out as 2D maths."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3570
+#: ../src/wxMaxima.cpp:3582
 msgid "Equations:"
 msgstr "Уравнения:"
 
-#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1455
-#: ../src/wxMaxima.cpp:1469 ../src/wxMaxima.cpp:1620 ../src/wxMaxima.cpp:1633
-#: ../src/wxMaxima.cpp:1643 ../src/wxMaxima.cpp:1666 ../src/wxMaxima.cpp:2034
-#: ../src/wxMaxima.cpp:2206 ../src/wxMaxima.cpp:5381 ../src/wxMaxima.cpp:5830
-#: ../src/wxMaxima.cpp:5881
+#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1460
+#: ../src/wxMaxima.cpp:1474 ../src/wxMaxima.cpp:1625 ../src/wxMaxima.cpp:1638
+#: ../src/wxMaxima.cpp:1648 ../src/wxMaxima.cpp:1671 ../src/wxMaxima.cpp:2039
+#: ../src/wxMaxima.cpp:2211 ../src/wxMaxima.cpp:5397 ../src/wxMaxima.cpp:5845
+#: ../src/wxMaxima.cpp:5896
 msgid "Error"
 msgstr "Ошибка"
 
-#: ../src/wxMaxima.cpp:2886 ../src/wxMaxima.cpp:2900 ../src/wxMaxima.cpp:2913
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617 ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:2894 ../src/wxMaxima.cpp:2908 ../src/wxMaxima.cpp:2921
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629 ../src/wxMaxima.cpp:3740
 msgid "Error!"
 msgstr "Ошибка!"
 
-#: ../src/wxMaximaFrame.cpp:1370
+#: ../src/wxMaximaFrame.cpp:1369
 msgid "Eta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:909
+#: ../src/wxMaximaFrame.cpp:908
 #, fuzzy
 msgid "Evaluate &Noun Forms"
 msgstr "Вычислить невычисляемые (noun) формы"
 
-#: ../src/wxMaximaFrame.cpp:589
+#: ../src/wxMaximaFrame.cpp:588
 #, fuzzy
 msgid "Evaluate All Cells\tCtrl-Shift-R"
 msgstr "Вычислить все\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:587
+#: ../src/wxMaximaFrame.cpp:586
 #, fuzzy
 msgid "Evaluate All Visible Cells\tCtrl-R"
 msgstr "Вычислить все\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:585 ../src/MathCtrl.cpp:942
+#: ../src/MathCtrl.cpp:984 ../src/wxMaximaFrame.cpp:584
 msgid "Evaluate Cell(s)"
 msgstr "Вычислить"
 
-#: ../src/wxMaximaFrame.cpp:591
+#: ../src/wxMaximaFrame.cpp:590
 #, fuzzy
 msgid "Evaluate Cells Above\tCtrl-Shift-P"
 msgstr "Вычислить все\tCtrl-R"
 
-#: ../src/MathCtrl.cpp:956 ../src/MathCtrl.cpp:1051
+#: ../src/MathCtrl.cpp:998 ../src/MathCtrl.cpp:1093
 #, fuzzy
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr "Вычислить поле\tShift-Enter"
 
-#: ../src/MathCtrl.cpp:961 ../src/MathCtrl.cpp:1053
+#: ../src/MathCtrl.cpp:1003 ../src/MathCtrl.cpp:1095
 #, fuzzy
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr "Вычислить поле\tShift-Enter"
 
-#: ../src/MathCtrl.cpp:971 ../src/MathCtrl.cpp:1057
+#: ../src/MathCtrl.cpp:1013 ../src/MathCtrl.cpp:1099
 #, fuzzy
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr "Вычислить поле\tShift-Enter"
 
-#: ../src/MathCtrl.cpp:966 ../src/MathCtrl.cpp:1055
+#: ../src/MathCtrl.cpp:1008 ../src/MathCtrl.cpp:1097
 #, fuzzy
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr "Вычислить поле\tShift-Enter"
 
-#: ../src/wxMaximaFrame.cpp:586
+#: ../src/wxMaximaFrame.cpp:585
 msgid "Evaluate active or selected cell(s)"
 msgstr "Отправить на вычисление выделенные ячейки"
 
-#: ../src/wxMaximaFrame.cpp:590
+#: ../src/wxMaximaFrame.cpp:589
 msgid "Evaluate all cells in the document"
 msgstr "Отправить на вычисление все ячейки в документе"
 
-#: ../src/wxMaximaFrame.cpp:910
+#: ../src/wxMaximaFrame.cpp:909
 msgid "Evaluate all noun forms in expression"
 msgstr "Вычислить все невычисляемые (noun) формы в выражении"
 
-#: ../src/wxMaximaFrame.cpp:588
+#: ../src/wxMaximaFrame.cpp:587
 #, fuzzy
 msgid "Evaluate all visible cells in the document"
 msgstr "Отправить на вычисление все ячейки в документе"
@@ -1632,7 +1635,7 @@ msgstr ""
 msgid "Evaluate to point"
 msgstr "Вычислить невычисляемые (noun) формы"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Example"
 msgstr "Пример"
 
@@ -1645,33 +1648,33 @@ msgstr "Текст примера"
 msgid "Examples:"
 msgstr "Пример"
 
-#: ../src/wxMaximaFrame.cpp:488
+#: ../src/wxMaximaFrame.cpp:487
 msgid "Exit wxMaxima"
 msgstr "Выход из wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:1214
+#: ../src/wxMaximaFrame.cpp:1213
 msgid "Expand"
 msgstr "Раскрыть"
 
-#: ../src/wxMaximaFrame.cpp:1219
+#: ../src/wxMaximaFrame.cpp:1218
 msgid "Expand (tr)"
 msgstr "Раскрыть (триг)"
 
-#: ../src/MathCtrl.cpp:997
+#: ../src/MathCtrl.cpp:1039
 #, fuzzy
 msgid "Expand Expression"
 msgstr "Раскрыть выражение"
 
-#: ../src/wxMaximaFrame.cpp:841
+#: ../src/wxMaximaFrame.cpp:840
 #, fuzzy
 msgid "Expand Logarithms"
 msgstr "Раскрыть логарифмы"
 
-#: ../src/wxMaximaFrame.cpp:840
+#: ../src/wxMaximaFrame.cpp:839
 msgid "Expand an expression"
 msgstr "Раскрыть выражение"
 
-#: ../src/wxMaximaFrame.cpp:874
+#: ../src/wxMaximaFrame.cpp:873
 msgid "Expand trigonometric expression"
 msgstr "Раскрыть тригонометрическое выражение"
 
@@ -1679,7 +1682,7 @@ msgstr "Раскрыть тригонометрическое выражение
 msgid "Expected the icon files to be found at"
 msgstr ""
 
-#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2834
+#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2842
 msgid "Export"
 msgstr "Экспорт"
 
@@ -1688,33 +1691,33 @@ msgid ""
 "Export animations to TeX (Images only move if the PDF viewer supports this)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:481
+#: ../src/wxMaximaFrame.cpp:480
 msgid "Export document to a HTML or pdfLaTeX file"
 msgstr "Экспортировать документ в HTML- или pdfLaTeX-файл"
 
-#: ../src/wxMaximaFrame.cpp:253
+#: ../src/wxMaximaFrame.cpp:252
 #, fuzzy
 msgid "Export failed."
 msgstr "Экспорт в TeX не удался!"
 
-#: ../src/wxMaximaFrame.cpp:239
+#: ../src/wxMaximaFrame.cpp:238
 msgid "Export successful."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2913
+#: ../src/wxMaxima.cpp:2921
 msgid "Exporting to HTML failed!"
 msgstr "Экспорт в HTML не удался!"
 
-#: ../src/wxMaxima.cpp:2886
+#: ../src/wxMaxima.cpp:2894
 msgid "Exporting to TeX failed!"
 msgstr "Экспорт в TeX не удался!"
 
-#: ../src/wxMaxima.cpp:2900
+#: ../src/wxMaxima.cpp:2908
 #, fuzzy
 msgid "Exporting to maxima batch file failed!"
 msgstr "Экспорт в TeX не удался!"
 
-#: ../src/wxMaximaFrame.cpp:229
+#: ../src/wxMaximaFrame.cpp:228
 #, fuzzy
 msgid "Exporting..."
 msgstr "&Экспортировать..."
@@ -1728,45 +1731,45 @@ msgid "Expression(s):"
 msgstr "Выражение(ния):"
 
 #: ../src/IntegrateWiz.cpp:30 ../src/LimitWiz.cpp:27 ../src/SeriesWiz.cpp:33
-#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3648
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:4205 ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5064
+#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3660
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:4217 ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5076
 msgid "Expression:"
 msgstr "Выражение:"
 
-#: ../src/wxMaximaFrame.cpp:1213
+#: ../src/wxMaximaFrame.cpp:1212
 msgid "Factor"
 msgstr "Факторизовать"
 
-#: ../src/wxMaximaFrame.cpp:836
+#: ../src/wxMaximaFrame.cpp:835
 #, fuzzy
 msgid "Factor Complex"
 msgstr "Факторизовать комплексное число"
 
-#: ../src/MathCtrl.cpp:996
+#: ../src/MathCtrl.cpp:1038
 #, fuzzy
 msgid "Factor Expression"
 msgstr "Факторизовать выражение"
 
-#: ../src/wxMaximaFrame.cpp:835
+#: ../src/wxMaximaFrame.cpp:834
 msgid "Factor an expression"
 msgstr "Факторизовать выражение"
 
-#: ../src/wxMaximaFrame.cpp:837
+#: ../src/wxMaximaFrame.cpp:836
 msgid "Factor an expression in Gaussian numbers"
 msgstr "Факторизовать выражение в гауссовых числах"
 
-#: ../src/wxMaximaFrame.cpp:862
+#: ../src/wxMaximaFrame.cpp:861
 #, fuzzy
 msgid "Factorials and &Gamma"
 msgstr "Факториалы и гамма-функции"
 
-#: ../src/wxMaxima.cpp:285
+#: ../src/wxMaxima.cpp:286
 msgid "Fatal error"
 msgstr "Фатальная ошибка"
 
-#: ../src/GroupCell.cpp:1571
+#: ../src/GroupCell.cpp:1572
 #, fuzzy, c-format
 msgid "Figure %d:"
 msgstr "Настройка"
@@ -1775,22 +1778,22 @@ msgstr "Настройка"
 msgid "File"
 msgstr "Файл"
 
-#: ../src/wxMaxima.cpp:1457 ../src/wxMaxima.cpp:1623 ../src/wxMaxima.cpp:1636
-#: ../src/wxMaxima.cpp:1646 ../src/wxMaxima.cpp:1668
+#: ../src/wxMaxima.cpp:1462 ../src/wxMaxima.cpp:1628 ../src/wxMaxima.cpp:1641
+#: ../src/wxMaxima.cpp:1651 ../src/wxMaxima.cpp:1673
 #, fuzzy
 msgid "File could not be opened"
 msgstr "Файл не найден"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File not found"
 msgstr "Файл не найден"
 
-#: ../src/wxMaxima.cpp:1511 ../src/wxMaxima.cpp:1729
+#: ../src/wxMaxima.cpp:1516 ../src/wxMaxima.cpp:1734
 #, fuzzy
 msgid "File opened"
 msgstr "Файл не найден"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File you tried to open does not exist."
 msgstr "Такого файла не существует."
 
@@ -1802,69 +1805,69 @@ msgstr "Файл:"
 msgid "Find"
 msgstr "Найти"
 
-#: ../src/wxMaximaFrame.cpp:523
+#: ../src/wxMaximaFrame.cpp:522
 msgid "Find\tCtrl-F"
 msgstr "Найти\tCtrl-F"
 
-#: ../src/wxMaximaFrame.cpp:787
+#: ../src/wxMaximaFrame.cpp:786
 msgid "Find &Limit..."
 msgstr "Найти &предел..."
 
-#: ../src/wxMaximaFrame.cpp:790
+#: ../src/wxMaximaFrame.cpp:789
 msgid "Find Minimum..."
 msgstr "Найти &минимум..."
 
-#: ../src/MathCtrl.cpp:993
+#: ../src/MathCtrl.cpp:1035
 msgid "Find Root..."
 msgstr "Найти корень..."
 
-#: ../src/wxMaximaFrame.cpp:791
+#: ../src/wxMaximaFrame.cpp:790
 #, fuzzy
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr "Найти предел выражения"
 
-#: ../src/wxMaximaFrame.cpp:788
+#: ../src/wxMaximaFrame.cpp:787
 msgid "Find a limit of an expression"
 msgstr "Найти предел выражения"
 
-#: ../src/wxMaximaFrame.cpp:693
+#: ../src/wxMaximaFrame.cpp:692
 msgid "Find a root of an equation on an interval"
 msgstr "Найти корень уравнения на интервале"
 
-#: ../src/wxMaximaFrame.cpp:695
+#: ../src/wxMaximaFrame.cpp:694
 msgid "Find all roots of a polynomial"
 msgstr "Найти все корни полинома"
 
-#: ../src/wxMaximaFrame.cpp:698
+#: ../src/wxMaximaFrame.cpp:697
 #, fuzzy
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr "Найти все корни полинома"
 
-#: ../src/wxMaxima.cpp:3220
+#: ../src/wxMaxima.cpp:3215
 msgid "Find and Replace"
 msgstr "Найти и заменить"
 
-#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:523
+#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:522
 msgid "Find and replace"
 msgstr "Найти и заменить"
 
-#: ../src/wxMaximaFrame.cpp:756
+#: ../src/wxMaximaFrame.cpp:755
 msgid "Find eigenvalues of a matrix"
 msgstr "Найти собственные значения матрицы"
 
-#: ../src/wxMaximaFrame.cpp:758
+#: ../src/wxMaximaFrame.cpp:757
 msgid "Find eigenvectors of a matrix"
 msgstr "Найти собственные векторы матрицы"
 
-#: ../src/wxMaxima.cpp:4210
+#: ../src/wxMaxima.cpp:4222
 msgid "Find minimum"
 msgstr "Найти минимум"
 
-#: ../src/wxMaximaFrame.cpp:701
+#: ../src/wxMaximaFrame.cpp:700
 msgid "Find real roots of a polynomial"
 msgstr "Найти вещественные корни полинома"
 
-#: ../src/wxMaxima.cpp:3493 ../src/wxMaxima.cpp:5036
+#: ../src/wxMaxima.cpp:3505 ../src/wxMaxima.cpp:5048
 msgid "Find root"
 msgstr "Найти корень"
 
@@ -1887,12 +1890,12 @@ msgstr ""
 msgid "Fixed font in text controls"
 msgstr "Фиксированный шрифт в элементах управления"
 
-#: ../src/wxMaximaFrame.cpp:623
+#: ../src/wxMaximaFrame.cpp:622
 #, fuzzy
 msgid "Fold All\tCtrl-Alt-["
 msgstr "Выделить всё\tCtrl-A"
 
-#: ../src/wxMaximaFrame.cpp:624
+#: ../src/wxMaximaFrame.cpp:623
 msgid "Fold all sections"
 msgstr ""
 
@@ -1901,25 +1904,25 @@ msgstr ""
 msgid "Follow"
 msgstr "желтый"
 
-#: ../src/ParenCell.cpp:319
+#: ../src/ParenCell.cpp:320
 msgid "Font issue: The Parenthesis sign is too small!"
 msgstr ""
 
-#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:381
+#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:382
 msgid ""
 "Font issue: The char height is too small! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:199
+#: ../src/SqrtCell.cpp:202
 msgid ""
 "Font issue: The sqrt() sign has the size 0! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:198
+#: ../src/SqrtCell.cpp:201
 msgid "Font issue? The contents of a sqrt() has the size 0."
 msgstr ""
 
@@ -1952,15 +1955,15 @@ msgstr "Французский"
 
 #: ../src/IntegrateWiz.cpp:37 ../src/Plot2dWiz.cpp:37 ../src/Plot2dWiz.cpp:47
 #: ../src/Plot2dWiz.cpp:536 ../src/Plot3dWiz.cpp:36 ../src/Plot3dWiz.cpp:45
-#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4240
+#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4252
 msgid "From:"
 msgstr "Из:"
 
-#: ../src/wxMaximaFrame.cpp:576
+#: ../src/wxMaximaFrame.cpp:575
 msgid "Full Screen\tAlt-Enter"
 msgstr "Полноэкранный режим\tAlt-Enter"
 
-#: ../src/wxMaxima.cpp:3342
+#: ../src/wxMaxima.cpp:3354
 msgid "Function"
 msgstr "Функция"
 
@@ -1968,32 +1971,32 @@ msgstr "Функция"
 msgid "Function names"
 msgstr "Имена функций"
 
-#: ../src/wxMaxima.cpp:3633
+#: ../src/wxMaxima.cpp:3645
 msgid "Function(s):"
 msgstr "Функции:"
 
-#: ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3803
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3815
+#: ../src/wxMaxima.cpp:3848
 msgid "Function:"
 msgstr "Функция:"
 
-#: ../src/wxMaximaFrame.cpp:904
+#: ../src/wxMaximaFrame.cpp:903
 msgid "Functions for complex simplification"
 msgstr "Функции для упрощения комплексных чисел"
 
-#: ../src/wxMaximaFrame.cpp:864
+#: ../src/wxMaximaFrame.cpp:863
 msgid "Functions for simplifying factorials and gamma function"
 msgstr "Функции для упрощения факториалов и гамма-функций"
 
-#: ../src/wxMaximaFrame.cpp:881
+#: ../src/wxMaximaFrame.cpp:880
 msgid "Functions for simplifying trigonometric expressions"
 msgstr "Функции для упрощения тригонометрических выражений"
 
-#: ../src/wxMaxima.cpp:4046
+#: ../src/wxMaxima.cpp:4058
 msgid "GCD"
 msgstr "НОД"
 
-#: ../src/wxMaxima.cpp:5152
+#: ../src/wxMaxima.cpp:5164
 msgid "GIF image (*.gif)|*.gif"
 msgstr "Изображение в формате GIF (*.gif)|*.gif"
 
@@ -2001,31 +2004,31 @@ msgstr "Изображение в формате GIF (*.gif)|*.gif"
 msgid "Galician"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1366
+#: ../src/wxMaximaFrame.cpp:1365
 msgid "Gamma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:391
+#: ../src/wxMaximaFrame.cpp:390
 msgid "General Math"
 msgstr "Математика"
 
-#: ../src/wxMaximaFrame.cpp:549
+#: ../src/wxMaximaFrame.cpp:548
 msgid "General Math\tAlt-Shift-M"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3766 ../src/wxMaxima.cpp:3785
+#: ../src/wxMaxima.cpp:3778 ../src/wxMaxima.cpp:3797
 msgid "Generate Matrix"
 msgstr "Создать матрицу"
 
-#: ../src/wxMaximaFrame.cpp:741
+#: ../src/wxMaximaFrame.cpp:740
 msgid "Generate Matrix from Expression..."
 msgstr "Создать матрицу из &выражения..."
 
-#: ../src/wxMaximaFrame.cpp:739
+#: ../src/wxMaximaFrame.cpp:738
 msgid "Generate a matrix from a 2-dimensional array"
 msgstr "Создать матрицу из двумерного массива"
 
-#: ../src/wxMaximaFrame.cpp:742
+#: ../src/wxMaximaFrame.cpp:741
 msgid "Generate a matrix from a lambda expression"
 msgstr "Сгенерировать матрицу из лямбда-функции"
 
@@ -2033,40 +2036,40 @@ msgstr "Сгенерировать матрицу из лямбда-функци
 msgid "German"
 msgstr "Немецкий"
 
-#: ../src/wxMaximaFrame.cpp:893
+#: ../src/wxMaximaFrame.cpp:892
 msgid "Get &Imaginary Part"
 msgstr "Получить &мнимую часть"
 
-#: ../src/wxMaximaFrame.cpp:793
+#: ../src/wxMaximaFrame.cpp:792
 #, fuzzy
 msgid "Get &Series..."
 msgstr "Разложить в ряд ... "
 
-#: ../src/wxMaximaFrame.cpp:804
+#: ../src/wxMaximaFrame.cpp:803
 msgid "Get Laplace transformation of an expression"
 msgstr "Вычислить преобразование Лапласа"
 
-#: ../src/wxMaximaFrame.cpp:890
+#: ../src/wxMaximaFrame.cpp:889
 msgid "Get Real P&art"
 msgstr "Получить &вещественную часть"
 
-#: ../src/wxMaximaFrame.cpp:807
+#: ../src/wxMaximaFrame.cpp:806
 msgid "Get inverse Laplace transformation of an expression"
 msgstr "Вычислить обратное преобразование Лапласа"
 
-#: ../src/wxMaximaFrame.cpp:794
+#: ../src/wxMaximaFrame.cpp:793
 msgid "Get the Taylor or power series of expression"
 msgstr "Вычислить разложение выражения в степенной ряд или ряд Тейлора"
 
-#: ../src/wxMaximaFrame.cpp:894
+#: ../src/wxMaximaFrame.cpp:893
 msgid "Get the imaginary part of complex expression"
 msgstr "Вычислить мнимую часть комплексного выражения"
 
-#: ../src/wxMaximaFrame.cpp:891
+#: ../src/wxMaximaFrame.cpp:890
 msgid "Get the real part of complex expression"
 msgstr "Вычислить вещественную часть комплексного выражения"
 
-#: ../src/MathCtrl.cpp:5932
+#: ../src/MathCtrl.cpp:5984
 msgid ""
 "Got a request to undo an action that involves an delete which isn't possible "
 "at this moment."
@@ -2076,12 +2079,12 @@ msgstr ""
 msgid "Greek"
 msgstr "Греческий"
 
-#: ../src/wxMaximaFrame.cpp:356
+#: ../src/wxMaximaFrame.cpp:355
 #, fuzzy
 msgid "Greek Letters"
 msgstr "Греческие константы"
 
-#: ../src/wxMaximaFrame.cpp:552
+#: ../src/wxMaximaFrame.cpp:551
 #, fuzzy
 msgid "Greek Letters\tAlt-Shift-G"
 msgstr "Статистика\tAlt-Shift-S"
@@ -2094,7 +2097,7 @@ msgstr "Греческие константы"
 msgid "Grid:"
 msgstr "Сетка:"
 
-#: ../src/wxMaxima.cpp:2836
+#: ../src/wxMaxima.cpp:2844
 #, fuzzy
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|pdfLaTeX file (*."
@@ -2109,12 +2112,12 @@ msgstr ""
 msgid "Help"
 msgstr "Справка"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 #, fuzzy
 msgid "Hide All Toolbars\tAlt-Shift--"
 msgstr "Скрыть все\tAlt-Shift--"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide all panes"
 msgstr "Скрыть все панели"
 
@@ -2123,19 +2126,19 @@ msgstr "Скрыть все панели"
 msgid "Highlight (dpart)"
 msgstr "Выделение"
 
-#: ../src/wxMaxima.cpp:4685
+#: ../src/wxMaxima.cpp:4697
 msgid "Histogram"
 msgstr "Гистограмма"
 
-#: ../src/wxMaximaFrame.cpp:1270
+#: ../src/wxMaximaFrame.cpp:1269
 msgid "Histogram..."
 msgstr "Гистограмма..."
 
-#: ../src/wxMaximaFrame.cpp:309
+#: ../src/wxMaximaFrame.cpp:308
 msgid "History"
 msgstr "История"
 
-#: ../src/wxMaximaFrame.cpp:555
+#: ../src/wxMaximaFrame.cpp:554
 #, fuzzy
 msgid "History\tAlt-Shift-I"
 msgstr "История\tAlt-Shift-H"
@@ -2152,11 +2155,11 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Венгерский"
 
-#: ../src/wxMaxima.cpp:3527
+#: ../src/wxMaxima.cpp:3539
 msgid "IC1"
 msgstr "НУ1"
 
-#: ../src/wxMaxima.cpp:3543
+#: ../src/wxMaxima.cpp:3555
 msgid "IC2"
 msgstr "НУ2"
 
@@ -2172,7 +2175,7 @@ msgid ""
 "same output cell."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:683
+#: ../src/wxMaximaFrame.cpp:682
 msgid ""
 "If maxima ever finishes evaluating without wxMaxima realizing this this menu "
 "item can force wxMaxima to try to send commands to maxima again."
@@ -2232,11 +2235,11 @@ msgid ""
 ">Interrupt' or 'Maxima->Restart Maxima' menu commands."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1499
+#: ../src/wxMaximaFrame.cpp:1518
 msgid "Image"
 msgstr "Изображение"
 
-#: ../src/wxMaxima.cpp:5644
+#: ../src/wxMaxima.cpp:5659
 msgid "Image files (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 msgstr "Изображения (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 
@@ -2263,7 +2266,7 @@ msgid ""
 "above it. Might increase readability for some fonts and short subscripts."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Include columns:"
 msgstr ""
 
@@ -2282,20 +2285,20 @@ msgstr ""
 msgid "Infinity"
 msgstr "Бесконечность"
 
-#: ../src/wxMaximaFrame.cpp:974
+#: ../src/wxMaximaFrame.cpp:973
 msgid "Info about Maxima build"
 msgstr "Информация о сборке Maxima"
 
-#: ../src/wxMaxima.cpp:4207
+#: ../src/wxMaxima.cpp:4219
 msgid "Initial Estimates:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:718
+#: ../src/wxMaximaFrame.cpp:717
 #, fuzzy
 msgid "Initial Value Problem (&1)..."
 msgstr "Задача с начальным условием (&1) ..."
 
-#: ../src/wxMaximaFrame.cpp:721
+#: ../src/wxMaximaFrame.cpp:720
 #, fuzzy
 msgid "Initial Value Problem (&2)..."
 msgstr "Задача с начальным условием (&2) ..."
@@ -2304,7 +2307,7 @@ msgstr "Задача с начальным условием (&2) ..."
 msgid "Input labels"
 msgstr "Метки ввода"
 
-#: ../src/wxMaximaFrame.cpp:403
+#: ../src/wxMaximaFrame.cpp:402
 msgid "Insert"
 msgstr "Вставить"
 
@@ -2312,98 +2315,98 @@ msgstr "Вставить"
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:612
+#: ../src/wxMaximaFrame.cpp:611
 msgid "Insert &Section Cell\tCtrl-3"
 msgstr "Новый &раздел\tCtrl-3"
 
-#: ../src/wxMaximaFrame.cpp:608
+#: ../src/wxMaximaFrame.cpp:607
 msgid "Insert &Text Cell\tCtrl-1"
 msgstr "Новый &комментарий\tCtrl-1"
 
-#: ../src/wxMaximaFrame.cpp:558
+#: ../src/wxMaximaFrame.cpp:557
 msgid "Insert Cell\tAlt-Shift-C"
 msgstr "Добавить ячейку\tAlt-Shift-C"
 
-#: ../src/wxMaxima.cpp:5642
+#: ../src/wxMaxima.cpp:5657
 msgid "Insert Image"
 msgstr "Вставить изображение"
 
-#: ../src/wxMaximaFrame.cpp:620
+#: ../src/wxMaximaFrame.cpp:619
 msgid "Insert Image..."
 msgstr "Вставить изображение..."
 
-#: ../src/wxMaximaFrame.cpp:606
+#: ../src/wxMaximaFrame.cpp:605
 msgid "Insert Input &Cell"
 msgstr "Новая &ячейка"
 
-#: ../src/wxMaximaFrame.cpp:618
+#: ../src/wxMaximaFrame.cpp:617
 msgid "Insert Page Break"
 msgstr "Вставить разрыв страницы"
 
-#: ../src/wxMaximaFrame.cpp:614
+#: ../src/wxMaximaFrame.cpp:613
 msgid "Insert S&ubsection Cell\tCtrl-4"
 msgstr "Новый &подраздел\tCtrl-4"
 
-#: ../src/wxMaximaFrame.cpp:616
+#: ../src/wxMaximaFrame.cpp:615
 #, fuzzy
 msgid "Insert S&ubsubsection Cell\tCtrl-5"
 msgstr "Новый &подраздел\tCtrl-4"
 
-#: ../src/MathCtrl.cpp:1015
+#: ../src/MathCtrl.cpp:1057
 msgid "Insert Section Cell"
 msgstr "Новый раздел"
 
-#: ../src/MathCtrl.cpp:1016
+#: ../src/MathCtrl.cpp:1058
 msgid "Insert Subsection Cell"
 msgstr "Новый подраздел"
 
-#: ../src/MathCtrl.cpp:1017
+#: ../src/MathCtrl.cpp:1059
 #, fuzzy
 msgid "Insert Subsubsection Cell"
 msgstr "Новый подраздел"
 
-#: ../src/wxMaximaFrame.cpp:610
+#: ../src/wxMaximaFrame.cpp:609
 msgid "Insert T&itle Cell\tCtrl-2"
 msgstr "Новый &заголовок\tCtrl-2"
 
-#: ../src/MathCtrl.cpp:1013
+#: ../src/MathCtrl.cpp:1055
 msgid "Insert Text Cell"
 msgstr "Новый комментарий"
 
-#: ../src/MathCtrl.cpp:1014
+#: ../src/MathCtrl.cpp:1056
 msgid "Insert Title Cell"
 msgstr "Новый заголовок"
 
-#: ../src/wxMaximaFrame.cpp:607
+#: ../src/wxMaximaFrame.cpp:606
 msgid "Insert a new input cell"
 msgstr "Вставить новое поле ввода"
 
-#: ../src/wxMaximaFrame.cpp:613
+#: ../src/wxMaximaFrame.cpp:612
 msgid "Insert a new section cell"
 msgstr "Вставить новый раздел"
 
-#: ../src/wxMaximaFrame.cpp:615
+#: ../src/wxMaximaFrame.cpp:614
 msgid "Insert a new subsection cell"
 msgstr "Вставить новый подраздел"
 
-#: ../src/wxMaximaFrame.cpp:617
+#: ../src/wxMaximaFrame.cpp:616
 #, fuzzy
 msgid "Insert a new subsubsection cell"
 msgstr "Вставить новый подраздел"
 
-#: ../src/wxMaximaFrame.cpp:609
+#: ../src/wxMaximaFrame.cpp:608
 msgid "Insert a new text cell"
 msgstr "Вставить новое текстовое поле"
 
-#: ../src/wxMaximaFrame.cpp:611
+#: ../src/wxMaximaFrame.cpp:610
 msgid "Insert a new title cell"
 msgstr "Вставить новый заголовок"
 
-#: ../src/wxMaximaFrame.cpp:619
+#: ../src/wxMaximaFrame.cpp:618
 msgid "Insert a page break"
 msgstr "Вставить разрыв страницы"
 
-#: ../src/wxMaximaFrame.cpp:621
+#: ../src/wxMaximaFrame.cpp:620
 msgid "Insert image"
 msgstr "Вставить изображение"
 
@@ -2416,27 +2419,27 @@ msgstr ""
 msgid "Integral sign"
 msgstr "Интегрировать выражение"
 
-#: ../src/wxMaxima.cpp:3992
+#: ../src/wxMaxima.cpp:4004
 msgid "Integral/Sum:"
 msgstr "Интеграл/сумма:"
 
-#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4105 ../src/wxMaxima.cpp:5051
+#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4117 ../src/wxMaxima.cpp:5063
 msgid "Integrate"
 msgstr "Интегрировать"
 
-#: ../src/wxMaxima.cpp:4091
+#: ../src/wxMaxima.cpp:4103
 msgid "Integrate (risch)"
 msgstr "Интегрировать (Рич)"
 
-#: ../src/wxMaximaFrame.cpp:778
+#: ../src/wxMaximaFrame.cpp:777
 msgid "Integrate expression"
 msgstr "Интегрировать выражение"
 
-#: ../src/wxMaximaFrame.cpp:780
+#: ../src/wxMaximaFrame.cpp:779
 msgid "Integrate expression with Risch algorithm"
 msgstr "Интегрировать выражение при помощи алгоритма Рича"
 
-#: ../src/wxMaximaFrame.cpp:1224 ../src/MathCtrl.cpp:1000
+#: ../src/MathCtrl.cpp:1042 ../src/wxMaximaFrame.cpp:1223
 msgid "Integrate..."
 msgstr "Интегрировать..."
 
@@ -2444,7 +2447,7 @@ msgstr "Интегрировать..."
 msgid "Interrupt"
 msgstr "Прервать"
 
-#: ../src/wxMaximaFrame.cpp:646 ../src/wxMaximaFrame.cpp:650
+#: ../src/wxMaximaFrame.cpp:645 ../src/wxMaximaFrame.cpp:649
 msgid "Interrupt current computation"
 msgstr "Прервать текущее вычисление"
 
@@ -2465,16 +2468,16 @@ msgstr ""
 "\n"
 "Пожалуйста, введите путь к программе maxima снова."
 
-#: ../src/wxMaxima.cpp:4137
+#: ../src/wxMaxima.cpp:4149
 msgid "Inverse Laplace"
 msgstr "Обратное преобразование Лапласа"
 
-#: ../src/wxMaximaFrame.cpp:806
+#: ../src/wxMaximaFrame.cpp:805
 #, fuzzy
 msgid "Inverse Laplace T&ransform..."
 msgstr "Обратное преобразование Лапласа ..."
 
-#: ../src/wxMaximaFrame.cpp:1372
+#: ../src/wxMaximaFrame.cpp:1371
 msgid "Iota"
 msgstr ""
 
@@ -2508,7 +2511,7 @@ msgstr "Японский"
 msgid "Kabyle"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1373
+#: ../src/wxMaximaFrame.cpp:1372
 msgid "Kappa"
 msgstr ""
 
@@ -2517,7 +2520,7 @@ msgstr ""
 msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4031
+#: ../src/wxMaxima.cpp:4043
 msgid "LCM"
 msgstr "НОК"
 
@@ -2533,7 +2536,7 @@ msgstr ""
 msgid "Label width:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1374
+#: ../src/wxMaximaFrame.cpp:1373
 msgid "Lambda"
 msgstr ""
 
@@ -2545,11 +2548,11 @@ msgstr "Язык, используемый в интерфейсе wxMaxima."
 msgid "Language:"
 msgstr "Язык:"
 
-#: ../src/wxMaxima.cpp:4120
+#: ../src/wxMaxima.cpp:4132
 msgid "Laplace"
 msgstr "Преобразование Лапласа"
 
-#: ../src/wxMaximaFrame.cpp:803
+#: ../src/wxMaximaFrame.cpp:802
 msgid "Laplace &Transform..."
 msgstr "Преобразование &Лапласа..."
 
@@ -2558,16 +2561,16 @@ msgstr "Преобразование &Лапласа..."
 msgid "Leads to"
 msgstr "стремится к"
 
-#: ../src/wxMaximaFrame.cpp:812
+#: ../src/wxMaximaFrame.cpp:811
 #, fuzzy
 msgid "Least Common Multiple..."
 msgstr "Наименьшее общее кратное ..."
 
-#: ../src/wxMaxima.cpp:4809
+#: ../src/wxMaxima.cpp:4821
 msgid "Least Squares Fit"
 msgstr "Подбор методом наименьших квадратов"
 
-#: ../src/wxMaximaFrame.cpp:1266
+#: ../src/wxMaximaFrame.cpp:1265
 msgid "Least Squares Fit..."
 msgstr "Подбор методом наименьших квадратов..."
 
@@ -2578,25 +2581,25 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4192
+#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4204
 msgid "Limit"
 msgstr "Предел"
 
-#: ../src/wxMaximaFrame.cpp:1225
+#: ../src/wxMaximaFrame.cpp:1224
 msgid "Limit..."
 msgstr "Предел ..."
 
-#: ../src/wxMaximaFrame.cpp:1265
+#: ../src/wxMaximaFrame.cpp:1264
 #, fuzzy
 msgid "Linear Regression..."
 msgstr "Интегрировать выражение"
 
-#: ../src/wxMaxima.cpp:3803
+#: ../src/wxMaxima.cpp:3815
 #, fuzzy
 msgid "List(s):"
 msgstr "Список:"
 
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3848
 msgid "List:"
 msgstr "Список:"
 
@@ -2604,16 +2607,16 @@ msgstr "Список:"
 msgid "Load"
 msgstr "Загрузить"
 
-#: ../src/wxMaxima.cpp:2932
+#: ../src/wxMaxima.cpp:2940
 msgid "Load Package"
 msgstr "Загрузить пакет"
 
-#: ../src/wxMaximaFrame.cpp:479
+#: ../src/wxMaximaFrame.cpp:478
 #, fuzzy
 msgid "Load a Maxima file using the batch command"
 msgstr "Загрузить программу для maxima при помощи команды batch"
 
-#: ../src/wxMaximaFrame.cpp:477
+#: ../src/wxMaximaFrame.cpp:476
 #, fuzzy
 msgid "Load a Maxima package file"
 msgstr "Загрузить пакет Maxima"
@@ -2626,51 +2629,51 @@ msgstr "Загрузить стиль из файла"
 msgid "Long Right arrow"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Lower bound:"
 msgstr "Нижняя граница:"
 
-#: ../src/wxMaximaFrame.cpp:771
+#: ../src/wxMaximaFrame.cpp:770
 #, fuzzy
 msgid "Ma&p to Matrix..."
 msgstr "Применить к элементам матрицы ..."
 
-#: ../src/wxMaximaFrame.cpp:547
+#: ../src/wxMaximaFrame.cpp:546
 #, fuzzy
 msgid "Main Toolbar\tAlt-Shift-B"
 msgstr "Панель инструментов\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:765
+#: ../src/wxMaximaFrame.cpp:764
 #, fuzzy
 msgid "Make &List..."
 msgstr "Создать список ..."
 
-#: ../src/wxMaxima.cpp:3821
+#: ../src/wxMaxima.cpp:3833
 msgid "Make list"
 msgstr "Создать список"
 
-#: ../src/wxMaximaFrame.cpp:766
+#: ../src/wxMaximaFrame.cpp:765
 msgid "Make list from expression"
 msgstr "Создать список на основе выражения"
 
-#: ../src/wxMaximaFrame.cpp:907
+#: ../src/wxMaximaFrame.cpp:906
 msgid "Make substitution in expression"
 msgstr "Выполнить подстановку в выражении"
 
-#: ../src/wxMaximaFrame.cpp:682
+#: ../src/wxMaximaFrame.cpp:681
 #, fuzzy
 msgid "Manually Trigger Evaluation"
 msgstr "Отображать время выполнения команд"
 
-#: ../src/wxMaxima.cpp:3805
+#: ../src/wxMaxima.cpp:3817
 msgid "Map"
 msgstr "Применить к элементам"
 
-#: ../src/wxMaximaFrame.cpp:770
+#: ../src/wxMaximaFrame.cpp:769
 msgid "Map function to a list"
 msgstr "Применить функцию к элементам списка"
 
-#: ../src/wxMaximaFrame.cpp:772
+#: ../src/wxMaximaFrame.cpp:771
 msgid "Map function to a matrix"
 msgstr "Применить функцию к элементам матрицы"
 
@@ -2687,23 +2690,23 @@ msgstr "Проверять расстановку скобок в текстов
 msgid "Math font:"
 msgstr "Шрифт для математики:"
 
-#: ../src/wxMaximaFrame.cpp:374
+#: ../src/wxMaximaFrame.cpp:373
 msgid "Mathematical Symbols"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3716
+#: ../src/wxMaxima.cpp:3728
 msgid "Matrix"
 msgstr "Матрица"
 
-#: ../src/wxMaxima.cpp:3702
+#: ../src/wxMaxima.cpp:3714
 msgid "Matrix map"
 msgstr "Применить к матрице"
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Matrix name:"
 msgstr "Название матрицы:"
 
-#: ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3749
+#: ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3761
 msgid "Matrix:"
 msgstr "Матрица:"
 
@@ -2711,7 +2714,7 @@ msgstr "Матрица:"
 msgid "Maxima"
 msgstr "Maxima"
 
-#: ../src/wxMaximaFrame.cpp:137
+#: ../src/wxMaximaFrame.cpp:136
 #, fuzzy
 msgid "Maxima has a question"
 msgstr "Опции Maxima"
@@ -2720,24 +2723,24 @@ msgstr "Опции Maxima"
 msgid "Maxima input"
 msgstr "Ввод Maxima"
 
-#: ../src/wxMaximaFrame.cpp:166
+#: ../src/wxMaximaFrame.cpp:165
 msgid "Maxima is calculating"
 msgstr "Maxima производит вычисления"
 
-#: ../src/wxMaximaFrame.cpp:111
+#: ../src/wxMaximaFrame.cpp:110
 #, fuzzy
 msgid "Maxima is ready for input."
 msgstr "Ввод Maxima"
 
-#: ../src/wxMaxima.cpp:2945
+#: ../src/wxMaxima.cpp:2953
 msgid "Maxima package (*.mac)|*.mac"
 msgstr "Пакет Maxima (*.mac)|*.mac"
 
-#: ../src/wxMaxima.cpp:2934
+#: ../src/wxMaxima.cpp:2942
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr "Пакет Maxima (*.mac)|*.mac|Пакет Lisp (*.lisp)|*.lisp|Все|*"
 
-#: ../src/wxMaxima.cpp:1014
+#: ../src/wxMaxima.cpp:1019
 msgid "Maxima process terminated."
 msgstr "Процесс Maxima завершен."
 
@@ -2750,7 +2753,7 @@ msgstr "Программа Maxima:"
 msgid "Maxima questions"
 msgstr "Опции Maxima"
 
-#: ../src/wxMaxima.cpp:942
+#: ../src/wxMaxima.cpp:947
 msgid "Maxima started. Waiting for connection..."
 msgstr "Maxima запущена. Установка связи ..."
 
@@ -2774,7 +2777,7 @@ msgstr ""
 "Maxima использует ':' для присвоения значений ('a : 3;') и ':=' для "
 "определения функций ('f(x) := x^2;')."
 
-#: ../src/wxMaxima.cpp:4597
+#: ../src/wxMaxima.cpp:4609
 #, fuzzy
 msgid "Maxima version: "
 msgstr "Опции Maxima"
@@ -2812,45 +2815,45 @@ msgstr ""
 msgid "Maximum displayed number of digits:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1263
+#: ../src/wxMaximaFrame.cpp:1262
 #, fuzzy
 msgid "Mean Difference Test..."
 msgstr "Дифференцировать..."
 
-#: ../src/wxMaximaFrame.cpp:1262
+#: ../src/wxMaximaFrame.cpp:1261
 #, fuzzy
 msgid "Mean Test..."
 msgstr "Создать список ..."
 
-#: ../src/wxMaximaFrame.cpp:1255
+#: ../src/wxMaximaFrame.cpp:1254
 #, fuzzy
 msgid "Mean..."
 msgstr "Применить к элементам..."
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Mean:"
 msgstr "Средняя величина:"
 
-#: ../src/wxMaximaFrame.cpp:1256
+#: ../src/wxMaximaFrame.cpp:1255
 #, fuzzy
 msgid "Median..."
 msgstr "Создать список ..."
 
-#: ../src/MathCtrl.cpp:945
+#: ../src/MathCtrl.cpp:987
 #, fuzzy
 msgid "Merge Cells"
 msgstr "&Удалить поля"
 
-#: ../src/wxMaximaFrame.cpp:633
+#: ../src/wxMaximaFrame.cpp:632
 #, fuzzy
 msgid "Merge Cells\tCtrl-M"
 msgstr "&Удалить поля"
 
-#: ../src/wxMaximaFrame.cpp:634
+#: ../src/wxMaximaFrame.cpp:633
 msgid "Merge the text from two input cells into one"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2668
+#: ../src/wxMaxima.cpp:2676
 msgid "Message from the stdout of Maxima: "
 msgstr ""
 
@@ -2858,20 +2861,20 @@ msgstr ""
 msgid "Method:"
 msgstr "Метод:"
 
-#: ../src/wxMaxima.cpp:5289
+#: ../src/wxMaxima.cpp:5301
 #, fuzzy
 msgid "Mismatched parenthesis"
 msgstr "Проверять расстановку скобок в текстовом вводе"
 
-#: ../src/wxMaxima.cpp:3972
+#: ../src/wxMaxima.cpp:3984
 msgid "Modulus"
 msgstr "Модуль"
 
-#: ../src/wxMaximaFrame.cpp:1375
+#: ../src/wxMaximaFrame.cpp:1374
 msgid "Mu"
 msgstr ""
 
-#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Name:"
 msgstr "Имя:"
 
@@ -2879,7 +2882,7 @@ msgstr "Имя:"
 msgid "New"
 msgstr "Новый"
 
-#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
+#: ../src/wxMaximaFrame.cpp:456 ../src/wxMaximaFrame.cpp:459
 msgid "New\tCtrl-N"
 msgstr "Новый\tCtrl-N "
 
@@ -2895,11 +2898,11 @@ msgstr ""
 msgid "New value:"
 msgstr "Новое значение:"
 
-#: ../src/wxMaxima.cpp:3993 ../src/wxMaxima.cpp:4119 ../src/wxMaxima.cpp:4136
+#: ../src/wxMaxima.cpp:4005 ../src/wxMaxima.cpp:4131 ../src/wxMaxima.cpp:4148
 msgid "New variable:"
 msgstr "Новая переменная:"
 
-#: ../src/wxMaximaFrame.cpp:630
+#: ../src/wxMaximaFrame.cpp:629
 msgid "Next Command\tAlt-Down"
 msgstr "Следующая команда\tAlt-Down"
 
@@ -2907,15 +2910,15 @@ msgstr "Следующая команда\tAlt-Down"
 msgid "No"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5362
+#: ../src/wxMaxima.cpp:5378
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3249 ../src/wxMaxima.cpp:3271
+#: ../src/wxMaxima.cpp:3260 ../src/wxMaxima.cpp:3283
 msgid "No matches found!"
 msgstr "Совпадений не найдено!"
 
-#: ../src/wxMaximaFrame.cpp:1264
+#: ../src/wxMaximaFrame.cpp:1263
 #, fuzzy
 msgid "Normality Test..."
 msgstr "Создать список ..."
@@ -2939,34 +2942,34 @@ msgstr ""
 msgid "Norwegian"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:3740
 msgid "Not a valid matrix dimension!"
 msgstr "Неверная размерность матрицы!"
 
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629
 msgid "Not a valid number of equations!"
 msgstr "Неверное число уравнений!"
 
-#: ../src/wxMaximaFrame.cpp:197
+#: ../src/wxMaximaFrame.cpp:196
 #, fuzzy
 msgid "Not connected to maxima"
 msgstr ""
 "\n"
 "Нет подключения к Maxima!\n"
 
-#: ../src/wxMaxima.cpp:4599
+#: ../src/wxMaxima.cpp:4611
 msgid "Not connected."
 msgstr "Нет подключения."
 
-#: ../src/wxMaximaFrame.cpp:1376
+#: ../src/wxMaximaFrame.cpp:1375
 msgid "Nu"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Num. deg:"
 msgstr "Степень числителя:"
 
-#: ../src/wxMaxima.cpp:3585 ../src/wxMaxima.cpp:3609
+#: ../src/wxMaxima.cpp:3597 ../src/wxMaxima.cpp:3621
 msgid "Number of equations:"
 msgstr "Число уравнений:"
 
@@ -2993,15 +2996,15 @@ msgstr "OK"
 msgid "Old value:"
 msgstr "Прежнее значение:"
 
-#: ../src/wxMaxima.cpp:3992 ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135
+#: ../src/wxMaxima.cpp:4004 ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147
 msgid "Old variable:"
 msgstr "Старая переменная:"
 
-#: ../src/wxMaximaFrame.cpp:1387
+#: ../src/wxMaximaFrame.cpp:1386
 msgid "Omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1378
+#: ../src/wxMaximaFrame.cpp:1377
 msgid "Omicron"
 msgstr ""
 
@@ -3015,21 +3018,21 @@ msgid ""
 "stream for messages."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4763
+#: ../src/wxMaxima.cpp:4775
 #, fuzzy
 msgid "One sample t-test"
 msgstr "Текст примера"
 
-#: ../src/wxMaximaFrame.cpp:971
+#: ../src/wxMaximaFrame.cpp:970
 msgid "Online tutorials"
 msgstr "Обучающие материалы в интернете"
 
 #: ../src/ConfigDialogue.cpp:656 ../src/main.cpp:347 ../src/ToolBar.cpp:119
-#: ../src/wxMaxima.cpp:2797
+#: ../src/wxMaxima.cpp:2805
 msgid "Open"
 msgstr "Открыть"
 
-#: ../src/wxMaximaFrame.cpp:466
+#: ../src/wxMaximaFrame.cpp:465
 #, fuzzy
 msgid "Open Recent"
 msgstr "Открыть сессию"
@@ -3038,11 +3041,11 @@ msgstr "Открыть сессию"
 msgid "Open a cell when Maxima expects input"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:464
+#: ../src/wxMaximaFrame.cpp:463
 msgid "Open a document"
 msgstr "Открыть документ"
 
-#: ../src/wxMaximaFrame.cpp:458 ../src/wxMaximaFrame.cpp:461
+#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
 msgid "Open a new window"
 msgstr "Открыть новое окно"
 
@@ -3050,12 +3053,12 @@ msgstr "Открыть новое окно"
 msgid "Open document"
 msgstr "Открыть документ"
 
-#: ../src/wxMaxima.cpp:4824
+#: ../src/wxMaxima.cpp:4836
 #, fuzzy
 msgid "Open matrix"
 msgstr "Ввести матрицу"
 
-#: ../src/wxMaxima.cpp:1446 ../src/wxMaxima.cpp:1518
+#: ../src/wxMaxima.cpp:1451 ../src/wxMaxima.cpp:1523
 msgid "Opening file"
 msgstr "Открытие файла"
 
@@ -3080,12 +3083,12 @@ msgstr "Копировать выделенные поля"
 msgid "Output labels"
 msgstr "Метки вывода"
 
-#: ../src/wxMaximaFrame.cpp:796
+#: ../src/wxMaximaFrame.cpp:795
 #, fuzzy
 msgid "P&ade Approximation..."
 msgstr "Аппроксимация Паде ..."
 
-#: ../src/wxMaxima.cpp:3132 ../src/wxMaxima.cpp:5133
+#: ../src/wxMaxima.cpp:3141 ../src/wxMaxima.cpp:5145
 #, fuzzy
 msgid ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
@@ -3095,15 +3098,15 @@ msgstr ""
 "PNG изображение (*.png)|*.png|JPEG изображение (*.jpg)|*.jpg|Windows bitmap "
 "(*.bmp)|*.bmp|X pixmap (*.xpm)|*.xpm"
 
-#: ../src/wxMaxima.cpp:4012
+#: ../src/wxMaxima.cpp:4024
 msgid "Pade approximation"
 msgstr "Аппроксимация Паде"
 
-#: ../src/wxMaximaFrame.cpp:797
+#: ../src/wxMaximaFrame.cpp:796
 msgid "Pade approximation of a Taylor series"
 msgstr "Паде-аппроксимация ряда Тейлора"
 
-#: ../src/wxMaximaFrame.cpp:1500
+#: ../src/wxMaximaFrame.cpp:1519
 msgid "Pagebreak"
 msgstr "Разрыв страницы"
 
@@ -3115,20 +3118,20 @@ msgstr ""
 msgid "Parametric plot"
 msgstr "Параметрический график"
 
-#: ../src/wxMaximaFrame.cpp:188
+#: ../src/wxMaximaFrame.cpp:187
 msgid "Parsing output"
 msgstr "Анализ вывода"
 
-#: ../src/wxMaximaFrame.cpp:819
+#: ../src/wxMaximaFrame.cpp:818
 #, fuzzy
 msgid "Partial &Fractions..."
 msgstr "Простые дроби ..."
 
-#: ../src/wxMaxima.cpp:4076
+#: ../src/wxMaxima.cpp:4088
 msgid "Partial fractions"
 msgstr "Простые дроби"
 
-#: ../src/wxMaxima.cpp:1769
+#: ../src/wxMaxima.cpp:1774
 msgid "Parts of the document will not be loaded correctly!"
 msgstr ""
 
@@ -3138,11 +3141,11 @@ msgid ""
 "Found unknown XML Tag name "
 msgstr ""
 
-#: ../src/ToolBar.cpp:143 ../src/MathCtrl.cpp:1010 ../src/MathCtrl.cpp:1025
+#: ../src/MathCtrl.cpp:1052 ../src/MathCtrl.cpp:1067 ../src/ToolBar.cpp:143
 msgid "Paste"
 msgstr "Вставить"
 
-#: ../src/wxMaximaFrame.cpp:518
+#: ../src/wxMaximaFrame.cpp:517
 msgid "Paste\tCtrl-V"
 msgstr "Вставить\tCtrl-V"
 
@@ -3151,7 +3154,7 @@ msgstr "Вставить\tCtrl-V"
 msgid "Paste from clipboard"
 msgstr "Вставить текст из буфера обмена"
 
-#: ../src/wxMaximaFrame.cpp:519
+#: ../src/wxMaximaFrame.cpp:518
 msgid "Paste text from clipboard"
 msgstr "Вставить текст из буфера обмена"
 
@@ -3159,19 +3162,19 @@ msgstr "Вставить текст из буфера обмена"
 msgid "Perpendicular to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1384
+#: ../src/wxMaximaFrame.cpp:1383
 msgid "Phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1379
+#: ../src/wxMaximaFrame.cpp:1378
 msgid "Pi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1273
+#: ../src/wxMaximaFrame.cpp:1272
 msgid "Piechart..."
 msgstr "Круговая диаграмма..."
 
-#: ../src/wxMaxima.cpp:1952
+#: ../src/wxMaxima.cpp:1957
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr "Настройте wxMaxima при помощи команды 'Правка->Настройка'."
 
@@ -3179,52 +3182,52 @@ msgstr "Настройте wxMaxima при помощи команды 'Прав
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr "Перезапустите wxMaxima, чтобы изменения вступили в силу!"
 
-#: ../src/wxMaximaFrame.cpp:923
+#: ../src/wxMaximaFrame.cpp:922
 msgid "Plot &2d..."
 msgstr "Двумерный график (&2D)..."
 
-#: ../src/wxMaximaFrame.cpp:925
+#: ../src/wxMaximaFrame.cpp:924
 msgid "Plot &3d..."
 msgstr "Трёхмерный график (&3D)..."
 
-#: ../src/wxMaximaFrame.cpp:927
+#: ../src/wxMaximaFrame.cpp:926
 msgid "Plot &Format..."
 msgstr "&Формат графиков..."
 
 #: ../src/Plot2dWiz.cpp:104 ../src/Plot2dWiz.cpp:450 ../src/Plot2dWiz.cpp:464
-#: ../src/wxMaxima.cpp:4283 ../src/wxMaxima.cpp:5102
+#: ../src/wxMaxima.cpp:4295 ../src/wxMaxima.cpp:5114
 msgid "Plot 2D"
 msgstr "Двумерный график"
 
-#: ../src/wxMaximaFrame.cpp:1227
+#: ../src/wxMaximaFrame.cpp:1226
 msgid "Plot 2D..."
 msgstr "Двумерный график..."
 
-#: ../src/MathCtrl.cpp:1003
+#: ../src/MathCtrl.cpp:1045
 msgid "Plot 2d..."
 msgstr "Двумерный график (2D)..."
 
-#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4269 ../src/wxMaxima.cpp:5115
+#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4281 ../src/wxMaxima.cpp:5127
 msgid "Plot 3D"
 msgstr "Трехмерный график"
 
-#: ../src/wxMaximaFrame.cpp:1228
+#: ../src/wxMaximaFrame.cpp:1227
 msgid "Plot 3D..."
 msgstr "Трехмерный график..."
 
-#: ../src/MathCtrl.cpp:1004
+#: ../src/MathCtrl.cpp:1046
 msgid "Plot 3d..."
 msgstr "Трёхмерный график (3D)..."
 
-#: ../src/wxMaxima.cpp:4296
+#: ../src/wxMaxima.cpp:4308
 msgid "Plot format"
 msgstr "Формат графика"
 
-#: ../src/wxMaximaFrame.cpp:924
+#: ../src/wxMaximaFrame.cpp:923
 msgid "Plot in 2 dimensions"
 msgstr "Двумерный график"
 
-#: ../src/wxMaximaFrame.cpp:926
+#: ../src/wxMaximaFrame.cpp:925
 msgid "Plot in 3 dimensions"
 msgstr "Трехмерный график"
 
@@ -3233,8 +3236,8 @@ msgid "Plot to file:"
 msgstr "Вывести график в файл:"
 
 #: ../src/BC2Wiz.cpp:30 ../src/BC2Wiz.cpp:36 ../src/LimitWiz.cpp:33
-#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
-#: ../src/wxMaxima.cpp:3648
+#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
+#: ../src/wxMaxima.cpp:3660
 msgid "Point:"
 msgstr "Точка:"
 
@@ -3242,11 +3245,11 @@ msgstr "Точка:"
 msgid "Polish"
 msgstr "Польский"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 1:"
 msgstr "Полином 1:"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 2:"
 msgstr "Полином 2:"
 
@@ -3258,11 +3261,11 @@ msgstr "Португальский (Бразилия)"
 msgid "Postscript file (*.eps)|*.eps|All|*"
 msgstr "Файл Postscript (*.eps)|*.eps|Все|*"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Precision"
 msgstr "Точность"
 
-#: ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:536
 msgid "Preferences...\tCtrl+,"
 msgstr ""
 
@@ -3274,7 +3277,7 @@ msgid ""
 "packages and from functions that are defined in the current file."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:628
+#: ../src/wxMaximaFrame.cpp:627
 msgid "Previous Command\tAlt-Up"
 msgstr "Предыдущая команда\tAlt-Вверх"
 
@@ -3282,11 +3285,11 @@ msgstr "Предыдущая команда\tAlt-Вверх"
 msgid "Print"
 msgstr "Печать"
 
-#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:484
+#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:483
 msgid "Print document"
 msgstr "Напечатать документ"
 
-#: ../src/wxMaxima.cpp:4242
+#: ../src/wxMaxima.cpp:4254
 msgid "Product"
 msgstr "Произведение"
 
@@ -3295,37 +3298,37 @@ msgstr "Произведение"
 msgid "Product sign"
 msgstr "Произведение"
 
-#: ../src/wxMaximaFrame.cpp:1386
+#: ../src/wxMaximaFrame.cpp:1385
 msgid "Psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:331
+#: ../src/wxMaximaFrame.cpp:330
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:592
+#: ../src/wxMaximaFrame.cpp:591
 #, fuzzy
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr "Отправить на вычисление все ячейки в документе"
 
-#: ../src/wxMaximaFrame.cpp:1278
+#: ../src/wxMaximaFrame.cpp:1277
 #, fuzzy
 msgid "Read Matrix..."
 msgstr "&Ввести матрицу..."
 
-#: ../src/wxMaximaFrame.cpp:177
+#: ../src/wxMaximaFrame.cpp:176
 msgid "Reading Maxima output"
 msgstr "Чтение вывода Maxima"
 
-#: ../src/wxMaximaFrame.cpp:153
+#: ../src/wxMaximaFrame.cpp:152
 msgid "Ready for user input"
 msgstr "Готова к вводу"
 
-#: ../src/wxMaximaFrame.cpp:631
+#: ../src/wxMaximaFrame.cpp:630
 msgid "Recall next command from history"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:629
+#: ../src/wxMaximaFrame.cpp:628
 msgid "Recall previous command from history"
 msgstr ""
 
@@ -3333,37 +3336,37 @@ msgstr ""
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1215
+#: ../src/wxMaximaFrame.cpp:1214
 msgid "Rectform"
 msgstr "Ст. форма"
 
-#: ../src/wxMaximaFrame.cpp:495
+#: ../src/wxMaximaFrame.cpp:494
 #, fuzzy
 msgid "Redo\tCtrl-Y"
 msgstr "Отмена\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:496
+#: ../src/wxMaximaFrame.cpp:495
 #, fuzzy
 msgid "Redo last change"
 msgstr "Отменить последнее изменение"
 
-#: ../src/wxMaximaFrame.cpp:1220
+#: ../src/wxMaximaFrame.cpp:1219
 msgid "Reduce (tr)"
 msgstr "Привести (триг.)"
 
-#: ../src/wxMaximaFrame.cpp:871
+#: ../src/wxMaximaFrame.cpp:870
 msgid "Reduce trigonometric expression"
 msgstr "Привести тригонометрическое выражение"
 
-#: ../src/wxMaxima.cpp:622 ../src/wxMaxima.cpp:5495
+#: ../src/wxMaxima.cpp:627 ../src/wxMaxima.cpp:5511
 msgid "Refusing to send cell to maxima: "
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:594
+#: ../src/wxMaximaFrame.cpp:593
 msgid "Remove All Output"
 msgstr "Удалить весь вывод"
 
-#: ../src/wxMaximaFrame.cpp:595
+#: ../src/wxMaximaFrame.cpp:594
 msgid "Remove output from input cells"
 msgstr "Удалить вывод из ячеек"
 
@@ -3372,7 +3375,7 @@ msgstr "Удалить вывод из ячеек"
 msgid "Replace All"
 msgstr "Выделить всё"
 
-#: ../src/wxMaxima.cpp:3282
+#: ../src/wxMaxima.cpp:3294
 #, c-format
 msgid "Replaced %d occurrences."
 msgstr "Заменено %d вхождений."
@@ -3381,11 +3384,11 @@ msgstr "Заменено %d вхождений."
 msgid "Replacement:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:976
+#: ../src/wxMaximaFrame.cpp:975
 msgid "Report bug"
 msgstr "Сообщить об ошибке"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "Restart Maxima"
 msgstr "Перезапустить Maxima"
 
@@ -3394,7 +3397,7 @@ msgstr "Перезапустить Maxima"
 msgid "Restart maxima"
 msgstr "Перезапустить Maxima"
 
-#: ../src/MathCtrl.cpp:4442
+#: ../src/MathCtrl.cpp:4497
 msgid "Result"
 msgstr ""
 
@@ -3402,7 +3405,7 @@ msgstr ""
 msgid "Return to the cell that is currently being evaluated"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1380
+#: ../src/wxMaximaFrame.cpp:1379
 msgid "Rho"
 msgstr ""
 
@@ -3410,22 +3413,22 @@ msgstr ""
 msgid "Right arrow"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:779
+#: ../src/wxMaximaFrame.cpp:778
 #, fuzzy
 msgid "Risch Integration..."
 msgstr "Интегрирование по Ричу ..."
 
-#: ../src/wxMaximaFrame.cpp:694
+#: ../src/wxMaximaFrame.cpp:693
 #, fuzzy
 msgid "Roots of &Polynomial"
 msgstr "Корни полинома"
 
-#: ../src/wxMaximaFrame.cpp:697
+#: ../src/wxMaximaFrame.cpp:696
 #, fuzzy
 msgid "Roots of Polynomial (bfloat)"
 msgstr "Корни полинома (вещественные)"
 
-#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Rows:"
 msgstr "Строки:"
 
@@ -3433,62 +3436,62 @@ msgstr "Строки:"
 msgid "Russian"
 msgstr "Русский"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 #, fuzzy
 msgid "Sample 1:"
 msgstr "Пример"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 #, fuzzy
 msgid "Sample 2:"
 msgstr "Пример"
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 #, fuzzy
 msgid "Sample:"
 msgstr "Пример"
 
 #: ../src/ConfigDialogue.cpp:781 ../src/ToolBar.cpp:122
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Save"
 msgstr "Сохранить"
 
-#: ../src/MathCtrl.cpp:921
+#: ../src/MathCtrl.cpp:963
 msgid "Save Animation..."
 msgstr "Сохранить анимацию..."
 
-#: ../src/wxMaxima.cpp:2565
+#: ../src/wxMaxima.cpp:2572
 msgid "Save As"
 msgstr "Сохранить как"
 
-#: ../src/wxMaximaFrame.cpp:474
+#: ../src/wxMaximaFrame.cpp:473
 msgid "Save As...\tShift-Ctrl-S"
 msgstr "Сохранить как...\tShift-Ctrl-S"
 
-#: ../src/MathCtrl.cpp:919
+#: ../src/MathCtrl.cpp:961
 msgid "Save Image..."
 msgstr "Сохранить изображение..."
 
-#: ../src/wxMaxima.cpp:3130
+#: ../src/wxMaxima.cpp:3139
 #, fuzzy
 msgid "Save Selection to Image"
 msgstr "Выделение в изображение"
 
-#: ../src/wxMaximaFrame.cpp:528
+#: ../src/wxMaximaFrame.cpp:527
 #, fuzzy
 msgid "Save Selection to Image..."
 msgstr "Выделение в изображение"
 
-#: ../src/wxMaxima.cpp:5150
+#: ../src/wxMaxima.cpp:5162
 #, fuzzy
 msgid "Save animation to file"
 msgstr "Сохранить выделение в файле"
 
-#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:473
+#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:472
 msgid "Save document"
 msgstr "Сохранить документ"
 
-#: ../src/wxMaximaFrame.cpp:475
+#: ../src/wxMaximaFrame.cpp:474
 msgid "Save document as"
 msgstr "Сохранить документ как"
 
@@ -3511,12 +3514,12 @@ msgstr "Запоминать положение и размер окна wxMaxim
 msgid "Save plot to file"
 msgstr "Сохранить график в файл"
 
-#: ../src/wxMaximaFrame.cpp:529
+#: ../src/wxMaximaFrame.cpp:528
 #, fuzzy
 msgid "Save selection from document to an image file"
 msgstr "Копировать выделение из документа в файл"
 
-#: ../src/wxMaxima.cpp:5131
+#: ../src/wxMaxima.cpp:5143
 msgid "Save selection to file"
 msgstr "Сохранить выделение в файле"
 
@@ -3532,28 +3535,28 @@ msgstr "Сохранить положение и размер окна wxMaxima"
 msgid "Save wxMaxima window size/position between sessions."
 msgstr "Запоминать положение и размер окна wxMaxima между сессиями"
 
-#: ../src/wxMaximaFrame.cpp:246
+#: ../src/wxMaximaFrame.cpp:245
 #, fuzzy
 msgid "Saving failed."
 msgstr "Не удалось запустить сервер"
 
-#: ../src/wxMaximaFrame.cpp:222
+#: ../src/wxMaximaFrame.cpp:221
 msgid "Saving successful."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:212
+#: ../src/wxMaximaFrame.cpp:211
 msgid "Saving..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4699
+#: ../src/wxMaxima.cpp:4711
 msgid "Scatterplot"
 msgstr "График рассеяния"
 
-#: ../src/wxMaximaFrame.cpp:1271
+#: ../src/wxMaximaFrame.cpp:1270
 msgid "Scatterplot..."
 msgstr "График рассеяния..."
 
-#: ../src/wxMaximaFrame.cpp:1498
+#: ../src/wxMaximaFrame.cpp:1517
 msgid "Section"
 msgstr "Раздел"
 
@@ -3561,26 +3564,26 @@ msgstr "Раздел"
 msgid "Section cell"
 msgstr "Раздел"
 
-#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:292 ../src/TextCell.cpp:306
-#: ../src/TextCell.cpp:322 ../src/TextCell.cpp:334
+#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:290 ../src/TextCell.cpp:304
+#: ../src/TextCell.cpp:320 ../src/TextCell.cpp:332
 msgid ""
 "Seems like something is broken with a font. Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/TextCell.cpp:139
+#: ../src/TextCell.cpp:137
 msgid ""
 "Seems like something is broken with the maths font. Installing http://www."
 "math.union.edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use "
 "JSmath fonts\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1011 ../src/MathCtrl.cpp:1027
+#: ../src/MathCtrl.cpp:1053 ../src/MathCtrl.cpp:1069
 msgid "Select All"
 msgstr "Выделить всё"
 
-#: ../src/wxMaximaFrame.cpp:525
+#: ../src/wxMaximaFrame.cpp:524
 msgid "Select All\tCtrl-A"
 msgstr "Выделить всё\tCtrl-A"
 
@@ -3588,7 +3591,7 @@ msgstr "Выделить всё\tCtrl-A"
 msgid "Select Maxima program"
 msgstr "Задать путь к Maxima"
 
-#: ../src/wxMaxima.cpp:4860
+#: ../src/wxMaxima.cpp:4872
 #, fuzzy
 msgid "Select Subsample"
 msgstr "Выделить всё"
@@ -3598,11 +3601,11 @@ msgstr "Выделить всё"
 msgid "Select a constant"
 msgstr "Выбрать константу"
 
-#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:526
+#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:525
 msgid "Select all"
 msgstr "Выделить всё"
 
-#: ../src/wxMaxima.cpp:3319
+#: ../src/wxMaxima.cpp:3331
 msgid "Select math display algorithm"
 msgstr "Выбрать способ отображения"
 
@@ -3616,23 +3619,23 @@ msgstr ""
 msgid "Selection"
 msgstr "Выделение"
 
-#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4178
+#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4190
 msgid "Series"
 msgstr "Ряд"
 
-#: ../src/wxMaximaFrame.cpp:1226
+#: ../src/wxMaximaFrame.cpp:1225
 msgid "Series..."
 msgstr "Ряды..."
 
-#: ../src/wxMaxima.cpp:863
+#: ../src/wxMaxima.cpp:868
 msgid "Server started"
 msgstr "Сервер запущен..."
 
-#: ../src/wxMaximaFrame.cpp:575
+#: ../src/wxMaximaFrame.cpp:574
 msgid "Set Zoom"
 msgstr "Задать увеличение"
 
-#: ../src/wxMaximaFrame.cpp:944
+#: ../src/wxMaximaFrame.cpp:943
 #, fuzzy
 msgid "Set bigfloat &Precision..."
 msgstr "Установить точность вычислений с плавающей точкой"
@@ -3641,64 +3644,64 @@ msgstr "Установить точность вычислений с плава
 msgid "Set fixed font in text controls."
 msgstr "Установить фиксированный шрифт в элементах ввода."
 
-#: ../src/wxMaximaFrame.cpp:928
+#: ../src/wxMaximaFrame.cpp:927
 msgid "Set plot format"
 msgstr "Установить формат графиков"
 
-#: ../src/wxMaximaFrame.cpp:945
+#: ../src/wxMaximaFrame.cpp:944
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can "
 "be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:569
+#: ../src/wxMaximaFrame.cpp:568
 msgid "Set zoom to 100%"
 msgstr "Установить масштаб 100%"
 
-#: ../src/wxMaximaFrame.cpp:570
+#: ../src/wxMaximaFrame.cpp:569
 msgid "Set zoom to 120%"
 msgstr "Установить масштаб 120%"
 
-#: ../src/wxMaximaFrame.cpp:571
+#: ../src/wxMaximaFrame.cpp:570
 msgid "Set zoom to 150%"
 msgstr "Установить масштаб 150%"
 
-#: ../src/wxMaximaFrame.cpp:572
+#: ../src/wxMaximaFrame.cpp:571
 msgid "Set zoom to 200%"
 msgstr "Установить масштаб 200%"
 
-#: ../src/wxMaximaFrame.cpp:573
+#: ../src/wxMaximaFrame.cpp:572
 msgid "Set zoom to 300%"
 msgstr "Установить масштаб 300%"
 
-#: ../src/wxMaximaFrame.cpp:568
+#: ../src/wxMaximaFrame.cpp:567
 msgid "Set zoom to 80%"
 msgstr "Установить масштаб 80%"
 
-#: ../src/wxMaximaFrame.cpp:732
+#: ../src/wxMaximaFrame.cpp:731
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr "Установить значения для решения ОДУ при помощи преобразования Лапласа"
 
-#: ../src/wxMaximaFrame.cpp:918
+#: ../src/wxMaximaFrame.cpp:917
 msgid "Setup modulus computation"
 msgstr "Установить вычисления по модулю"
 
-#: ../src/wxMaximaFrame.cpp:662
+#: ../src/wxMaximaFrame.cpp:661
 #, fuzzy
 msgid "Show &Definition..."
 msgstr "Показать определение"
 
-#: ../src/wxMaximaFrame.cpp:660
+#: ../src/wxMaximaFrame.cpp:659
 #, fuzzy
 msgid "Show &Functions"
 msgstr "Показать функции"
 
-#: ../src/wxMaximaFrame.cpp:967
+#: ../src/wxMaximaFrame.cpp:966
 #, fuzzy
 msgid "Show &Tips..."
 msgstr "Показать подсказку"
 
-#: ../src/wxMaximaFrame.cpp:665
+#: ../src/wxMaximaFrame.cpp:664
 #, fuzzy
 msgid "Show &Variables"
 msgstr "Показать переменные"
@@ -3708,44 +3711,44 @@ msgstr "Показать переменные"
 msgid "Show Maxima help"
 msgstr "Показать справку по Maxima"
 
-#: ../src/wxMaximaFrame.cpp:603
+#: ../src/wxMaximaFrame.cpp:602
 #, fuzzy
 msgid "Show Template\tCtrl-Shift-K"
 msgstr "Пересчитать все поля\tCtrl-Shift-R"
 
-#: ../src/wxMaximaFrame.cpp:968
+#: ../src/wxMaximaFrame.cpp:967
 msgid "Show a tip"
 msgstr "Показать подсказку"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Show all commands similar to:"
 msgstr "Показать все команды, похожие на:"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Show an example for the command:"
 msgstr "Показать пример для команды:"
 
-#: ../src/wxMaximaFrame.cpp:962
+#: ../src/wxMaximaFrame.cpp:961
 msgid "Show an example of usage"
 msgstr "Показать пример использования"
 
-#: ../src/wxMaximaFrame.cpp:965
+#: ../src/wxMaximaFrame.cpp:964
 msgid "Show commands similar to"
 msgstr "Показать команды, подобные"
 
-#: ../src/wxMaximaFrame.cpp:661
+#: ../src/wxMaximaFrame.cpp:660
 msgid "Show defined functions"
 msgstr "Показать определенные функции"
 
-#: ../src/wxMaximaFrame.cpp:666
+#: ../src/wxMaximaFrame.cpp:665
 msgid "Show defined variables"
 msgstr "Показать определенные переменные"
 
-#: ../src/wxMaximaFrame.cpp:663
+#: ../src/wxMaximaFrame.cpp:662
 msgid "Show definition of a function"
 msgstr "Показать определение функции"
 
-#: ../src/wxMaximaFrame.cpp:604
+#: ../src/wxMaximaFrame.cpp:603
 #, fuzzy
 msgid "Show function template"
 msgstr "Показать функции"
@@ -3760,7 +3763,7 @@ msgstr "Показывать длинные выражения в консоли
 msgid "Show long expressions:"
 msgstr "Показывать длинные выражения"
 
-#: ../src/wxMaxima.cpp:3341
+#: ../src/wxMaxima.cpp:3353
 msgid "Show the definition of function:"
 msgstr "Показать определение функции:"
 
@@ -3769,46 +3772,46 @@ msgstr "Показать определение функции:"
 msgid "Show user-defined labels instead of (%oxx)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:953 ../src/wxMaximaFrame.cpp:956
+#: ../src/wxMaximaFrame.cpp:952 ../src/wxMaximaFrame.cpp:955
 #, fuzzy
 msgid "Show wxMaxima help"
 msgstr "Показать справку по Maxima"
 
-#: ../src/wxMaximaFrame.cpp:1381
+#: ../src/wxMaximaFrame.cpp:1380
 msgid "Sigma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1211
+#: ../src/wxMaximaFrame.cpp:1210
 msgid "Simplify"
 msgstr "Упростить"
 
-#: ../src/wxMaximaFrame.cpp:831
+#: ../src/wxMaximaFrame.cpp:830
 #, fuzzy
 msgid "Simplify &Radicals"
 msgstr "Упростить радикалы"
 
-#: ../src/wxMaximaFrame.cpp:1212
+#: ../src/wxMaximaFrame.cpp:1211
 msgid "Simplify (r)"
 msgstr "Упростить (рац.)"
 
-#: ../src/wxMaximaFrame.cpp:1218
+#: ../src/wxMaximaFrame.cpp:1217
 msgid "Simplify (tr)"
 msgstr "Упростить (триг.)"
 
-#: ../src/MathCtrl.cpp:995
+#: ../src/MathCtrl.cpp:1037
 #, fuzzy
 msgid "Simplify Expression"
 msgstr "Упростить выражение"
 
-#: ../src/wxMaximaFrame.cpp:857
+#: ../src/wxMaximaFrame.cpp:856
 msgid "Simplify an expression containing factorials"
 msgstr "Упростить выражение с факториалами"
 
-#: ../src/wxMaximaFrame.cpp:832
+#: ../src/wxMaximaFrame.cpp:831
 msgid "Simplify expression containing radicals"
 msgstr "Упростить выражение с радикалами"
 
-#: ../src/wxMaximaFrame.cpp:830
+#: ../src/wxMaximaFrame.cpp:829
 msgid "Simplify rational expression"
 msgstr "Упростить рациональное выражение"
 
@@ -3816,7 +3819,7 @@ msgstr "Упростить рациональное выражение"
 msgid "Simplify the sum"
 msgstr "Упростить сумму"
 
-#: ../src/wxMaximaFrame.cpp:868
+#: ../src/wxMaximaFrame.cpp:867
 msgid "Simplify trigonometric expression"
 msgstr "Упростить тригонометрическое выражение"
 
@@ -3828,93 +3831,93 @@ msgid ""
 "along with your document."
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
+#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
 msgid "Solution:"
 msgstr "Решение:"
 
-#: ../src/wxMaxima.cpp:3461 ../src/wxMaxima.cpp:3475 ../src/wxMaxima.cpp:5020
+#: ../src/wxMaxima.cpp:3473 ../src/wxMaxima.cpp:3487 ../src/wxMaxima.cpp:5032
 msgid "Solve"
 msgstr "Решить"
 
-#: ../src/wxMaximaFrame.cpp:706
+#: ../src/wxMaximaFrame.cpp:705
 #, fuzzy
 msgid "Solve &Algebraic System..."
 msgstr "Решить алгебраическую систему ..."
 
-#: ../src/wxMaximaFrame.cpp:703
+#: ../src/wxMaximaFrame.cpp:702
 #, fuzzy
 msgid "Solve &Linear System..."
 msgstr "Решить линейную систему ..."
 
-#: ../src/wxMaximaFrame.cpp:714
+#: ../src/wxMaximaFrame.cpp:713
 msgid "Solve &ODE..."
 msgstr "Решить &ОДУ..."
 
-#: ../src/wxMaximaFrame.cpp:690
+#: ../src/wxMaximaFrame.cpp:689
 #, fuzzy
 msgid "Solve (to_poly)..."
 msgstr "Решить ..."
 
-#: ../src/wxMaxima.cpp:3511 ../src/wxMaxima.cpp:3635
+#: ../src/wxMaxima.cpp:3523 ../src/wxMaxima.cpp:3647
 msgid "Solve ODE"
 msgstr "Решить ОДУ"
 
-#: ../src/wxMaximaFrame.cpp:728
+#: ../src/wxMaximaFrame.cpp:727
 msgid "Solve ODE with Lapla&ce..."
 msgstr "Решить ОДУ при помощи преобразования &Лапласа..."
 
-#: ../src/wxMaximaFrame.cpp:1222
+#: ../src/wxMaximaFrame.cpp:1221
 msgid "Solve ODE..."
 msgstr "Решить ОДУ..."
 
-#: ../src/wxMaxima.cpp:3586 ../src/wxMaxima.cpp:3597
+#: ../src/wxMaxima.cpp:3598 ../src/wxMaxima.cpp:3609
 msgid "Solve algebraic system"
 msgstr "Решить алгебраическую систему"
 
-#: ../src/wxMaximaFrame.cpp:707
+#: ../src/wxMaximaFrame.cpp:706
 msgid "Solve algebraic system of equations"
 msgstr "Решить систему алгебраических уравнений"
 
-#: ../src/wxMaximaFrame.cpp:725
+#: ../src/wxMaximaFrame.cpp:724
 msgid "Solve boundary value problem for second degree ODE"
 msgstr "Решить граничную задачу для ОДУ второго порядка"
 
-#: ../src/wxMaximaFrame.cpp:689
+#: ../src/wxMaximaFrame.cpp:688
 msgid "Solve equation(s)"
 msgstr "Решить уравнение(ния)"
 
-#: ../src/wxMaximaFrame.cpp:691
+#: ../src/wxMaximaFrame.cpp:690
 #, fuzzy
 msgid "Solve equation(s) with to_poly_solve"
 msgstr "Решить уравнение(ния)"
 
-#: ../src/wxMaximaFrame.cpp:719
+#: ../src/wxMaximaFrame.cpp:718
 msgid "Solve initial value problem for first degree ODE"
 msgstr "Решить задачу с начальным условием для ОДУ первого порядка"
 
-#: ../src/wxMaximaFrame.cpp:722
+#: ../src/wxMaximaFrame.cpp:721
 msgid "Solve initial value problem for second degree ODE"
 msgstr "Решить задачу с начальным условием для ОДУ второго порядка"
 
-#: ../src/wxMaxima.cpp:3610 ../src/wxMaxima.cpp:3621
+#: ../src/wxMaxima.cpp:3622 ../src/wxMaxima.cpp:3633
 msgid "Solve linear system"
 msgstr "Решить линейную систему"
 
-#: ../src/wxMaximaFrame.cpp:704
+#: ../src/wxMaximaFrame.cpp:703
 msgid "Solve linear system of equations"
 msgstr "Решить систему линейных уравнений"
 
-#: ../src/wxMaximaFrame.cpp:715
+#: ../src/wxMaximaFrame.cpp:714
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr "Решить обычное дифференциальное уравнение не выше второго порядка"
 
-#: ../src/wxMaximaFrame.cpp:729
+#: ../src/wxMaximaFrame.cpp:728
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
 "Решить обыкновенное дифференциальное уравнение при помощи преобразования "
 "Лапласа"
 
-#: ../src/wxMaximaFrame.cpp:1221 ../src/MathCtrl.cpp:992
+#: ../src/MathCtrl.cpp:1034 ../src/wxMaximaFrame.cpp:1220
 msgid "Solve..."
 msgstr "Решить..."
 
@@ -3938,7 +3941,7 @@ msgstr "Дополнительно"
 msgid "Special constants"
 msgstr "Специальные константы"
 
-#: ../src/MathCtrl.cpp:922
+#: ../src/MathCtrl.cpp:964
 msgid "Start Animation"
 msgstr "Запустить анимацию"
 
@@ -3957,28 +3960,28 @@ msgstr ""
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:294
+#: ../src/wxMaxima.cpp:295
 msgid "Starting Maxima process failed"
 msgstr "Не удалось запустить Maxima"
 
-#: ../src/wxMaxima.cpp:928
+#: ../src/wxMaxima.cpp:933
 msgid "Starting Maxima..."
 msgstr "Запуск Maxima..."
 
-#: ../src/wxMaxima.cpp:292 ../src/wxMaxima.cpp:860
+#: ../src/wxMaxima.cpp:293 ../src/wxMaxima.cpp:865
 msgid "Starting server failed"
 msgstr "Не удалось запустить сервер"
 
-#: ../src/wxMaxima.cpp:841
+#: ../src/wxMaxima.cpp:846
 #, c-format
 msgid "Starting server on port %d"
 msgstr "Запуск сервера на порту %d"
 
-#: ../src/wxMaximaFrame.cpp:342
+#: ../src/wxMaximaFrame.cpp:341
 msgid "Statistics"
 msgstr "Статистика"
 
-#: ../src/wxMaximaFrame.cpp:550
+#: ../src/wxMaximaFrame.cpp:549
 msgid "Statistics\tAlt-Shift-S"
 msgstr "Статистика\tAlt-Shift-S"
 
@@ -3994,12 +3997,12 @@ msgstr "Стиль"
 msgid "Styles"
 msgstr "Стили"
 
-#: ../src/wxMaximaFrame.cpp:1283
+#: ../src/wxMaximaFrame.cpp:1282
 #, fuzzy
 msgid "Subsample..."
 msgstr "Пример"
 
-#: ../src/wxMaximaFrame.cpp:1496
+#: ../src/wxMaximaFrame.cpp:1515
 msgid "Subsection"
 msgstr "Подраздел"
 
@@ -4007,20 +4010,20 @@ msgstr "Подраздел"
 msgid "Subsection cell"
 msgstr "Подраздел"
 
-#: ../src/wxMaximaFrame.cpp:1216
+#: ../src/wxMaximaFrame.cpp:1215
 msgid "Subst..."
 msgstr "Подстановка..."
 
-#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3423
-#: ../src/wxMaxima.cpp:5089
+#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3435
+#: ../src/wxMaxima.cpp:5101
 msgid "Substitute"
 msgstr "Подставить"
 
-#: ../src/wxMaximaFrame.cpp:906 ../src/MathCtrl.cpp:998
+#: ../src/MathCtrl.cpp:1040 ../src/wxMaximaFrame.cpp:905
 msgid "Substitute..."
 msgstr "Подставить..."
 
-#: ../src/wxMaximaFrame.cpp:1497
+#: ../src/wxMaximaFrame.cpp:1516
 #, fuzzy
 msgid "Subsubsection"
 msgstr "Подраздел"
@@ -4030,7 +4033,7 @@ msgstr "Подраздел"
 msgid "Subsubsection cell"
 msgstr "Подраздел"
 
-#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4226
+#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4238
 msgid "Sum"
 msgstr "Сумма"
 
@@ -4038,37 +4041,37 @@ msgstr "Сумма"
 msgid "Sum sign"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:553
+#: ../src/wxMaximaFrame.cpp:552
 #, fuzzy
 msgid "Symbols\tAlt-Shift-Y"
 msgstr "Статистика\tAlt-Shift-S"
 
-#: ../src/wxMaxima.cpp:4456
+#: ../src/wxMaxima.cpp:4468
 msgid "System info"
 msgstr "Информация о системе"
 
-#: ../src/wxMaximaFrame.cpp:320
+#: ../src/wxMaximaFrame.cpp:319
 msgid "Table of Contents"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:556
+#: ../src/wxMaximaFrame.cpp:555
 #, fuzzy
 msgid "Table of Contents\tAlt-Shift-T"
 msgstr "Панель инструментов\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:1382
+#: ../src/wxMaximaFrame.cpp:1381
 msgid "Tau"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Taylor series:"
 msgstr "Ряд Тейлора:"
 
-#: ../src/wxMaxima.cpp:3963
+#: ../src/wxMaxima.cpp:3975
 msgid "Tellrat"
 msgstr "Tellrat"
 
-#: ../src/wxMaximaFrame.cpp:1494
+#: ../src/wxMaximaFrame.cpp:1513
 msgid "Text"
 msgstr "Текст"
 
@@ -4114,7 +4117,7 @@ msgstr ""
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr ""
 
-#: ../src/TextCell.cpp:136
+#: ../src/TextCell.cpp:134
 msgid ""
 "The letter \"X\" is of width zero. Installing http://www.math.union.edu/"
 "~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts\" in "
@@ -4131,7 +4134,7 @@ msgstr ""
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:959
+#: ../src/wxMaximaFrame.cpp:958
 msgid "The offline manual of maxima"
 msgstr ""
 
@@ -4165,14 +4168,14 @@ msgid ""
 "find tutorials on using wxMaxima and Maxima."
 msgstr ""
 
-#: ../src/SlideShowCell.cpp:332
+#: ../src/SlideShowCell.cpp:336
 msgid ""
 "There was an error during GIF export!\n"
 "\n"
 "Make sure ImageMagick is installed and wxMaxima can find the convert program."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:442
+#: ../src/wxMaxima.cpp:447
 msgid ""
 "There was an error in generated XML!\n"
 "\n"
@@ -4182,7 +4185,7 @@ msgstr ""
 "\n"
 "Пожалуйста, обратитесь к разработчику."
 
-#: ../src/wxMaximaFrame.cpp:1371
+#: ../src/wxMaximaFrame.cpp:1370
 msgid "Theta"
 msgstr ""
 
@@ -4190,7 +4193,7 @@ msgstr ""
 msgid "Ticks:"
 msgstr "Число точек:"
 
-#: ../src/wxMaxima.cpp:4153 ../src/wxMaxima.cpp:5065
+#: ../src/wxMaxima.cpp:4165 ../src/wxMaxima.cpp:5077
 msgid "Times:"
 msgstr "Порядок производной:"
 
@@ -4198,7 +4201,7 @@ msgstr "Порядок производной:"
 msgid "Tips not available, sorry!"
 msgstr "Подсказки недоступны, извините!"
 
-#: ../src/wxMaximaFrame.cpp:1495
+#: ../src/wxMaximaFrame.cpp:1514
 msgid "Title"
 msgstr "Заголовок"
 
@@ -4213,19 +4216,19 @@ msgid ""
 "all sublevels of that cell will also fold/unfold."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:938
+#: ../src/wxMaximaFrame.cpp:937
 msgid "To &Bigfloat"
 msgstr "В число с плавающей точкой повышенной &точности"
 
-#: ../src/wxMaximaFrame.cpp:935
+#: ../src/wxMaximaFrame.cpp:934
 msgid "To &Float"
 msgstr "В число с &плавающей точкой"
 
-#: ../src/MathCtrl.cpp:990
+#: ../src/MathCtrl.cpp:1032
 msgid "To Float"
 msgstr "В число с плавающей точкой"
 
-#: ../src/wxMaximaFrame.cpp:941
+#: ../src/wxMaximaFrame.cpp:940
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr ""
 
@@ -4261,54 +4264,54 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:41 ../src/Plot2dWiz.cpp:40 ../src/Plot2dWiz.cpp:50
 #: ../src/Plot2dWiz.cpp:539 ../src/Plot3dWiz.cpp:39 ../src/Plot3dWiz.cpp:48
-#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4241
+#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4253
 msgid "To:"
 msgstr "К:"
 
-#: ../src/wxMaximaFrame.cpp:912
+#: ../src/wxMaximaFrame.cpp:911
 #, fuzzy
 msgid "Toggle &Algebraic Flag"
 msgstr "Переключить флаг algebraic"
 
-#: ../src/wxMaximaFrame.cpp:933
+#: ../src/wxMaximaFrame.cpp:932
 #, fuzzy
 msgid "Toggle &Numeric Output"
 msgstr "Переключить флаг numeric"
 
-#: ../src/wxMaximaFrame.cpp:673
+#: ../src/wxMaximaFrame.cpp:672
 #, fuzzy
 msgid "Toggle &Time Display"
 msgstr "Переключить отображение времени вычисления"
 
-#: ../src/wxMaximaFrame.cpp:913
+#: ../src/wxMaximaFrame.cpp:912
 msgid "Toggle algebraic flag"
 msgstr "Переключить флаг algebraic"
 
-#: ../src/wxMaximaFrame.cpp:577
+#: ../src/wxMaximaFrame.cpp:576
 msgid "Toggle full screen editing"
 msgstr "Включить/выключить режим полноэкранного редактирования"
 
-#: ../src/wxMaximaFrame.cpp:934
+#: ../src/wxMaximaFrame.cpp:933
 msgid "Toggle numeric output"
 msgstr "Переключить численное вычисление"
 
-#: ../src/wxMaxima.cpp:4464
+#: ../src/wxMaxima.cpp:4476
 msgid "Toolbar icons"
 msgstr "Иконки на панели инструментов"
 
-#: ../src/wxMaxima.cpp:4465
+#: ../src/wxMaxima.cpp:4477
 msgid "Translated by"
 msgstr "Перевод"
 
-#: ../src/wxMaximaFrame.cpp:763
+#: ../src/wxMaximaFrame.cpp:762
 msgid "Transpose a matrix"
 msgstr "Транспонировать матрицу"
 
-#: ../src/MathCtrl.cpp:5834
+#: ../src/MathCtrl.cpp:5886
 msgid "Trying to undo an action without starting cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5901
+#: ../src/MathCtrl.cpp:5953
 msgid "Trying to undo something but the undo action is empty."
 msgstr ""
 
@@ -4316,11 +4319,11 @@ msgstr ""
 msgid "Turkish"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:970
+#: ../src/wxMaximaFrame.cpp:969
 msgid "Tutorials"
 msgstr "Обучающие материалы"
 
-#: ../src/wxMaxima.cpp:4778
+#: ../src/wxMaxima.cpp:4790
 #, fuzzy
 msgid "Two sample t-test"
 msgstr "Текст примера"
@@ -4333,15 +4336,15 @@ msgstr "Тип:"
 msgid "Ukrainian"
 msgstr "Украинский"
 
-#: ../src/wxMaxima.cpp:5356
+#: ../src/wxMaxima.cpp:5372
 msgid "Un-closed parenthesis"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5323
+#: ../src/wxMaxima.cpp:5335
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5889
 msgid ""
 "Unable to interpret the version info I got from http://andrejv.github.io//"
 "wxmaxima/version.txt: "
@@ -4355,11 +4358,11 @@ msgstr "Подчеркивание"
 msgid "Underscore converts to subscripts:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:492
+#: ../src/wxMaximaFrame.cpp:491
 msgid "Undo\tCtrl-Z"
 msgstr "Отмена\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:493
+#: ../src/wxMaximaFrame.cpp:492
 msgid "Undo last change"
 msgstr "Отменить последнее изменение"
 
@@ -4367,26 +4370,26 @@ msgstr "Отменить последнее изменение"
 msgid "Undo limit (0 for none):"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:625
+#: ../src/wxMaximaFrame.cpp:624
 #, fuzzy
 msgid "Unfold All\tCtrl-Alt-]"
 msgstr "Выделить всё\tCtrl-A"
 
-#: ../src/wxMaximaFrame.cpp:626
+#: ../src/wxMaximaFrame.cpp:625
 #, fuzzy
 msgid "Unfold all folded sections"
 msgstr "Развернуть все свернутые группы"
 
-#: ../src/wxMaxima.cpp:4458
+#: ../src/wxMaxima.cpp:4470
 msgid "Unicode Support"
 msgstr "Поддержка Unicode"
 
-#: ../src/wxMaxima.cpp:5335
+#: ../src/wxMaxima.cpp:5347
 #, fuzzy
 msgid "Unterminated comment."
 msgstr "Раскомментировать"
 
-#: ../src/wxMaxima.cpp:5309
+#: ../src/wxMaxima.cpp:5321
 msgid "Unterminated string."
 msgstr ""
 
@@ -4394,15 +4397,15 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5859 ../src/wxMaxima.cpp:5866 ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5874 ../src/wxMaxima.cpp:5881 ../src/wxMaxima.cpp:5889
 msgid "Upgrade"
 msgstr "Обновиться"
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Upper bound:"
 msgstr "Верхняя граница:"
 
-#: ../src/wxMaximaFrame.cpp:1383
+#: ../src/wxMaximaFrame.cpp:1382
 #, fuzzy
 msgid "Upsilon"
 msgstr "Выражение:"
@@ -4447,22 +4450,22 @@ msgstr ""
 msgid "User-defined labels"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3525
-#: ../src/wxMaxima.cpp:3541 ../src/wxMaxima.cpp:3649
+#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3537
+#: ../src/wxMaxima.cpp:3553 ../src/wxMaxima.cpp:3661
 msgid "Value:"
 msgstr "Значение:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:5019 ../src/wxMaxima.cpp:5064
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:5031 ../src/wxMaxima.cpp:5076
 msgid "Variable(s):"
 msgstr "Переменные:"
 
 #: ../src/IntegrateWiz.cpp:33 ../src/LimitWiz.cpp:30 ../src/Plot2dWiz.cpp:34
 #: ../src/Plot2dWiz.cpp:44 ../src/Plot2dWiz.cpp:533 ../src/Plot3dWiz.cpp:33
 #: ../src/Plot3dWiz.cpp:42 ../src/SeriesWiz.cpp:36 ../src/SumWiz.cpp:30
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3749
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3761
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5045
 msgid "Variable:"
 msgstr "Переменная:"
 
@@ -4470,26 +4473,26 @@ msgstr "Переменная:"
 msgid "Variables"
 msgstr "Переменные"
 
-#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3571 ../src/wxMaxima.cpp:4206
-#: ../src/wxMaxima.cpp:4807
+#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3583 ../src/wxMaxima.cpp:4218
+#: ../src/wxMaxima.cpp:4819
 msgid "Variables:"
 msgstr "Переменные:"
 
-#: ../src/wxMaximaFrame.cpp:1257
+#: ../src/wxMaximaFrame.cpp:1256
 #, fuzzy
 msgid "Variance..."
 msgstr "Переменная:"
 
-#: ../src/wxMaximaFrame.cpp:580
+#: ../src/wxMaximaFrame.cpp:579
 msgid "View"
 msgstr ""
 
-#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1674 ../src/wxMaxima.cpp:1769
-#: ../src/wxMaxima.cpp:1950
+#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1679 ../src/wxMaxima.cpp:1774
+#: ../src/wxMaxima.cpp:1955
 msgid "Warning"
 msgstr "Предупреждение"
 
-#: ../src/wxMaximaFrame.cpp:109 ../src/wxMaximaFrame.cpp:295
+#: ../src/wxMaximaFrame.cpp:108 ../src/wxMaximaFrame.cpp:294
 msgid "Welcome to wxMaxima"
 msgstr "Добро пожаловать в wxMaxima"
 
@@ -4512,7 +4515,7 @@ msgid ""
 "introducing an empty line."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2567
+#: ../src/wxMaxima.cpp:2574
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) "
 "(*.wxm)|*.wxm"
@@ -4528,7 +4531,7 @@ msgid ""
 "as equation markers"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6798
+#: ../src/MathCtrl.cpp:6856
 msgid "Wrapped search"
 msgstr ""
 
@@ -4536,16 +4539,16 @@ msgstr ""
 msgid "Write matching parenthesis in text controls."
 msgstr "Писать соответствующие скобки в текстовых элементах управления."
 
-#: ../src/wxMaxima.cpp:4461
+#: ../src/wxMaxima.cpp:4473
 msgid "Written by"
 msgstr "Автор"
 
-#: ../src/wxMaximaFrame.cpp:557
+#: ../src/wxMaximaFrame.cpp:556
 #, fuzzy
 msgid "XML Inspector"
 msgstr "Вставить"
 
-#: ../src/wxMaximaFrame.cpp:1377
+#: ../src/wxMaximaFrame.cpp:1376
 msgid "Xi"
 msgstr ""
 
@@ -4600,7 +4603,7 @@ msgid ""
 "cells."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5856
+#: ../src/wxMaxima.cpp:5871
 #, c-format
 msgid ""
 "You have version %s. Current version is %s.\n"
@@ -4608,41 +4611,41 @@ msgid ""
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5921
+#: ../src/wxMaxima.cpp:5936
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5866
+#: ../src/wxMaxima.cpp:5881
 msgid "Your version of wxMaxima is up to date."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1369
+#: ../src/wxMaximaFrame.cpp:1368
 msgid "Zeta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:562
+#: ../src/wxMaximaFrame.cpp:561
 #, fuzzy
 msgid "Zoom &In\tCtrl-+"
 msgstr "У&величить\tAlt-I"
 
-#: ../src/wxMaximaFrame.cpp:564
+#: ../src/wxMaximaFrame.cpp:563
 #, fuzzy
 msgid "Zoom Ou&t\tCtrl--"
 msgstr "У&меньшить\tAlt-O"
 
-#: ../src/wxMaximaFrame.cpp:563
+#: ../src/wxMaximaFrame.cpp:562
 msgid "Zoom in 10%"
 msgstr "Увеличить на 10%"
 
-#: ../src/wxMaximaFrame.cpp:565
+#: ../src/wxMaximaFrame.cpp:564
 msgid "Zoom out 10%"
 msgstr "Уменьшить на 10%"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaximaFrame.cpp:287
 msgid "[ unsaved ]"
 msgstr "[ не сохранено ]"
 
-#: ../src/wxMaxima.cpp:5700
+#: ../src/wxMaxima.cpp:5715
 msgid "[ unsaved* ]"
 msgstr "[ не сохранено* ]"
 
@@ -4651,17 +4654,17 @@ msgstr "[ не сохранено* ]"
 msgid "[%i digits]"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4392
+#: ../src/MathCtrl.cpp:4447
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" style=\"max-width:90%%;\" >\n"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4517
+#: ../src/MathCtrl.cpp:4572
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" >"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1333
+#: ../src/wxMaximaFrame.cpp:1332
 msgid "alpha"
 msgstr ""
 
@@ -4674,7 +4677,7 @@ msgstr "желто-коричневый"
 msgid "antisymmetric"
 msgstr "антисимметричная"
 
-#: ../src/wxMaximaFrame.cpp:1334
+#: ../src/wxMaximaFrame.cpp:1333
 msgid "beta"
 msgstr ""
 
@@ -4718,7 +4721,7 @@ msgstr ""
 msgid "bug:Invalid sup tag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1354
+#: ../src/wxMaximaFrame.cpp:1353
 #, fuzzy
 msgid "chi"
 msgstr "орхидея"
@@ -4732,7 +4735,7 @@ msgstr ""
 msgid "default"
 msgstr "по умолчанию"
 
-#: ../src/wxMaximaFrame.cpp:1336
+#: ../src/wxMaximaFrame.cpp:1335
 msgid "delta"
 msgstr ""
 
@@ -4744,7 +4747,7 @@ msgstr "диагональная"
 msgid "empty"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1337
+#: ../src/wxMaximaFrame.cpp:1336
 #, fuzzy
 msgid "epsilon"
 msgstr "Выражение:"
@@ -4753,7 +4756,7 @@ msgstr "Выражение:"
 msgid "equivalent"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1339
+#: ../src/wxMaximaFrame.cpp:1338
 msgid "eta"
 msgstr ""
 
@@ -4769,7 +4772,7 @@ msgid ""
 "all=_ marks subscripts."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1335
+#: ../src/wxMaximaFrame.cpp:1334
 msgid "gamma"
 msgstr ""
 
@@ -4798,15 +4801,15 @@ msgstr "встроенный"
 msgid "intersection"
 msgstr "Направление:"
 
-#: ../src/wxMaximaFrame.cpp:1341
+#: ../src/wxMaximaFrame.cpp:1340
 msgid "iota"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1342
+#: ../src/wxMaximaFrame.cpp:1341
 msgid "kappa"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1343
+#: ../src/wxMaximaFrame.cpp:1342
 msgid "lambda"
 msgstr ""
 
@@ -4823,7 +4826,7 @@ msgstr "Подраздел"
 msgid "logscale"
 msgstr "логарифмическая шкала"
 
-#: ../src/wxMaxima.cpp:3783
+#: ../src/wxMaxima.cpp:3795
 msgid "matrix[i,j]:"
 msgstr "matrix[i,j]:"
 
@@ -4831,7 +4834,7 @@ msgstr "matrix[i,j]:"
 msgid "maxima's pwd is path to document"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1344
+#: ../src/wxMaximaFrame.cpp:1343
 msgid "mu"
 msgstr ""
 
@@ -4848,7 +4851,7 @@ msgstr ""
 msgid "nand"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4524
+#: ../src/wxMaxima.cpp:4536
 msgid "no"
 msgstr "нет"
 
@@ -4874,15 +4877,15 @@ msgstr ""
 msgid "not subset or equal"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1345
+#: ../src/wxMaximaFrame.cpp:1344
 msgid "nu"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1356
+#: ../src/wxMaximaFrame.cpp:1355
 msgid "omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1347
+#: ../src/wxMaximaFrame.cpp:1346
 msgid "omicron"
 msgstr ""
 
@@ -4895,11 +4898,11 @@ msgstr ""
 msgid "partial sign"
 msgstr "Простые дроби"
 
-#: ../src/wxMaximaFrame.cpp:1353
+#: ../src/wxMaximaFrame.cpp:1352
 msgid "phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1348
+#: ../src/wxMaximaFrame.cpp:1347
 #, fuzzy
 msgid "pi"
 msgstr "розовый"
@@ -4912,11 +4915,11 @@ msgstr ""
 msgid "proportional to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1355
+#: ../src/wxMaximaFrame.cpp:1354
 msgid "psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1349
+#: ../src/wxMaximaFrame.cpp:1348
 msgid "rho"
 msgstr ""
 
@@ -4924,7 +4927,7 @@ msgstr ""
 msgid "right"
 msgstr "справа"
 
-#: ../src/wxMaximaFrame.cpp:1350
+#: ../src/wxMaximaFrame.cpp:1349
 msgid "sigma"
 msgstr ""
 
@@ -4946,7 +4949,7 @@ msgstr "Подраздел"
 msgid "symmetric"
 msgstr "симметричная"
 
-#: ../src/wxMaximaFrame.cpp:1351
+#: ../src/wxMaximaFrame.cpp:1350
 msgid "tau"
 msgstr ""
 
@@ -4958,7 +4961,7 @@ msgstr ""
 msgid "there is no"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1340
+#: ../src/wxMaximaFrame.cpp:1339
 msgid "theta"
 msgstr ""
 
@@ -4974,12 +4977,12 @@ msgstr ""
 msgid "union"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5903
+#: ../src/wxMaxima.cpp:5918
 msgid "unsaved"
 msgstr "не сохранено"
 
-#: ../src/wxMaximaFrame.cpp:290 ../src/wxMaxima.cpp:2559
-#: ../src/wxMaxima.cpp:2826
+#: ../src/wxMaxima.cpp:2566 ../src/wxMaxima.cpp:2834
+#: ../src/wxMaximaFrame.cpp:289
 msgid "untitled"
 msgstr "без названия"
 
@@ -4988,27 +4991,27 @@ msgstr "без названия"
 msgid "untitled %d"
 msgstr "без названия %d"
 
-#: ../src/wxMaximaFrame.cpp:1352
+#: ../src/wxMaximaFrame.cpp:1351
 #, fuzzy
 msgid "upsilon"
 msgstr "Выражение:"
 
-#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4538
+#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4550
 msgid "wxMaxima"
 msgstr "wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
-#: ../src/wxMaxima.cpp:5700 ../src/wxMaxima.cpp:5709 ../src/wxMaxima.cpp:5712
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaxima.cpp:5715 ../src/wxMaxima.cpp:5724
+#: ../src/wxMaxima.cpp:5727 ../src/wxMaximaFrame.cpp:287
 #, c-format
 msgid "wxMaxima %s "
 msgstr "wxMaxima %s"
 
-#: ../src/wxMaximaFrame.cpp:952
+#: ../src/wxMaximaFrame.cpp:951
 #, fuzzy
 msgid "wxMaxima &Help\tCtrl+?"
 msgstr "Спра&вка по Maxima\tF1"
 
-#: ../src/wxMaximaFrame.cpp:955
+#: ../src/wxMaximaFrame.cpp:954
 #, fuzzy
 msgid "wxMaxima &Help\tF1"
 msgstr "Спра&вка по Maxima\tF1"
@@ -5020,11 +5023,11 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1619
+#: ../src/wxMaxima.cpp:1624
 msgid "wxMaxima cannot open content.xml in the .wxmx zip archive "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1633
+#: ../src/wxMaxima.cpp:1638
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
@@ -5032,7 +5035,7 @@ msgstr ""
 msgid "wxMaxima configuration"
 msgstr "Конфигурация wxMaxima"
 
-#: ../src/wxMaxima.cpp:1947
+#: ../src/wxMaxima.cpp:1952
 msgid ""
 "wxMaxima could not find Maxima!\n"
 "\n"
@@ -5044,7 +5047,7 @@ msgstr ""
 "Задайте путь к ней в 'Правка->Настройка'.\n"
 "Затем запустите Maxima снова, выбрав 'Maxima->Перезапустить Maxima'"
 
-#: ../src/wxMaxima.cpp:2204
+#: ../src/wxMaxima.cpp:2209
 msgid ""
 "wxMaxima could not find help files.\n"
 "\n"
@@ -5054,7 +5057,7 @@ msgstr ""
 "\n"
 "Проверьте правильность установки программы."
 
-#: ../src/wxMaxima.cpp:2032
+#: ../src/wxMaxima.cpp:2037
 msgid ""
 "wxMaxima could not find tip files.\n"
 "\n"
@@ -5064,7 +5067,7 @@ msgstr ""
 "\n"
 "Проверьте правильность установки программы."
 
-#: ../src/wxMaxima.cpp:282
+#: ../src/wxMaxima.cpp:283
 msgid ""
 "wxMaxima could not start the server.\n"
 "\n"
@@ -5085,23 +5088,23 @@ msgstr ""
 "Диалоги wxMaxima применяют команды со стандартными аргументами, обычно '%'. "
 "Если вы выделите текст в документе, то вместо '%' будет использован он."
 
-#: ../src/wxMaxima.cpp:2330
+#: ../src/wxMaxima.cpp:2336
 msgid "wxMaxima document"
 msgstr "Документ wxMaxima"
 
-#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2799
+#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2807
 msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 msgstr "Документ wxMaxima (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 
-#: ../src/wxMaxima.cpp:1455 ../src/wxMaxima.cpp:1469
+#: ../src/wxMaxima.cpp:1460 ../src/wxMaxima.cpp:1474
 msgid "wxMaxima encountered an error loading "
 msgstr "Ошибка при загрузке "
 
-#: ../src/wxMaxima.cpp:4463
+#: ../src/wxMaxima.cpp:4475
 msgid "wxMaxima icon"
 msgstr "Значок wxMaxima"
 
-#: ../src/wxMaxima.cpp:4455
+#: ../src/wxMaxima.cpp:4467
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "MAXIMA based on wxWidgets."
@@ -5109,7 +5112,7 @@ msgstr ""
 "wxMaxima — графический интерфейс на wxWidgets для системы аналитических "
 "вычислений Maxima."
 
-#: ../src/wxMaxima.cpp:4516
+#: ../src/wxMaxima.cpp:4528
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "Maxima based on wxWidgets."
@@ -5129,11 +5132,11 @@ msgstr ""
 msgid "x"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1346
+#: ../src/wxMaximaFrame.cpp:1345
 msgid "xi"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1643
+#: ../src/wxMaxima.cpp:1648
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
@@ -5142,11 +5145,11 @@ msgstr ""
 msgid "xor"
 msgstr "Экспорт"
 
-#: ../src/wxMaxima.cpp:4522
+#: ../src/wxMaxima.cpp:4534
 msgid "yes"
 msgstr "да"
 
-#: ../src/wxMaximaFrame.cpp:1338
+#: ../src/wxMaximaFrame.cpp:1337
 msgid "zeta"
 msgstr ""
 

--- a/locales/tr.po
+++ b/locales/tr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tr\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-07 21:42+0200\n"
+"POT-Creation-Date: 2016-10-16 17:47+0900\n"
 "PO-Revision-Date: 2015-12-13 23:30+0200\n"
 "Last-Translator: Tufan Şirin <tsirin@turgutozal.edu.tr>\n"
 "Language-Team: Tufan Şirin <tsirin@turgutozal.edu.tr>\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.6\n"
 
-#: ../src/wxMaxima.cpp:4519
+#: ../src/wxMaxima.cpp:4531
 #, c-format
 msgid ""
 "\n"
@@ -29,7 +29,7 @@ msgstr ""
 "wxWidgets: %d.%d.%d\n"
 "Unicode Desteği: %s"
 
-#: ../src/wxMaxima.cpp:4532
+#: ../src/wxMaxima.cpp:4544
 msgid ""
 "\n"
 "Lisp: "
@@ -37,7 +37,7 @@ msgstr ""
 "\n"
 "Lisp: "
 
-#: ../src/wxMaxima.cpp:4528
+#: ../src/wxMaxima.cpp:4540
 msgid ""
 "\n"
 "Maxima version: "
@@ -45,7 +45,7 @@ msgstr ""
 "\n"
 "Maxima Sürümü: "
 
-#: ../src/wxMaxima.cpp:5381
+#: ../src/wxMaxima.cpp:5397
 msgid ""
 "\n"
 "Not connected to Maxima!\n"
@@ -53,7 +53,7 @@ msgstr ""
 "\n"
 "Maximay'la bağlantı kurulamadı \n"
 
-#: ../src/wxMaxima.cpp:4530
+#: ../src/wxMaxima.cpp:4542
 msgid ""
 "\n"
 "Not connected."
@@ -73,7 +73,7 @@ msgstr ""
 msgid " (Graphics) "
 msgstr "(Grafikler)"
 
-#: ../src/EditorCell.cpp:3045 ../src/EditorCell.cpp:3227
+#: ../src/EditorCell.cpp:3088 ../src/EditorCell.cpp:3270
 #, c-format
 msgid " ... + %i hidden lines"
 msgstr ""
@@ -85,7 +85,7 @@ msgstr ""
 "....[Yapılandırmada izin verilenden daha uzun bir çıktı olduğundan "
 "çıkarılmış ek satırlar]"
 
-#: ../src/wxMaxima.cpp:1673
+#: ../src/wxMaxima.cpp:1678
 msgid ""
 " was saved using a newer version of wxMaxima so it may not load correctly. "
 "Please update your wxMaxima."
@@ -93,7 +93,7 @@ msgstr ""
 "wxMaxima'nın daha yeni bir sürümü ile kaydedildi; doğru şekilde "
 "yüklenmeyebilir  Lütfen wxMaxima'yı güncelleyin."
 
-#: ../src/wxMaxima.cpp:1665
+#: ../src/wxMaxima.cpp:1670
 msgid ""
 " was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr ""
@@ -108,64 +108,64 @@ msgstr ""
 msgid "\"implies\" symbol"
 msgstr "\"uygular\" işareti"
 
-#: ../src/wxMaximaFrame.cpp:101
+#: ../src/wxMaximaFrame.cpp:100
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr "%i hücreleri değerlendirme sırasında (bekliyor)"
 
-#: ../src/wxMaximaFrame.cpp:773
+#: ../src/wxMaximaFrame.cpp:772
 msgid "&Algebra"
 msgstr "&Cebir"
 
-#: ../src/wxMaximaFrame.cpp:767
+#: ../src/wxMaximaFrame.cpp:766
 msgid "&Apply to List..."
 msgstr "&Listeye Uygula"
 
-#: ../src/wxMaximaFrame.cpp:964
+#: ../src/wxMaximaFrame.cpp:963
 msgid "&Apropos..."
 msgstr "&İlgili"
 
-#: ../src/wxMaximaFrame.cpp:478
+#: ../src/wxMaximaFrame.cpp:477
 msgid "&Batch File...\tCtrl-B"
 msgstr "&Kütük Dosyası\tCtrl-B"
 
-#: ../src/wxMaximaFrame.cpp:724
+#: ../src/wxMaximaFrame.cpp:723
 msgid "&Boundary Value Problem..."
 msgstr "&Sınır Değeri Problemi"
 
-#: ../src/wxMaximaFrame.cpp:975
+#: ../src/wxMaximaFrame.cpp:974
 msgid "&Bug Report"
 msgstr "Hata Raporu"
 
-#: ../src/wxMaximaFrame.cpp:825
+#: ../src/wxMaximaFrame.cpp:824
 msgid "&Calculus"
 msgstr "&Kalkülüs"
 
-#: ../src/wxMaximaFrame.cpp:876
+#: ../src/wxMaximaFrame.cpp:875
 msgid "&Canonical Form"
 msgstr "&Kanonik Form"
 
-#: ../src/wxMaximaFrame.cpp:749
+#: ../src/wxMaximaFrame.cpp:748
 msgid "&Characteristic Polynomial..."
 msgstr "&Karakteristik Polinom"
 
-#: ../src/wxMaximaFrame.cpp:654
+#: ../src/wxMaximaFrame.cpp:653
 msgid "&Clear Memory"
 msgstr "&Belleği temizle"
 
-#: ../src/wxMaximaFrame.cpp:859
+#: ../src/wxMaximaFrame.cpp:858
 msgid "&Combine Factorials"
 msgstr "&Çarpanları Birleştir"
 
-#: ../src/wxMaximaFrame.cpp:902
+#: ../src/wxMaximaFrame.cpp:901
 msgid "&Complex Simplification"
 msgstr "&Karmaşık Sadeleştirme"
 
-#: ../src/wxMaximaFrame.cpp:822
+#: ../src/wxMaximaFrame.cpp:821
 msgid "&Continued Fraction"
 msgstr "&Sürekli Kesirler"
 
-#: ../src/wxMaximaFrame.cpp:502
+#: ../src/wxMaximaFrame.cpp:501
 msgid "&Copy\tCtrl-C"
 msgstr "&Kopyala\tCtrl-C"
 
@@ -173,108 +173,108 @@ msgstr "&Kopyala\tCtrl-C"
 msgid "&Definite integration"
 msgstr "&Belirli İntegral"
 
-#: ../src/wxMaximaFrame.cpp:896
+#: ../src/wxMaximaFrame.cpp:895
 msgid "&Demoivre"
 msgstr "&de Moivre formülü"
 
-#: ../src/wxMaximaFrame.cpp:752
+#: ../src/wxMaximaFrame.cpp:751
 msgid "&Determinant"
 msgstr "&Determinant"
 
-#: ../src/wxMaximaFrame.cpp:785
+#: ../src/wxMaximaFrame.cpp:784
 msgid "&Differentiate..."
 msgstr "&Diferansiyelini bul"
 
-#: ../src/wxMaximaFrame.cpp:543
+#: ../src/wxMaximaFrame.cpp:542
 msgid "&Edit"
 msgstr "&Düzenle"
 
-#: ../src/wxMaximaFrame.cpp:709
+#: ../src/wxMaximaFrame.cpp:708
 msgid "&Eliminate Variable..."
 msgstr "&Değişkeni yok et"
 
-#: ../src/wxMaximaFrame.cpp:744
+#: ../src/wxMaximaFrame.cpp:743
 msgid "&Enter Matrix..."
 msgstr "&Matris gir"
 
-#: ../src/wxMaximaFrame.cpp:961
+#: ../src/wxMaximaFrame.cpp:960
 msgid "&Example..."
 msgstr "&Örnek"
 
-#: ../src/wxMaximaFrame.cpp:839
+#: ../src/wxMaximaFrame.cpp:838
 msgid "&Expand Expression"
 msgstr "&İfadeyi Genişlet"
 
-#: ../src/wxMaximaFrame.cpp:873
+#: ../src/wxMaximaFrame.cpp:872
 msgid "&Expand Trigonometric"
 msgstr "&Trigonometrik Genişlet"
 
-#: ../src/wxMaximaFrame.cpp:899
+#: ../src/wxMaximaFrame.cpp:898
 msgid "&Exponentialize"
 msgstr "&Üstel Hale Getir"
 
-#: ../src/wxMaximaFrame.cpp:480
+#: ../src/wxMaximaFrame.cpp:479
 msgid "&Export..."
 msgstr "&Çıkar"
 
-#: ../src/wxMaximaFrame.cpp:834
+#: ../src/wxMaximaFrame.cpp:833
 msgid "&Factor Expression"
 msgstr "&İfadenin Özdeşi"
 
-#: ../src/wxMaximaFrame.cpp:489
+#: ../src/wxMaximaFrame.cpp:488
 msgid "&File"
 msgstr "&Dosya"
 
-#: ../src/wxMaximaFrame.cpp:692
+#: ../src/wxMaximaFrame.cpp:691
 msgid "&Find Root..."
 msgstr "&Köklerini Bul"
 
-#: ../src/wxMaximaFrame.cpp:738
+#: ../src/wxMaximaFrame.cpp:737
 msgid "&Generate Matrix..."
 msgstr "&Matris Oluştur"
 
-#: ../src/wxMaximaFrame.cpp:809
+#: ../src/wxMaximaFrame.cpp:808
 msgid "&Greatest Common Divisor..."
 msgstr "&OBEB"
 
-#: ../src/wxMaximaFrame.cpp:994
+#: ../src/wxMaximaFrame.cpp:993
 msgid "&Help"
 msgstr "&Yardım"
 
-#: ../src/wxMaximaFrame.cpp:777
+#: ../src/wxMaximaFrame.cpp:776
 msgid "&Integrate..."
 msgstr "&İntegral"
 
-#: ../src/wxMaximaFrame.cpp:645
+#: ../src/wxMaximaFrame.cpp:644
 msgid "&Interrupt\tCtrl-."
 msgstr "&Yarıda Kes\tCtrl-G"
 
-#: ../src/wxMaximaFrame.cpp:649
+#: ../src/wxMaximaFrame.cpp:648
 msgid "&Interrupt\tCtrl-G"
 msgstr "&Yarıda Kes\tCtrl-G"
 
-#: ../src/wxMaximaFrame.cpp:746
+#: ../src/wxMaximaFrame.cpp:745
 msgid "&Invert Matrix"
 msgstr "&Ters Matris"
 
-#: ../src/wxMaximaFrame.cpp:476
+#: ../src/wxMaximaFrame.cpp:475
 msgid "&Load Package...\tCtrl-L"
 msgstr "&Paket Yükle\tCtrl-L"
 
-#: ../src/wxMaximaFrame.cpp:769
+#: ../src/wxMaximaFrame.cpp:768
 #, fuzzy
 msgid "&Map to List(s)..."
 msgstr "&Listeye Eşle"
 
-#: ../src/wxMaximaFrame.cpp:684
+#: ../src/wxMaximaFrame.cpp:683
 msgid "&Maxima"
 msgstr "&Maxima"
 
-#: ../src/wxMaximaFrame.cpp:958
+#: ../src/wxMaximaFrame.cpp:957
 msgid "&Maxima help"
 msgstr "&Maxima Yardımı"
 
-#: ../src/wxMaximaFrame.cpp:917
+#: ../src/wxMaximaFrame.cpp:916
 msgid "&Modulus Computation..."
 msgstr "&Modüler Hesaplama"
 
@@ -282,7 +282,7 @@ msgstr "&Modüler Hesaplama"
 msgid "&New\tCtrl-N"
 msgstr "&Yeni\tCtrl-N"
 
-#: ../src/wxMaximaFrame.cpp:947
+#: ../src/wxMaximaFrame.cpp:946
 msgid "&Numeric"
 msgstr "&Numerik"
 
@@ -298,11 +298,11 @@ msgstr "&Nusum"
 msgid "&Open\tCtrl-O"
 msgstr "&Aç\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:463
+#: ../src/wxMaximaFrame.cpp:462
 msgid "&Open...\tCtrl-O"
 msgstr "&Aç...\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:929
+#: ../src/wxMaximaFrame.cpp:928
 msgid "&Plot"
 msgstr "&Grafik Çiz"
 
@@ -310,7 +310,7 @@ msgstr "&Grafik Çiz"
 msgid "&Power series"
 msgstr "&Kuvvet Serileri"
 
-#: ../src/wxMaximaFrame.cpp:483
+#: ../src/wxMaximaFrame.cpp:482
 msgid "&Print...\tCtrl-P"
 msgstr "&Yazdır...\tCtrl-P"
 
@@ -318,39 +318,39 @@ msgstr "&Yazdır...\tCtrl-P"
 msgid "&Rational"
 msgstr "&Rasyonel"
 
-#: ../src/wxMaximaFrame.cpp:870
+#: ../src/wxMaximaFrame.cpp:869
 msgid "&Reduce Trigonometric"
 msgstr "&Trigonometrik İndirge"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "&Restart Maxima"
 msgstr "&Maxima'yı Yeniden Başlat"
 
-#: ../src/wxMaximaFrame.cpp:700
+#: ../src/wxMaximaFrame.cpp:699
 msgid "&Roots of Polynomial (Real)"
 msgstr "&Polinom Kökü (Gerçel)"
 
-#: ../src/wxMaximaFrame.cpp:472
+#: ../src/wxMaximaFrame.cpp:471
 msgid "&Save\tCtrl-S"
 msgstr "&Kaydet\tCtrl-S"
 
-#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:919
+#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:918
 msgid "&Simplify"
 msgstr "&Sadeleştir"
 
-#: ../src/wxMaximaFrame.cpp:829
+#: ../src/wxMaximaFrame.cpp:828
 msgid "&Simplify Expression"
 msgstr "&İfadeyi Sadeleştir"
 
-#: ../src/wxMaximaFrame.cpp:856
+#: ../src/wxMaximaFrame.cpp:855
 msgid "&Simplify Factorials"
 msgstr "&Faktöryelleri Sadeleştir"
 
-#: ../src/wxMaximaFrame.cpp:867
+#: ../src/wxMaximaFrame.cpp:866
 msgid "&Simplify Trigonometric"
 msgstr "&Trigonomtrik Sadeleştir"
 
-#: ../src/wxMaximaFrame.cpp:688
+#: ../src/wxMaximaFrame.cpp:687
 msgid "&Solve..."
 msgstr "&Çöz"
 
@@ -362,11 +362,11 @@ msgstr "&Özel"
 msgid "&Taylor series"
 msgstr "&Taylor Serileri"
 
-#: ../src/wxMaximaFrame.cpp:762
+#: ../src/wxMaximaFrame.cpp:761
 msgid "&Transpose Matrix"
 msgstr "&Matrisin Transpozesi"
 
-#: ../src/wxMaximaFrame.cpp:879
+#: ../src/wxMaximaFrame.cpp:878
 msgid "&Trigonometric Simplification"
 msgstr "&Trigonometrik Sadeleştirme"
 
@@ -384,7 +384,7 @@ msgstr "(Varsayılan dili kullan)"
 msgid "- Infinity"
 msgstr "- Sonsuz"
 
-#: ../src/wxMaxima.cpp:351
+#: ../src/wxMaxima.cpp:356
 msgid ""
 "... [suppressed additional lines since the output is longer than allowed in "
 "the configuration] "
@@ -396,16 +396,16 @@ msgstr ""
 msgid "1/2"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:103
+#: ../src/wxMaximaFrame.cpp:102
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4601
+#: ../src/wxMaxima.cpp:4613
 msgid "<br>Lisp: "
 msgstr "<br>Lisp: "
 
-#: ../src/wxMaxima.cpp:5487
+#: ../src/wxMaxima.cpp:5503
 msgid ""
 "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
@@ -438,11 +438,11 @@ msgid ""
 "\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1472
+#: ../src/wxMaximaFrame.cpp:1495
 msgid "A symbol from the configuration dialogue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:731
+#: ../src/wxMaximaFrame.cpp:730
 msgid "A&t Value..."
 msgstr "&Başlangıç Şartı"
 
@@ -450,12 +450,12 @@ msgstr "&Başlangıç Şartı"
 msgid "Abort evaluation on error"
 msgstr "Hata oluştuğunda değerlendirmeyi durdur"
 
-#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaxima.cpp:4603
+#: ../src/wxMaxima.cpp:4615 ../src/wxMaximaFrame.cpp:985
 msgid "About"
 msgstr "Hakkında"
 
-#: ../src/wxMaximaFrame.cpp:987 ../src/wxMaximaFrame.cpp:990
-#: ../src/wxMaximaFrame.cpp:991
+#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaximaFrame.cpp:989
+#: ../src/wxMaximaFrame.cpp:990
 msgid "About wxMaxima"
 msgstr "wxMaxima hakkında"
 
@@ -463,23 +463,23 @@ msgstr "wxMaxima hakkında"
 msgid "Active cell bracket"
 msgstr "Aktif hücre ayıracı"
 
-#: ../src/wxMaximaFrame.cpp:760
+#: ../src/wxMaximaFrame.cpp:759
 msgid "Ad&joint Matrix"
 msgstr "&Ek Matris"
 
-#: ../src/wxMaximaFrame.cpp:914
+#: ../src/wxMaximaFrame.cpp:913
 msgid "Add Algebraic E&quality..."
 msgstr "&Cebirsel Eşitlik Ekle"
 
-#: ../src/wxMaximaFrame.cpp:657
+#: ../src/wxMaximaFrame.cpp:656
 msgid "Add a directory to search path"
 msgstr "Arama yoluna dizin ekle"
 
-#: ../src/wxMaxima.cpp:3353
+#: ../src/wxMaxima.cpp:3365
 msgid "Add dir to path:"
 msgstr "Yola dizin ekle :"
 
-#: ../src/wxMaximaFrame.cpp:915
+#: ../src/wxMaximaFrame.cpp:914
 msgid "Add equality to the rational simplifier"
 msgstr "Rasyonel sadeleştiriciye eşitlik ekle"
 
@@ -487,7 +487,7 @@ msgstr "Rasyonel sadeleştiriciye eşitlik ekle"
 msgid "Add the .wxmx file to the HTML export"
 msgstr ".wxmx dosyasını HTML çıkarımına ekle"
 
-#: ../src/wxMaximaFrame.cpp:656
+#: ../src/wxMaximaFrame.cpp:655
 msgid "Add to &Path..."
 msgstr "&Yola ekle"
 
@@ -531,27 +531,27 @@ msgstr "Eski Değişken:"
 msgid "All|*"
 msgstr "Hepsi|*"
 
-#: ../src/wxMaximaFrame.cpp:1364
+#: ../src/wxMaximaFrame.cpp:1363
 msgid "Alpha"
 msgstr "Alpha"
 
-#: ../src/wxMaxima.cpp:3838
+#: ../src/wxMaxima.cpp:3850
 msgid "Apply"
 msgstr "Uygula"
 
-#: ../src/wxMaximaFrame.cpp:768
+#: ../src/wxMaximaFrame.cpp:767
 msgid "Apply function to a list"
 msgstr "Fonksiyonu bir listeye uygula"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Apropos"
 msgstr "İlgili"
 
-#: ../src/wxMaxima.cpp:3764
+#: ../src/wxMaxima.cpp:3776
 msgid "Array:"
 msgstr "Dizin:"
 
-#: ../src/wxMaxima.cpp:4462
+#: ../src/wxMaxima.cpp:4474
 msgid "Artwork by"
 msgstr "Çizim:"
 
@@ -559,7 +559,7 @@ msgstr "Çizim:"
 msgid "Ask to save untitled documents"
 msgstr "İsim verilmemiş belgeyi kaydederken sor"
 
-#: ../src/wxMaxima.cpp:3650
+#: ../src/wxMaxima.cpp:3662
 msgid "At value"
 msgstr "Başlangıç Değeri"
 
@@ -586,11 +586,11 @@ msgstr ""
 msgid "Autosave interval (minutes, 0 means: off):"
 msgstr "Otomatik kaydetme aralığı (dakika,0 kapalı demektir)"
 
-#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3557
+#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3569
 msgid "BC2"
 msgstr "SŞ2"
 
-#: ../src/wxMaximaFrame.cpp:1272
+#: ../src/wxMaximaFrame.cpp:1271
 msgid "Barsplot..."
 msgstr "Sütun Diyagramı"
 
@@ -598,7 +598,7 @@ msgstr "Sütun Diyagramı"
 msgid "Bat files (*.bat)|*.bat|All|*"
 msgstr "bat Dosyaları (*.bat)|*.bat|tümü|*"
 
-#: ../src/wxMaxima.cpp:2943
+#: ../src/wxMaxima.cpp:2951
 msgid "Batch File"
 msgstr "Kütük Dosyası"
 
@@ -617,7 +617,7 @@ msgstr ""
 "hücrelerdeki değişiklikleri etkilemeyen ince ayar bir geri alma işlemi "
 "yapabilir."
 
-#: ../src/wxMaximaFrame.cpp:1365
+#: ../src/wxMaximaFrame.cpp:1364
 msgid "Beta"
 msgstr "Beta"
 
@@ -630,11 +630,11 @@ msgstr "Çıkarım için Bitmap ölçüsü"
 msgid "Bold"
 msgstr "Koyu"
 
-#: ../src/wxMaxima.cpp:2359
+#: ../src/wxMaxima.cpp:2366
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr "Yatay ve dikey imleçlerin her ikisi de aynı anda aktif"
 
-#: ../src/wxMaximaFrame.cpp:1274
+#: ../src/wxMaximaFrame.cpp:1273
 msgid "Boxplot..."
 msgstr "Kutu Diyagram çiz"
 
@@ -646,15 +646,15 @@ msgstr "Göz at"
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr "Hata: Bilinmeyen bir öge için otomatik tamamlama isteği."
 
-#: ../src/MathCtrl.cpp:2080
+#: ../src/MathCtrl.cpp:2127
 msgid "Bug: Cell left but not entered."
 msgstr "Hata: Hücre geride bırakıldı ancak (değerlendirmeye) girmedi."
 
-#: ../src/wxMaxima.cpp:1178
+#: ../src/wxMaxima.cpp:1183
 msgid "Bug: Found a math end marker without any start marker."
 msgstr "Hata: Başlangıç işaretçisi olmadan bir matematik sonlandrıcı işareti."
 
-#: ../src/wxMaxima.cpp:1222
+#: ../src/wxMaxima.cpp:1227
 msgid "Bug: Found the end of autocompletion symbols but no beginning"
 msgstr "Hata: Başlamamış otomatik tamamlama sonlandırması bulundu"
 
@@ -666,11 +666,11 @@ msgstr ""
 msgid "Bug: Fraction without enumerator"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2312
+#: ../src/MathCtrl.cpp:2359
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr "Hata: Bir soru alındı ama yanıtı içeren bir hücre yok"
 
-#: ../src/MathCtrl.cpp:5839
+#: ../src/MathCtrl.cpp:5891
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of "
 "the worksheet."
@@ -678,13 +678,13 @@ msgstr ""
 "Hata: Çalışma yaprağının başladığı noktanın üstünde bir hücrenin içeriğini "
 "değiştirme istemi."
 
-#: ../src/MathCtrl.cpp:5913
+#: ../src/MathCtrl.cpp:5965
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 "Hata: Çalışma yaprağının başlangıcının üstünde bir hücreyi silme isteği. "
 
-#: ../src/MathCtrl.cpp:5882
+#: ../src/MathCtrl.cpp:5934
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
@@ -695,43 +695,43 @@ msgstr ""
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
 msgstr "Hata: Math hücresi ait olduğu bir Grup hücresi olmadığını düşünüyor."
 
-#: ../src/GroupCell.cpp:780 ../src/GroupCell.cpp:951
+#: ../src/GroupCell.cpp:781 ../src/GroupCell.cpp:952
 msgid "Bug: No image counter to write to!"
 msgstr ""
 
-#: ../src/AbsCell.cpp:193
+#: ../src/AbsCell.cpp:199
 msgid "Bug: No last cell in an absCell!"
 msgstr ""
 
-#: ../src/ConjugateCell.cpp:185
+#: ../src/ConjugateCell.cpp:194
 msgid "Bug: No last cell in an conjugateCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:471
+#: ../src/FracCell.cpp:472
 msgid "Bug: No last cell in an denominator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:267
+#: ../src/ExptCell.cpp:270
 msgid "Bug: No last cell in an exponent of an exptCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:459
+#: ../src/FracCell.cpp:460
 msgid "Bug: No last cell in an numerator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:257
+#: ../src/ExptCell.cpp:260
 msgid "Bug: No last cell in the base of an exptCell!"
 msgstr ""
 
-#: ../src/ParenCell.cpp:534
+#: ../src/ParenCell.cpp:535
 msgid "Bug: No last cell inside a parenthesis!"
 msgstr ""
 
-#: ../src/SqrtCell.cpp:312
+#: ../src/SqrtCell.cpp:317
 msgid "Bug: No last cell inside a square root!"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2123
+#: ../src/MathCtrl.cpp:2170
 msgid ""
 "Bug: Start or end of merging of subsequent editing actions was requested two "
 "times in a row."
@@ -739,7 +739,7 @@ msgstr ""
 "Hata: Bir sonraki düzenleme eylemlerinin birleştirmesinin  başlatılması yada "
 "sonlandırılması, bir satırda iki defa istendi. "
 
-#: ../src/MathCtrl.cpp:2090
+#: ../src/MathCtrl.cpp:2137
 msgid "Bug: Text changed, but no active cell."
 msgstr "Hata: Metin değişti, ancak aktif hücre yok"
 
@@ -747,13 +747,13 @@ msgstr "Hata: Metin değişti, ancak aktif hücre yok"
 msgid "Bug: Trying to append NULL to a group cell."
 msgstr "Hata: Hücresi olmayan bir hücre içeriğini yazmaya çalışıyor."
 
-#: ../src/MathCtrl.cpp:555
+#: ../src/MathCtrl.cpp:600
 msgid "Bug: Trying to append maxima's output to a cell outside the worksheet."
 msgstr ""
 "Hata: Maxima çıktısını çalışma yaprağı dışındaki bir hücreye eklemeye "
 "çalışıyor."
 
-#: ../src/MathCtrl.cpp:2014
+#: ../src/MathCtrl.cpp:2061
 msgid ""
 "Bug: Trying to merge individual cell adds to a region in the undo buffer but "
 "there are other cells between them."
@@ -761,33 +761,33 @@ msgstr ""
 "Hata: Geri al arabelleğinin bir bölgesinde ayrı ayrı hücreleri birleştirmeye "
 "çalışıyor Ancak ikisi arasında başka hücreler var."
 
-#: ../src/MathCtrl.cpp:6522
+#: ../src/MathCtrl.cpp:6577
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
 "Hata:Yatay-çizilen imleci bir HücreGrubu içinde hareket ettirmeye çalışıyor."
 
-#: ../src/MathCtrl.cpp:2092
+#: ../src/MathCtrl.cpp:2139
 msgid "Bug: Trying to record a cell contents change without a cell."
 msgstr "Hata: Hücresi olmayan bir hücre içeriğini yazmaya çalışıyor."
 
-#: ../src/MathCtrl.cpp:1495
+#: ../src/MathCtrl.cpp:1540
 msgid "Bug: Trying to select inside a cell without having a current cell"
 msgstr ""
 "Hata: Geçerli bir hücresi olmayan bir hücrenin içinde seçim yapmaya çalışıyor"
 
-#: ../src/MathCtrl.cpp:5883
+#: ../src/MathCtrl.cpp:5935
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
 "Hata: Hücre içeriği değişiklikleri ve hücre ekleme durumlarının her ikisi "
 "için Geri Al eylemi."
 
-#: ../src/MathCtrl.cpp:5844 ../src/MathCtrl.cpp:5918 ../src/MathCtrl.cpp:5952
+#: ../src/MathCtrl.cpp:5896 ../src/MathCtrl.cpp:5970 ../src/MathCtrl.cpp:6004
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr "Hata: Geri al isteği çalışma yaprağı dışındaki bir hücreye ait."
 
-#: ../src/wxMaximaFrame.cpp:973
+#: ../src/wxMaximaFrame.cpp:972
 msgid "Build &Info"
 msgstr "Oluşturma & Bilgi"
 
@@ -806,51 +806,51 @@ msgstr ""
 "sonra açılan pencerede 'Enter tuşu komutları değerlendirir'sekmesi "
 "tıklanmalıdır.Tersi için tekrar tıklanarak işaret kaldırılır."
 
-#: ../src/wxMaximaFrame.cpp:782
+#: ../src/wxMaximaFrame.cpp:781
 msgid "C&hange Variable..."
 msgstr "Değişkeni değiştir"
 
-#: ../src/wxMaximaFrame.cpp:540
+#: ../src/wxMaximaFrame.cpp:539
 msgid "C&onfigure"
 msgstr "&Yapılandır"
 
-#: ../src/wxMaximaFrame.cpp:801
+#: ../src/wxMaximaFrame.cpp:800
 msgid "Calculate &Product..."
 msgstr "&Çarpımı hesapla"
 
-#: ../src/wxMaximaFrame.cpp:799
+#: ../src/wxMaximaFrame.cpp:798
 msgid "Calculate Su&m..."
 msgstr "&Toplamı hesapla"
 
-#: ../src/wxMaximaFrame.cpp:939
+#: ../src/wxMaximaFrame.cpp:938
 msgid "Calculate bigfloat value of the last result"
 msgstr "En Son Sonucun Büyük Kayan Sayı Değerini Heapla"
 
-#: ../src/wxMaximaFrame.cpp:936
+#: ../src/wxMaximaFrame.cpp:935
 msgid "Calculate float value of the last result"
 msgstr "En Son Sonucunu Kayan Sayı Değerini Heapla"
 
-#: ../src/wxMaxima.cpp:3971
+#: ../src/wxMaxima.cpp:3983
 msgid "Calculate modulus:"
 msgstr "Modülleri Hesapla:"
 
-#: ../src/wxMaximaFrame.cpp:942
+#: ../src/wxMaximaFrame.cpp:941
 msgid "Calculate numeric value of the last result"
 msgstr "En son sonucun sayısal değerini hesapla "
 
-#: ../src/wxMaximaFrame.cpp:802
+#: ../src/wxMaximaFrame.cpp:801
 msgid "Calculate products"
 msgstr "Çarpımları Hesapla"
 
-#: ../src/wxMaximaFrame.cpp:800
+#: ../src/wxMaximaFrame.cpp:799
 msgid "Calculate sums"
 msgstr "Toplamları Hesapla"
 
-#: ../src/wxMaxima.cpp:5830
+#: ../src/wxMaxima.cpp:5845
 msgid "Can not connect to the web server."
 msgstr "Web sunucusuna bağlanamıyor."
 
-#: ../src/wxMaxima.cpp:5881
+#: ../src/wxMaxima.cpp:5896
 msgid "Can not download version info."
 msgstr "Sürüm bilgisi indirilemiyor."
 
@@ -866,15 +866,15 @@ msgstr "Sürüm bilgisi indirilemiyor."
 #: ../src/PlotFormatWiz.cpp:48 ../src/SeriesWiz.cpp:49 ../src/SeriesWiz.cpp:51
 #: ../src/SubstituteWiz.cpp:41 ../src/SubstituteWiz.cpp:43 ../src/SumWiz.cpp:44
 #: ../src/SumWiz.cpp:46 ../src/SystemWiz.cpp:38 ../src/SystemWiz.cpp:40
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Cancel"
 msgstr "İptal et"
 
-#: ../src/wxMaximaFrame.cpp:126 ../src/wxMaxima.cpp:932
+#: ../src/wxMaxima.cpp:937 ../src/wxMaximaFrame.cpp:125
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1217
+#: ../src/wxMaximaFrame.cpp:1216
 msgid "Canonical (tr)"
 msgstr "Kanonik (trig)"
 
@@ -882,7 +882,7 @@ msgstr "Kanonik (trig)"
 msgid "Catalan"
 msgstr "Katalanca"
 
-#: ../src/wxMaximaFrame.cpp:638
+#: ../src/wxMaximaFrame.cpp:637
 msgid "Ce&ll"
 msgstr "&Hücre"
 
@@ -890,41 +890,41 @@ msgstr "&Hücre"
 msgid "Cell bracket"
 msgstr "Hücre parantezi"
 
-#: ../src/wxMaxima.cpp:5261
+#: ../src/wxMaxima.cpp:5273
 msgid "Cell ends in a backslash"
 msgstr "Hücre ters kesme işareti ile bitiyor"
 
-#: ../src/wxMaximaFrame.cpp:676
+#: ../src/wxMaximaFrame.cpp:675
 msgid "Change &2d Display"
 msgstr "2B gösterimini değiştir"
 
-#: ../src/wxMaximaFrame.cpp:677
+#: ../src/wxMaximaFrame.cpp:676
 msgid "Change the 2d display algorithm used to display math output"
 msgstr ""
 "'Matemetiksel çıktı (sonuç)'ları göstermek için kullanılan 2B algoritmasını "
 "değiştir"
 
-#: ../src/wxMaxima.cpp:3995
+#: ../src/wxMaxima.cpp:4007
 msgid "Change variable"
 msgstr "Değişkeni değiştir"
 
-#: ../src/wxMaximaFrame.cpp:783
+#: ../src/wxMaximaFrame.cpp:782
 msgid "Change variable in integral or sum"
 msgstr "İntegral ve ya toplam daki değişkeni değiştir"
 
-#: ../src/wxMaxima.cpp:3751
+#: ../src/wxMaxima.cpp:3763
 msgid "Char poly"
 msgstr "Karakt. Polinom "
 
-#: ../src/wxMaximaFrame.cpp:978
+#: ../src/wxMaximaFrame.cpp:977
 msgid "Check for Updates"
 msgstr "Güncellemeleri denetle"
 
-#: ../src/wxMaximaFrame.cpp:979
+#: ../src/wxMaximaFrame.cpp:978
 msgid "Check if a newer version of wxMaxima/Maxima exist."
 msgstr "wxMaxima/Maxima'nın daha yeni bir sürümü olup olmadığına bak."
 
-#: ../src/wxMaximaFrame.cpp:1385
+#: ../src/wxMaximaFrame.cpp:1384
 msgid "Chi"
 msgstr "Chi"
 
@@ -945,15 +945,15 @@ msgstr "Yazı tipini değiştir"
 msgid "Choose new plot format:"
 msgstr "Yeni grafik çizim formatı seç"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710
 msgid "Classes:"
 msgstr "Sınıflar"
 
-#: ../src/wxMaximaFrame.cpp:469
+#: ../src/wxMaximaFrame.cpp:468
 msgid "Close\tCtrl-W"
 msgstr "Kapat\tCtrl-W"
 
-#: ../src/wxMaximaFrame.cpp:470
+#: ../src/wxMaximaFrame.cpp:469
 msgid "Close window"
 msgstr "Pencereyi kapat"
 
@@ -985,19 +985,19 @@ msgstr "Kod vurgulama: Dizinler"
 msgid "Code highlighting: Variables"
 msgstr "Kod vurgulama: Değişkenler"
 
-#: ../src/wxMaxima.cpp:4806
+#: ../src/wxMaxima.cpp:4818
 msgid "Col. names:"
 msgstr "Sütun adları:"
 
-#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Columns:"
 msgstr "Sütunlar:"
 
-#: ../src/wxMaximaFrame.cpp:860
+#: ../src/wxMaximaFrame.cpp:859
 msgid "Combine factorials in an expression"
 msgstr "Bir ifadedeki faktöryelleri ortak paranteze alarak düzenle"
 
-#: ../src/wxMaxima.cpp:5293
+#: ../src/wxMaxima.cpp:5305
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
@@ -1009,25 +1009,25 @@ msgstr "Virgülle ayrılmış x koordinatları."
 msgid "Comma separated y coordinates"
 msgstr "Virgülle ayrılmış y koordinatları"
 
-#: ../src/MathCtrl.cpp:1030
+#: ../src/MathCtrl.cpp:1072
 msgid "Comment Selection"
 msgstr "Komut Seçimi"
 
-#: ../src/wxMaximaFrame.cpp:533
+#: ../src/wxMaximaFrame.cpp:532
 msgid "Comment out the currently selected text"
 msgstr ""
 "Seçili metnin (başına ve sonuna /*....*/ koyarak) değerlendirmeye "
 "alınmamasını sağla."
 
-#: ../src/wxMaximaFrame.cpp:532
+#: ../src/wxMaximaFrame.cpp:531
 msgid "Comment selection\tCtrl-/"
 msgstr "Seçimi yorumla\tCtrl-/"
 
-#: ../src/wxMaximaFrame.cpp:601
+#: ../src/wxMaximaFrame.cpp:600
 msgid "Complete Word\tCtrl-K"
 msgstr "Kelimeyi tamamla \tCtrl-K"
 
-#: ../src/wxMaximaFrame.cpp:602
+#: ../src/wxMaximaFrame.cpp:601
 msgid "Complete word"
 msgstr "Kelimeyi tamamla"
 
@@ -1035,35 +1035,35 @@ msgstr "Kelimeyi tamamla"
 msgid "Completely stop maxima and restart it"
 msgstr "Maxima'yı tamamen kapatın ve yeniden başlatın"
 
-#: ../src/wxMaximaFrame.cpp:823
+#: ../src/wxMaximaFrame.cpp:822
 msgid "Compute continued fraction of a value"
 msgstr "Bir değerin sürekli kesirlerini hesapla"
 
-#: ../src/wxMaximaFrame.cpp:761
+#: ../src/wxMaximaFrame.cpp:760
 msgid "Compute the adjoint matrix"
 msgstr "Ek (adjoint) Matrisi hesapla"
 
-#: ../src/wxMaximaFrame.cpp:750
+#: ../src/wxMaximaFrame.cpp:749
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr "Bir Matrisin karakteristik polinomunu hesapla"
 
-#: ../src/wxMaximaFrame.cpp:753
+#: ../src/wxMaximaFrame.cpp:752
 msgid "Compute the determinant of a matrix"
 msgstr "Bir matrisin determinantını hesapla"
 
-#: ../src/wxMaximaFrame.cpp:810
+#: ../src/wxMaximaFrame.cpp:809
 msgid "Compute the greatest common divisor"
 msgstr "OBEB i hesapla"
 
-#: ../src/wxMaximaFrame.cpp:747
+#: ../src/wxMaximaFrame.cpp:746
 msgid "Compute the inverse of a matrix"
 msgstr "Bir matrisin tersini hesapla"
 
-#: ../src/wxMaximaFrame.cpp:813
+#: ../src/wxMaximaFrame.cpp:812
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr "OKEK hesapla (önce load(functs) paketini yükle)"
 
-#: ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4868
 msgid "Condition:"
 msgstr "Şart:"
 
@@ -1075,8 +1075,8 @@ msgstr "Config dosyası (*.ini)|*.ini"
 msgid "Configuration warning"
 msgstr "Yapılandırma uyarısı"
 
-#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:538
-#: ../src/wxMaximaFrame.cpp:541
+#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:540
 msgid "Configure wxMaxima"
 msgstr "Maxima'yı yapılandır"
 
@@ -1085,129 +1085,131 @@ msgstr "Maxima'yı yapılandır"
 msgid "Constant"
 msgstr "Sabit"
 
-#: ../src/wxMaximaFrame.cpp:844
+#: ../src/wxMaximaFrame.cpp:843
 msgid "Contract Logarithms"
 msgstr "Logaritmik ifadeyi kısalt"
 
-#: ../src/wxMaximaFrame.cpp:851
+#: ../src/wxMaximaFrame.cpp:850
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr "İkilileri, Beta Gama fonksiyonlarının faktöriyeline çevir"
 
-#: ../src/wxMaximaFrame.cpp:854
+#: ../src/wxMaximaFrame.cpp:853
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr "İkilileri, Beta Gama fonksiyonlarının faktöriyeline çevir"
 
-#: ../src/wxMaximaFrame.cpp:888
+#: ../src/wxMaximaFrame.cpp:887
 msgid "Convert complex expression to polar form"
 msgstr "Karmaşık ifadeyi kutupsal forma çevir "
 
-#: ../src/wxMaximaFrame.cpp:885
+#: ../src/wxMaximaFrame.cpp:884
 msgid "Convert complex expression to rect form"
 msgstr "Karmaşık ifadeyi kartezyen forma çevir"
 
-#: ../src/wxMaximaFrame.cpp:897
+#: ../src/wxMaximaFrame.cpp:896
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr "Sanal argümanın üstel fonksiyonunu trigonometrik olarak ifade et"
 
-#: ../src/wxMaximaFrame.cpp:842
+#: ../src/wxMaximaFrame.cpp:841
 msgid "Convert logarithm of product to sum of logarithms"
 msgstr "Çarpımların logartimasını toplamların logaritmasına dönüştür"
 
-#: ../src/wxMaximaFrame.cpp:845
+#: ../src/wxMaximaFrame.cpp:844
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "Logaritmaların toplamını çarpımın logaritmasına dönüştür"
 
-#: ../src/wxMaximaFrame.cpp:850
+#: ../src/wxMaximaFrame.cpp:849
 msgid "Convert to &Factorials"
 msgstr "Faktöriyellere dönüştür"
 
-#: ../src/wxMaximaFrame.cpp:853
+#: ../src/wxMaximaFrame.cpp:852
 msgid "Convert to &Gamma"
 msgstr "Gama'ya dönüştür"
 
-#: ../src/wxMaximaFrame.cpp:887
+#: ../src/wxMaximaFrame.cpp:886
 msgid "Convert to &Polarform"
 msgstr "Kutupsal forma dönüştürr"
 
-#: ../src/wxMaximaFrame.cpp:884
+#: ../src/wxMaximaFrame.cpp:883
 msgid "Convert to &Rectform"
 msgstr "Kartezyen forma dönüştür"
 
-#: ../src/wxMaximaFrame.cpp:877
+#: ../src/wxMaximaFrame.cpp:876
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr "Trigonometric ifadeyi kanonik yarı-doğrusal forma dönüştür"
 
-#: ../src/wxMaximaFrame.cpp:900
+#: ../src/wxMaximaFrame.cpp:899
 msgid "Convert trigonometric functions to exponential form"
 msgstr "Trigonometric ifadeyi üstel forma dönüştür"
 
-#: ../src/ToolBar.cpp:140 ../src/MathCtrl.cpp:918 ../src/MathCtrl.cpp:931
-#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1024
+#: ../src/MathCtrl.cpp:960 ../src/MathCtrl.cpp:973 ../src/MathCtrl.cpp:1019
+#: ../src/MathCtrl.cpp:1066 ../src/ToolBar.cpp:140
 msgid "Copy"
 msgstr "Kopyala"
 
-#: ../src/wxMaximaFrame.cpp:597
+#: ../src/wxMaximaFrame.cpp:596
 msgid "Copy Previous Input\tCtrl-I"
 msgstr "Bir önceki girdiyi Kopyala\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:599
+#: ../src/wxMaximaFrame.cpp:598
 msgid "Copy Previous Output\tCtrl-U"
 msgstr "Bir önceki çıktıyı Kopyala\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:514 ../src/MathCtrl.cpp:936 ../src/MathCtrl.cpp:982
+#: ../src/MathCtrl.cpp:978 ../src/MathCtrl.cpp:1024
+#: ../src/wxMaximaFrame.cpp:513
 msgid "Copy as Image"
 msgstr "Resim olarak Kopyala"
 
-#: ../src/wxMaximaFrame.cpp:507 ../src/MathCtrl.cpp:932 ../src/MathCtrl.cpp:978
+#: ../src/MathCtrl.cpp:974 ../src/MathCtrl.cpp:1020
+#: ../src/wxMaximaFrame.cpp:506
 msgid "Copy as LaTeX"
 msgstr "LaTeX metni olarak Kopyala"
 
-#: ../src/wxMaximaFrame.cpp:510
+#: ../src/wxMaximaFrame.cpp:509
 #, fuzzy
 msgid "Copy as MathML"
 msgstr "Resim olarak Kopyala"
 
-#: ../src/MathCtrl.cpp:935 ../src/MathCtrl.cpp:980
+#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1022
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:504
+#: ../src/wxMaximaFrame.cpp:503
 msgid "Copy as Text\tCtrl-Shift-C"
 msgstr "Düz metin olarak Kopyala\tCtrl-Shift-C"
 
-#: ../src/MathCtrl.cpp:933 ../src/MathCtrl.cpp:979
+#: ../src/MathCtrl.cpp:975 ../src/MathCtrl.cpp:1021
 #, fuzzy
 msgid "Copy as plain text"
 msgstr "Resim olarak Kopyala"
 
-#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:503
+#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:502
 msgid "Copy selection"
 msgstr "Seçimi Kopyala"
 
-#: ../src/wxMaximaFrame.cpp:515
+#: ../src/wxMaximaFrame.cpp:514
 msgid "Copy selection from document as an image"
 msgstr "Belgeden seçileni resim olarak kopyala"
 
-#: ../src/wxMaximaFrame.cpp:505
+#: ../src/wxMaximaFrame.cpp:504
 msgid "Copy selection from document as text"
 msgstr "Belgeden seçileni metin olarak kopyala"
 
-#: ../src/wxMaximaFrame.cpp:508
+#: ../src/wxMaximaFrame.cpp:507
 msgid "Copy selection from document in LaTeX format"
 msgstr "LaTeX belgesinde seçileni kopyala"
 
-#: ../src/wxMaximaFrame.cpp:511
+#: ../src/wxMaximaFrame.cpp:510
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:598
+#: ../src/wxMaximaFrame.cpp:597
 msgid "Create a new cell with previous input"
 msgstr "Bir önceki girdi ile yeni bir hücre oluştur"
 
-#: ../src/wxMaximaFrame.cpp:600
+#: ../src/wxMaximaFrame.cpp:599
 msgid "Create a new cell with previous output"
 msgstr "Bir önceki çıktı ile yeni bir hücre oluştur"
 
@@ -1215,15 +1217,15 @@ msgstr "Bir önceki çıktı ile yeni bir hücre oluştur"
 msgid "Cursor"
 msgstr "İmleç"
 
-#: ../src/ToolBar.cpp:137 ../src/MathCtrl.cpp:1023
+#: ../src/MathCtrl.cpp:1065 ../src/ToolBar.cpp:137
 msgid "Cut"
 msgstr "Kes"
 
-#: ../src/wxMaximaFrame.cpp:499
+#: ../src/wxMaximaFrame.cpp:498
 msgid "Cut\tCtrl-X"
 msgstr "Kes\tCtrl-X"
 
-#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:500
+#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:499
 msgid "Cut selection"
 msgstr "Seçimi kes"
 
@@ -1235,18 +1237,18 @@ msgstr "Çekçe"
 msgid "Danish"
 msgstr "Danimarkaca"
 
-#: ../src/wxMaxima.cpp:4799 ../src/wxMaxima.cpp:4806 ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4811 ../src/wxMaxima.cpp:4818 ../src/wxMaxima.cpp:4868
 msgid "Data Matrix:"
 msgstr "Veri Matrisi:"
 
-#: ../src/wxMaxima.cpp:4826
+#: ../src/wxMaxima.cpp:4838
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr "Veri dosyası (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698 ../src/wxMaxima.cpp:4712
-#: ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726 ../src/wxMaxima.cpp:4734
-#: ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748 ../src/wxMaxima.cpp:4755
-#: ../src/wxMaxima.cpp:4791
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710 ../src/wxMaxima.cpp:4724
+#: ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738 ../src/wxMaxima.cpp:4746
+#: ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760 ../src/wxMaxima.cpp:4767
+#: ../src/wxMaxima.cpp:4803
 msgid "Data:"
 msgstr "Veri:"
 
@@ -1255,7 +1257,7 @@ msgstr "Veri:"
 msgid "Debug: watch maxima's stdout stream"
 msgstr "Onar: Maxima'nın stdout (standart çıktı) akışını izle"
 
-#: ../src/wxMaximaFrame.cpp:820
+#: ../src/wxMaximaFrame.cpp:819
 msgid "Decompose rational function to partial fractions"
 msgstr "Rasyonel fonksiyonu parçalı fonksiyonlara ayır"
 
@@ -1288,47 +1290,47 @@ msgstr ""
 "Oynatılacak animasyonunu varsayılan hızını (saniyedeki çerçeve sayısı) "
 "tanımlayın."
 
-#: ../src/wxMaxima.cpp:3403 ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3415 ../src/wxMaxima.cpp:3424
 msgid "Delete"
 msgstr "Sil"
 
-#: ../src/wxMaximaFrame.cpp:667
+#: ../src/wxMaximaFrame.cpp:666
 msgid "Delete F&unction..."
 msgstr "Fonksiyonu Sil"
 
-#: ../src/MathCtrl.cpp:939 ../src/MathCtrl.cpp:985
+#: ../src/MathCtrl.cpp:981 ../src/MathCtrl.cpp:1027
 msgid "Delete Selection"
 msgstr "Seçimi Sil"
 
-#: ../src/wxMaximaFrame.cpp:669
+#: ../src/wxMaximaFrame.cpp:668
 msgid "Delete V&ariable..."
 msgstr "Değişkeni Sil"
 
-#: ../src/wxMaximaFrame.cpp:668
+#: ../src/wxMaximaFrame.cpp:667
 msgid "Delete a function"
 msgstr "Bir Fonksiyonu Sil"
 
-#: ../src/wxMaximaFrame.cpp:670
+#: ../src/wxMaximaFrame.cpp:669
 msgid "Delete a variable"
 msgstr "Bir Değişkeni Sil"
 
-#: ../src/wxMaximaFrame.cpp:655
+#: ../src/wxMaximaFrame.cpp:654
 msgid "Delete all values from memory"
 msgstr "Bellekteki Tüm Değerleri Sil"
 
-#: ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3424
 msgid "Delete function(s):"
 msgstr "Fonksiyon(ları) Sil:"
 
-#: ../src/wxMaxima.cpp:3403
+#: ../src/wxMaxima.cpp:3415
 msgid "Delete variable(s):"
 msgstr "Değiken(leri) sil:"
 
-#: ../src/wxMaximaFrame.cpp:1367
+#: ../src/wxMaximaFrame.cpp:1366
 msgid "Delta"
 msgstr "Delta"
 
-#: ../src/wxMaxima.cpp:4011
+#: ../src/wxMaxima.cpp:4023
 msgid "Denom. deg:"
 msgstr "denom deg:"
 
@@ -1336,35 +1338,35 @@ msgstr "denom deg:"
 msgid "Depth:"
 msgstr "Derinlik:"
 
-#: ../src/wxMaxima.cpp:3541
+#: ../src/wxMaxima.cpp:3553
 msgid "Derivative:"
 msgstr "Türev:"
 
-#: ../src/wxMaximaFrame.cpp:1258
+#: ../src/wxMaximaFrame.cpp:1257
 msgid "Deviation..."
 msgstr "Sapma"
 
-#: ../src/wxMaximaFrame.cpp:816
+#: ../src/wxMaximaFrame.cpp:815
 msgid "Di&vide Polynomials..."
 msgstr "Polinomları Böl"
 
-#: ../src/wxMaximaFrame.cpp:1223
+#: ../src/wxMaximaFrame.cpp:1222
 msgid "Diff..."
 msgstr "Diferansiyel"
 
-#: ../src/wxMaxima.cpp:4154 ../src/wxMaxima.cpp:5066
+#: ../src/wxMaxima.cpp:4166 ../src/wxMaxima.cpp:5078
 msgid "Differentiate"
 msgstr "Diferansiyelini al"
 
-#: ../src/wxMaximaFrame.cpp:786
+#: ../src/wxMaximaFrame.cpp:785
 msgid "Differentiate expression"
 msgstr "İfadenin diferansiyelini al"
 
-#: ../src/MathCtrl.cpp:1001
+#: ../src/MathCtrl.cpp:1043
 msgid "Differentiate..."
 msgstr "Diferansiyelini al"
 
-#: ../src/LimitWiz.cpp:37 ../src/FindReplacePane.cpp:76
+#: ../src/FindReplacePane.cpp:76 ../src/LimitWiz.cpp:37
 msgid "Direction:"
 msgstr "Uyarı:"
 
@@ -1372,48 +1374,49 @@ msgstr "Uyarı:"
 msgid "Discrete plot"
 msgstr "Kesikli çizim"
 
-#: ../src/wxMaximaFrame.cpp:679
+#: ../src/wxMaximaFrame.cpp:678
 msgid "Display Te&X Form"
 msgstr "TeX formatını göster"
 
-#: ../src/wxMaxima.cpp:3320
+#: ../src/wxMaxima.cpp:3332
 msgid "Display algorithm"
 msgstr "Gösterim algoritması"
 
-#: ../src/wxMaximaFrame.cpp:680
+#: ../src/wxMaximaFrame.cpp:679
 msgid "Display last result in TeX form"
 msgstr "Son sonucu TeX formunda göster"
 
-#: ../src/wxMaximaFrame.cpp:674
+#: ../src/wxMaximaFrame.cpp:673
 msgid "Display time used for evaluation"
 msgstr "Geçen süreyi göster"
 
-#: ../src/wxMaxima.cpp:4061
+#: ../src/wxMaxima.cpp:4073
 msgid "Divide"
 msgstr "Böl"
 
-#: ../src/MathCtrl.cpp:1032
+#: ../src/MathCtrl.cpp:1074
 msgid "Divide Cell"
 msgstr "Hücreyi Böl"
 
-#: ../src/wxMaximaFrame.cpp:635
+#: ../src/wxMaximaFrame.cpp:634
 #, fuzzy
 msgid "Divide Cell\tCtrl-D"
 msgstr "Hücreyi Böl"
 
-#: ../src/wxMaximaFrame.cpp:817
+#: ../src/wxMaximaFrame.cpp:816
 msgid "Divide numbers or polynomials"
 msgstr "Sayıları yada polinomları böl"
 
-#: ../src/wxMaximaFrame.cpp:636
+#: ../src/wxMaximaFrame.cpp:635
 msgid "Divide this input cell into two cells"
 msgstr "Bu Girdi hücresini ikiye böl"
 
-#: ../src/wxMaxima.cpp:5917
-msgid "Do you want to save the changes you made in the document \""
+#: ../src/wxMaxima.cpp:5932
+#, fuzzy, c-format
+msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr "Belgede yaptığınız değişiklikleri kaydetmek isityormusunuz? \""
 
-#: ../src/wxMaxima.cpp:1664 ../src/wxMaxima.cpp:1672
+#: ../src/wxMaxima.cpp:1669 ../src/wxMaxima.cpp:1677
 msgid "Document "
 msgstr "Belge"
 
@@ -1434,7 +1437,7 @@ msgstr ""
 "Maxima girdi (input) metinlerini ve resimleri ayrı ayrı sıkıştırmayın (zip "
 "işlemi). Git ve svn gibi kontrol sistemleri sürüm kontrolünü yapamazlar."
 
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Don't save"
 msgstr "Kaydetme"
 
@@ -1442,27 +1445,27 @@ msgstr "Kaydetme"
 msgid "Down"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:734
+#: ../src/wxMaximaFrame.cpp:733
 msgid "E&quations"
 msgstr "Denklemler"
 
-#: ../src/wxMaximaFrame.cpp:487
+#: ../src/wxMaximaFrame.cpp:486
 msgid "E&xit\tCtrl-Q"
 msgstr "&ÇIK\tCtrl-Q"
 
-#: ../src/wxMaximaFrame.cpp:757
+#: ../src/wxMaximaFrame.cpp:756
 msgid "Eige&nvectors"
 msgstr "Özvektörler"
 
-#: ../src/wxMaximaFrame.cpp:755
+#: ../src/wxMaximaFrame.cpp:754
 msgid "Eigen&values"
 msgstr "Özdeğerler"
 
-#: ../src/wxMaxima.cpp:3572
+#: ../src/wxMaxima.cpp:3584
 msgid "Eliminate"
 msgstr "Ortadan kaldır"
 
-#: ../src/wxMaximaFrame.cpp:710
+#: ../src/wxMaximaFrame.cpp:709
 msgid "Eliminate a variable from a system of equations"
 msgstr "Bir denklem sisteminde bir değişkeni sadeleştirerek ortadan kaldır"
 
@@ -1474,21 +1477,21 @@ msgstr "İspat ın sonu"
 msgid "English"
 msgstr "İngilizce"
 
-#: ../src/wxMaxima.cpp:4712 ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726
-#: ../src/wxMaxima.cpp:4734 ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748
-#: ../src/wxMaxima.cpp:4755 ../src/wxMaxima.cpp:4791 ../src/wxMaxima.cpp:4799
+#: ../src/wxMaxima.cpp:4724 ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738
+#: ../src/wxMaxima.cpp:4746 ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760
+#: ../src/wxMaxima.cpp:4767 ../src/wxMaxima.cpp:4803 ../src/wxMaxima.cpp:4811
 msgid "Enter Data"
 msgstr "Veri gir"
 
-#: ../src/wxMaximaFrame.cpp:1279
+#: ../src/wxMaximaFrame.cpp:1278
 msgid "Enter Matrix..."
 msgstr "Matris Girin"
 
-#: ../src/wxMaximaFrame.cpp:745
+#: ../src/wxMaximaFrame.cpp:744
 msgid "Enter a matrix"
 msgstr "Bir Matris Girin"
 
-#: ../src/wxMaxima.cpp:3962
+#: ../src/wxMaxima.cpp:3974
 msgid "Enter an equation for rational simplification:"
 msgstr "Rasyonel sadeleştirilmek üzere bir denklem Girin:"
 
@@ -1500,11 +1503,11 @@ msgstr "Değişkenlerin listesini 'virgülle ayrılmış' olarak girin"
 msgid "Enter evaluates cells"
 msgstr "Enter tuşu hücreleri değerlendirsin"
 
-#: ../src/wxMaxima.cpp:3734
+#: ../src/wxMaxima.cpp:3746
 msgid "Enter matrix"
 msgstr "Matris Oluşturun"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Enter new precision for bigfloats:"
 msgstr "Yeni ondalık-hassasiyeti belirleyin:"
 
@@ -1512,11 +1515,11 @@ msgstr "Yeni ondalık-hassasiyeti belirleyin:"
 msgid "Enter the path to the Maxima executable."
 msgstr "Maxima'nın uygulayabileceği şekilde girin"
 
-#: ../src/wxMaximaFrame.cpp:1368
+#: ../src/wxMaximaFrame.cpp:1367
 msgid "Epsilon"
 msgstr "Epsilon"
 
-#: ../src/wxMaxima.cpp:4208
+#: ../src/wxMaxima.cpp:4220
 msgid "Epsilon:"
 msgstr "Epsilon:"
 
@@ -1525,13 +1528,13 @@ msgstr "Epsilon:"
 msgid "Equation %d:"
 msgstr "Denklem %d:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:3633
-#: ../src/wxMaxima.cpp:5019
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:3645
+#: ../src/wxMaxima.cpp:5031
 msgid "Equation(s):"
 msgstr "Denklem(ler):"
 
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3993
-#: ../src/wxMaxima.cpp:4807 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:4005
+#: ../src/wxMaxima.cpp:4819 ../src/wxMaxima.cpp:5045
 msgid "Equation:"
 msgstr "Denklem:"
 
@@ -1542,77 +1545,77 @@ msgid ""
 "be introduced one into another. Also they are always printed out as 2D maths."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3570
+#: ../src/wxMaxima.cpp:3582
 msgid "Equations:"
 msgstr "Denklemler:"
 
-#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1455
-#: ../src/wxMaxima.cpp:1469 ../src/wxMaxima.cpp:1620 ../src/wxMaxima.cpp:1633
-#: ../src/wxMaxima.cpp:1643 ../src/wxMaxima.cpp:1666 ../src/wxMaxima.cpp:2034
-#: ../src/wxMaxima.cpp:2206 ../src/wxMaxima.cpp:5381 ../src/wxMaxima.cpp:5830
-#: ../src/wxMaxima.cpp:5881
+#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1460
+#: ../src/wxMaxima.cpp:1474 ../src/wxMaxima.cpp:1625 ../src/wxMaxima.cpp:1638
+#: ../src/wxMaxima.cpp:1648 ../src/wxMaxima.cpp:1671 ../src/wxMaxima.cpp:2039
+#: ../src/wxMaxima.cpp:2211 ../src/wxMaxima.cpp:5397 ../src/wxMaxima.cpp:5845
+#: ../src/wxMaxima.cpp:5896
 msgid "Error"
 msgstr "HATA"
 
-#: ../src/wxMaxima.cpp:2886 ../src/wxMaxima.cpp:2900 ../src/wxMaxima.cpp:2913
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617 ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:2894 ../src/wxMaxima.cpp:2908 ../src/wxMaxima.cpp:2921
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629 ../src/wxMaxima.cpp:3740
 msgid "Error!"
 msgstr "HATA!"
 
-#: ../src/wxMaximaFrame.cpp:1370
+#: ../src/wxMaximaFrame.cpp:1369
 msgid "Eta"
 msgstr "Eta"
 
-#: ../src/wxMaximaFrame.cpp:909
+#: ../src/wxMaximaFrame.cpp:908
 msgid "Evaluate &Noun Forms"
 msgstr "&İsim Formlarını Değerlendir "
 
-#: ../src/wxMaximaFrame.cpp:589
+#: ../src/wxMaximaFrame.cpp:588
 msgid "Evaluate All Cells\tCtrl-Shift-R"
 msgstr "Bütün Hücreleri Değerlendir \tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:587
+#: ../src/wxMaximaFrame.cpp:586
 msgid "Evaluate All Visible Cells\tCtrl-R"
 msgstr "Görünen bütün hücreleri Değerlendir \tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:585 ../src/MathCtrl.cpp:942
+#: ../src/MathCtrl.cpp:984 ../src/wxMaximaFrame.cpp:584
 msgid "Evaluate Cell(s)"
 msgstr "Hücre(leri) Değerlendir"
 
-#: ../src/wxMaximaFrame.cpp:591
+#: ../src/wxMaximaFrame.cpp:590
 #, fuzzy
 msgid "Evaluate Cells Above\tCtrl-Shift-P"
 msgstr "Bunun üstündeki Hücreleri Değerlendir \tCtrl-Shift-P"
 
-#: ../src/MathCtrl.cpp:956 ../src/MathCtrl.cpp:1051
+#: ../src/MathCtrl.cpp:998 ../src/MathCtrl.cpp:1093
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr "Değerlendir kısmı\tShift+Ctrl+Enter"
 
-#: ../src/MathCtrl.cpp:961 ../src/MathCtrl.cpp:1053
+#: ../src/MathCtrl.cpp:1003 ../src/MathCtrl.cpp:1095
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr "Değerlendir  Bölümü\tShift+Ctrl+Enter"
 
-#: ../src/MathCtrl.cpp:971 ../src/MathCtrl.cpp:1057
+#: ../src/MathCtrl.cpp:1013 ../src/MathCtrl.cpp:1099
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr "Alt-Alt kısmı değerlendir \tShift+Ctrl+Enter"
 
-#: ../src/MathCtrl.cpp:966 ../src/MathCtrl.cpp:1055
+#: ../src/MathCtrl.cpp:1008 ../src/MathCtrl.cpp:1097
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr "Alt kısmı Değerlendir\\tShift+Ctrl+Enter"
 
-#: ../src/wxMaximaFrame.cpp:586
+#: ../src/wxMaximaFrame.cpp:585
 msgid "Evaluate active or selected cell(s)"
 msgstr "Aktif yada seçilmiş hücreleri değerlendir"
 
-#: ../src/wxMaximaFrame.cpp:590
+#: ../src/wxMaximaFrame.cpp:589
 msgid "Evaluate all cells in the document"
 msgstr "Belgedeki tüm hücreleri değerlendir"
 
-#: ../src/wxMaximaFrame.cpp:910
+#: ../src/wxMaximaFrame.cpp:909
 msgid "Evaluate all noun forms in expression"
 msgstr "İfadedeki bütün isim formlarını değerlendir"
 
-#: ../src/wxMaximaFrame.cpp:588
+#: ../src/wxMaximaFrame.cpp:587
 msgid "Evaluate all visible cells in the document"
 msgstr "Belgedeki Görünen bütün hücreleri değerlendir"
 
@@ -1624,7 +1627,7 @@ msgstr "Dosyayı başlangıcından imlecin üstündeki hücreye kadar değerlend
 msgid "Evaluate to point"
 msgstr "Noktaya Değerlendir "
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Example"
 msgstr "Örnek"
 
@@ -1637,31 +1640,31 @@ msgstr "Örnek Metin"
 msgid "Examples:"
 msgstr "Örnek"
 
-#: ../src/wxMaximaFrame.cpp:488
+#: ../src/wxMaximaFrame.cpp:487
 msgid "Exit wxMaxima"
 msgstr "wxMaxima'dan Çık"
 
-#: ../src/wxMaximaFrame.cpp:1214
+#: ../src/wxMaximaFrame.cpp:1213
 msgid "Expand"
 msgstr "Genişlet"
 
-#: ../src/wxMaximaFrame.cpp:1219
+#: ../src/wxMaximaFrame.cpp:1218
 msgid "Expand (tr)"
 msgstr "Genişlet (trig.)"
 
-#: ../src/MathCtrl.cpp:997
+#: ../src/MathCtrl.cpp:1039
 msgid "Expand Expression"
 msgstr "İfadeyi Genişlet"
 
-#: ../src/wxMaximaFrame.cpp:841
+#: ../src/wxMaximaFrame.cpp:840
 msgid "Expand Logarithms"
 msgstr "Logaritmaları Genişlet"
 
-#: ../src/wxMaximaFrame.cpp:840
+#: ../src/wxMaximaFrame.cpp:839
 msgid "Expand an expression"
 msgstr "Bir ifadeyi genişlet"
 
-#: ../src/wxMaximaFrame.cpp:874
+#: ../src/wxMaximaFrame.cpp:873
 msgid "Expand trigonometric expression"
 msgstr "Trigonometric ifadeyi genişlet"
 
@@ -1669,7 +1672,7 @@ msgstr "Trigonometric ifadeyi genişlet"
 msgid "Expected the icon files to be found at"
 msgstr "Simge dosyalarının bulunması beklenen yer"
 
-#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2834
+#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2842
 msgid "Export"
 msgstr "Çıkart"
 
@@ -1680,31 +1683,31 @@ msgstr ""
 "Animasyonları TeX'e çıkar (PDF görüntüleyicisi destekliyorsa resimler "
 "gönderilir.)"
 
-#: ../src/wxMaximaFrame.cpp:481
+#: ../src/wxMaximaFrame.cpp:480
 msgid "Export document to a HTML or pdfLaTeX file"
 msgstr "BelgeyiHTML yada pdfLaTeX olarak çıkart"
 
-#: ../src/wxMaximaFrame.cpp:253
+#: ../src/wxMaximaFrame.cpp:252
 msgid "Export failed."
 msgstr "Çıkarım başarısız."
 
-#: ../src/wxMaximaFrame.cpp:239
+#: ../src/wxMaximaFrame.cpp:238
 msgid "Export successful."
 msgstr "Çıkarım başarılı"
 
-#: ../src/wxMaxima.cpp:2913
+#: ../src/wxMaxima.cpp:2921
 msgid "Exporting to HTML failed!"
 msgstr "HTML formatına dönüştürme işlemi başarılamadı'"
 
-#: ../src/wxMaxima.cpp:2886
+#: ../src/wxMaxima.cpp:2894
 msgid "Exporting to TeX failed!"
 msgstr "TeX formatına dönüştürme işlemi başarılamadı!"
 
-#: ../src/wxMaxima.cpp:2900
+#: ../src/wxMaxima.cpp:2908
 msgid "Exporting to maxima batch file failed!"
 msgstr "Maxima Kütük Dosyası olarak çıkarım başarısız!"
 
-#: ../src/wxMaximaFrame.cpp:229
+#: ../src/wxMaximaFrame.cpp:228
 msgid "Exporting..."
 msgstr "Çıkarılıyor (Dönüştürülüyor)"
 
@@ -1717,42 +1720,42 @@ msgid "Expression(s):"
 msgstr "İfade(ler):"
 
 #: ../src/IntegrateWiz.cpp:30 ../src/LimitWiz.cpp:27 ../src/SeriesWiz.cpp:33
-#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3648
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:4205 ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5064
+#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3660
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:4217 ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5076
 msgid "Expression:"
 msgstr "İfade:"
 
-#: ../src/wxMaximaFrame.cpp:1213
+#: ../src/wxMaximaFrame.cpp:1212
 msgid "Factor"
 msgstr "Çarpan"
 
-#: ../src/wxMaximaFrame.cpp:836
+#: ../src/wxMaximaFrame.cpp:835
 msgid "Factor Complex"
 msgstr "KarmaşıkSayı Çarpanları"
 
-#: ../src/MathCtrl.cpp:996
+#: ../src/MathCtrl.cpp:1038
 msgid "Factor Expression"
 msgstr "İfadenin Çarpanları"
 
-#: ../src/wxMaximaFrame.cpp:835
+#: ../src/wxMaximaFrame.cpp:834
 msgid "Factor an expression"
 msgstr "Birİfadenin Çarpanları"
 
-#: ../src/wxMaximaFrame.cpp:837
+#: ../src/wxMaximaFrame.cpp:836
 msgid "Factor an expression in Gaussian numbers"
 msgstr "Gauss Sayıları Şeklindeki ifadenin çarpanı"
 
-#: ../src/wxMaximaFrame.cpp:862
+#: ../src/wxMaximaFrame.cpp:861
 msgid "Factorials and &Gamma"
 msgstr "Faktöriyeller ve &Gamma "
 
-#: ../src/wxMaxima.cpp:285
+#: ../src/wxMaxima.cpp:286
 msgid "Fatal error"
 msgstr "Ölümcül Hata"
 
-#: ../src/GroupCell.cpp:1571
+#: ../src/GroupCell.cpp:1572
 #, c-format
 msgid "Figure %d:"
 msgstr "Şekil %d:"
@@ -1761,20 +1764,20 @@ msgstr "Şekil %d:"
 msgid "File"
 msgstr "Dosya"
 
-#: ../src/wxMaxima.cpp:1457 ../src/wxMaxima.cpp:1623 ../src/wxMaxima.cpp:1636
-#: ../src/wxMaxima.cpp:1646 ../src/wxMaxima.cpp:1668
+#: ../src/wxMaxima.cpp:1462 ../src/wxMaxima.cpp:1628 ../src/wxMaxima.cpp:1641
+#: ../src/wxMaxima.cpp:1651 ../src/wxMaxima.cpp:1673
 msgid "File could not be opened"
 msgstr "Dosya açılamadı"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File not found"
 msgstr "Dosya bulunamadı"
 
-#: ../src/wxMaxima.cpp:1511 ../src/wxMaxima.cpp:1729
+#: ../src/wxMaxima.cpp:1516 ../src/wxMaxima.cpp:1734
 msgid "File opened"
 msgstr "Dosya açıldı"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File you tried to open does not exist."
 msgstr "Açmaya çalıştığınız dosya yok"
 
@@ -1786,67 +1789,67 @@ msgstr "Dosya"
 msgid "Find"
 msgstr "Bul"
 
-#: ../src/wxMaximaFrame.cpp:523
+#: ../src/wxMaximaFrame.cpp:522
 msgid "Find\tCtrl-F"
 msgstr "Bul\tCtrl-F"
 
-#: ../src/wxMaximaFrame.cpp:787
+#: ../src/wxMaximaFrame.cpp:786
 msgid "Find &Limit..."
 msgstr "Hesapla &Limit"
 
-#: ../src/wxMaximaFrame.cpp:790
+#: ../src/wxMaximaFrame.cpp:789
 msgid "Find Minimum..."
 msgstr "Minimumu hesapla"
 
-#: ../src/MathCtrl.cpp:993
+#: ../src/MathCtrl.cpp:1035
 msgid "Find Root..."
 msgstr "Kökünü bul"
 
-#: ../src/wxMaximaFrame.cpp:791
+#: ../src/wxMaximaFrame.cpp:790
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr "Bir ifadenin (sıkıştırılmamış) minimumunu bul"
 
-#: ../src/wxMaximaFrame.cpp:788
+#: ../src/wxMaximaFrame.cpp:787
 msgid "Find a limit of an expression"
 msgstr "Bir ifadenin bir limitini bul"
 
-#: ../src/wxMaximaFrame.cpp:693
+#: ../src/wxMaximaFrame.cpp:692
 msgid "Find a root of an equation on an interval"
 msgstr "Bir denklemin bir aralıkta bir kökünü bul"
 
-#: ../src/wxMaximaFrame.cpp:695
+#: ../src/wxMaximaFrame.cpp:694
 msgid "Find all roots of a polynomial"
 msgstr "Polinomun bütün köklerini bul"
 
-#: ../src/wxMaximaFrame.cpp:698
+#: ../src/wxMaximaFrame.cpp:697
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr "(Büyük kayan sayı) polinomun bütün köklerini bul"
 
-#: ../src/wxMaxima.cpp:3220
+#: ../src/wxMaxima.cpp:3215
 msgid "Find and Replace"
 msgstr "Bul ve yerleştir"
 
-#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:523
+#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:522
 msgid "Find and replace"
 msgstr "Bul ve yerleştir"
 
-#: ../src/wxMaximaFrame.cpp:756
+#: ../src/wxMaximaFrame.cpp:755
 msgid "Find eigenvalues of a matrix"
 msgstr "Bir matrisini özdeğerlerini bul"
 
-#: ../src/wxMaximaFrame.cpp:758
+#: ../src/wxMaximaFrame.cpp:757
 msgid "Find eigenvectors of a matrix"
 msgstr "Bir matrisini özvektörlerini bul"
 
-#: ../src/wxMaxima.cpp:4210
+#: ../src/wxMaxima.cpp:4222
 msgid "Find minimum"
 msgstr "Minimum hesapla"
 
-#: ../src/wxMaximaFrame.cpp:701
+#: ../src/wxMaximaFrame.cpp:700
 msgid "Find real roots of a polynomial"
 msgstr "Polinomun gerçel köklerini bul"
 
-#: ../src/wxMaxima.cpp:3493 ../src/wxMaxima.cpp:5036
+#: ../src/wxMaxima.cpp:3505 ../src/wxMaxima.cpp:5048
 msgid "Find root"
 msgstr "Kökünü hesapla"
 
@@ -1870,11 +1873,11 @@ msgstr ""
 msgid "Fixed font in text controls"
 msgstr "Metin kontrolünde değişmez yazı tipi"
 
-#: ../src/wxMaximaFrame.cpp:623
+#: ../src/wxMaximaFrame.cpp:622
 msgid "Fold All\tCtrl-Alt-["
 msgstr "Hepsini Klasörle\tCtrl-A-["
 
-#: ../src/wxMaximaFrame.cpp:624
+#: ../src/wxMaximaFrame.cpp:623
 msgid "Fold all sections"
 msgstr "Bütün bölümleri Klasörle"
 
@@ -1882,11 +1885,11 @@ msgstr "Bütün bölümleri Klasörle"
 msgid "Follow"
 msgstr "İzle"
 
-#: ../src/ParenCell.cpp:319
+#: ../src/ParenCell.cpp:320
 msgid "Font issue: The Parenthesis sign is too small!"
 msgstr "Yazı karakteri sorunu: Parantez işareti çok küçük!"
 
-#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:381
+#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:382
 msgid ""
 "Font issue: The char height is too small! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
@@ -1896,7 +1899,7 @@ msgstr ""
 "jsmath/download/jsMath-fonts.html den yüklemek ve \"Yapılandır\" bölümünden "
 "\"Use JSmath fonts\"= JSmath fontlarını kullan ı seçmek sorunu çözebilir."
 
-#: ../src/SqrtCell.cpp:199
+#: ../src/SqrtCell.cpp:202
 msgid ""
 "Font issue: The sqrt() sign has the size 0! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
@@ -1907,7 +1910,7 @@ msgstr ""
 "bölümünden \"Use JSmath fonts\"= JSmath fontlarını kullan ı seçmek sorunu "
 "çözebilir."
 
-#: ../src/SqrtCell.cpp:198
+#: ../src/SqrtCell.cpp:201
 msgid "Font issue? The contents of a sqrt() has the size 0."
 msgstr "Yazı karakteri problemi? sqrt()'nin içeriği boş."
 
@@ -1938,15 +1941,15 @@ msgstr "Fransızca"
 
 #: ../src/IntegrateWiz.cpp:37 ../src/Plot2dWiz.cpp:37 ../src/Plot2dWiz.cpp:47
 #: ../src/Plot2dWiz.cpp:536 ../src/Plot3dWiz.cpp:36 ../src/Plot3dWiz.cpp:45
-#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4240
+#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4252
 msgid "From:"
 msgstr "Nereden:"
 
-#: ../src/wxMaximaFrame.cpp:576
+#: ../src/wxMaximaFrame.cpp:575
 msgid "Full Screen\tAlt-Enter"
 msgstr "Tüm Ekran\tAlt-Return"
 
-#: ../src/wxMaxima.cpp:3342
+#: ../src/wxMaxima.cpp:3354
 msgid "Function"
 msgstr "Fonksiyon"
 
@@ -1954,32 +1957,32 @@ msgstr "Fonksiyon"
 msgid "Function names"
 msgstr "Fonksiyon isimleri"
 
-#: ../src/wxMaxima.cpp:3633
+#: ../src/wxMaxima.cpp:3645
 msgid "Function(s):"
 msgstr "Fonksiyon(lar):"
 
-#: ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3803
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3815
+#: ../src/wxMaxima.cpp:3848
 msgid "Function:"
 msgstr "Fonksiyon:"
 
-#: ../src/wxMaximaFrame.cpp:904
+#: ../src/wxMaximaFrame.cpp:903
 msgid "Functions for complex simplification"
 msgstr "Karmaşık sadeleştirme fonksiyonları"
 
-#: ../src/wxMaximaFrame.cpp:864
+#: ../src/wxMaximaFrame.cpp:863
 msgid "Functions for simplifying factorials and gamma function"
 msgstr "Gamma fonksiyonu ve çarpanlarına ayırma fonksiyonları"
 
-#: ../src/wxMaximaFrame.cpp:881
+#: ../src/wxMaximaFrame.cpp:880
 msgid "Functions for simplifying trigonometric expressions"
 msgstr "Trigonometrik ifadeleri sadeleştirme fonksiyonları"
 
-#: ../src/wxMaxima.cpp:4046
+#: ../src/wxMaxima.cpp:4058
 msgid "GCD"
 msgstr "OBEB"
 
-#: ../src/wxMaxima.cpp:5152
+#: ../src/wxMaxima.cpp:5164
 msgid "GIF image (*.gif)|*.gif"
 msgstr "GIF resmi (*.gif)|*.gif"
 
@@ -1987,31 +1990,31 @@ msgstr "GIF resmi (*.gif)|*.gif"
 msgid "Galician"
 msgstr "Galiçyaca"
 
-#: ../src/wxMaximaFrame.cpp:1366
+#: ../src/wxMaximaFrame.cpp:1365
 msgid "Gamma"
 msgstr "Gamma"
 
-#: ../src/wxMaximaFrame.cpp:391
+#: ../src/wxMaximaFrame.cpp:390
 msgid "General Math"
 msgstr "Genel Matematik"
 
-#: ../src/wxMaximaFrame.cpp:549
+#: ../src/wxMaximaFrame.cpp:548
 msgid "General Math\tAlt-Shift-M"
 msgstr "Genel Matematik\tAlt-Shift-M"
 
-#: ../src/wxMaxima.cpp:3766 ../src/wxMaxima.cpp:3785
+#: ../src/wxMaxima.cpp:3778 ../src/wxMaxima.cpp:3797
 msgid "Generate Matrix"
 msgstr "Matris oluştur"
 
-#: ../src/wxMaximaFrame.cpp:741
+#: ../src/wxMaximaFrame.cpp:740
 msgid "Generate Matrix from Expression..."
 msgstr "Bir ifadeden matris oluştur"
 
-#: ../src/wxMaximaFrame.cpp:739
+#: ../src/wxMaximaFrame.cpp:738
 msgid "Generate a matrix from a 2-dimensional array"
 msgstr "2B dizinden matris oluştur"
 
-#: ../src/wxMaximaFrame.cpp:742
+#: ../src/wxMaximaFrame.cpp:741
 msgid "Generate a matrix from a lambda expression"
 msgstr "Bir Lambda ifadesinden matris oluştur"
 
@@ -2019,39 +2022,39 @@ msgstr "Bir Lambda ifadesinden matris oluştur"
 msgid "German"
 msgstr "Almanca"
 
-#: ../src/wxMaximaFrame.cpp:893
+#: ../src/wxMaximaFrame.cpp:892
 msgid "Get &Imaginary Part"
 msgstr "Sanal bölümü hesapla"
 
-#: ../src/wxMaximaFrame.cpp:793
+#: ../src/wxMaximaFrame.cpp:792
 msgid "Get &Series..."
 msgstr "Serileri hesapla"
 
-#: ../src/wxMaximaFrame.cpp:804
+#: ../src/wxMaximaFrame.cpp:803
 msgid "Get Laplace transformation of an expression"
 msgstr "Bir ifadenin Laplace Dönüşümünü hesapla"
 
-#: ../src/wxMaximaFrame.cpp:890
+#: ../src/wxMaximaFrame.cpp:889
 msgid "Get Real P&art"
 msgstr "Gerçel &Bölümü Hesapla"
 
-#: ../src/wxMaximaFrame.cpp:807
+#: ../src/wxMaximaFrame.cpp:806
 msgid "Get inverse Laplace transformation of an expression"
 msgstr "Bir İfadenin Ters Laplace Dönüşümünü Hesapla"
 
-#: ../src/wxMaximaFrame.cpp:794
+#: ../src/wxMaximaFrame.cpp:793
 msgid "Get the Taylor or power series of expression"
 msgstr "Bir ifadenin Taylor Serisini yada kuvvet serisini hesapla"
 
-#: ../src/wxMaximaFrame.cpp:894
+#: ../src/wxMaximaFrame.cpp:893
 msgid "Get the imaginary part of complex expression"
 msgstr "KarmaşıkSayı bir ifadenin sanal kısmını hesapla "
 
-#: ../src/wxMaximaFrame.cpp:891
+#: ../src/wxMaximaFrame.cpp:890
 msgid "Get the real part of complex expression"
 msgstr "KarmaşıkSayı bir ifadenin gerçek kısmını hesapla"
 
-#: ../src/MathCtrl.cpp:5932
+#: ../src/MathCtrl.cpp:5984
 msgid ""
 "Got a request to undo an action that involves an delete which isn't possible "
 "at this moment."
@@ -2063,12 +2066,12 @@ msgstr ""
 msgid "Greek"
 msgstr "Yunanca"
 
-#: ../src/wxMaximaFrame.cpp:356
+#: ../src/wxMaximaFrame.cpp:355
 #, fuzzy
 msgid "Greek Letters"
 msgstr "Yunan harfleri"
 
-#: ../src/wxMaximaFrame.cpp:552
+#: ../src/wxMaximaFrame.cpp:551
 #, fuzzy
 msgid "Greek Letters\tAlt-Shift-G"
 msgstr "Yunan harfleri\tAlt-Shift-G"
@@ -2081,7 +2084,7 @@ msgstr "Yunanca Sabitler"
 msgid "Grid:"
 msgstr "Izgara:"
 
-#: ../src/wxMaxima.cpp:2836
+#: ../src/wxMaxima.cpp:2844
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|pdfLaTeX file (*."
 "tex)|*.tex"
@@ -2097,11 +2100,11 @@ msgstr "HTML/Metin Hücreleri: Bütün satır kesmelerini çıkarım yap"
 msgid "Help"
 msgstr "Yardım"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide All Toolbars\tAlt-Shift--"
 msgstr "Araç çubuklarının hepsini gizle\tAlt-Shift--"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide all panes"
 msgstr "Bütün panoları gizle"
 
@@ -2109,19 +2112,19 @@ msgstr "Bütün panoları gizle"
 msgid "Highlight (dpart)"
 msgstr "Belirginleştir"
 
-#: ../src/wxMaxima.cpp:4685
+#: ../src/wxMaxima.cpp:4697
 msgid "Histogram"
 msgstr "Histogram"
 
-#: ../src/wxMaximaFrame.cpp:1270
+#: ../src/wxMaximaFrame.cpp:1269
 msgid "Histogram..."
 msgstr "Histogram..."
 
-#: ../src/wxMaximaFrame.cpp:309
+#: ../src/wxMaximaFrame.cpp:308
 msgid "History"
 msgstr "Geçmiş"
 
-#: ../src/wxMaximaFrame.cpp:555
+#: ../src/wxMaximaFrame.cpp:554
 msgid "History\tAlt-Shift-I"
 msgstr "Geçmiş\tAlt-Shift-I"
 
@@ -2141,11 +2144,11 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Macarca"
 
-#: ../src/wxMaxima.cpp:3527
+#: ../src/wxMaxima.cpp:3539
 msgid "IC1"
 msgstr "BŞ1"
 
-#: ../src/wxMaxima.cpp:3543
+#: ../src/wxMaxima.cpp:3555
 msgid "IC2"
 msgstr "BŞ2"
 
@@ -2164,7 +2167,7 @@ msgstr ""
 "etiket yerine bu etiketi gösterecektir, maxima otomatik olarak aynı çıktı "
 "hücresine bağlanır."
 
-#: ../src/wxMaximaFrame.cpp:683
+#: ../src/wxMaximaFrame.cpp:682
 msgid ""
 "If maxima ever finishes evaluating without wxMaxima realizing this this menu "
 "item can force wxMaxima to try to send commands to maxima again."
@@ -2242,11 +2245,11 @@ msgstr ""
 "Mkomut menüsünden Maxima-> Interrupt (Yarıda Kes) yada Maxima-> Restart "
 "Maxima (Maximayı Yeninden Başlat) yapın"
 
-#: ../src/wxMaximaFrame.cpp:1499
+#: ../src/wxMaximaFrame.cpp:1518
 msgid "Image"
 msgstr "Resim"
 
-#: ../src/wxMaxima.cpp:5644
+#: ../src/wxMaxima.cpp:5659
 msgid "Image files (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 msgstr "Resim Dosyları (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 
@@ -2275,7 +2278,7 @@ msgstr ""
 "LaTeX çıkarımlarında: Üs ifadelerini indisin üstüne değil de indisten sonra "
 "koyun.Kısa indislerin ve bazı fontların okunabilinirliğini arttırabilir."
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Include columns:"
 msgstr "Sütunları kapsa:"
 
@@ -2294,19 +2297,19 @@ msgstr ""
 msgid "Infinity"
 msgstr "Sonsuz"
 
-#: ../src/wxMaximaFrame.cpp:974
+#: ../src/wxMaximaFrame.cpp:973
 msgid "Info about Maxima build"
 msgstr "Maxima yapısı hakkında bilgi"
 
-#: ../src/wxMaxima.cpp:4207
+#: ../src/wxMaxima.cpp:4219
 msgid "Initial Estimates:"
 msgstr "Başlangıç Tahminleri:"
 
-#: ../src/wxMaximaFrame.cpp:718
+#: ../src/wxMaximaFrame.cpp:717
 msgid "Initial Value Problem (&1)..."
 msgstr "Başlangıç Değer Problemi (&1)"
 
-#: ../src/wxMaximaFrame.cpp:721
+#: ../src/wxMaximaFrame.cpp:720
 msgid "Initial Value Problem (&2)..."
 msgstr "Başlangıç Değer Problemi (&2)"
 
@@ -2314,7 +2317,7 @@ msgstr "Başlangıç Değer Problemi (&2)"
 msgid "Input labels"
 msgstr "GİRDİ Etiketleri"
 
-#: ../src/wxMaximaFrame.cpp:403
+#: ../src/wxMaximaFrame.cpp:402
 msgid "Insert"
 msgstr "Yerleştir"
 
@@ -2322,95 +2325,95 @@ msgstr "Yerleştir"
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr "Bir hücrenin başında bir işlemciden önce % yerleştir"
 
-#: ../src/wxMaximaFrame.cpp:612
+#: ../src/wxMaximaFrame.cpp:611
 msgid "Insert &Section Cell\tCtrl-3"
 msgstr "Kısım Hücresi Yerleştir\tCtrl-3"
 
-#: ../src/wxMaximaFrame.cpp:608
+#: ../src/wxMaximaFrame.cpp:607
 msgid "Insert &Text Cell\tCtrl-1"
 msgstr "Metin Hücresi Yerleştir\tCtrl-1"
 
-#: ../src/wxMaximaFrame.cpp:558
+#: ../src/wxMaximaFrame.cpp:557
 msgid "Insert Cell\tAlt-Shift-C"
 msgstr "Hücre Yerleştir\tAlt-Shift-C"
 
-#: ../src/wxMaxima.cpp:5642
+#: ../src/wxMaxima.cpp:5657
 msgid "Insert Image"
 msgstr "Resim Yerleştir"
 
-#: ../src/wxMaximaFrame.cpp:620
+#: ../src/wxMaximaFrame.cpp:619
 msgid "Insert Image..."
 msgstr "Resim Yerleştir..."
 
-#: ../src/wxMaximaFrame.cpp:606
+#: ../src/wxMaximaFrame.cpp:605
 msgid "Insert Input &Cell"
 msgstr "GİRDİ Hücresi Yerleştir"
 
-#: ../src/wxMaximaFrame.cpp:618
+#: ../src/wxMaximaFrame.cpp:617
 msgid "Insert Page Break"
 msgstr "Sayfa Kesmesi Ekle"
 
-#: ../src/wxMaximaFrame.cpp:614
+#: ../src/wxMaximaFrame.cpp:613
 msgid "Insert S&ubsection Cell\tCtrl-4"
 msgstr "Alt Kısım hücresi Ekle\tCtrl-4"
 
-#: ../src/wxMaximaFrame.cpp:616
+#: ../src/wxMaximaFrame.cpp:615
 msgid "Insert S&ubsubsection Cell\tCtrl-5"
 msgstr "Alt-alt &Kısım hücresi Ekle\tCtrl-5"
 
-#: ../src/MathCtrl.cpp:1015
+#: ../src/MathCtrl.cpp:1057
 msgid "Insert Section Cell"
 msgstr "Kısım Hücresi Ekle"
 
-#: ../src/MathCtrl.cpp:1016
+#: ../src/MathCtrl.cpp:1058
 msgid "Insert Subsection Cell"
 msgstr "Alt Kısım hücresi Ekle"
 
-#: ../src/MathCtrl.cpp:1017
+#: ../src/MathCtrl.cpp:1059
 msgid "Insert Subsubsection Cell"
 msgstr "Alt-alt Kısım hücresi Ekle"
 
-#: ../src/wxMaximaFrame.cpp:610
+#: ../src/wxMaximaFrame.cpp:609
 msgid "Insert T&itle Cell\tCtrl-2"
 msgstr "Başlık Hücresi Ekle\tCtrl-2"
 
-#: ../src/MathCtrl.cpp:1013
+#: ../src/MathCtrl.cpp:1055
 msgid "Insert Text Cell"
 msgstr "Metin Hücresi Ekle"
 
-#: ../src/MathCtrl.cpp:1014
+#: ../src/MathCtrl.cpp:1056
 msgid "Insert Title Cell"
 msgstr "Başlık Hücresi Ekle"
 
-#: ../src/wxMaximaFrame.cpp:607
+#: ../src/wxMaximaFrame.cpp:606
 msgid "Insert a new input cell"
 msgstr "Yeni GİRDİ Hücresi Ekle"
 
-#: ../src/wxMaximaFrame.cpp:613
+#: ../src/wxMaximaFrame.cpp:612
 msgid "Insert a new section cell"
 msgstr "Yeni Kısım Hücresi Ekle"
 
-#: ../src/wxMaximaFrame.cpp:615
+#: ../src/wxMaximaFrame.cpp:614
 msgid "Insert a new subsection cell"
 msgstr "Yeni Alt Kısım Hücresi Ekle"
 
-#: ../src/wxMaximaFrame.cpp:617
+#: ../src/wxMaximaFrame.cpp:616
 msgid "Insert a new subsubsection cell"
 msgstr "Yeni bir Alt-alt Kısım Hücresi Ekle"
 
-#: ../src/wxMaximaFrame.cpp:609
+#: ../src/wxMaximaFrame.cpp:608
 msgid "Insert a new text cell"
 msgstr "Yeni Metin Hücresi Ekle"
 
-#: ../src/wxMaximaFrame.cpp:611
+#: ../src/wxMaximaFrame.cpp:610
 msgid "Insert a new title cell"
 msgstr "Yeni Bir Başlık Hücresi Ekle"
 
-#: ../src/wxMaximaFrame.cpp:619
+#: ../src/wxMaximaFrame.cpp:618
 msgid "Insert a page break"
 msgstr "Bir Sayfa Kesmesi Ekle"
 
-#: ../src/wxMaximaFrame.cpp:621
+#: ../src/wxMaximaFrame.cpp:620
 msgid "Insert image"
 msgstr "Resim Yerleştir"
 
@@ -2422,27 +2425,27 @@ msgstr ""
 msgid "Integral sign"
 msgstr "İntegral işareti"
 
-#: ../src/wxMaxima.cpp:3992
+#: ../src/wxMaxima.cpp:4004
 msgid "Integral/Sum:"
 msgstr "İntegral/Toplam:"
 
-#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4105 ../src/wxMaxima.cpp:5051
+#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4117 ../src/wxMaxima.cpp:5063
 msgid "Integrate"
 msgstr "İntegralini Al"
 
-#: ../src/wxMaxima.cpp:4091
+#: ../src/wxMaxima.cpp:4103
 msgid "Integrate (risch)"
 msgstr "İntegralini Al (risch)"
 
-#: ../src/wxMaximaFrame.cpp:778
+#: ../src/wxMaximaFrame.cpp:777
 msgid "Integrate expression"
 msgstr "İfadenin İntegralini Al"
 
-#: ../src/wxMaximaFrame.cpp:780
+#: ../src/wxMaximaFrame.cpp:779
 msgid "Integrate expression with Risch algorithm"
 msgstr "Risch algoritmasıyla İntegralini al"
 
-#: ../src/wxMaximaFrame.cpp:1224 ../src/MathCtrl.cpp:1000
+#: ../src/MathCtrl.cpp:1042 ../src/wxMaximaFrame.cpp:1223
 msgid "Integrate..."
 msgstr "İntegralini Al..."
 
@@ -2450,7 +2453,7 @@ msgstr "İntegralini Al..."
 msgid "Interrupt"
 msgstr "Yarıda Kes"
 
-#: ../src/wxMaximaFrame.cpp:646 ../src/wxMaximaFrame.cpp:650
+#: ../src/wxMaximaFrame.cpp:645 ../src/wxMaximaFrame.cpp:649
 msgid "Interrupt current computation"
 msgstr "Yapılan İşlemi Yarıda Kes"
 
@@ -2472,15 +2475,15 @@ msgstr ""
 "\n"
 "Maxima programına uygun yolla girin."
 
-#: ../src/wxMaxima.cpp:4137
+#: ../src/wxMaxima.cpp:4149
 msgid "Inverse Laplace"
 msgstr "Ters Laplace "
 
-#: ../src/wxMaximaFrame.cpp:806
+#: ../src/wxMaximaFrame.cpp:805
 msgid "Inverse Laplace T&ransform..."
 msgstr "Ters Laplace Dönüşümü"
 
-#: ../src/wxMaximaFrame.cpp:1372
+#: ../src/wxMaximaFrame.cpp:1371
 msgid "Iota"
 msgstr "Iota"
 
@@ -2520,7 +2523,7 @@ msgstr "Japonca"
 msgid "Kabyle"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1373
+#: ../src/wxMaximaFrame.cpp:1372
 msgid "Kappa"
 msgstr "Kappa"
 
@@ -2529,7 +2532,7 @@ msgstr "Kappa"
 msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr "Özel sembolleri yüzde işareti ile yaz: %e, %i, v.b."
 
-#: ../src/wxMaxima.cpp:4031
+#: ../src/wxMaxima.cpp:4043
 msgid "LCM"
 msgstr "OKEK"
 
@@ -2546,7 +2549,7 @@ msgstr ""
 msgid "Label width:"
 msgstr "ile etiketle"
 
-#: ../src/wxMaximaFrame.cpp:1374
+#: ../src/wxMaximaFrame.cpp:1373
 msgid "Lambda"
 msgstr "Lambda"
 
@@ -2558,11 +2561,11 @@ msgstr "wxMaxima arayüzü için kullanılan dil."
 msgid "Language:"
 msgstr "Dil:"
 
-#: ../src/wxMaxima.cpp:4120
+#: ../src/wxMaxima.cpp:4132
 msgid "Laplace"
 msgstr "Laplace"
 
-#: ../src/wxMaximaFrame.cpp:803
+#: ../src/wxMaximaFrame.cpp:802
 msgid "Laplace &Transform..."
 msgstr "Laplace Dönüşümü"
 
@@ -2570,15 +2573,15 @@ msgstr "Laplace Dönüşümü"
 msgid "Leads to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:812
+#: ../src/wxMaximaFrame.cpp:811
 msgid "Least Common Multiple..."
 msgstr "OKEK"
 
-#: ../src/wxMaxima.cpp:4809
+#: ../src/wxMaxima.cpp:4821
 msgid "Least Squares Fit"
 msgstr "En Az Karelere uydur"
 
-#: ../src/wxMaximaFrame.cpp:1266
+#: ../src/wxMaximaFrame.cpp:1265
 msgid "Least Squares Fit..."
 msgstr "En Az Karelere uydur..."
 
@@ -2593,24 +2596,24 @@ msgstr ""
 "bakılmaksızın) kütüphanelere ulaşılabilinir. Bu dizin çalışma yaprağına "
 "\"maxima_userdir;\" yazarak bulunabilir."
 
-#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4192
+#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4204
 msgid "Limit"
 msgstr "Limit"
 
-#: ../src/wxMaximaFrame.cpp:1225
+#: ../src/wxMaximaFrame.cpp:1224
 msgid "Limit..."
 msgstr "Limit..."
 
-#: ../src/wxMaximaFrame.cpp:1265
+#: ../src/wxMaximaFrame.cpp:1264
 msgid "Linear Regression..."
 msgstr "Doğrusal Regresyon..."
 
-#: ../src/wxMaxima.cpp:3803
+#: ../src/wxMaxima.cpp:3815
 #, fuzzy
 msgid "List(s):"
 msgstr "Liste:"
 
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3848
 msgid "List:"
 msgstr "Liste:"
 
@@ -2618,15 +2621,15 @@ msgstr "Liste:"
 msgid "Load"
 msgstr "Yükle"
 
-#: ../src/wxMaxima.cpp:2932
+#: ../src/wxMaxima.cpp:2940
 msgid "Load Package"
 msgstr "Paket Yükle"
 
-#: ../src/wxMaximaFrame.cpp:479
+#: ../src/wxMaximaFrame.cpp:478
 msgid "Load a Maxima file using the batch command"
 msgstr "Bir Maxima dosyasını kütük komutu ile yükle"
 
-#: ../src/wxMaximaFrame.cpp:477
+#: ../src/wxMaximaFrame.cpp:476
 msgid "Load a Maxima package file"
 msgstr "Bir Maxima dosyasını yükle"
 
@@ -2638,48 +2641,48 @@ msgstr "Sitili dosyadan yükle"
 msgid "Long Right arrow"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Lower bound:"
 msgstr "Alt Sınır:"
 
-#: ../src/wxMaximaFrame.cpp:771
+#: ../src/wxMaximaFrame.cpp:770
 msgid "Ma&p to Matrix..."
 msgstr "Matrise Eşle..."
 
-#: ../src/wxMaximaFrame.cpp:547
+#: ../src/wxMaximaFrame.cpp:546
 msgid "Main Toolbar\tAlt-Shift-B"
 msgstr "Temel Araç Çubuğu\tAlt-Shift-B"
 
-#: ../src/wxMaximaFrame.cpp:765
+#: ../src/wxMaximaFrame.cpp:764
 msgid "Make &List..."
 msgstr "Liste yap..."
 
-#: ../src/wxMaxima.cpp:3821
+#: ../src/wxMaxima.cpp:3833
 msgid "Make list"
 msgstr "Liste yap"
 
-#: ../src/wxMaximaFrame.cpp:766
+#: ../src/wxMaximaFrame.cpp:765
 msgid "Make list from expression"
 msgstr "İfadeden liste oluştur"
 
-#: ../src/wxMaximaFrame.cpp:907
+#: ../src/wxMaximaFrame.cpp:906
 msgid "Make substitution in expression"
 msgstr "İfadede değiştirme yap"
 
-#: ../src/wxMaximaFrame.cpp:682
+#: ../src/wxMaximaFrame.cpp:681
 #, fuzzy
 msgid "Manually Trigger Evaluation"
 msgstr "Değerlendirmeyi manuel olarak çalıştır"
 
-#: ../src/wxMaxima.cpp:3805
+#: ../src/wxMaxima.cpp:3817
 msgid "Map"
 msgstr "Eşle"
 
-#: ../src/wxMaximaFrame.cpp:770
+#: ../src/wxMaximaFrame.cpp:769
 msgid "Map function to a list"
 msgstr "Fonksiyonu listeye Eşle"
 
-#: ../src/wxMaximaFrame.cpp:772
+#: ../src/wxMaximaFrame.cpp:771
 msgid "Map function to a matrix"
 msgstr "Fonksiyonu matrise Eşle"
 
@@ -2696,23 +2699,23 @@ msgstr "Metin kontrolünde parantezi eşleştir"
 msgid "Math font:"
 msgstr "Mat. yazı tipi:"
 
-#: ../src/wxMaximaFrame.cpp:374
+#: ../src/wxMaximaFrame.cpp:373
 msgid "Mathematical Symbols"
 msgstr "Matematik Sembolleri"
 
-#: ../src/wxMaxima.cpp:3716
+#: ../src/wxMaxima.cpp:3728
 msgid "Matrix"
 msgstr "Matris"
 
-#: ../src/wxMaxima.cpp:3702
+#: ../src/wxMaxima.cpp:3714
 msgid "Matrix map"
 msgstr "Matris Eşle"
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Matrix name:"
 msgstr "Matrisin adı:"
 
-#: ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3749
+#: ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3761
 msgid "Matrix:"
 msgstr "Matris:"
 
@@ -2720,7 +2723,7 @@ msgstr "Matris:"
 msgid "Maxima"
 msgstr "Maxima"
 
-#: ../src/wxMaximaFrame.cpp:137
+#: ../src/wxMaximaFrame.cpp:136
 #, fuzzy
 msgid "Maxima has a question"
 msgstr "Maxima'nın bir sorusu var"
@@ -2729,24 +2732,24 @@ msgstr "Maxima'nın bir sorusu var"
 msgid "Maxima input"
 msgstr "Maxima GİRDİsi"
 
-#: ../src/wxMaximaFrame.cpp:166
+#: ../src/wxMaximaFrame.cpp:165
 msgid "Maxima is calculating"
 msgstr "Maxima hesaplıyor"
 
-#: ../src/wxMaximaFrame.cpp:111
+#: ../src/wxMaximaFrame.cpp:110
 #, fuzzy
 msgid "Maxima is ready for input."
 msgstr "Maxima GİRDİsi"
 
-#: ../src/wxMaxima.cpp:2945
+#: ../src/wxMaxima.cpp:2953
 msgid "Maxima package (*.mac)|*.mac"
 msgstr "Maxima Paketi (*.mac)|*.mac"
 
-#: ../src/wxMaxima.cpp:2934
+#: ../src/wxMaxima.cpp:2942
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr "Maxima Paketi (*.mac)|*.mac|Lisp Paketi (*.lisp)|*.lisp|Tümü|*"
 
-#: ../src/wxMaxima.cpp:1014
+#: ../src/wxMaxima.cpp:1019
 msgid "Maxima process terminated."
 msgstr "Maxima'nın çalışması sonlandı."
 
@@ -2758,7 +2761,7 @@ msgstr "Maxima programı:"
 msgid "Maxima questions"
 msgstr "Maxima sorular"
 
-#: ../src/wxMaxima.cpp:942
+#: ../src/wxMaxima.cpp:947
 msgid "Maxima started. Waiting for connection..."
 msgstr "Maxima başlatıldı.Bağlantı için bekleniyor..."
 
@@ -2791,7 +2794,7 @@ msgstr ""
 "Maxima'da değişkene değer verirken ':' kullanılır ('a : 3;') vefonksiyon "
 "yazılırken ':=' kullanılır.('f(x) := x^2;')."
 
-#: ../src/wxMaxima.cpp:4597
+#: ../src/wxMaxima.cpp:4609
 msgid "Maxima version: "
 msgstr "Maxima Sürümü: "
 
@@ -2828,40 +2831,40 @@ msgstr ""
 msgid "Maximum displayed number of digits:"
 msgstr "Gösterilecek en fazla basamak sayısı"
 
-#: ../src/wxMaximaFrame.cpp:1263
+#: ../src/wxMaximaFrame.cpp:1262
 msgid "Mean Difference Test..."
 msgstr "Ortalama Fark Testi"
 
-#: ../src/wxMaximaFrame.cpp:1262
+#: ../src/wxMaximaFrame.cpp:1261
 msgid "Mean Test..."
 msgstr "Ortalama Testi..."
 
-#: ../src/wxMaximaFrame.cpp:1255
+#: ../src/wxMaximaFrame.cpp:1254
 msgid "Mean..."
 msgstr "Ortalama..."
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Mean:"
 msgstr "Ortalama:"
 
-#: ../src/wxMaximaFrame.cpp:1256
+#: ../src/wxMaximaFrame.cpp:1255
 msgid "Median..."
 msgstr "Medyan..."
 
-#: ../src/MathCtrl.cpp:945
+#: ../src/MathCtrl.cpp:987
 msgid "Merge Cells"
 msgstr "Hücreleri birleştir"
 
-#: ../src/wxMaximaFrame.cpp:633
+#: ../src/wxMaximaFrame.cpp:632
 #, fuzzy
 msgid "Merge Cells\tCtrl-M"
 msgstr "Hücreleri birleştir"
 
-#: ../src/wxMaximaFrame.cpp:634
+#: ../src/wxMaximaFrame.cpp:633
 msgid "Merge the text from two input cells into one"
 msgstr "Metni iki girdi hücresinden tek hücreye birleştir"
 
-#: ../src/wxMaxima.cpp:2668
+#: ../src/wxMaxima.cpp:2676
 msgid "Message from the stdout of Maxima: "
 msgstr "Maxima'nın stdout (standard çıkış) ın dan mesaj"
 
@@ -2869,19 +2872,19 @@ msgstr "Maxima'nın stdout (standard çıkış) ın dan mesaj"
 msgid "Method:"
 msgstr "Metod:"
 
-#: ../src/wxMaxima.cpp:5289
+#: ../src/wxMaxima.cpp:5301
 msgid "Mismatched parenthesis"
 msgstr "Eşleşmeyen parantezler"
 
-#: ../src/wxMaxima.cpp:3972
+#: ../src/wxMaxima.cpp:3984
 msgid "Modulus"
 msgstr "Modül"
 
-#: ../src/wxMaximaFrame.cpp:1375
+#: ../src/wxMaximaFrame.cpp:1374
 msgid "Mu"
 msgstr ""
 
-#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Name:"
 msgstr "İsim:"
 
@@ -2889,7 +2892,7 @@ msgstr "İsim:"
 msgid "New"
 msgstr "Yeni"
 
-#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
+#: ../src/wxMaximaFrame.cpp:456 ../src/wxMaximaFrame.cpp:459
 msgid "New\tCtrl-N"
 msgstr "Yeni\tCtrl-N"
 
@@ -2905,11 +2908,11 @@ msgstr ""
 msgid "New value:"
 msgstr "Yeni Değer:"
 
-#: ../src/wxMaxima.cpp:3993 ../src/wxMaxima.cpp:4119 ../src/wxMaxima.cpp:4136
+#: ../src/wxMaxima.cpp:4005 ../src/wxMaxima.cpp:4131 ../src/wxMaxima.cpp:4148
 msgid "New variable:"
 msgstr "Yeni Değişken:"
 
-#: ../src/wxMaximaFrame.cpp:630
+#: ../src/wxMaximaFrame.cpp:629
 msgid "Next Command\tAlt-Down"
 msgstr "Sonraki komut\tAlt-Down"
 
@@ -2917,15 +2920,15 @@ msgstr "Sonraki komut\tAlt-Down"
 msgid "No"
 msgstr "Hayır"
 
-#: ../src/wxMaxima.cpp:5362
+#: ../src/wxMaxima.cpp:5378
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr "Komut sonunda ($) ya da (;) yok"
 
-#: ../src/wxMaxima.cpp:3249 ../src/wxMaxima.cpp:3271
+#: ../src/wxMaxima.cpp:3260 ../src/wxMaxima.cpp:3283
 msgid "No matches found!"
 msgstr "Eşleşme bulunamadı!"
 
-#: ../src/wxMaximaFrame.cpp:1264
+#: ../src/wxMaximaFrame.cpp:1263
 msgid "Normality Test..."
 msgstr "Normallik Sınaması..."
 
@@ -2954,31 +2957,31 @@ msgstr ""
 msgid "Norwegian"
 msgstr "Norveçce"
 
-#: ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:3740
 msgid "Not a valid matrix dimension!"
 msgstr "Geçerli bir Matris boyutu değil!"
 
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629
 msgid "Not a valid number of equations!"
 msgstr "Geçerli bir denklemler sayısı değil!"
 
-#: ../src/wxMaximaFrame.cpp:197
+#: ../src/wxMaximaFrame.cpp:196
 msgid "Not connected to maxima"
 msgstr "Maxima'ya bağlanamadı"
 
-#: ../src/wxMaxima.cpp:4599
+#: ../src/wxMaxima.cpp:4611
 msgid "Not connected."
 msgstr "Bağlanamadı."
 
-#: ../src/wxMaximaFrame.cpp:1376
+#: ../src/wxMaximaFrame.cpp:1375
 msgid "Nu"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Num. deg:"
 msgstr "Say.derecesi:"
 
-#: ../src/wxMaxima.cpp:3585 ../src/wxMaxima.cpp:3609
+#: ../src/wxMaxima.cpp:3597 ../src/wxMaxima.cpp:3621
 msgid "Number of equations:"
 msgstr "Denklemlerin sayısı:"
 
@@ -3005,15 +3008,15 @@ msgstr "OK"
 msgid "Old value:"
 msgstr "Eski değer:"
 
-#: ../src/wxMaxima.cpp:3992 ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135
+#: ../src/wxMaxima.cpp:4004 ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147
 msgid "Old variable:"
 msgstr "Eski Değişken:"
 
-#: ../src/wxMaximaFrame.cpp:1387
+#: ../src/wxMaximaFrame.cpp:1386
 msgid "Omega"
 msgstr "Omega"
 
-#: ../src/wxMaximaFrame.cpp:1378
+#: ../src/wxMaximaFrame.cpp:1377
 msgid "Omicron"
 msgstr ""
 
@@ -3032,20 +3035,20 @@ msgstr ""
 "lisp sistemin stderr akışını kullanarak hata mesajları gönderir. Eğer bu "
 "kutu işaretliyse maxima'nın stdout stream mesajlarını izlemeyiz."
 
-#: ../src/wxMaxima.cpp:4763
+#: ../src/wxMaxima.cpp:4775
 msgid "One sample t-test"
 msgstr "Bir örnek t-testi"
 
-#: ../src/wxMaximaFrame.cpp:971
+#: ../src/wxMaximaFrame.cpp:970
 msgid "Online tutorials"
 msgstr "Çevirimiçi Çalışma Notları"
 
 #: ../src/ConfigDialogue.cpp:656 ../src/main.cpp:347 ../src/ToolBar.cpp:119
-#: ../src/wxMaxima.cpp:2797
+#: ../src/wxMaxima.cpp:2805
 msgid "Open"
 msgstr "Aç"
 
-#: ../src/wxMaximaFrame.cpp:466
+#: ../src/wxMaximaFrame.cpp:465
 msgid "Open Recent"
 msgstr "Yakın Geçmişi Aç"
 
@@ -3053,11 +3056,11 @@ msgstr "Yakın Geçmişi Aç"
 msgid "Open a cell when Maxima expects input"
 msgstr "Maxima girdi beklerken yeni bir hücre aç"
 
-#: ../src/wxMaximaFrame.cpp:464
+#: ../src/wxMaximaFrame.cpp:463
 msgid "Open a document"
 msgstr "Bir Belge Aç"
 
-#: ../src/wxMaximaFrame.cpp:458 ../src/wxMaximaFrame.cpp:461
+#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
 msgid "Open a new window"
 msgstr "Yeni Bir Pencere Aç"
 
@@ -3065,11 +3068,11 @@ msgstr "Yeni Bir Pencere Aç"
 msgid "Open document"
 msgstr "Belge Aç"
 
-#: ../src/wxMaxima.cpp:4824
+#: ../src/wxMaxima.cpp:4836
 msgid "Open matrix"
 msgstr "Matris Aç"
 
-#: ../src/wxMaxima.cpp:1446 ../src/wxMaxima.cpp:1518
+#: ../src/wxMaxima.cpp:1451 ../src/wxMaxima.cpp:1523
 msgid "Opening file"
 msgstr "Dosya açılıyor"
 
@@ -3093,11 +3096,11 @@ msgstr "Kullanılmayan Hücreler"
 msgid "Output labels"
 msgstr "Çıktı Etiketleri"
 
-#: ../src/wxMaximaFrame.cpp:796
+#: ../src/wxMaximaFrame.cpp:795
 msgid "P&ade Approximation..."
 msgstr "Padé Yaklaşımı..."
 
-#: ../src/wxMaxima.cpp:3132 ../src/wxMaxima.cpp:5133
+#: ../src/wxMaxima.cpp:3141 ../src/wxMaxima.cpp:5145
 msgid ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
 "bmp|Portable animap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X "
@@ -3107,15 +3110,15 @@ msgstr ""
 "bmp|Portable animap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X "
 "pixmap (*.xpm)|*.xpm"
 
-#: ../src/wxMaxima.cpp:4012
+#: ../src/wxMaxima.cpp:4024
 msgid "Pade approximation"
 msgstr "Padé Yaklaşımı"
 
-#: ../src/wxMaximaFrame.cpp:797
+#: ../src/wxMaximaFrame.cpp:796
 msgid "Pade approximation of a Taylor series"
 msgstr "Bir Taylor Serisinin Padé Yaklaşımı"
 
-#: ../src/wxMaximaFrame.cpp:1500
+#: ../src/wxMaximaFrame.cpp:1519
 msgid "Pagebreak"
 msgstr "Sayfa sonu"
 
@@ -3127,19 +3130,19 @@ msgstr "'e paralel"
 msgid "Parametric plot"
 msgstr "Parametrik Çizim"
 
-#: ../src/wxMaximaFrame.cpp:188
+#: ../src/wxMaximaFrame.cpp:187
 msgid "Parsing output"
 msgstr "ÇIKTI Analiz Ediliyor"
 
-#: ../src/wxMaximaFrame.cpp:819
+#: ../src/wxMaximaFrame.cpp:818
 msgid "Partial &Fractions..."
 msgstr "Parçalı Kesirler..."
 
-#: ../src/wxMaxima.cpp:4076
+#: ../src/wxMaxima.cpp:4088
 msgid "Partial fractions"
 msgstr "Parçalı Kesirler"
 
-#: ../src/wxMaxima.cpp:1769
+#: ../src/wxMaxima.cpp:1774
 msgid "Parts of the document will not be loaded correctly!"
 msgstr "Belgenin parçaları düzgün olarak yüklenemedi!"
 
@@ -3150,11 +3153,11 @@ msgid ""
 "Found unknown XML Tag name "
 msgstr "Belgenin parçaları düzgün olarak yüklenemedi!"
 
-#: ../src/ToolBar.cpp:143 ../src/MathCtrl.cpp:1010 ../src/MathCtrl.cpp:1025
+#: ../src/MathCtrl.cpp:1052 ../src/MathCtrl.cpp:1067 ../src/ToolBar.cpp:143
 msgid "Paste"
 msgstr "Yapıştır"
 
-#: ../src/wxMaximaFrame.cpp:518
+#: ../src/wxMaximaFrame.cpp:517
 msgid "Paste\tCtrl-V"
 msgstr "Yapıştır\tCtrl-V"
 
@@ -3162,7 +3165,7 @@ msgstr "Yapıştır\tCtrl-V"
 msgid "Paste from clipboard"
 msgstr "Panodan Yapıştır"
 
-#: ../src/wxMaximaFrame.cpp:519
+#: ../src/wxMaximaFrame.cpp:518
 msgid "Paste text from clipboard"
 msgstr "Metni Panodan Yapıştır"
 
@@ -3170,19 +3173,19 @@ msgstr "Metni Panodan Yapıştır"
 msgid "Perpendicular to"
 msgstr "'e dik"
 
-#: ../src/wxMaximaFrame.cpp:1384
+#: ../src/wxMaximaFrame.cpp:1383
 msgid "Phi"
 msgstr "Phi"
 
-#: ../src/wxMaximaFrame.cpp:1379
+#: ../src/wxMaximaFrame.cpp:1378
 msgid "Pi"
 msgstr "Pi"
 
-#: ../src/wxMaximaFrame.cpp:1273
+#: ../src/wxMaximaFrame.cpp:1272
 msgid "Piechart..."
 msgstr "Pasta dilimi"
 
-#: ../src/wxMaxima.cpp:1952
+#: ../src/wxMaxima.cpp:1957
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr "Lütfen wxMaxima'yı 'Düzenle-> Yapılandır' ile yapılandırınız."
 
@@ -3190,52 +3193,52 @@ msgstr "Lütfen wxMaxima'yı 'Düzenle-> Yapılandır' ile yapılandırınız."
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr "Değişikliklerin aktif olabilmesi içi wxMaxima'yı yeniden başlat"
 
-#: ../src/wxMaximaFrame.cpp:923
+#: ../src/wxMaximaFrame.cpp:922
 msgid "Plot &2d..."
 msgstr "2B Grafik "
 
-#: ../src/wxMaximaFrame.cpp:925
+#: ../src/wxMaximaFrame.cpp:924
 msgid "Plot &3d..."
 msgstr "3B Grafik"
 
-#: ../src/wxMaximaFrame.cpp:927
+#: ../src/wxMaximaFrame.cpp:926
 msgid "Plot &Format..."
 msgstr "Grafik Formatı"
 
 #: ../src/Plot2dWiz.cpp:104 ../src/Plot2dWiz.cpp:450 ../src/Plot2dWiz.cpp:464
-#: ../src/wxMaxima.cpp:4283 ../src/wxMaxima.cpp:5102
+#: ../src/wxMaxima.cpp:4295 ../src/wxMaxima.cpp:5114
 msgid "Plot 2D"
 msgstr "2B Grafik"
 
-#: ../src/wxMaximaFrame.cpp:1227
+#: ../src/wxMaximaFrame.cpp:1226
 msgid "Plot 2D..."
 msgstr "2B Grafik..."
 
-#: ../src/MathCtrl.cpp:1003
+#: ../src/MathCtrl.cpp:1045
 msgid "Plot 2d..."
 msgstr "2B Grafik..."
 
-#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4269 ../src/wxMaxima.cpp:5115
+#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4281 ../src/wxMaxima.cpp:5127
 msgid "Plot 3D"
 msgstr "3B Grafik"
 
-#: ../src/wxMaximaFrame.cpp:1228
+#: ../src/wxMaximaFrame.cpp:1227
 msgid "Plot 3D..."
 msgstr "3B Grafik..."
 
-#: ../src/MathCtrl.cpp:1004
+#: ../src/MathCtrl.cpp:1046
 msgid "Plot 3d..."
 msgstr "3B Grafik...."
 
-#: ../src/wxMaxima.cpp:4296
+#: ../src/wxMaxima.cpp:4308
 msgid "Plot format"
 msgstr "Grafik Formatı"
 
-#: ../src/wxMaximaFrame.cpp:924
+#: ../src/wxMaximaFrame.cpp:923
 msgid "Plot in 2 dimensions"
 msgstr "2 Boyutlu Grafik çiz"
 
-#: ../src/wxMaximaFrame.cpp:926
+#: ../src/wxMaximaFrame.cpp:925
 msgid "Plot in 3 dimensions"
 msgstr "3 Boyutlu Grafik çiz"
 
@@ -3244,8 +3247,8 @@ msgid "Plot to file:"
 msgstr "Grafiği Bir Dosyaya çiz:"
 
 #: ../src/BC2Wiz.cpp:30 ../src/BC2Wiz.cpp:36 ../src/LimitWiz.cpp:33
-#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
-#: ../src/wxMaxima.cpp:3648
+#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
+#: ../src/wxMaxima.cpp:3660
 msgid "Point:"
 msgstr "Nokta:"
 
@@ -3253,11 +3256,11 @@ msgstr "Nokta:"
 msgid "Polish"
 msgstr "Polonyaca"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 1:"
 msgstr "Polinom 1:"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 2:"
 msgstr "Polinom 2:"
 
@@ -3269,11 +3272,11 @@ msgstr "Portekizce (Brezilya)"
 msgid "Postscript file (*.eps)|*.eps|All|*"
 msgstr "Postscript Dosyası (*.eps)|*.eps|Hepsi|*"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Precision"
 msgstr "OndalıkHassasiyet"
 
-#: ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:536
 msgid "Preferences...\tCtrl+,"
 msgstr "Öncelikli Tercihler\tCtrl+,"
 
@@ -3290,7 +3293,7 @@ msgstr ""
 "aynı anda hali hazırda yüklenmiş olan paketlerdeki ve dosyadaki "
 "parametreleri de ele alır."
 
-#: ../src/wxMaximaFrame.cpp:628
+#: ../src/wxMaximaFrame.cpp:627
 msgid "Previous Command\tAlt-Up"
 msgstr "Bir Önceki Komut\tAlt-Up"
 
@@ -3298,11 +3301,11 @@ msgstr "Bir Önceki Komut\tAlt-Up"
 msgid "Print"
 msgstr "Yazdır"
 
-#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:484
+#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:483
 msgid "Print document"
 msgstr "Belgeyi Yazdır"
 
-#: ../src/wxMaxima.cpp:4242
+#: ../src/wxMaxima.cpp:4254
 msgid "Product"
 msgstr "Çarpım"
 
@@ -3310,36 +3313,36 @@ msgstr "Çarpım"
 msgid "Product sign"
 msgstr "Çarpım işareti"
 
-#: ../src/wxMaximaFrame.cpp:1386
+#: ../src/wxMaximaFrame.cpp:1385
 msgid "Psi"
 msgstr "Psi"
 
-#: ../src/wxMaximaFrame.cpp:331
+#: ../src/wxMaximaFrame.cpp:330
 msgid "Raw XML monitor"
 msgstr "Raw XML monitor"
 
-#: ../src/wxMaximaFrame.cpp:592
+#: ../src/wxMaximaFrame.cpp:591
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr ""
 "İmlecin bulunduğu hücrenin üstündeki bütün hücreleri tekrar değerlendir"
 
-#: ../src/wxMaximaFrame.cpp:1278
+#: ../src/wxMaximaFrame.cpp:1277
 msgid "Read Matrix..."
 msgstr "Matrisi Oku...."
 
-#: ../src/wxMaximaFrame.cpp:177
+#: ../src/wxMaximaFrame.cpp:176
 msgid "Reading Maxima output"
 msgstr "'Maxima çıktısı'nı okuyor"
 
-#: ../src/wxMaximaFrame.cpp:153
+#: ../src/wxMaximaFrame.cpp:152
 msgid "Ready for user input"
 msgstr "Kullanıcı girdisine hazır"
 
-#: ../src/wxMaximaFrame.cpp:631
+#: ../src/wxMaximaFrame.cpp:630
 msgid "Recall next command from history"
 msgstr "Sonraki komutu geçmişten bul"
 
-#: ../src/wxMaximaFrame.cpp:629
+#: ../src/wxMaximaFrame.cpp:628
 msgid "Recall previous command from history"
 msgstr "Sonraki komutu geçmişten bul"
 
@@ -3347,35 +3350,35 @@ msgstr "Sonraki komutu geçmişten bul"
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1215
+#: ../src/wxMaximaFrame.cpp:1214
 msgid "Rectform"
 msgstr "Kartezyen Form"
 
-#: ../src/wxMaximaFrame.cpp:495
+#: ../src/wxMaximaFrame.cpp:494
 msgid "Redo\tCtrl-Y"
 msgstr "Yinele\tCtrl-Y"
 
-#: ../src/wxMaximaFrame.cpp:496
+#: ../src/wxMaximaFrame.cpp:495
 msgid "Redo last change"
 msgstr "Son değişkliği Yinele"
 
-#: ../src/wxMaximaFrame.cpp:1220
+#: ../src/wxMaximaFrame.cpp:1219
 msgid "Reduce (tr)"
 msgstr "İndirge (trig.)"
 
-#: ../src/wxMaximaFrame.cpp:871
+#: ../src/wxMaximaFrame.cpp:870
 msgid "Reduce trigonometric expression"
 msgstr "Trigonometric İfadeyi İndirge"
 
-#: ../src/wxMaxima.cpp:622 ../src/wxMaxima.cpp:5495
+#: ../src/wxMaxima.cpp:627 ../src/wxMaxima.cpp:5511
 msgid "Refusing to send cell to maxima: "
 msgstr "Hücreyi maxima'ya göndermeyi reddediyor:"
 
-#: ../src/wxMaximaFrame.cpp:594
+#: ../src/wxMaximaFrame.cpp:593
 msgid "Remove All Output"
 msgstr "Tüm Çıktıları Temizle"
 
-#: ../src/wxMaximaFrame.cpp:595
+#: ../src/wxMaximaFrame.cpp:594
 msgid "Remove output from input cells"
 msgstr "Girdi Hücrelerindeki Çıktıları Temizle"
 
@@ -3384,7 +3387,7 @@ msgstr "Girdi Hücrelerindeki Çıktıları Temizle"
 msgid "Replace All"
 msgstr "Tümünü Seç"
 
-#: ../src/wxMaxima.cpp:3282
+#: ../src/wxMaxima.cpp:3294
 #, c-format
 msgid "Replaced %d occurrences."
 msgstr "Yerleştirilmiş %d Olgular."
@@ -3393,11 +3396,11 @@ msgstr "Yerleştirilmiş %d Olgular."
 msgid "Replacement:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:976
+#: ../src/wxMaximaFrame.cpp:975
 msgid "Report bug"
 msgstr "Hatayı Bildir"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "Restart Maxima"
 msgstr "Maxima'yı Yeniden Başlat"
 
@@ -3405,7 +3408,7 @@ msgstr "Maxima'yı Yeniden Başlat"
 msgid "Restart maxima"
 msgstr "Maxima'yı Yeniden Başlat"
 
-#: ../src/MathCtrl.cpp:4442
+#: ../src/MathCtrl.cpp:4497
 msgid "Result"
 msgstr "Sonuç"
 
@@ -3413,7 +3416,7 @@ msgstr "Sonuç"
 msgid "Return to the cell that is currently being evaluated"
 msgstr "Değerlendirilmekte olan hücreye dön"
 
-#: ../src/wxMaximaFrame.cpp:1380
+#: ../src/wxMaximaFrame.cpp:1379
 msgid "Rho"
 msgstr "Rho"
 
@@ -3421,19 +3424,19 @@ msgstr "Rho"
 msgid "Right arrow"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:779
+#: ../src/wxMaximaFrame.cpp:778
 msgid "Risch Integration..."
 msgstr "Risch İntegrali"
 
-#: ../src/wxMaximaFrame.cpp:694
+#: ../src/wxMaximaFrame.cpp:693
 msgid "Roots of &Polynomial"
 msgstr "&Polinomun Kökleri"
 
-#: ../src/wxMaximaFrame.cpp:697
+#: ../src/wxMaximaFrame.cpp:696
 msgid "Roots of Polynomial (bfloat)"
 msgstr "Polinomun Kökleri (büyKaySayı)"
 
-#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Rows:"
 msgstr "Sıralar:"
 
@@ -3441,56 +3444,56 @@ msgstr "Sıralar:"
 msgid "Russian"
 msgstr "Rusça"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 1:"
 msgstr "Örnek 1:"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 2:"
 msgstr "Örnek 2:"
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Sample:"
 msgstr "Örnek:"
 
 #: ../src/ConfigDialogue.cpp:781 ../src/ToolBar.cpp:122
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Save"
 msgstr "Kaydet"
 
-#: ../src/MathCtrl.cpp:921
+#: ../src/MathCtrl.cpp:963
 msgid "Save Animation..."
 msgstr "Animasyonu Kaydet"
 
-#: ../src/wxMaxima.cpp:2565
+#: ../src/wxMaxima.cpp:2572
 msgid "Save As"
 msgstr "Faklı Kaydet"
 
-#: ../src/wxMaximaFrame.cpp:474
+#: ../src/wxMaximaFrame.cpp:473
 msgid "Save As...\tShift-Ctrl-S"
 msgstr "Faklı Kaydet\tShift-Ctrl-S"
 
-#: ../src/MathCtrl.cpp:919
+#: ../src/MathCtrl.cpp:961
 msgid "Save Image..."
 msgstr "Resmi Kaydet..."
 
-#: ../src/wxMaxima.cpp:3130
+#: ../src/wxMaxima.cpp:3139
 msgid "Save Selection to Image"
 msgstr "Seçileni Resim Olarak Kaydet"
 
-#: ../src/wxMaximaFrame.cpp:528
+#: ../src/wxMaximaFrame.cpp:527
 msgid "Save Selection to Image..."
 msgstr "Seçileni Resim Olarak Kaydet..."
 
-#: ../src/wxMaxima.cpp:5150
+#: ../src/wxMaxima.cpp:5162
 msgid "Save animation to file"
 msgstr "Animasyonu Dosyaya Kaydet"
 
-#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:473
+#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:472
 msgid "Save document"
 msgstr "Belgeyi Kaydet"
 
-#: ../src/wxMaximaFrame.cpp:475
+#: ../src/wxMaximaFrame.cpp:474
 msgid "Save document as"
 msgstr "Belgeyi Farklı Kaydet"
 
@@ -3514,11 +3517,11 @@ msgstr "Panellerin Yerleşimini Yeni Oturumlar için Kaydet."
 msgid "Save plot to file"
 msgstr "Grafiği Dosyaya Kaydet"
 
-#: ../src/wxMaximaFrame.cpp:529
+#: ../src/wxMaximaFrame.cpp:528
 msgid "Save selection from document to an image file"
 msgstr "Seçileni Bir Resim Dosyası Olarak Kaydet"
 
-#: ../src/wxMaxima.cpp:5131
+#: ../src/wxMaxima.cpp:5143
 msgid "Save selection to file"
 msgstr "Seçileni Dosyaya Kaydet"
 
@@ -3534,27 +3537,27 @@ msgstr "wxMaxima penceresinin boyut\\pozisyonunu kaydet"
 msgid "Save wxMaxima window size/position between sessions."
 msgstr "wxMaxima penceresinin  boyut\\pozisyonunu yeni oturumlar için Kaydet."
 
-#: ../src/wxMaximaFrame.cpp:246
+#: ../src/wxMaximaFrame.cpp:245
 msgid "Saving failed."
 msgstr "Kaydetme başarısız"
 
-#: ../src/wxMaximaFrame.cpp:222
+#: ../src/wxMaximaFrame.cpp:221
 msgid "Saving successful."
 msgstr "Kaydetme başarılı"
 
-#: ../src/wxMaximaFrame.cpp:212
+#: ../src/wxMaximaFrame.cpp:211
 msgid "Saving..."
 msgstr "Kaydediyor"
 
-#: ../src/wxMaxima.cpp:4699
+#: ../src/wxMaxima.cpp:4711
 msgid "Scatterplot"
 msgstr "Dağılım Grafiği"
 
-#: ../src/wxMaximaFrame.cpp:1271
+#: ../src/wxMaximaFrame.cpp:1270
 msgid "Scatterplot..."
 msgstr "Dağılım Grafiği..."
 
-#: ../src/wxMaximaFrame.cpp:1498
+#: ../src/wxMaximaFrame.cpp:1517
 msgid "Section"
 msgstr "Kısım"
 
@@ -3562,8 +3565,8 @@ msgstr "Kısım"
 msgid "Section cell"
 msgstr "Kısım Hücresi"
 
-#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:292 ../src/TextCell.cpp:306
-#: ../src/TextCell.cpp:322 ../src/TextCell.cpp:334
+#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:290 ../src/TextCell.cpp:304
+#: ../src/TextCell.cpp:320 ../src/TextCell.cpp:332
 msgid ""
 "Seems like something is broken with a font. Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
@@ -3574,7 +3577,7 @@ msgstr ""
 "bölümünden \"Use JSmath fonts\"= JSmath fontlarını kullan ı seçmek sorunu "
 "çözebilir."
 
-#: ../src/TextCell.cpp:139
+#: ../src/TextCell.cpp:137
 msgid ""
 "Seems like something is broken with the maths font. Installing http://www."
 "math.union.edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use "
@@ -3585,11 +3588,11 @@ msgstr ""
 "\"Yapılandır\" bölümünden \"Use JSmath fonts\"= JSmath fontlarını kullan ı "
 "seçmek sorunu çözebilir."
 
-#: ../src/MathCtrl.cpp:1011 ../src/MathCtrl.cpp:1027
+#: ../src/MathCtrl.cpp:1053 ../src/MathCtrl.cpp:1069
 msgid "Select All"
 msgstr "Tümünü Seç"
 
-#: ../src/wxMaximaFrame.cpp:525
+#: ../src/wxMaximaFrame.cpp:524
 msgid "Select All\tCtrl-A"
 msgstr "Tümünü Seç\tCtrl-A"
 
@@ -3597,7 +3600,7 @@ msgstr "Tümünü Seç\tCtrl-A"
 msgid "Select Maxima program"
 msgstr "Maxima Programını Seç"
 
-#: ../src/wxMaxima.cpp:4860
+#: ../src/wxMaxima.cpp:4872
 msgid "Select Subsample"
 msgstr "Alt Örnek Seç"
 
@@ -3606,11 +3609,11 @@ msgstr "Alt Örnek Seç"
 msgid "Select a constant"
 msgstr "Bir Sabit Seç"
 
-#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:526
+#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:525
 msgid "Select all"
 msgstr "Tümünü Seç"
 
-#: ../src/wxMaxima.cpp:3319
+#: ../src/wxMaxima.cpp:3331
 msgid "Select math display algorithm"
 msgstr "Matematik Gösterim Algoritmasını Seç"
 
@@ -3627,23 +3630,23 @@ msgstr ""
 msgid "Selection"
 msgstr "Seçim"
 
-#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4178
+#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4190
 msgid "Series"
 msgstr "Seriler"
 
-#: ../src/wxMaximaFrame.cpp:1226
+#: ../src/wxMaximaFrame.cpp:1225
 msgid "Series..."
 msgstr "Seriler..."
 
-#: ../src/wxMaxima.cpp:863
+#: ../src/wxMaxima.cpp:868
 msgid "Server started"
 msgstr "Sunucu Başladı"
 
-#: ../src/wxMaximaFrame.cpp:575
+#: ../src/wxMaximaFrame.cpp:574
 msgid "Set Zoom"
 msgstr "Yakınlaştır\\Uzaklaştır"
 
-#: ../src/wxMaximaFrame.cpp:944
+#: ../src/wxMaximaFrame.cpp:943
 msgid "Set bigfloat &Precision..."
 msgstr "BüyükKayanSayı &Hassasiyeti Belirt"
 
@@ -3651,11 +3654,11 @@ msgstr "BüyükKayanSayı &Hassasiyeti Belirt"
 msgid "Set fixed font in text controls."
 msgstr "Metin Kontrolünde Değişmez Yazı Tipi ayarla."
 
-#: ../src/wxMaximaFrame.cpp:928
+#: ../src/wxMaximaFrame.cpp:927
 msgid "Set plot format"
 msgstr "Grafik Çizme Formatını Belirt"
 
-#: ../src/wxMaximaFrame.cpp:945
+#: ../src/wxMaximaFrame.cpp:944
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can "
 "be generated by entering 1.5b12 or as bfloat(1.234)"
@@ -3663,52 +3666,52 @@ msgstr ""
 "Büyük Kayan sayı olarak tanımlanmış sayılarda hassasiyeti ayarlayın. Bu tür "
 "sayılar 1.5b12 ya da  bfloat(1.234) şeklinde üretilebilir."
 
-#: ../src/wxMaximaFrame.cpp:569
+#: ../src/wxMaximaFrame.cpp:568
 msgid "Set zoom to 100%"
 msgstr "%100 Yakınlık"
 
-#: ../src/wxMaximaFrame.cpp:570
+#: ../src/wxMaximaFrame.cpp:569
 msgid "Set zoom to 120%"
 msgstr "%120 Yakınlık"
 
-#: ../src/wxMaximaFrame.cpp:571
+#: ../src/wxMaximaFrame.cpp:570
 msgid "Set zoom to 150%"
 msgstr "%150 Yakınlık"
 
-#: ../src/wxMaximaFrame.cpp:572
+#: ../src/wxMaximaFrame.cpp:571
 msgid "Set zoom to 200%"
 msgstr "%200 Yakınlık"
 
-#: ../src/wxMaximaFrame.cpp:573
+#: ../src/wxMaximaFrame.cpp:572
 msgid "Set zoom to 300%"
 msgstr "%300 Yakınlık"
 
-#: ../src/wxMaximaFrame.cpp:568
+#: ../src/wxMaximaFrame.cpp:567
 msgid "Set zoom to 80%"
 msgstr "%80 Yakınlık"
 
-#: ../src/wxMaximaFrame.cpp:732
+#: ../src/wxMaximaFrame.cpp:731
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
 "ADD'yi Laplace dönüşümleri ile çözerken başlangıç değerlerini düzenle. "
 
-#: ../src/wxMaximaFrame.cpp:918
+#: ../src/wxMaximaFrame.cpp:917
 msgid "Setup modulus computation"
 msgstr "Modül Hesaplamasını Kur"
 
-#: ../src/wxMaximaFrame.cpp:662
+#: ../src/wxMaximaFrame.cpp:661
 msgid "Show &Definition..."
 msgstr "Göster &Tanım..."
 
-#: ../src/wxMaximaFrame.cpp:660
+#: ../src/wxMaximaFrame.cpp:659
 msgid "Show &Functions"
 msgstr "Göster &Fonksiyonlar"
 
-#: ../src/wxMaximaFrame.cpp:967
+#: ../src/wxMaximaFrame.cpp:966
 msgid "Show &Tips..."
 msgstr "Göster &Yararlı Öneriler..."
 
-#: ../src/wxMaximaFrame.cpp:665
+#: ../src/wxMaximaFrame.cpp:664
 msgid "Show &Variables"
 msgstr "Göster &Değişken"
 
@@ -3716,43 +3719,43 @@ msgstr "Göster &Değişken"
 msgid "Show Maxima help"
 msgstr "Maxima Yardımını Göster"
 
-#: ../src/wxMaximaFrame.cpp:603
+#: ../src/wxMaximaFrame.cpp:602
 msgid "Show Template\tCtrl-Shift-K"
 msgstr "Şablonu Göster\tCtrl-Shift-K"
 
-#: ../src/wxMaximaFrame.cpp:968
+#: ../src/wxMaximaFrame.cpp:967
 msgid "Show a tip"
 msgstr "Bir Yararlı Bilgi Göster"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Show all commands similar to:"
 msgstr "'...:'ya benzer bütün komutları Göster"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Show an example for the command:"
 msgstr "'...:' Komutu için bir örnek Göster"
 
-#: ../src/wxMaximaFrame.cpp:962
+#: ../src/wxMaximaFrame.cpp:961
 msgid "Show an example of usage"
 msgstr "Kullanımı için Örnek Ver"
 
-#: ../src/wxMaximaFrame.cpp:965
+#: ../src/wxMaximaFrame.cpp:964
 msgid "Show commands similar to"
 msgstr "'...:'ya benzer komutları Göster"
 
-#: ../src/wxMaximaFrame.cpp:661
+#: ../src/wxMaximaFrame.cpp:660
 msgid "Show defined functions"
 msgstr "Tanımlanmış Fonksiyonları Göster"
 
-#: ../src/wxMaximaFrame.cpp:666
+#: ../src/wxMaximaFrame.cpp:665
 msgid "Show defined variables"
 msgstr "Tanımlanmış Değişkenleri Göster"
 
-#: ../src/wxMaximaFrame.cpp:663
+#: ../src/wxMaximaFrame.cpp:662
 msgid "Show definition of a function"
 msgstr "Bir Fonksiyonun Tanımını Göster"
 
-#: ../src/wxMaximaFrame.cpp:604
+#: ../src/wxMaximaFrame.cpp:603
 msgid "Show function template"
 msgstr "Fonksiyon Şablonunu Göster"
 
@@ -3765,7 +3768,7 @@ msgstr "wxMaxima Belgesinde Uzun İfadeleri Göster"
 msgid "Show long expressions:"
 msgstr "Uzun İfadeleri Göster"
 
-#: ../src/wxMaxima.cpp:3341
+#: ../src/wxMaxima.cpp:3353
 msgid "Show the definition of function:"
 msgstr "Fonksiyonun Tanımını Göster:"
 
@@ -3774,43 +3777,43 @@ msgstr "Fonksiyonun Tanımını Göster:"
 msgid "Show user-defined labels instead of (%oxx)"
 msgstr "(%oxx) yerine kullanıcı tanımlı etiketleri göster"
 
-#: ../src/wxMaximaFrame.cpp:953 ../src/wxMaximaFrame.cpp:956
+#: ../src/wxMaximaFrame.cpp:952 ../src/wxMaximaFrame.cpp:955
 msgid "Show wxMaxima help"
 msgstr "wxMaxima Yardımını Göster"
 
-#: ../src/wxMaximaFrame.cpp:1381
+#: ../src/wxMaximaFrame.cpp:1380
 msgid "Sigma"
 msgstr "Sigma"
 
-#: ../src/wxMaximaFrame.cpp:1211
+#: ../src/wxMaximaFrame.cpp:1210
 msgid "Simplify"
 msgstr "Sadeleştir"
 
-#: ../src/wxMaximaFrame.cpp:831
+#: ../src/wxMaximaFrame.cpp:830
 msgid "Simplify &Radicals"
 msgstr "Sadeleştir &Kökler"
 
-#: ../src/wxMaximaFrame.cpp:1212
+#: ../src/wxMaximaFrame.cpp:1211
 msgid "Simplify (r)"
 msgstr "Sadeleştir(özd)"
 
-#: ../src/wxMaximaFrame.cpp:1218
+#: ../src/wxMaximaFrame.cpp:1217
 msgid "Simplify (tr)"
 msgstr "Sadeleştir (trig_özd)"
 
-#: ../src/MathCtrl.cpp:995
+#: ../src/MathCtrl.cpp:1037
 msgid "Simplify Expression"
 msgstr "İfadeyi Sadeleştir"
 
-#: ../src/wxMaximaFrame.cpp:857
+#: ../src/wxMaximaFrame.cpp:856
 msgid "Simplify an expression containing factorials"
 msgstr "Faktöryel İçeren İfadeyi Sadeleştir"
 
-#: ../src/wxMaximaFrame.cpp:832
+#: ../src/wxMaximaFrame.cpp:831
 msgid "Simplify expression containing radicals"
 msgstr "Kökleri Olan İfadeyi Sadeleştir"
 
-#: ../src/wxMaximaFrame.cpp:830
+#: ../src/wxMaximaFrame.cpp:829
 msgid "Simplify rational expression"
 msgstr "Rasyonel İfadeyi Sadeleştir"
 
@@ -3818,7 +3821,7 @@ msgstr "Rasyonel İfadeyi Sadeleştir"
 msgid "Simplify the sum"
 msgstr "Toplamı Sadeleştir"
 
-#: ../src/wxMaximaFrame.cpp:868
+#: ../src/wxMaximaFrame.cpp:867
 msgid "Simplify trigonometric expression"
 msgstr "Trigonometrik İfadeyi Sadeleştir"
 
@@ -3834,87 +3837,87 @@ msgstr ""
 "görünmesini istiyorsanız belgenizi 'xml wxMaxima belgesi olarak "
 "kaydetmelisiniz'"
 
-#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
+#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
 msgid "Solution:"
 msgstr "Çözüm:"
 
-#: ../src/wxMaxima.cpp:3461 ../src/wxMaxima.cpp:3475 ../src/wxMaxima.cpp:5020
+#: ../src/wxMaxima.cpp:3473 ../src/wxMaxima.cpp:3487 ../src/wxMaxima.cpp:5032
 msgid "Solve"
 msgstr "Çöz"
 
-#: ../src/wxMaximaFrame.cpp:706
+#: ../src/wxMaximaFrame.cpp:705
 msgid "Solve &Algebraic System..."
 msgstr "&Cebirsel Sistemi Çöz..."
 
-#: ../src/wxMaximaFrame.cpp:703
+#: ../src/wxMaximaFrame.cpp:702
 msgid "Solve &Linear System..."
 msgstr "&Lineer sistemi Çöz..."
 
-#: ../src/wxMaximaFrame.cpp:714
+#: ../src/wxMaximaFrame.cpp:713
 msgid "Solve &ODE..."
 msgstr "&ADD Çöz..."
 
-#: ../src/wxMaximaFrame.cpp:690
+#: ../src/wxMaximaFrame.cpp:689
 msgid "Solve (to_poly)..."
 msgstr "Çöz (to_poly_solve)ile..."
 
-#: ../src/wxMaxima.cpp:3511 ../src/wxMaxima.cpp:3635
+#: ../src/wxMaxima.cpp:3523 ../src/wxMaxima.cpp:3647
 msgid "Solve ODE"
 msgstr "ADD Çöz"
 
-#: ../src/wxMaximaFrame.cpp:728
+#: ../src/wxMaximaFrame.cpp:727
 msgid "Solve ODE with Lapla&ce..."
 msgstr "ADDyi Laplace ile Çöz..."
 
-#: ../src/wxMaximaFrame.cpp:1222
+#: ../src/wxMaximaFrame.cpp:1221
 msgid "Solve ODE..."
 msgstr "ADD Çöz..."
 
-#: ../src/wxMaxima.cpp:3586 ../src/wxMaxima.cpp:3597
+#: ../src/wxMaxima.cpp:3598 ../src/wxMaxima.cpp:3609
 msgid "Solve algebraic system"
 msgstr "Cebirsel Sistemi Çöz"
 
-#: ../src/wxMaximaFrame.cpp:707
+#: ../src/wxMaximaFrame.cpp:706
 msgid "Solve algebraic system of equations"
 msgstr "Cebirsel Denklem Sistemini Çöz"
 
-#: ../src/wxMaximaFrame.cpp:725
+#: ../src/wxMaximaFrame.cpp:724
 msgid "Solve boundary value problem for second degree ODE"
 msgstr "İkinci Derece ADD sınır Değer Problemini Çöz"
 
-#: ../src/wxMaximaFrame.cpp:689
+#: ../src/wxMaximaFrame.cpp:688
 msgid "Solve equation(s)"
 msgstr "Denklem(leri) Çöz"
 
-#: ../src/wxMaximaFrame.cpp:691
+#: ../src/wxMaximaFrame.cpp:690
 msgid "Solve equation(s) with to_poly_solve"
 msgstr "Denklem(leri)'to_poly_solve'ile Çöz"
 
-#: ../src/wxMaximaFrame.cpp:719
+#: ../src/wxMaximaFrame.cpp:718
 msgid "Solve initial value problem for first degree ODE"
 msgstr "Birinci derece ADD için Başlangıç Değer Problemini Çöz"
 
-#: ../src/wxMaximaFrame.cpp:722
+#: ../src/wxMaximaFrame.cpp:721
 msgid "Solve initial value problem for second degree ODE"
 msgstr "İkinci derece ADD için Başlangıç Değer Problemini Çöz"
 
-#: ../src/wxMaxima.cpp:3610 ../src/wxMaxima.cpp:3621
+#: ../src/wxMaxima.cpp:3622 ../src/wxMaxima.cpp:3633
 msgid "Solve linear system"
 msgstr "Lineer Sistemi Çöz"
 
-#: ../src/wxMaximaFrame.cpp:704
+#: ../src/wxMaximaFrame.cpp:703
 msgid "Solve linear system of equations"
 msgstr "Lineer Denklem Sistemini Çöz"
 
-#: ../src/wxMaximaFrame.cpp:715
+#: ../src/wxMaximaFrame.cpp:714
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr "En Yüksek İkinci Derece olan ADD yi Çöz"
 
-#: ../src/wxMaximaFrame.cpp:729
+#: ../src/wxMaximaFrame.cpp:728
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr "ADD leri Laplace Dönüşümü ile Çöz"
 
-#: ../src/wxMaximaFrame.cpp:1221 ../src/MathCtrl.cpp:992
+#: ../src/MathCtrl.cpp:1034 ../src/wxMaximaFrame.cpp:1220
 msgid "Solve..."
 msgstr "Çöz..."
 
@@ -3941,7 +3944,7 @@ msgstr "Özel"
 msgid "Special constants"
 msgstr "Özel Sabitler"
 
-#: ../src/MathCtrl.cpp:922
+#: ../src/MathCtrl.cpp:964
 msgid "Start Animation"
 msgstr "Animasyonu Başlat"
 
@@ -3961,28 +3964,28 @@ msgstr ""
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:294
+#: ../src/wxMaxima.cpp:295
 msgid "Starting Maxima process failed"
 msgstr "Maxima'yı başlatma işlemi hata ile sonuçlandı"
 
-#: ../src/wxMaxima.cpp:928
+#: ../src/wxMaxima.cpp:933
 msgid "Starting Maxima..."
 msgstr "Maxima Başlatılıyor..."
 
-#: ../src/wxMaxima.cpp:292 ../src/wxMaxima.cpp:860
+#: ../src/wxMaxima.cpp:293 ../src/wxMaxima.cpp:865
 msgid "Starting server failed"
 msgstr "Sunucu başlatımı hata ile sonuçlandı"
 
-#: ../src/wxMaxima.cpp:841
+#: ../src/wxMaxima.cpp:846
 #, c-format
 msgid "Starting server on port %d"
 msgstr "Sunucu port %d da başlatılıyor"
 
-#: ../src/wxMaximaFrame.cpp:342
+#: ../src/wxMaximaFrame.cpp:341
 msgid "Statistics"
 msgstr "İstatistik"
 
-#: ../src/wxMaximaFrame.cpp:550
+#: ../src/wxMaximaFrame.cpp:549
 msgid "Statistics\tAlt-Shift-S"
 msgstr "İstatistik\tAlt-Shift-S"
 
@@ -3998,11 +4001,11 @@ msgstr "Stil"
 msgid "Styles"
 msgstr "Stiller"
 
-#: ../src/wxMaximaFrame.cpp:1283
+#: ../src/wxMaximaFrame.cpp:1282
 msgid "Subsample..."
 msgstr "Alt Örnek"
 
-#: ../src/wxMaximaFrame.cpp:1496
+#: ../src/wxMaximaFrame.cpp:1515
 msgid "Subsection"
 msgstr "Alt Kısım"
 
@@ -4010,20 +4013,20 @@ msgstr "Alt Kısım"
 msgid "Subsection cell"
 msgstr "Alt Kısım Hücresi"
 
-#: ../src/wxMaximaFrame.cpp:1216
+#: ../src/wxMaximaFrame.cpp:1215
 msgid "Subst..."
 msgstr "Yerine koy..."
 
-#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3423
-#: ../src/wxMaxima.cpp:5089
+#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3435
+#: ../src/wxMaxima.cpp:5101
 msgid "Substitute"
 msgstr "Yerine koy"
 
-#: ../src/wxMaximaFrame.cpp:906 ../src/MathCtrl.cpp:998
+#: ../src/MathCtrl.cpp:1040 ../src/wxMaximaFrame.cpp:905
 msgid "Substitute..."
 msgstr "Yerine koy..."
 
-#: ../src/wxMaximaFrame.cpp:1497
+#: ../src/wxMaximaFrame.cpp:1516
 msgid "Subsubsection"
 msgstr "Alt-alt Kısım"
 
@@ -4031,7 +4034,7 @@ msgstr "Alt-alt Kısım"
 msgid "Subsubsection cell"
 msgstr "Alt-alt Kısım Hücresi"
 
-#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4226
+#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4238
 msgid "Sum"
 msgstr "Toplam"
 
@@ -4039,36 +4042,36 @@ msgstr "Toplam"
 msgid "Sum sign"
 msgstr "Toplam işareti"
 
-#: ../src/wxMaximaFrame.cpp:553
+#: ../src/wxMaximaFrame.cpp:552
 msgid "Symbols\tAlt-Shift-Y"
 msgstr "Semboller\tAlt-Shift-Y"
 
-#: ../src/wxMaxima.cpp:4456
+#: ../src/wxMaxima.cpp:4468
 msgid "System info"
 msgstr "Sistem Bilgisi"
 
-#: ../src/wxMaximaFrame.cpp:320
+#: ../src/wxMaximaFrame.cpp:319
 msgid "Table of Contents"
 msgstr "İçerik Tablosu"
 
-#: ../src/wxMaximaFrame.cpp:556
+#: ../src/wxMaximaFrame.cpp:555
 #, fuzzy
 msgid "Table of Contents\tAlt-Shift-T"
 msgstr "İçerik Tablosu \tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:1382
+#: ../src/wxMaximaFrame.cpp:1381
 msgid "Tau"
 msgstr "Tau"
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Taylor series:"
 msgstr "Taylor Serileri:"
 
-#: ../src/wxMaxima.cpp:3963
+#: ../src/wxMaxima.cpp:3975
 msgid "Tellrat"
 msgstr "Tellrat"
 
-#: ../src/wxMaximaFrame.cpp:1494
+#: ../src/wxMaximaFrame.cpp:1513
 msgid "Text"
 msgstr "Metin"
 
@@ -4117,7 +4120,7 @@ msgstr ""
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr "LaTeX belge sınıfı bizim belgelerimizi kullanmak için yönlendirilir."
 
-#: ../src/TextCell.cpp:136
+#: ../src/TextCell.cpp:134
 msgid ""
 "The letter \"X\" is of width zero. Installing http://www.math.union.edu/"
 "~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts\" in "
@@ -4137,7 +4140,7 @@ msgstr ""
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:959
+#: ../src/wxMaximaFrame.cpp:958
 msgid "The offline manual of maxima"
 msgstr "Maxima'nın Çevirim dışı kullanma kılavuzu"
 
@@ -4176,7 +4179,7 @@ msgstr ""
 "wxmaxima.sourceforge.net/wiki/index.php yi ziyaret ederek wxMaxima and "
 "Maxima kullanımı hakkında bilgi ve ders notlarına ulaşabilirsiniz."
 
-#: ../src/SlideShowCell.cpp:332
+#: ../src/SlideShowCell.cpp:336
 msgid ""
 "There was an error during GIF export!\n"
 "\n"
@@ -4187,7 +4190,7 @@ msgstr ""
 "ImageMagick programının bilgisayarınızda yüklü olduğundan ve wxMaxima'nın "
 "dönüştürme programını bulduğundan emin olun "
 
-#: ../src/wxMaxima.cpp:442
+#: ../src/wxMaxima.cpp:447
 msgid ""
 "There was an error in generated XML!\n"
 "\n"
@@ -4197,7 +4200,7 @@ msgstr ""
 "\n"
 "Lütfen bunu hata olarak bildirin"
 
-#: ../src/wxMaximaFrame.cpp:1371
+#: ../src/wxMaximaFrame.cpp:1370
 msgid "Theta"
 msgstr "Theta"
 
@@ -4205,7 +4208,7 @@ msgstr "Theta"
 msgid "Ticks:"
 msgstr "İnce nokta ayarları:"
 
-#: ../src/wxMaxima.cpp:4153 ../src/wxMaxima.cpp:5065
+#: ../src/wxMaxima.cpp:4165 ../src/wxMaxima.cpp:5077
 msgid "Times:"
 msgstr "Tekrarlar:"
 
@@ -4213,7 +4216,7 @@ msgstr "Tekrarlar:"
 msgid "Tips not available, sorry!"
 msgstr "Yararlı Bilgi Bulunamadı Üzgünüz, "
 
-#: ../src/wxMaximaFrame.cpp:1495
+#: ../src/wxMaximaFrame.cpp:1514
 msgid "Title"
 msgstr "Başlık"
 
@@ -4231,19 +4234,19 @@ msgstr ""
 "GİZLE yada GÖSTER için hücereye bitişik kareyi tıklayın. Shift+tık "
 "yaparsanız o hücrenin bütün alt seviyeleri GİZLE\\GÖSTER komutuna uyar."
 
-#: ../src/wxMaximaFrame.cpp:938
+#: ../src/wxMaximaFrame.cpp:937
 msgid "To &Bigfloat"
 msgstr "BüyükKayanSayı ya"
 
-#: ../src/wxMaximaFrame.cpp:935
+#: ../src/wxMaximaFrame.cpp:934
 msgid "To &Float"
 msgstr "KayanSayıya"
 
-#: ../src/MathCtrl.cpp:990
+#: ../src/MathCtrl.cpp:1032
 msgid "To Float"
 msgstr "KayanSayıya"
 
-#: ../src/wxMaximaFrame.cpp:941
+#: ../src/wxMaximaFrame.cpp:940
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr "Numeri&k'e \tCtrl+Shift+N"
 
@@ -4285,52 +4288,52 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:41 ../src/Plot2dWiz.cpp:40 ../src/Plot2dWiz.cpp:50
 #: ../src/Plot2dWiz.cpp:539 ../src/Plot3dWiz.cpp:39 ../src/Plot3dWiz.cpp:48
-#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4241
+#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4253
 msgid "To:"
 msgstr "To:"
 
-#: ../src/wxMaximaFrame.cpp:912
+#: ../src/wxMaximaFrame.cpp:911
 msgid "Toggle &Algebraic Flag"
 msgstr "Cebirsel Dizeyi Çalıştır"
 
-#: ../src/wxMaximaFrame.cpp:933
+#: ../src/wxMaximaFrame.cpp:932
 msgid "Toggle &Numeric Output"
 msgstr "Numerik Çıktıyı çalıştır"
 
-#: ../src/wxMaximaFrame.cpp:673
+#: ../src/wxMaximaFrame.cpp:672
 msgid "Toggle &Time Display"
 msgstr "Zaman gösterimini çalıştır"
 
-#: ../src/wxMaximaFrame.cpp:913
+#: ../src/wxMaximaFrame.cpp:912
 msgid "Toggle algebraic flag"
 msgstr "Cebirsel Dizeyi (Flag) Çalıştır"
 
-#: ../src/wxMaximaFrame.cpp:577
+#: ../src/wxMaximaFrame.cpp:576
 msgid "Toggle full screen editing"
 msgstr "Tam Ekran Düzenlemesini Çalıştır"
 
-#: ../src/wxMaximaFrame.cpp:934
+#: ../src/wxMaximaFrame.cpp:933
 msgid "Toggle numeric output"
 msgstr "Numerik Çıktıyı Çalıştır"
 
-#: ../src/wxMaxima.cpp:4464
+#: ../src/wxMaxima.cpp:4476
 msgid "Toolbar icons"
 msgstr "Araç Çubuğu Simgeleri"
 
-#: ../src/wxMaxima.cpp:4465
+#: ../src/wxMaxima.cpp:4477
 msgid "Translated by"
 msgstr "Çeviri:"
 
-#: ../src/wxMaximaFrame.cpp:763
+#: ../src/wxMaximaFrame.cpp:762
 msgid "Transpose a matrix"
 msgstr "Transpoze Matris"
 
-#: ../src/MathCtrl.cpp:5834
+#: ../src/MathCtrl.cpp:5886
 msgid "Trying to undo an action without starting cell."
 msgstr ""
 "Hücre (değerlendirlmesi) başlatılmadan bir eylemi geri almaya çalışıyor."
 
-#: ../src/MathCtrl.cpp:5901
+#: ../src/MathCtrl.cpp:5953
 msgid "Trying to undo something but the undo action is empty."
 msgstr "Birşeyi geri almaya çalışıyor ancak geri alacak bir şey yok."
 
@@ -4338,11 +4341,11 @@ msgstr "Birşeyi geri almaya çalışıyor ancak geri alacak bir şey yok."
 msgid "Turkish"
 msgstr "Türkçe"
 
-#: ../src/wxMaximaFrame.cpp:970
+#: ../src/wxMaximaFrame.cpp:969
 msgid "Tutorials"
 msgstr "Ders Notları"
 
-#: ../src/wxMaxima.cpp:4778
+#: ../src/wxMaxima.cpp:4790
 msgid "Two sample t-test"
 msgstr "İki Örnek t-testi"
 
@@ -4354,15 +4357,15 @@ msgstr "Tip:"
 msgid "Ukrainian"
 msgstr "Ukraynaca"
 
-#: ../src/wxMaxima.cpp:5356
+#: ../src/wxMaxima.cpp:5372
 msgid "Un-closed parenthesis"
 msgstr "Kapanmamış parantezler"
 
-#: ../src/wxMaxima.cpp:5323
+#: ../src/wxMaxima.cpp:5335
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr "Kapatılmamış parantez"
 
-#: ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5889
 msgid ""
 "Unable to interpret the version info I got from http://andrejv.github.io//"
 "wxmaxima/version.txt: "
@@ -4378,11 +4381,11 @@ msgstr "Altı Çizili"
 msgid "Underscore converts to subscripts:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:492
+#: ../src/wxMaximaFrame.cpp:491
 msgid "Undo\tCtrl-Z"
 msgstr "Geri Al\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:493
+#: ../src/wxMaximaFrame.cpp:492
 msgid "Undo last change"
 msgstr "Son Değişikliği Geri Al"
 
@@ -4391,23 +4394,23 @@ msgstr "Son Değişikliği Geri Al"
 msgid "Undo limit (0 for none):"
 msgstr "Geri alma limiti ( 0, geri alma işlemi yapma! demektir)"
 
-#: ../src/wxMaximaFrame.cpp:625
+#: ../src/wxMaximaFrame.cpp:624
 msgid "Unfold All\tCtrl-Alt-]"
 msgstr "Hepsini Klasörden Çıkar\tCtrl-A]"
 
-#: ../src/wxMaximaFrame.cpp:626
+#: ../src/wxMaximaFrame.cpp:625
 msgid "Unfold all folded sections"
 msgstr "Klasörlenmiş bütün kısımları Klasörden Çıkar"
 
-#: ../src/wxMaxima.cpp:4458
+#: ../src/wxMaxima.cpp:4470
 msgid "Unicode Support"
 msgstr "Unicode Desteği"
 
-#: ../src/wxMaxima.cpp:5335
+#: ../src/wxMaxima.cpp:5347
 msgid "Unterminated comment."
 msgstr "Sonlandırılmamış yorum"
 
-#: ../src/wxMaxima.cpp:5309
+#: ../src/wxMaxima.cpp:5321
 msgid "Unterminated string."
 msgstr "Sonlandırılmamış dizi"
 
@@ -4415,15 +4418,15 @@ msgstr "Sonlandırılmamış dizi"
 msgid "Up"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5859 ../src/wxMaxima.cpp:5866 ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5874 ../src/wxMaxima.cpp:5881 ../src/wxMaxima.cpp:5889
 msgid "Upgrade"
 msgstr "Güncelle"
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Upper bound:"
 msgstr "Üst Sınır:"
 
-#: ../src/wxMaximaFrame.cpp:1383
+#: ../src/wxMaximaFrame.cpp:1382
 #, fuzzy
 msgid "Upsilon"
 msgstr "Epsilon"
@@ -4475,22 +4478,22 @@ msgstr ""
 msgid "User-defined labels"
 msgstr "Kullanıcı tanımlı etiketler"
 
-#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3525
-#: ../src/wxMaxima.cpp:3541 ../src/wxMaxima.cpp:3649
+#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3537
+#: ../src/wxMaxima.cpp:3553 ../src/wxMaxima.cpp:3661
 msgid "Value:"
 msgstr "Değer:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:5019 ../src/wxMaxima.cpp:5064
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:5031 ../src/wxMaxima.cpp:5076
 msgid "Variable(s):"
 msgstr "Değişken(ler):"
 
 #: ../src/IntegrateWiz.cpp:33 ../src/LimitWiz.cpp:30 ../src/Plot2dWiz.cpp:34
 #: ../src/Plot2dWiz.cpp:44 ../src/Plot2dWiz.cpp:533 ../src/Plot3dWiz.cpp:33
 #: ../src/Plot3dWiz.cpp:42 ../src/SeriesWiz.cpp:36 ../src/SumWiz.cpp:30
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3749
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3761
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5045
 msgid "Variable:"
 msgstr "Değişken:"
 
@@ -4498,25 +4501,25 @@ msgstr "Değişken:"
 msgid "Variables"
 msgstr "Değişken(ler)"
 
-#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3571 ../src/wxMaxima.cpp:4206
-#: ../src/wxMaxima.cpp:4807
+#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3583 ../src/wxMaxima.cpp:4218
+#: ../src/wxMaxima.cpp:4819
 msgid "Variables:"
 msgstr "Değişken(ler):"
 
-#: ../src/wxMaximaFrame.cpp:1257
+#: ../src/wxMaximaFrame.cpp:1256
 msgid "Variance..."
 msgstr "Varyans..."
 
-#: ../src/wxMaximaFrame.cpp:580
+#: ../src/wxMaximaFrame.cpp:579
 msgid "View"
 msgstr "Görünüm"
 
-#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1674 ../src/wxMaxima.cpp:1769
-#: ../src/wxMaxima.cpp:1950
+#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1679 ../src/wxMaxima.cpp:1774
+#: ../src/wxMaxima.cpp:1955
 msgid "Warning"
 msgstr "Uyarı"
 
-#: ../src/wxMaximaFrame.cpp:109 ../src/wxMaximaFrame.cpp:295
+#: ../src/wxMaximaFrame.cpp:108 ../src/wxMaximaFrame.cpp:294
 msgid "Welcome to wxMaxima"
 msgstr "wxMaxima'ya Hoş Geldiniz!"
 
@@ -4545,7 +4548,7 @@ msgstr ""
 "çalışma yaprağında olan satır kesmelerini  HTML çıkarımında  yapacaktır. Bu "
 "seçenek seçilmediğinde satır kesmeleri boş bir satırla gösterilecektir. "
 
-#: ../src/wxMaxima.cpp:2567
+#: ../src/wxMaxima.cpp:2574
 #, fuzzy
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) "
@@ -4562,7 +4565,7 @@ msgid ""
 "as equation markers"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6798
+#: ../src/MathCtrl.cpp:6856
 msgid "Wrapped search"
 msgstr ""
 
@@ -4570,15 +4573,15 @@ msgstr ""
 msgid "Write matching parenthesis in text controls."
 msgstr "Metin kontrolünde parantez eşleştirmesini yaz"
 
-#: ../src/wxMaxima.cpp:4461
+#: ../src/wxMaxima.cpp:4473
 msgid "Written by"
 msgstr "Yazan:"
 
-#: ../src/wxMaximaFrame.cpp:557
+#: ../src/wxMaximaFrame.cpp:556
 msgid "XML Inspector"
 msgstr "XML Denetleyecisi"
 
-#: ../src/wxMaximaFrame.cpp:1377
+#: ../src/wxMaximaFrame.cpp:1376
 msgid "Xi"
 msgstr "Xi"
 
@@ -4648,7 +4651,7 @@ msgstr ""
 "ettirerek.Seçtikten sonra Shift+Enter ile Değerlendir yapabilir yada "
 "silebilirsiniz"
 
-#: ../src/wxMaxima.cpp:5856
+#: ../src/wxMaxima.cpp:5871
 #, c-format
 msgid ""
 "You have version %s. Current version is %s.\n"
@@ -4659,39 +4662,39 @@ msgstr ""
 "\n"
 "wxMaxima web sayfasını ziyaret için OK i seçin."
 
-#: ../src/wxMaxima.cpp:5921
+#: ../src/wxMaxima.cpp:5936
 msgid "Your changes will be lost if you don't save them."
 msgstr "Kaydetmezseniz yaptığınız değişiklikler kaybolabilir."
 
-#: ../src/wxMaxima.cpp:5866
+#: ../src/wxMaxima.cpp:5881
 msgid "Your version of wxMaxima is up to date."
 msgstr "Kullandığınız wxMaxima güncellenebilir."
 
-#: ../src/wxMaximaFrame.cpp:1369
+#: ../src/wxMaximaFrame.cpp:1368
 msgid "Zeta"
 msgstr "Zeta"
 
-#: ../src/wxMaximaFrame.cpp:562
+#: ../src/wxMaximaFrame.cpp:561
 msgid "Zoom &In\tCtrl-+"
 msgstr "Yakınlaştır\tCtrl-+"
 
-#: ../src/wxMaximaFrame.cpp:564
+#: ../src/wxMaximaFrame.cpp:563
 msgid "Zoom Ou&t\tCtrl--"
 msgstr "Uzaklaştır\tCtrl-+"
 
-#: ../src/wxMaximaFrame.cpp:563
+#: ../src/wxMaximaFrame.cpp:562
 msgid "Zoom in 10%"
 msgstr "%10 yakınlaştır"
 
-#: ../src/wxMaximaFrame.cpp:565
+#: ../src/wxMaximaFrame.cpp:564
 msgid "Zoom out 10%"
 msgstr "%10 uzaklaştır"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaximaFrame.cpp:287
 msgid "[ unsaved ]"
 msgstr "[Kaydedilmemiş]"
 
-#: ../src/wxMaxima.cpp:5700
+#: ../src/wxMaxima.cpp:5715
 msgid "[ unsaved* ]"
 msgstr "[Kaydedilmemiş*]"
 
@@ -4700,21 +4703,21 @@ msgstr "[Kaydedilmemiş*]"
 msgid "[%i digits]"
 msgstr "[%i basamaklar]"
 
-#: ../src/MathCtrl.cpp:4392
+#: ../src/MathCtrl.cpp:4447
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" style=\"max-width:90%%;\" >\n"
 msgstr ""
 "_%d.gif\"  alt=\"Hareketli çizim (Animasyon)\" style=\"maks-genişlik:90%%;\" "
 ">\n"
 
-#: ../src/MathCtrl.cpp:4517
+#: ../src/MathCtrl.cpp:4572
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" >"
 msgstr ""
 "_%d.gif\"  alt=\"Hareketli çizim (Animasyon)\" style=\"maks-genişlik:90%%;\" "
 ">"
 
-#: ../src/wxMaximaFrame.cpp:1333
+#: ../src/wxMaximaFrame.cpp:1332
 msgid "alpha"
 msgstr "Alfa"
 
@@ -4726,7 +4729,7 @@ msgstr "ve"
 msgid "antisymmetric"
 msgstr "antisimetrik"
 
-#: ../src/wxMaximaFrame.cpp:1334
+#: ../src/wxMaximaFrame.cpp:1333
 msgid "beta"
 msgstr "beta"
 
@@ -4770,7 +4773,7 @@ msgstr ""
 msgid "bug:Invalid sup tag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1354
+#: ../src/wxMaximaFrame.cpp:1353
 msgid "chi"
 msgstr "orkide"
 
@@ -4783,7 +4786,7 @@ msgstr ""
 msgid "default"
 msgstr "varsayılan"
 
-#: ../src/wxMaximaFrame.cpp:1336
+#: ../src/wxMaximaFrame.cpp:1335
 msgid "delta"
 msgstr "delta"
 
@@ -4795,7 +4798,7 @@ msgstr "çarpraz"
 msgid "empty"
 msgstr "boş"
 
-#: ../src/wxMaximaFrame.cpp:1337
+#: ../src/wxMaximaFrame.cpp:1336
 msgid "epsilon"
 msgstr "epsilon"
 
@@ -4803,7 +4806,7 @@ msgstr "epsilon"
 msgid "equivalent"
 msgstr "denk"
 
-#: ../src/wxMaximaFrame.cpp:1339
+#: ../src/wxMaximaFrame.cpp:1338
 msgid "eta"
 msgstr "eta"
 
@@ -4819,7 +4822,7 @@ msgid ""
 "all=_ marks subscripts."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1335
+#: ../src/wxMaximaFrame.cpp:1334
 msgid "gamma"
 msgstr "gamma"
 
@@ -4845,15 +4848,15 @@ msgstr "satır içi"
 msgid "intersection"
 msgstr "kesişim"
 
-#: ../src/wxMaximaFrame.cpp:1341
+#: ../src/wxMaximaFrame.cpp:1340
 msgid "iota"
 msgstr "ioata"
 
-#: ../src/wxMaximaFrame.cpp:1342
+#: ../src/wxMaximaFrame.cpp:1341
 msgid "kappa"
 msgstr "kappa"
 
-#: ../src/wxMaximaFrame.cpp:1343
+#: ../src/wxMaximaFrame.cpp:1342
 msgid "lambda"
 msgstr "lambda"
 
@@ -4869,7 +4872,7 @@ msgstr "az ya da eşit"
 msgid "logscale"
 msgstr "log ölçek"
 
-#: ../src/wxMaxima.cpp:3783
+#: ../src/wxMaxima.cpp:3795
 msgid "matrix[i,j]:"
 msgstr "matris[i,j]:"
 
@@ -4877,7 +4880,7 @@ msgstr "matris[i,j]:"
 msgid "maxima's pwd is path to document"
 msgstr "Maxima'nın pwd si (print working directory) belgeye yönlendirilmiştir."
 
-#: ../src/wxMaximaFrame.cpp:1344
+#: ../src/wxMaximaFrame.cpp:1343
 msgid "mu"
 msgstr ""
 
@@ -4894,7 +4897,7 @@ msgstr ""
 msgid "nand"
 msgstr "nand"
 
-#: ../src/wxMaxima.cpp:4524
+#: ../src/wxMaxima.cpp:4536
 msgid "no"
 msgstr "hayır"
 
@@ -4918,15 +4921,15 @@ msgstr "alt küme değil"
 msgid "not subset or equal"
 msgstr "alt küme değil ya da eşit"
 
-#: ../src/wxMaximaFrame.cpp:1345
+#: ../src/wxMaximaFrame.cpp:1344
 msgid "nu"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1356
+#: ../src/wxMaximaFrame.cpp:1355
 msgid "omega"
 msgstr "omega"
 
-#: ../src/wxMaximaFrame.cpp:1347
+#: ../src/wxMaximaFrame.cpp:1346
 msgid "omicron"
 msgstr ""
 
@@ -4938,11 +4941,11 @@ msgstr "ya da"
 msgid "partial sign"
 msgstr "Kısmi işareti"
 
-#: ../src/wxMaximaFrame.cpp:1353
+#: ../src/wxMaximaFrame.cpp:1352
 msgid "phi"
 msgstr "phi"
 
-#: ../src/wxMaximaFrame.cpp:1348
+#: ../src/wxMaximaFrame.cpp:1347
 msgid "pi"
 msgstr "pi"
 
@@ -4954,11 +4957,11 @@ msgstr ""
 msgid "proportional to"
 msgstr "'e ile doğru orantılı"
 
-#: ../src/wxMaximaFrame.cpp:1355
+#: ../src/wxMaximaFrame.cpp:1354
 msgid "psi"
 msgstr "psi"
 
-#: ../src/wxMaximaFrame.cpp:1349
+#: ../src/wxMaximaFrame.cpp:1348
 msgid "rho"
 msgstr "ro"
 
@@ -4966,7 +4969,7 @@ msgstr "ro"
 msgid "right"
 msgstr "sağ"
 
-#: ../src/wxMaximaFrame.cpp:1350
+#: ../src/wxMaximaFrame.cpp:1349
 msgid "sigma"
 msgstr "sigma"
 
@@ -4986,7 +4989,7 @@ msgstr "alt küme ya da eşit"
 msgid "symmetric"
 msgstr "simetrik"
 
-#: ../src/wxMaximaFrame.cpp:1351
+#: ../src/wxMaximaFrame.cpp:1350
 msgid "tau"
 msgstr "tau"
 
@@ -4998,7 +5001,7 @@ msgstr ""
 msgid "there is no"
 msgstr "bulunmuyor"
 
-#: ../src/wxMaximaFrame.cpp:1340
+#: ../src/wxMaximaFrame.cpp:1339
 msgid "theta"
 msgstr "theta"
 
@@ -5014,12 +5017,12 @@ msgstr ""
 msgid "union"
 msgstr "birleşim"
 
-#: ../src/wxMaxima.cpp:5903
+#: ../src/wxMaxima.cpp:5918
 msgid "unsaved"
 msgstr "kaydedilmemiş"
 
-#: ../src/wxMaximaFrame.cpp:290 ../src/wxMaxima.cpp:2559
-#: ../src/wxMaxima.cpp:2826
+#: ../src/wxMaxima.cpp:2566 ../src/wxMaxima.cpp:2834
+#: ../src/wxMaximaFrame.cpp:289
 msgid "untitled"
 msgstr "Başlıksız"
 
@@ -5028,26 +5031,26 @@ msgstr "Başlıksız"
 msgid "untitled %d"
 msgstr "Başlıksız %d"
 
-#: ../src/wxMaximaFrame.cpp:1352
+#: ../src/wxMaximaFrame.cpp:1351
 #, fuzzy
 msgid "upsilon"
 msgstr "Epsilon"
 
-#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4538
+#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4550
 msgid "wxMaxima"
 msgstr "wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
-#: ../src/wxMaxima.cpp:5700 ../src/wxMaxima.cpp:5709 ../src/wxMaxima.cpp:5712
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaxima.cpp:5715 ../src/wxMaxima.cpp:5724
+#: ../src/wxMaxima.cpp:5727 ../src/wxMaximaFrame.cpp:287
 #, c-format
 msgid "wxMaxima %s "
 msgstr "wxMaxima %s "
 
-#: ../src/wxMaximaFrame.cpp:952
+#: ../src/wxMaximaFrame.cpp:951
 msgid "wxMaxima &Help\tCtrl+?"
 msgstr "wxMaxima &Yardım\tCtrl+?"
 
-#: ../src/wxMaximaFrame.cpp:955
+#: ../src/wxMaximaFrame.cpp:954
 msgid "wxMaxima &Help\tF1"
 msgstr "wxMaxima &Yardım\tF1"
 
@@ -5063,11 +5066,11 @@ msgstr ""
 "yazmak durumunda kalmaz. Bu directory dosyası (nın nerede) wxMaxima "
 "sayfasına \"maxima_userdir ;\" yazarak bulunabilir."
 
-#: ../src/wxMaxima.cpp:1619
+#: ../src/wxMaxima.cpp:1624
 msgid "wxMaxima cannot open content.xml in the .wxmx zip archive "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1633
+#: ../src/wxMaxima.cpp:1638
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
@@ -5075,7 +5078,7 @@ msgstr ""
 msgid "wxMaxima configuration"
 msgstr "wxMaxima'nın yapılandırması"
 
-#: ../src/wxMaxima.cpp:1947
+#: ../src/wxMaxima.cpp:1952
 msgid ""
 "wxMaxima could not find Maxima!\n"
 "\n"
@@ -5087,7 +5090,7 @@ msgstr ""
 "Lütfen wxMaxima'yı 'Düzenle->Yapılandır' ile yapılandır.\n"
 "Sonra da Maxima'yı 'Maxima->Maxima'yı yeniden başlat' ile başlatın."
 
-#: ../src/wxMaxima.cpp:2204
+#: ../src/wxMaxima.cpp:2209
 msgid ""
 "wxMaxima could not find help files.\n"
 "\n"
@@ -5096,7 +5099,7 @@ msgstr ""
 "wxMaxima yardım dosyalarını bulamadı.\n"
 "Kurulumunuzu kontrol edin lütfen."
 
-#: ../src/wxMaxima.cpp:2032
+#: ../src/wxMaxima.cpp:2037
 msgid ""
 "wxMaxima could not find tip files.\n"
 "\n"
@@ -5106,7 +5109,7 @@ msgstr ""
 "\n"
 "Kurulumunuzu kontrol edin lütfen."
 
-#: ../src/wxMaxima.cpp:282
+#: ../src/wxMaxima.cpp:283
 msgid ""
 "wxMaxima could not start the server.\n"
 "\n"
@@ -5127,23 +5130,23 @@ msgstr ""
 "kullanılır. Eğer siz belgenizde bir seçme yaptıysanızseçtiniz kısım (lar) "
 "'%' yerine kullanılır."
 
-#: ../src/wxMaxima.cpp:2330
+#: ../src/wxMaxima.cpp:2336
 msgid "wxMaxima document"
 msgstr "wxMaxima Belgesi"
 
-#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2799
+#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2807
 msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 msgstr "wxMaxima Belgesi (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 
-#: ../src/wxMaxima.cpp:1455 ../src/wxMaxima.cpp:1469
+#: ../src/wxMaxima.cpp:1460 ../src/wxMaxima.cpp:1474
 msgid "wxMaxima encountered an error loading "
 msgstr "wxMaxima bir yükleme hatası ile karşılaştı. "
 
-#: ../src/wxMaxima.cpp:4463
+#: ../src/wxMaxima.cpp:4475
 msgid "wxMaxima icon"
 msgstr "wxMaxima Simgesi"
 
-#: ../src/wxMaxima.cpp:4455
+#: ../src/wxMaxima.cpp:4467
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "MAXIMA based on wxWidgets."
@@ -5151,7 +5154,7 @@ msgstr ""
 "wxMaxima, wxWidgets ile geliştirilmiştir.Bilgisayar Cebiri Sistemi "
 "Maxima'nın bir grafiksel  kullanıcı arayüzüdür."
 
-#: ../src/wxMaxima.cpp:4516
+#: ../src/wxMaxima.cpp:4528
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "Maxima based on wxWidgets."
@@ -5171,11 +5174,11 @@ msgstr ""
 msgid "x"
 msgstr "x"
 
-#: ../src/wxMaximaFrame.cpp:1346
+#: ../src/wxMaximaFrame.cpp:1345
 msgid "xi"
 msgstr "xi"
 
-#: ../src/wxMaxima.cpp:1643
+#: ../src/wxMaxima.cpp:1648
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
@@ -5183,11 +5186,11 @@ msgstr ""
 msgid "xor"
 msgstr "xor"
 
-#: ../src/wxMaxima.cpp:4522
+#: ../src/wxMaxima.cpp:4534
 msgid "yes"
 msgstr "evet"
 
-#: ../src/wxMaximaFrame.cpp:1338
+#: ../src/wxMaximaFrame.cpp:1337
 msgid "zeta"
 msgstr "zeta"
 

--- a/locales/uk.po
+++ b/locales/uk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxMaxima\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-07 21:42+0200\n"
+"POT-Creation-Date: 2016-10-16 17:47+0900\n"
 "PO-Revision-Date: 2016-06-26 18:35+0300\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
 "Language-Team: Ukrainian <trans-uk@lists.fedoraproject.org>\n"
@@ -20,7 +20,7 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Lokalize 1.5\n"
 
-#: ../src/wxMaxima.cpp:4519
+#: ../src/wxMaxima.cpp:4531
 #, c-format
 msgid ""
 "\n"
@@ -33,7 +33,7 @@ msgstr ""
 "wxWidgets: %d.%d.%d\n"
 "Підтримка Unicode: %s"
 
-#: ../src/wxMaxima.cpp:4532
+#: ../src/wxMaxima.cpp:4544
 msgid ""
 "\n"
 "Lisp: "
@@ -41,7 +41,7 @@ msgstr ""
 "\n"
 "Lisp: "
 
-#: ../src/wxMaxima.cpp:4528
+#: ../src/wxMaxima.cpp:4540
 msgid ""
 "\n"
 "Maxima version: "
@@ -49,7 +49,7 @@ msgstr ""
 "\n"
 "Версія Maxima: "
 
-#: ../src/wxMaxima.cpp:5381
+#: ../src/wxMaxima.cpp:5397
 msgid ""
 "\n"
 "Not connected to Maxima!\n"
@@ -57,7 +57,7 @@ msgstr ""
 "\n"
 "Не з’єднано з Maxima!\n"
 
-#: ../src/wxMaxima.cpp:4530
+#: ../src/wxMaxima.cpp:4542
 msgid ""
 "\n"
 "Not connected."
@@ -77,7 +77,7 @@ msgstr "      -l <назва>"
 msgid " (Graphics) "
 msgstr " (графіка) "
 
-#: ../src/EditorCell.cpp:3045 ../src/EditorCell.cpp:3227
+#: ../src/EditorCell.cpp:3088 ../src/EditorCell.cpp:3270
 #, c-format
 msgid " ... + %i hidden lines"
 msgstr ""
@@ -86,7 +86,7 @@ msgstr ""
 msgid " << Expression longer than allowed by the configuration setting! >>"
 msgstr " << Вираз є довшим за розмір, визначений у налаштуваннях! >>"
 
-#: ../src/wxMaxima.cpp:1673
+#: ../src/wxMaxima.cpp:1678
 msgid ""
 " was saved using a newer version of wxMaxima so it may not load correctly. "
 "Please update your wxMaxima."
@@ -94,7 +94,7 @@ msgstr ""
 " було збережено за допомогою новішої версії wxMaxima, отже дані може бути "
 "завантажено з помилками. Будь ласка, оновіть вашу версію wxMaxima."
 
-#: ../src/wxMaxima.cpp:1665
+#: ../src/wxMaxima.cpp:1670
 msgid ""
 " was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr ""
@@ -109,64 +109,64 @@ msgstr "«Копіювати як LaTeX» додає позначки рівня
 msgid "\"implies\" symbol"
 msgstr "символ «слідує»"
 
-#: ../src/wxMaximaFrame.cpp:101
+#: ../src/wxMaximaFrame.cpp:100
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr "%i комірок у черзі обчислення"
 
-#: ../src/wxMaximaFrame.cpp:773
+#: ../src/wxMaximaFrame.cpp:772
 msgid "&Algebra"
 msgstr "&Алгебра"
 
-#: ../src/wxMaximaFrame.cpp:767
+#: ../src/wxMaximaFrame.cpp:766
 msgid "&Apply to List..."
 msgstr "&Застосувати до списку…"
 
-#: ../src/wxMaximaFrame.cpp:964
+#: ../src/wxMaximaFrame.cpp:963
 msgid "&Apropos..."
 msgstr "&Подібні команди…"
 
-#: ../src/wxMaximaFrame.cpp:478
+#: ../src/wxMaximaFrame.cpp:477
 msgid "&Batch File...\tCtrl-B"
 msgstr "&Пакетний файл…\tCtrl-B"
 
-#: ../src/wxMaximaFrame.cpp:724
+#: ../src/wxMaximaFrame.cpp:723
 msgid "&Boundary Value Problem..."
 msgstr "&Крайова задача…"
 
-#: ../src/wxMaximaFrame.cpp:975
+#: ../src/wxMaximaFrame.cpp:974
 msgid "&Bug Report"
 msgstr "&Надіслати звіт щодо вади"
 
-#: ../src/wxMaximaFrame.cpp:825
+#: ../src/wxMaximaFrame.cpp:824
 msgid "&Calculus"
 msgstr "&Аналіз"
 
-#: ../src/wxMaximaFrame.cpp:876
+#: ../src/wxMaximaFrame.cpp:875
 msgid "&Canonical Form"
 msgstr "&Канонічна форма"
 
-#: ../src/wxMaximaFrame.cpp:749
+#: ../src/wxMaximaFrame.cpp:748
 msgid "&Characteristic Polynomial..."
 msgstr "&Характеристичний поліном…"
 
-#: ../src/wxMaximaFrame.cpp:654
+#: ../src/wxMaximaFrame.cpp:653
 msgid "&Clear Memory"
 msgstr "С&порожнити пам’ять"
 
-#: ../src/wxMaximaFrame.cpp:859
+#: ../src/wxMaximaFrame.cpp:858
 msgid "&Combine Factorials"
 msgstr "&Об’єднати факторіали"
 
-#: ../src/wxMaximaFrame.cpp:902
+#: ../src/wxMaximaFrame.cpp:901
 msgid "&Complex Simplification"
 msgstr "&Комплексне спрощення"
 
-#: ../src/wxMaximaFrame.cpp:822
+#: ../src/wxMaximaFrame.cpp:821
 msgid "&Continued Fraction"
 msgstr "&Неперервний дріб"
 
-#: ../src/wxMaximaFrame.cpp:502
+#: ../src/wxMaximaFrame.cpp:501
 msgid "&Copy\tCtrl-C"
 msgstr "&Копіювати\tCtrl-C"
 
@@ -174,107 +174,107 @@ msgstr "&Копіювати\tCtrl-C"
 msgid "&Definite integration"
 msgstr "&Визначене інтегрування"
 
-#: ../src/wxMaximaFrame.cpp:896
+#: ../src/wxMaximaFrame.cpp:895
 msgid "&Demoivre"
 msgstr "У &тригонометричну форму"
 
-#: ../src/wxMaximaFrame.cpp:752
+#: ../src/wxMaximaFrame.cpp:751
 msgid "&Determinant"
 msgstr "&Визначник"
 
-#: ../src/wxMaximaFrame.cpp:785
+#: ../src/wxMaximaFrame.cpp:784
 msgid "&Differentiate..."
 msgstr "&Диференціювати…"
 
-#: ../src/wxMaximaFrame.cpp:543
+#: ../src/wxMaximaFrame.cpp:542
 msgid "&Edit"
 msgstr "З&міни"
 
-#: ../src/wxMaximaFrame.cpp:709
+#: ../src/wxMaximaFrame.cpp:708
 msgid "&Eliminate Variable..."
 msgstr "З&нищити змінну…"
 
-#: ../src/wxMaximaFrame.cpp:744
+#: ../src/wxMaximaFrame.cpp:743
 msgid "&Enter Matrix..."
 msgstr "&Ввести матрицю…"
 
-#: ../src/wxMaximaFrame.cpp:961
+#: ../src/wxMaximaFrame.cpp:960
 msgid "&Example..."
 msgstr "П&риклад…"
 
-#: ../src/wxMaximaFrame.cpp:839
+#: ../src/wxMaximaFrame.cpp:838
 msgid "&Expand Expression"
 msgstr "&Розкрити вираз"
 
-#: ../src/wxMaximaFrame.cpp:873
+#: ../src/wxMaximaFrame.cpp:872
 msgid "&Expand Trigonometric"
 msgstr "&Розкрити тригонометричний вираз"
 
-#: ../src/wxMaximaFrame.cpp:899
+#: ../src/wxMaximaFrame.cpp:898
 msgid "&Exponentialize"
 msgstr "У &експоненційну форму"
 
-#: ../src/wxMaximaFrame.cpp:480
+#: ../src/wxMaximaFrame.cpp:479
 msgid "&Export..."
 msgstr "&Експортувати…"
 
-#: ../src/wxMaximaFrame.cpp:834
+#: ../src/wxMaximaFrame.cpp:833
 msgid "&Factor Expression"
 msgstr "Розкласти на &множники"
 
-#: ../src/wxMaximaFrame.cpp:489
+#: ../src/wxMaximaFrame.cpp:488
 msgid "&File"
 msgstr "&Файл"
 
-#: ../src/wxMaximaFrame.cpp:692
+#: ../src/wxMaximaFrame.cpp:691
 msgid "&Find Root..."
 msgstr "З&найти корінь…"
 
-#: ../src/wxMaximaFrame.cpp:738
+#: ../src/wxMaximaFrame.cpp:737
 msgid "&Generate Matrix..."
 msgstr "С&творити матрицю…"
 
-#: ../src/wxMaximaFrame.cpp:809
+#: ../src/wxMaximaFrame.cpp:808
 msgid "&Greatest Common Divisor..."
 msgstr "Най&більший спільний дільник…"
 
-#: ../src/wxMaximaFrame.cpp:994
+#: ../src/wxMaximaFrame.cpp:993
 msgid "&Help"
 msgstr "&Довідка"
 
-#: ../src/wxMaximaFrame.cpp:777
+#: ../src/wxMaximaFrame.cpp:776
 msgid "&Integrate..."
 msgstr "&Інтегрувати…"
 
-#: ../src/wxMaximaFrame.cpp:645
+#: ../src/wxMaximaFrame.cpp:644
 msgid "&Interrupt\tCtrl-."
 msgstr "П&ерервати\tCtrl-."
 
-#: ../src/wxMaximaFrame.cpp:649
+#: ../src/wxMaximaFrame.cpp:648
 msgid "&Interrupt\tCtrl-G"
 msgstr "П&ерервати\tCtrl-G"
 
-#: ../src/wxMaximaFrame.cpp:746
+#: ../src/wxMaximaFrame.cpp:745
 msgid "&Invert Matrix"
 msgstr "&Обернена матриця"
 
-#: ../src/wxMaximaFrame.cpp:476
+#: ../src/wxMaximaFrame.cpp:475
 msgid "&Load Package...\tCtrl-L"
 msgstr "З&авантажити пакунок…\tCtrl-L"
 
-#: ../src/wxMaximaFrame.cpp:769
+#: ../src/wxMaximaFrame.cpp:768
 msgid "&Map to List(s)..."
 msgstr "&Відобразити у списки…"
 
-#: ../src/wxMaximaFrame.cpp:684
+#: ../src/wxMaximaFrame.cpp:683
 msgid "&Maxima"
 msgstr "&Maxima"
 
-#: ../src/wxMaximaFrame.cpp:958
+#: ../src/wxMaximaFrame.cpp:957
 msgid "&Maxima help"
 msgstr "Дов&ідка з Maxima"
 
-#: ../src/wxMaximaFrame.cpp:917
+#: ../src/wxMaximaFrame.cpp:916
 msgid "&Modulus Computation..."
 msgstr "Обчислення за &модулем…"
 
@@ -282,7 +282,7 @@ msgstr "Обчислення за &модулем…"
 msgid "&New\tCtrl-N"
 msgstr "&Створити\tCtrl-N"
 
-#: ../src/wxMaximaFrame.cpp:947
+#: ../src/wxMaximaFrame.cpp:946
 msgid "&Numeric"
 msgstr "&Обчислення"
 
@@ -298,11 +298,11 @@ msgstr "&Підсумовування (nusum)"
 msgid "&Open\tCtrl-O"
 msgstr "&Відкрити\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:463
+#: ../src/wxMaximaFrame.cpp:462
 msgid "&Open...\tCtrl-O"
 msgstr "&Відкрити...\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:929
+#: ../src/wxMaximaFrame.cpp:928
 msgid "&Plot"
 msgstr "&Креслення"
 
@@ -310,7 +310,7 @@ msgstr "&Креслення"
 msgid "&Power series"
 msgstr "С&тепеневий ряд"
 
-#: ../src/wxMaximaFrame.cpp:483
+#: ../src/wxMaximaFrame.cpp:482
 msgid "&Print...\tCtrl-P"
 msgstr "На&друкувати\tCtrl-P"
 
@@ -318,39 +318,39 @@ msgstr "На&друкувати\tCtrl-P"
 msgid "&Rational"
 msgstr "&Раціональний вираз"
 
-#: ../src/wxMaximaFrame.cpp:870
+#: ../src/wxMaximaFrame.cpp:869
 msgid "&Reduce Trigonometric"
 msgstr "&Приведення тригонометричне"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "&Restart Maxima"
 msgstr "Пе&резапустити Maxima"
 
-#: ../src/wxMaximaFrame.cpp:700
+#: ../src/wxMaximaFrame.cpp:699
 msgid "&Roots of Polynomial (Real)"
 msgstr "&Корені полінома (дійсні)"
 
-#: ../src/wxMaximaFrame.cpp:472
+#: ../src/wxMaximaFrame.cpp:471
 msgid "&Save\tCtrl-S"
 msgstr "З&берегти\tCtrl-S"
 
-#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:919
+#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:918
 msgid "&Simplify"
 msgstr "С&прощення"
 
-#: ../src/wxMaximaFrame.cpp:829
+#: ../src/wxMaximaFrame.cpp:828
 msgid "&Simplify Expression"
 msgstr "&Спростити вираз"
 
-#: ../src/wxMaximaFrame.cpp:856
+#: ../src/wxMaximaFrame.cpp:855
 msgid "&Simplify Factorials"
 msgstr "С&простити факторіали"
 
-#: ../src/wxMaximaFrame.cpp:867
+#: ../src/wxMaximaFrame.cpp:866
 msgid "&Simplify Trigonometric"
 msgstr "Сп&ростити тригонометричний вираз"
 
-#: ../src/wxMaximaFrame.cpp:688
+#: ../src/wxMaximaFrame.cpp:687
 msgid "&Solve..."
 msgstr "&Розв’язати…"
 
@@ -362,11 +362,11 @@ msgstr "&Додатково"
 msgid "&Taylor series"
 msgstr "Ряд &Тейлора"
 
-#: ../src/wxMaximaFrame.cpp:762
+#: ../src/wxMaximaFrame.cpp:761
 msgid "&Transpose Matrix"
 msgstr "&Транспонувати матрицю"
 
-#: ../src/wxMaximaFrame.cpp:879
+#: ../src/wxMaximaFrame.cpp:878
 msgid "&Trigonometric Simplification"
 msgstr "&Тригонометричне спрощення"
 
@@ -384,7 +384,7 @@ msgstr "(Використовувати типову мову)"
 msgid "- Infinity"
 msgstr "– нескінченність"
 
-#: ../src/wxMaxima.cpp:351
+#: ../src/wxMaxima.cpp:356
 msgid ""
 "... [suppressed additional lines since the output is longer than allowed in "
 "the configuration] "
@@ -396,16 +396,16 @@ msgstr ""
 msgid "1/2"
 msgstr "1/2"
 
-#: ../src/wxMaximaFrame.cpp:103
+#: ../src/wxMaximaFrame.cpp:102
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4601
+#: ../src/wxMaxima.cpp:4613
 msgid "<br>Lisp: "
 msgstr "<br>Lisp: "
 
-#: ../src/wxMaxima.cpp:5487
+#: ../src/wxMaxima.cpp:5503
 msgid ""
 "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
@@ -439,11 +439,11 @@ msgid ""
 "\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1472
+#: ../src/wxMaximaFrame.cpp:1495
 msgid "A symbol from the configuration dialogue"
 msgstr "Символ із діалогового вікна налаштовування"
 
-#: ../src/wxMaximaFrame.cpp:731
+#: ../src/wxMaximaFrame.cpp:730
 msgid "A&t Value..."
 msgstr "Значення &у точці…"
 
@@ -451,12 +451,12 @@ msgstr "Значення &у точці…"
 msgid "Abort evaluation on error"
 msgstr "Перервати обчислення, якщо трапиться помилка"
 
-#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaxima.cpp:4603
+#: ../src/wxMaxima.cpp:4615 ../src/wxMaximaFrame.cpp:985
 msgid "About"
 msgstr "Про програму"
 
-#: ../src/wxMaximaFrame.cpp:987 ../src/wxMaximaFrame.cpp:990
-#: ../src/wxMaximaFrame.cpp:991
+#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaximaFrame.cpp:989
+#: ../src/wxMaximaFrame.cpp:990
 msgid "About wxMaxima"
 msgstr "Про wxMaxima"
 
@@ -464,23 +464,23 @@ msgstr "Про wxMaxima"
 msgid "Active cell bracket"
 msgstr "Дужка активної комірки"
 
-#: ../src/wxMaximaFrame.cpp:760
+#: ../src/wxMaximaFrame.cpp:759
 msgid "Ad&joint Matrix"
 msgstr "Спр&яжена матриця"
 
-#: ../src/wxMaximaFrame.cpp:914
+#: ../src/wxMaximaFrame.cpp:913
 msgid "Add Algebraic E&quality..."
 msgstr "Додати &алгебраїчну рівність…"
 
-#: ../src/wxMaximaFrame.cpp:657
+#: ../src/wxMaximaFrame.cpp:656
 msgid "Add a directory to search path"
 msgstr "Додати каталог до шляху пошуку"
 
-#: ../src/wxMaxima.cpp:3353
+#: ../src/wxMaxima.cpp:3365
 msgid "Add dir to path:"
 msgstr "Додати каталог до шляху:"
 
-#: ../src/wxMaximaFrame.cpp:915
+#: ../src/wxMaximaFrame.cpp:914
 msgid "Add equality to the rational simplifier"
 msgstr "Додати рівність до спрощувача раціональних виразів"
 
@@ -488,7 +488,7 @@ msgstr "Додати рівність до спрощувача раціонал
 msgid "Add the .wxmx file to the HTML export"
 msgstr "Додати файл .wxmx до експортованого HTML"
 
-#: ../src/wxMaximaFrame.cpp:656
+#: ../src/wxMaximaFrame.cpp:655
 msgid "Add to &Path..."
 msgstr "Додати до &шляху…"
 
@@ -530,27 +530,27 @@ msgstr "Усі назви змінних"
 msgid "All|*"
 msgstr "Всі|*"
 
-#: ../src/wxMaximaFrame.cpp:1364
+#: ../src/wxMaximaFrame.cpp:1363
 msgid "Alpha"
 msgstr "Α"
 
-#: ../src/wxMaxima.cpp:3838
+#: ../src/wxMaxima.cpp:3850
 msgid "Apply"
 msgstr "Застосувати"
 
-#: ../src/wxMaximaFrame.cpp:768
+#: ../src/wxMaximaFrame.cpp:767
 msgid "Apply function to a list"
 msgstr "Застосувати функцію до списку"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Apropos"
 msgstr "Подібні команди"
 
-#: ../src/wxMaxima.cpp:3764
+#: ../src/wxMaxima.cpp:3776
 msgid "Array:"
 msgstr "Масив:"
 
-#: ../src/wxMaxima.cpp:4462
+#: ../src/wxMaxima.cpp:4474
 msgid "Artwork by"
 msgstr "Графіка"
 
@@ -558,7 +558,7 @@ msgstr "Графіка"
 msgid "Ask to save untitled documents"
 msgstr "Запитувати щодо збереження документів без назв"
 
-#: ../src/wxMaxima.cpp:3650
+#: ../src/wxMaxima.cpp:3662
 msgid "At value"
 msgstr "Значення у точці"
 
@@ -584,11 +584,11 @@ msgstr ""
 msgid "Autosave interval (minutes, 0 means: off):"
 msgstr "Інтервал автозбереження (у хвилинах, 0 — вимкнути):"
 
-#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3557
+#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3569
 msgid "BC2"
 msgstr "BC2"
 
-#: ../src/wxMaximaFrame.cpp:1272
+#: ../src/wxMaximaFrame.cpp:1271
 msgid "Barsplot..."
 msgstr "Стовпчикова діаграма…"
 
@@ -596,7 +596,7 @@ msgstr "Стовпчикова діаграма…"
 msgid "Bat files (*.bat)|*.bat|All|*"
 msgstr "Пакетні файли (*.bat)|*.bat|Всі|*"
 
-#: ../src/wxMaxima.cpp:2943
+#: ../src/wxMaxima.cpp:2951
 msgid "Batch File"
 msgstr "Пакетний файл"
 
@@ -614,7 +614,7 @@ msgstr ""
 "комірці можна скасувати дії саме у цій комірці, без впливу на пізніші зміни, "
 "внесені у інших комірках."
 
-#: ../src/wxMaximaFrame.cpp:1365
+#: ../src/wxMaximaFrame.cpp:1364
 msgid "Beta"
 msgstr "Β"
 
@@ -626,11 +626,11 @@ msgstr "Масштаб растра для експортування:"
 msgid "Bold"
 msgstr "Жирний"
 
-#: ../src/wxMaxima.cpp:2359
+#: ../src/wxMaxima.cpp:2366
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr "Активними є одночасно горизонтальний і вертикальний курсори"
 
-#: ../src/wxMaximaFrame.cpp:1274
+#: ../src/wxMaximaFrame.cpp:1273
 msgid "Boxplot..."
 msgstr "Скринькова діаграма…"
 
@@ -642,15 +642,15 @@ msgstr "Перегляд"
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr "Вада: надіслано запит щодо автодоповнення для невідомого типу записів."
 
-#: ../src/MathCtrl.cpp:2080
+#: ../src/MathCtrl.cpp:2127
 msgid "Bug: Cell left but not entered."
 msgstr "Вада: полишено комірку без введення даних."
 
-#: ../src/wxMaxima.cpp:1178
+#: ../src/wxMaxima.cpp:1183
 msgid "Bug: Found a math end marker without any start marker."
 msgstr "Вада: знайдено позначку завершення формули без позначки її початку."
 
-#: ../src/wxMaxima.cpp:1222
+#: ../src/wxMaxima.cpp:1227
 msgid "Bug: Found the end of autocompletion symbols but no beginning"
 msgstr ""
 "Вада: знайдено завершальні символи автоматичного доповнення, але не знайдено "
@@ -664,24 +664,24 @@ msgstr "Вада: дріб без знаменника"
 msgid "Bug: Fraction without enumerator"
 msgstr "Вада: дріб без чисельника"
 
-#: ../src/MathCtrl.cpp:2312
+#: ../src/MathCtrl.cpp:2359
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr "Вада: маємо питання, але не маємо комірки для відповіді на нього"
 
-#: ../src/MathCtrl.cpp:5839
+#: ../src/MathCtrl.cpp:5891
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of "
 "the worksheet."
 msgstr ""
 "Вада: отримано запит на зміну вмісту комірки над початком робочого аркуша."
 
-#: ../src/MathCtrl.cpp:5913
+#: ../src/MathCtrl.cpp:5965
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 "Вада: отримано запит на вилучення комірки над початком робочого аркуша."
 
-#: ../src/MathCtrl.cpp:5882
+#: ../src/MathCtrl.cpp:5934
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
@@ -695,46 +695,46 @@ msgstr ""
 "Вада: комірка рівняння, у якої немає групи комірок, до якої ця комірка "
 "належить"
 
-#: ../src/GroupCell.cpp:780 ../src/GroupCell.cpp:951
+#: ../src/GroupCell.cpp:781 ../src/GroupCell.cpp:952
 msgid "Bug: No image counter to write to!"
 msgstr ""
 
-#: ../src/AbsCell.cpp:193
+#: ../src/AbsCell.cpp:199
 msgid "Bug: No last cell in an absCell!"
 msgstr ""
 
-#: ../src/ConjugateCell.cpp:185
+#: ../src/ConjugateCell.cpp:194
 msgid "Bug: No last cell in an conjugateCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:471
+#: ../src/FracCell.cpp:472
 #, fuzzy
 msgid "Bug: No last cell in an denominator!"
 msgstr "Вада: дріб без знаменника"
 
-#: ../src/ExptCell.cpp:267
+#: ../src/ExptCell.cpp:270
 msgid "Bug: No last cell in an exponent of an exptCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:459
+#: ../src/FracCell.cpp:460
 #, fuzzy
 msgid "Bug: No last cell in an numerator!"
 msgstr "Вада: дріб без чисельника"
 
-#: ../src/ExptCell.cpp:257
+#: ../src/ExptCell.cpp:260
 msgid "Bug: No last cell in the base of an exptCell!"
 msgstr ""
 
-#: ../src/ParenCell.cpp:534
+#: ../src/ParenCell.cpp:535
 msgid "Bug: No last cell inside a parenthesis!"
 msgstr ""
 
-#: ../src/SqrtCell.cpp:312
+#: ../src/SqrtCell.cpp:317
 #, fuzzy
 msgid "Bug: No last cell inside a square root!"
 msgstr "Вада: дріб без чисельника"
 
-#: ../src/MathCtrl.cpp:2123
+#: ../src/MathCtrl.cpp:2170
 msgid ""
 "Bug: Start or end of merging of subsequent editing actions was requested two "
 "times in a row."
@@ -742,7 +742,7 @@ msgstr ""
 "Вада: надіслано запит на початок і завершення об’єднання послідовних дій з "
 "редагування два рази поспіль."
 
-#: ../src/MathCtrl.cpp:2090
+#: ../src/MathCtrl.cpp:2137
 msgid "Bug: Text changed, but no active cell."
 msgstr "Вада: змінено текст, але немає активної комірки."
 
@@ -750,13 +750,13 @@ msgstr "Вада: змінено текст, але немає активної 
 msgid "Bug: Trying to append NULL to a group cell."
 msgstr "Вада: спроба дописування NULL до комірки групи."
 
-#: ../src/MathCtrl.cpp:555
+#: ../src/MathCtrl.cpp:600
 msgid "Bug: Trying to append maxima's output to a cell outside the worksheet."
 msgstr ""
 "Вада: спроба дописати виведені maxima дані до комірки поза межами робочого "
 "аркуша."
 
-#: ../src/MathCtrl.cpp:2014
+#: ../src/MathCtrl.cpp:2061
 msgid ""
 "Bug: Trying to merge individual cell adds to a region in the undo buffer but "
 "there are other cells between them."
@@ -764,33 +764,33 @@ msgstr ""
 "Вада: спроба об’єднати окремі комірки додає область у буфері скасування, але "
 "між цими комірками є інші комірки."
 
-#: ../src/MathCtrl.cpp:6522
+#: ../src/MathCtrl.cpp:6577
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
 "Вада: спроба пересунути горизонтальний курсор до місця усередині GroupCell."
 
-#: ../src/MathCtrl.cpp:2092
+#: ../src/MathCtrl.cpp:2139
 msgid "Bug: Trying to record a cell contents change without a cell."
 msgstr "Вада: спроба запису зміни вмісту комірки без визначення комірки."
 
-#: ../src/MathCtrl.cpp:1495
+#: ../src/MathCtrl.cpp:1540
 msgid "Bug: Trying to select inside a cell without having a current cell"
 msgstr "Вада: спроба позначити щось у комірці без визначення поточної комірки"
 
-#: ../src/MathCtrl.cpp:5883
+#: ../src/MathCtrl.cpp:5935
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
 "Вада: дія зі скасування із одночасною зміною вмісту комірки і додаванням "
 "комірки."
 
-#: ../src/MathCtrl.cpp:5844 ../src/MathCtrl.cpp:5918 ../src/MathCtrl.cpp:5952
+#: ../src/MathCtrl.cpp:5896 ../src/MathCtrl.cpp:5970 ../src/MathCtrl.cpp:6004
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
 "Вада: запит щодо скасування дій із коміркою поза межами робочого аркуша."
 
-#: ../src/wxMaximaFrame.cpp:973
+#: ../src/wxMaximaFrame.cpp:972
 msgid "Build &Info"
 msgstr "Ві&домості щодо збирання"
 
@@ -807,51 +807,51 @@ msgstr ""
 "Налаштувати»: позначте пункт «Enter для обчислення у комірках». За допомогою "
 "цього пункту ви зможете поміняти місцями призначення клавіатурних скорочень."
 
-#: ../src/wxMaximaFrame.cpp:782
+#: ../src/wxMaximaFrame.cpp:781
 msgid "C&hange Variable..."
 msgstr "З&мінити значення змінної…"
 
-#: ../src/wxMaximaFrame.cpp:540
+#: ../src/wxMaximaFrame.cpp:539
 msgid "C&onfigure"
 msgstr "&Налаштувати"
 
-#: ../src/wxMaximaFrame.cpp:801
+#: ../src/wxMaximaFrame.cpp:800
 msgid "Calculate &Product..."
 msgstr "Обчислити &добуток…"
 
-#: ../src/wxMaximaFrame.cpp:799
+#: ../src/wxMaximaFrame.cpp:798
 msgid "Calculate Su&m..."
 msgstr "Обчислити с&уму…"
 
-#: ../src/wxMaximaFrame.cpp:939
+#: ../src/wxMaximaFrame.cpp:938
 msgid "Calculate bigfloat value of the last result"
 msgstr "Обчислити останній результат з підвищеною точністю"
 
-#: ../src/wxMaximaFrame.cpp:936
+#: ../src/wxMaximaFrame.cpp:935
 msgid "Calculate float value of the last result"
 msgstr "Обчислити останній результат зі звичайною точністю"
 
-#: ../src/wxMaxima.cpp:3971
+#: ../src/wxMaxima.cpp:3983
 msgid "Calculate modulus:"
 msgstr "Модуль обчислень:"
 
-#: ../src/wxMaximaFrame.cpp:942
+#: ../src/wxMaximaFrame.cpp:941
 msgid "Calculate numeric value of the last result"
 msgstr "Визначити числове значення останнього результату"
 
-#: ../src/wxMaximaFrame.cpp:802
+#: ../src/wxMaximaFrame.cpp:801
 msgid "Calculate products"
 msgstr "Обчислити добутки"
 
-#: ../src/wxMaximaFrame.cpp:800
+#: ../src/wxMaximaFrame.cpp:799
 msgid "Calculate sums"
 msgstr "Обчислити суми"
 
-#: ../src/wxMaxima.cpp:5830
+#: ../src/wxMaxima.cpp:5845
 msgid "Can not connect to the web server."
 msgstr "Не вдалося встановити з’єднання з вебсервером."
 
-#: ../src/wxMaxima.cpp:5881
+#: ../src/wxMaxima.cpp:5896
 msgid "Can not download version info."
 msgstr "Не вдалося отримати дані щодо версії."
 
@@ -867,15 +867,15 @@ msgstr "Не вдалося отримати дані щодо версії."
 #: ../src/PlotFormatWiz.cpp:48 ../src/SeriesWiz.cpp:49 ../src/SeriesWiz.cpp:51
 #: ../src/SubstituteWiz.cpp:41 ../src/SubstituteWiz.cpp:43 ../src/SumWiz.cpp:44
 #: ../src/SumWiz.cpp:46 ../src/SystemWiz.cpp:38 ../src/SystemWiz.cpp:40
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: ../src/wxMaximaFrame.cpp:126 ../src/wxMaxima.cpp:932
+#: ../src/wxMaxima.cpp:937 ../src/wxMaximaFrame.cpp:125
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1217
+#: ../src/wxMaximaFrame.cpp:1216
 msgid "Canonical (tr)"
 msgstr "Канонічна форма (триг)"
 
@@ -883,7 +883,7 @@ msgstr "Канонічна форма (триг)"
 msgid "Catalan"
 msgstr "каталонська"
 
-#: ../src/wxMaximaFrame.cpp:638
+#: ../src/wxMaximaFrame.cpp:637
 msgid "Ce&ll"
 msgstr "&Комірка"
 
@@ -891,41 +891,41 @@ msgstr "&Комірка"
 msgid "Cell bracket"
 msgstr "Дужка комірки"
 
-#: ../src/wxMaxima.cpp:5261
+#: ../src/wxMaxima.cpp:5273
 msgid "Cell ends in a backslash"
 msgstr "Комірка закінчується зворотною похилою рискою"
 
-#: ../src/wxMaximaFrame.cpp:676
+#: ../src/wxMaximaFrame.cpp:675
 msgid "Change &2d Display"
 msgstr "Змінити спосіб по&казу"
 
-#: ../src/wxMaximaFrame.cpp:677
+#: ../src/wxMaximaFrame.cpp:676
 msgid "Change the 2d display algorithm used to display math output"
 msgstr ""
 "Змінити алгоритм показу плоского зображення, що використовується для показу "
 "математичних виразів"
 
-#: ../src/wxMaxima.cpp:3995
+#: ../src/wxMaxima.cpp:4007
 msgid "Change variable"
 msgstr "Замінити змінну"
 
-#: ../src/wxMaximaFrame.cpp:783
+#: ../src/wxMaximaFrame.cpp:782
 msgid "Change variable in integral or sum"
 msgstr "Замінити змінну в інтегралі або сумі"
 
-#: ../src/wxMaxima.cpp:3751
+#: ../src/wxMaxima.cpp:3763
 msgid "Char poly"
 msgstr "Характеристичний поліном"
 
-#: ../src/wxMaximaFrame.cpp:978
+#: ../src/wxMaximaFrame.cpp:977
 msgid "Check for Updates"
 msgstr "Перевірити наявність оновлень"
 
-#: ../src/wxMaximaFrame.cpp:979
+#: ../src/wxMaximaFrame.cpp:978
 msgid "Check if a newer version of wxMaxima/Maxima exist."
 msgstr "Перевірити, чи не випущено новішу версію wxMaxima/Maxima."
 
-#: ../src/wxMaximaFrame.cpp:1385
+#: ../src/wxMaximaFrame.cpp:1384
 msgid "Chi"
 msgstr "Χ"
 
@@ -946,15 +946,15 @@ msgstr "Вибрати шрифт"
 msgid "Choose new plot format:"
 msgstr "Вкажіть новий формат графіків:"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710
 msgid "Classes:"
 msgstr "Класи:"
 
-#: ../src/wxMaximaFrame.cpp:469
+#: ../src/wxMaximaFrame.cpp:468
 msgid "Close\tCtrl-W"
 msgstr "Закрити\tCtrl-W"
 
-#: ../src/wxMaximaFrame.cpp:470
+#: ../src/wxMaximaFrame.cpp:469
 msgid "Close window"
 msgstr "Закрити вікно"
 
@@ -986,19 +986,19 @@ msgstr "Підсвічування коду: рядки"
 msgid "Code highlighting: Variables"
 msgstr "Підсвічування коду: змінні"
 
-#: ../src/wxMaxima.cpp:4806
+#: ../src/wxMaxima.cpp:4818
 msgid "Col. names:"
 msgstr "Назви стовпців:"
 
-#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Columns:"
 msgstr "Стовпців:"
 
-#: ../src/wxMaximaFrame.cpp:860
+#: ../src/wxMaximaFrame.cpp:859
 msgid "Combine factorials in an expression"
 msgstr "Об’єднати факторіали у один вираз"
 
-#: ../src/wxMaxima.cpp:5293
+#: ../src/wxMaxima.cpp:5305
 msgid "Comma directly followed by a closing parenthesis"
 msgstr "За комою одразу вказано завершальну дужку"
 
@@ -1010,23 +1010,23 @@ msgstr "Список координат за віссю x, відокремле�
 msgid "Comma separated y coordinates"
 msgstr "Список координат за віссю y, відокремлених комами"
 
-#: ../src/MathCtrl.cpp:1030
+#: ../src/MathCtrl.cpp:1072
 msgid "Comment Selection"
 msgstr "Закоментувати позначене"
 
-#: ../src/wxMaximaFrame.cpp:533
+#: ../src/wxMaximaFrame.cpp:532
 msgid "Comment out the currently selected text"
 msgstr "Закоментувати поточний позначений фрагмент тексту"
 
-#: ../src/wxMaximaFrame.cpp:532
+#: ../src/wxMaximaFrame.cpp:531
 msgid "Comment selection\tCtrl-/"
 msgstr "Закоментувати позначене\tCtrl-/"
 
-#: ../src/wxMaximaFrame.cpp:601
+#: ../src/wxMaximaFrame.cpp:600
 msgid "Complete Word\tCtrl-K"
 msgstr "Завершити слово\tCtrl-K"
 
-#: ../src/wxMaximaFrame.cpp:602
+#: ../src/wxMaximaFrame.cpp:601
 msgid "Complete word"
 msgstr "Завершити слово"
 
@@ -1034,37 +1034,37 @@ msgstr "Завершити слово"
 msgid "Completely stop maxima and restart it"
 msgstr "Повністю зупинити і перезапустити maxima"
 
-#: ../src/wxMaximaFrame.cpp:823
+#: ../src/wxMaximaFrame.cpp:822
 msgid "Compute continued fraction of a value"
 msgstr "Обчислити значення неперервного дробу"
 
-#: ../src/wxMaximaFrame.cpp:761
+#: ../src/wxMaximaFrame.cpp:760
 msgid "Compute the adjoint matrix"
 msgstr "Обчислити спряжену матрицю"
 
-#: ../src/wxMaximaFrame.cpp:750
+#: ../src/wxMaximaFrame.cpp:749
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr "Обчислити характеристичний поліном матриці"
 
-#: ../src/wxMaximaFrame.cpp:753
+#: ../src/wxMaximaFrame.cpp:752
 msgid "Compute the determinant of a matrix"
 msgstr "Обчислити визначник матриці"
 
-#: ../src/wxMaximaFrame.cpp:810
+#: ../src/wxMaximaFrame.cpp:809
 msgid "Compute the greatest common divisor"
 msgstr "Обчислити найбільший спільний дільник"
 
-#: ../src/wxMaximaFrame.cpp:747
+#: ../src/wxMaximaFrame.cpp:746
 msgid "Compute the inverse of a matrix"
 msgstr "Обчислити обернену матрицю"
 
-#: ../src/wxMaximaFrame.cpp:813
+#: ../src/wxMaximaFrame.cpp:812
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
 "Обчислити найменше спільне кратне (віддайте команду load(functs) перед "
 "використанням)"
 
-#: ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4868
 msgid "Condition:"
 msgstr "Умова:"
 
@@ -1076,8 +1076,8 @@ msgstr "Файл налаштувань (*.ini)|*.ini"
 msgid "Configuration warning"
 msgstr "Попередження щодо налаштувань"
 
-#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:538
-#: ../src/wxMaximaFrame.cpp:541
+#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:540
 msgid "Configure wxMaxima"
 msgstr "Налаштувати wxMaxima"
 
@@ -1086,121 +1086,123 @@ msgstr "Налаштувати wxMaxima"
 msgid "Constant"
 msgstr "Стала"
 
-#: ../src/wxMaximaFrame.cpp:844
+#: ../src/wxMaximaFrame.cpp:843
 msgid "Contract Logarithms"
 msgstr "Об’єднати логарифми"
 
-#: ../src/wxMaximaFrame.cpp:851
+#: ../src/wxMaximaFrame.cpp:850
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr ""
 "Перетворити біноміальні коефіцієнти, бета- і гамма-функції у факторіали"
 
-#: ../src/wxMaximaFrame.cpp:854
+#: ../src/wxMaximaFrame.cpp:853
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr ""
 "Перетворити біноміальні коефіцієнти, факторіали й бета-функції у гама-функції"
 
-#: ../src/wxMaximaFrame.cpp:888
+#: ../src/wxMaximaFrame.cpp:887
 msgid "Convert complex expression to polar form"
 msgstr "Перетворити комплексний вираз у тригонометричну форму"
 
-#: ../src/wxMaximaFrame.cpp:885
+#: ../src/wxMaximaFrame.cpp:884
 msgid "Convert complex expression to rect form"
 msgstr "Перетворювати комплексний вираз у алгебраїчну форму"
 
-#: ../src/wxMaximaFrame.cpp:897
+#: ../src/wxMaximaFrame.cpp:896
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
 "Перетворити експоненційну функцію уявного аргументу у тригонометричну форму"
 
-#: ../src/wxMaximaFrame.cpp:842
+#: ../src/wxMaximaFrame.cpp:841
 msgid "Convert logarithm of product to sum of logarithms"
 msgstr "Перетворити логарифм добутку у суму логарифмів"
 
-#: ../src/wxMaximaFrame.cpp:845
+#: ../src/wxMaximaFrame.cpp:844
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "Перетворити суму логарифмів у логарифм добутку"
 
-#: ../src/wxMaximaFrame.cpp:850
+#: ../src/wxMaximaFrame.cpp:849
 msgid "Convert to &Factorials"
 msgstr "Перетворити у &факторіали"
 
-#: ../src/wxMaximaFrame.cpp:853
+#: ../src/wxMaximaFrame.cpp:852
 msgid "Convert to &Gamma"
 msgstr "Перетворити у &гамма-функцію"
 
-#: ../src/wxMaximaFrame.cpp:887
+#: ../src/wxMaximaFrame.cpp:886
 msgid "Convert to &Polarform"
 msgstr "Перетворювати у тригонометричну форму"
 
-#: ../src/wxMaximaFrame.cpp:884
+#: ../src/wxMaximaFrame.cpp:883
 msgid "Convert to &Rectform"
 msgstr "Перетворювати у &алгебраїчну форму"
 
-#: ../src/wxMaximaFrame.cpp:877
+#: ../src/wxMaximaFrame.cpp:876
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr "Перетворити тригонометричний вираз в канонічну квазілінійну форму"
 
-#: ../src/wxMaximaFrame.cpp:900
+#: ../src/wxMaximaFrame.cpp:899
 msgid "Convert trigonometric functions to exponential form"
 msgstr "Перетворювати тригонометричні функції у експоненційну форму"
 
-#: ../src/ToolBar.cpp:140 ../src/MathCtrl.cpp:918 ../src/MathCtrl.cpp:931
-#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1024
+#: ../src/MathCtrl.cpp:960 ../src/MathCtrl.cpp:973 ../src/MathCtrl.cpp:1019
+#: ../src/MathCtrl.cpp:1066 ../src/ToolBar.cpp:140
 msgid "Copy"
 msgstr "Копіювати"
 
-#: ../src/wxMaximaFrame.cpp:597
+#: ../src/wxMaximaFrame.cpp:596
 msgid "Copy Previous Input\tCtrl-I"
 msgstr "Копіювати попередню введену команду\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:599
+#: ../src/wxMaximaFrame.cpp:598
 msgid "Copy Previous Output\tCtrl-U"
 msgstr "Копіювати попередній результат\tCtrl-U"
 
-#: ../src/wxMaximaFrame.cpp:514 ../src/MathCtrl.cpp:936 ../src/MathCtrl.cpp:982
+#: ../src/MathCtrl.cpp:978 ../src/MathCtrl.cpp:1024
+#: ../src/wxMaximaFrame.cpp:513
 msgid "Copy as Image"
 msgstr "Копіювати як зображення"
 
-#: ../src/wxMaximaFrame.cpp:507 ../src/MathCtrl.cpp:932 ../src/MathCtrl.cpp:978
+#: ../src/MathCtrl.cpp:974 ../src/MathCtrl.cpp:1020
+#: ../src/wxMaximaFrame.cpp:506
 msgid "Copy as LaTeX"
 msgstr "Копіювати як LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:510
+#: ../src/wxMaximaFrame.cpp:509
 msgid "Copy as MathML"
 msgstr "Копіювати як MathML"
 
-#: ../src/MathCtrl.cpp:935 ../src/MathCtrl.cpp:980
+#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1022
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr "Копіювати як MathML (наприклад для текстових процесорів)"
 
-#: ../src/wxMaximaFrame.cpp:504
+#: ../src/wxMaximaFrame.cpp:503
 msgid "Copy as Text\tCtrl-Shift-C"
 msgstr "Копіювати як текст\tCtrl-Shift-C"
 
-#: ../src/MathCtrl.cpp:933 ../src/MathCtrl.cpp:979
+#: ../src/MathCtrl.cpp:975 ../src/MathCtrl.cpp:1021
 #, fuzzy
 msgid "Copy as plain text"
 msgstr "Копіювати як зображення"
 
-#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:503
+#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:502
 msgid "Copy selection"
 msgstr "Копіювати позначене"
 
-#: ../src/wxMaximaFrame.cpp:515
+#: ../src/wxMaximaFrame.cpp:514
 msgid "Copy selection from document as an image"
 msgstr "Копіювати позначений фрагмент документа як зображення"
 
-#: ../src/wxMaximaFrame.cpp:505
+#: ../src/wxMaximaFrame.cpp:504
 msgid "Copy selection from document as text"
 msgstr "Копіювати позначений фрагмент документа як текст"
 
-#: ../src/wxMaximaFrame.cpp:508
+#: ../src/wxMaximaFrame.cpp:507
 msgid "Copy selection from document in LaTeX format"
 msgstr "Копіювати позначений фрагмент документа у форматі LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:511
+#: ../src/wxMaximaFrame.cpp:510
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
@@ -1208,11 +1210,11 @@ msgstr ""
 "Скопіювати позначений фрагмент з документа у форматі MathML, який "
 "використовується для показу рівнянь у багатьох текстових процесорах"
 
-#: ../src/wxMaximaFrame.cpp:598
+#: ../src/wxMaximaFrame.cpp:597
 msgid "Create a new cell with previous input"
 msgstr "Створити нову комірку з попередньою введеною командою"
 
-#: ../src/wxMaximaFrame.cpp:600
+#: ../src/wxMaximaFrame.cpp:599
 msgid "Create a new cell with previous output"
 msgstr "Створити нову комірку з попереднім результатом обчислень"
 
@@ -1220,15 +1222,15 @@ msgstr "Створити нову комірку з попереднім рез�
 msgid "Cursor"
 msgstr "Курсор"
 
-#: ../src/ToolBar.cpp:137 ../src/MathCtrl.cpp:1023
+#: ../src/MathCtrl.cpp:1065 ../src/ToolBar.cpp:137
 msgid "Cut"
 msgstr "Вирізати"
 
-#: ../src/wxMaximaFrame.cpp:499
+#: ../src/wxMaximaFrame.cpp:498
 msgid "Cut\tCtrl-X"
 msgstr "Вирізати\tCtrl+X"
 
-#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:500
+#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:499
 msgid "Cut selection"
 msgstr "Вирізати позначене"
 
@@ -1240,18 +1242,18 @@ msgstr "чеська"
 msgid "Danish"
 msgstr "данська"
 
-#: ../src/wxMaxima.cpp:4799 ../src/wxMaxima.cpp:4806 ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4811 ../src/wxMaxima.cpp:4818 ../src/wxMaxima.cpp:4868
 msgid "Data Matrix:"
 msgstr "Матриця даних:"
 
-#: ../src/wxMaxima.cpp:4826
+#: ../src/wxMaxima.cpp:4838
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr "Файл даних (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698 ../src/wxMaxima.cpp:4712
-#: ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726 ../src/wxMaxima.cpp:4734
-#: ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748 ../src/wxMaxima.cpp:4755
-#: ../src/wxMaxima.cpp:4791
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710 ../src/wxMaxima.cpp:4724
+#: ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738 ../src/wxMaxima.cpp:4746
+#: ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760 ../src/wxMaxima.cpp:4767
+#: ../src/wxMaxima.cpp:4803
 msgid "Data:"
 msgstr "Дані:"
 
@@ -1259,7 +1261,7 @@ msgstr "Дані:"
 msgid "Debug: watch maxima's stdout stream"
 msgstr "Діагностика: спостерігати за потоком stdout maxima"
 
-#: ../src/wxMaximaFrame.cpp:820
+#: ../src/wxMaximaFrame.cpp:819
 msgid "Decompose rational function to partial fractions"
 msgstr "Розкласти раціональну функцію на прості дроби"
 
@@ -1290,47 +1292,47 @@ msgid ""
 msgstr ""
 "Визначити типову швидкість (у кадрах за секунду) для відтворення анімацій."
 
-#: ../src/wxMaxima.cpp:3403 ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3415 ../src/wxMaxima.cpp:3424
 msgid "Delete"
 msgstr "Вилучити"
 
-#: ../src/wxMaximaFrame.cpp:667
+#: ../src/wxMaximaFrame.cpp:666
 msgid "Delete F&unction..."
 msgstr "Вилучити ф&ункцію…"
 
-#: ../src/MathCtrl.cpp:939 ../src/MathCtrl.cpp:985
+#: ../src/MathCtrl.cpp:981 ../src/MathCtrl.cpp:1027
 msgid "Delete Selection"
 msgstr "Вилучити позначене"
 
-#: ../src/wxMaximaFrame.cpp:669
+#: ../src/wxMaximaFrame.cpp:668
 msgid "Delete V&ariable..."
 msgstr "Вилучити змі&нну…"
 
-#: ../src/wxMaximaFrame.cpp:668
+#: ../src/wxMaximaFrame.cpp:667
 msgid "Delete a function"
 msgstr "Вилучити функцію"
 
-#: ../src/wxMaximaFrame.cpp:670
+#: ../src/wxMaximaFrame.cpp:669
 msgid "Delete a variable"
 msgstr "Вилучити змінну"
 
-#: ../src/wxMaximaFrame.cpp:655
+#: ../src/wxMaximaFrame.cpp:654
 msgid "Delete all values from memory"
 msgstr "Вилучити з пам’яті всі значення"
 
-#: ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3424
 msgid "Delete function(s):"
 msgstr "Вилучити функції:"
 
-#: ../src/wxMaxima.cpp:3403
+#: ../src/wxMaxima.cpp:3415
 msgid "Delete variable(s):"
 msgstr "Вилучити змінні:"
 
-#: ../src/wxMaximaFrame.cpp:1367
+#: ../src/wxMaximaFrame.cpp:1366
 msgid "Delta"
 msgstr "Δ"
 
-#: ../src/wxMaxima.cpp:4011
+#: ../src/wxMaxima.cpp:4023
 msgid "Denom. deg:"
 msgstr "Степінь знаменника:"
 
@@ -1338,35 +1340,35 @@ msgstr "Степінь знаменника:"
 msgid "Depth:"
 msgstr "Глибина:"
 
-#: ../src/wxMaxima.cpp:3541
+#: ../src/wxMaxima.cpp:3553
 msgid "Derivative:"
 msgstr "Похідна:"
 
-#: ../src/wxMaximaFrame.cpp:1258
+#: ../src/wxMaximaFrame.cpp:1257
 msgid "Deviation..."
 msgstr "Відхилення…"
 
-#: ../src/wxMaximaFrame.cpp:816
+#: ../src/wxMaximaFrame.cpp:815
 msgid "Di&vide Polynomials..."
 msgstr "&Ділення поліномів…"
 
-#: ../src/wxMaximaFrame.cpp:1223
+#: ../src/wxMaximaFrame.cpp:1222
 msgid "Diff..."
 msgstr "Диференціювати…"
 
-#: ../src/wxMaxima.cpp:4154 ../src/wxMaxima.cpp:5066
+#: ../src/wxMaxima.cpp:4166 ../src/wxMaxima.cpp:5078
 msgid "Differentiate"
 msgstr "Продиференціювати"
 
-#: ../src/wxMaximaFrame.cpp:786
+#: ../src/wxMaximaFrame.cpp:785
 msgid "Differentiate expression"
 msgstr "Продиференціювати вираз"
 
-#: ../src/MathCtrl.cpp:1001
+#: ../src/MathCtrl.cpp:1043
 msgid "Differentiate..."
 msgstr "Продиференціювати…"
 
-#: ../src/LimitWiz.cpp:37 ../src/FindReplacePane.cpp:76
+#: ../src/FindReplacePane.cpp:76 ../src/LimitWiz.cpp:37
 msgid "Direction:"
 msgstr "Напрямок:"
 
@@ -1374,48 +1376,49 @@ msgstr "Напрямок:"
 msgid "Discrete plot"
 msgstr "Графік дискретної функції"
 
-#: ../src/wxMaximaFrame.cpp:679
+#: ../src/wxMaximaFrame.cpp:678
 msgid "Display Te&X Form"
 msgstr "В&ивести у форматі TeX"
 
-#: ../src/wxMaxima.cpp:3320
+#: ../src/wxMaxima.cpp:3332
 msgid "Display algorithm"
 msgstr "Спосіб виведення"
 
-#: ../src/wxMaximaFrame.cpp:680
+#: ../src/wxMaximaFrame.cpp:679
 msgid "Display last result in TeX form"
 msgstr "Показати останній результат у форматі TeX"
 
-#: ../src/wxMaximaFrame.cpp:674
+#: ../src/wxMaximaFrame.cpp:673
 msgid "Display time used for evaluation"
 msgstr "Показати час, витрачений на обчислення"
 
-#: ../src/wxMaxima.cpp:4061
+#: ../src/wxMaxima.cpp:4073
 msgid "Divide"
 msgstr "Ділити"
 
-#: ../src/MathCtrl.cpp:1032
+#: ../src/MathCtrl.cpp:1074
 msgid "Divide Cell"
 msgstr "Ділити комірку"
 
-#: ../src/wxMaximaFrame.cpp:635
+#: ../src/wxMaximaFrame.cpp:634
 #, fuzzy
 msgid "Divide Cell\tCtrl-D"
 msgstr "Ділити комірку"
 
-#: ../src/wxMaximaFrame.cpp:817
+#: ../src/wxMaximaFrame.cpp:816
 msgid "Divide numbers or polynomials"
 msgstr "Ділити числа або поліноми"
 
-#: ../src/wxMaximaFrame.cpp:636
+#: ../src/wxMaximaFrame.cpp:635
 msgid "Divide this input cell into two cells"
 msgstr "Поділити цю комірку введення на дві комірки"
 
-#: ../src/wxMaxima.cpp:5917
-msgid "Do you want to save the changes you made in the document \""
+#: ../src/wxMaxima.cpp:5932
+#, fuzzy, c-format
+msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr "Хочете зберегти зміни, які було внесено до документа «"
 
-#: ../src/wxMaxima.cpp:1664 ../src/wxMaxima.cpp:1672
+#: ../src/wxMaxima.cpp:1669 ../src/wxMaxima.cpp:1677
 msgid "Document "
 msgstr "Документ "
 
@@ -1437,7 +1440,7 @@ msgstr ""
 "системам керування версіями, зокрема git та svn, ефективно визначати "
 "відмінності між версіями."
 
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Don't save"
 msgstr "Не зберігати"
 
@@ -1445,27 +1448,27 @@ msgstr "Не зберігати"
 msgid "Down"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:734
+#: ../src/wxMaximaFrame.cpp:733
 msgid "E&quations"
 msgstr "&Рівняння"
 
-#: ../src/wxMaximaFrame.cpp:487
+#: ../src/wxMaximaFrame.cpp:486
 msgid "E&xit\tCtrl-Q"
 msgstr "Ви&йти\tCtrl-Q"
 
-#: ../src/wxMaximaFrame.cpp:757
+#: ../src/wxMaximaFrame.cpp:756
 msgid "Eige&nvectors"
 msgstr "В&ласні вектори"
 
-#: ../src/wxMaximaFrame.cpp:755
+#: ../src/wxMaximaFrame.cpp:754
 msgid "Eigen&values"
 msgstr "Вл&асні значення"
 
-#: ../src/wxMaxima.cpp:3572
+#: ../src/wxMaxima.cpp:3584
 msgid "Eliminate"
 msgstr "Виключити"
 
-#: ../src/wxMaximaFrame.cpp:710
+#: ../src/wxMaximaFrame.cpp:709
 msgid "Eliminate a variable from a system of equations"
 msgstr "Виключити змінну із системи рівнянь"
 
@@ -1477,21 +1480,21 @@ msgstr "Кінець доведення"
 msgid "English"
 msgstr "англійська"
 
-#: ../src/wxMaxima.cpp:4712 ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726
-#: ../src/wxMaxima.cpp:4734 ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748
-#: ../src/wxMaxima.cpp:4755 ../src/wxMaxima.cpp:4791 ../src/wxMaxima.cpp:4799
+#: ../src/wxMaxima.cpp:4724 ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738
+#: ../src/wxMaxima.cpp:4746 ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760
+#: ../src/wxMaxima.cpp:4767 ../src/wxMaxima.cpp:4803 ../src/wxMaxima.cpp:4811
 msgid "Enter Data"
 msgstr "Введіть дані"
 
-#: ../src/wxMaximaFrame.cpp:1279
+#: ../src/wxMaximaFrame.cpp:1278
 msgid "Enter Matrix..."
 msgstr "Ввести матрицю…"
 
-#: ../src/wxMaximaFrame.cpp:745
+#: ../src/wxMaximaFrame.cpp:744
 msgid "Enter a matrix"
 msgstr "Введення матриці"
 
-#: ../src/wxMaxima.cpp:3962
+#: ../src/wxMaxima.cpp:3974
 msgid "Enter an equation for rational simplification:"
 msgstr "Введіть рівняння для раціонального спрощення:"
 
@@ -1503,11 +1506,11 @@ msgstr "Введіть список змінних, відокремлених �
 msgid "Enter evaluates cells"
 msgstr "Enter для обчислення у комірках"
 
-#: ../src/wxMaxima.cpp:3734
+#: ../src/wxMaxima.cpp:3746
 msgid "Enter matrix"
 msgstr "Введіть матрицю"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Enter new precision for bigfloats:"
 msgstr "Вкажіть нову підвищену точність:"
 
@@ -1515,11 +1518,11 @@ msgstr "Вкажіть нову підвищену точність:"
 msgid "Enter the path to the Maxima executable."
 msgstr "Вкажіть шлях до виконуваного файла Maxima."
 
-#: ../src/wxMaximaFrame.cpp:1368
+#: ../src/wxMaximaFrame.cpp:1367
 msgid "Epsilon"
 msgstr "Ε"
 
-#: ../src/wxMaxima.cpp:4208
+#: ../src/wxMaxima.cpp:4220
 msgid "Epsilon:"
 msgstr "ε:"
 
@@ -1528,13 +1531,13 @@ msgstr "ε:"
 msgid "Equation %d:"
 msgstr "Рівняння %d:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:3633
-#: ../src/wxMaxima.cpp:5019
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:3645
+#: ../src/wxMaxima.cpp:5031
 msgid "Equation(s):"
 msgstr "Рівняння:"
 
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3993
-#: ../src/wxMaxima.cpp:4807 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:4005
+#: ../src/wxMaxima.cpp:4819 ../src/wxMaxima.cpp:5045
 msgid "Equation:"
 msgstr "Рівняння:"
 
@@ -1545,76 +1548,76 @@ msgid ""
 "be introduced one into another. Also they are always printed out as 2D maths."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3570
+#: ../src/wxMaxima.cpp:3582
 msgid "Equations:"
 msgstr "Рівняння:"
 
-#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1455
-#: ../src/wxMaxima.cpp:1469 ../src/wxMaxima.cpp:1620 ../src/wxMaxima.cpp:1633
-#: ../src/wxMaxima.cpp:1643 ../src/wxMaxima.cpp:1666 ../src/wxMaxima.cpp:2034
-#: ../src/wxMaxima.cpp:2206 ../src/wxMaxima.cpp:5381 ../src/wxMaxima.cpp:5830
-#: ../src/wxMaxima.cpp:5881
+#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1460
+#: ../src/wxMaxima.cpp:1474 ../src/wxMaxima.cpp:1625 ../src/wxMaxima.cpp:1638
+#: ../src/wxMaxima.cpp:1648 ../src/wxMaxima.cpp:1671 ../src/wxMaxima.cpp:2039
+#: ../src/wxMaxima.cpp:2211 ../src/wxMaxima.cpp:5397 ../src/wxMaxima.cpp:5845
+#: ../src/wxMaxima.cpp:5896
 msgid "Error"
 msgstr "Помилка"
 
-#: ../src/wxMaxima.cpp:2886 ../src/wxMaxima.cpp:2900 ../src/wxMaxima.cpp:2913
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617 ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:2894 ../src/wxMaxima.cpp:2908 ../src/wxMaxima.cpp:2921
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629 ../src/wxMaxima.cpp:3740
 msgid "Error!"
 msgstr "Помилка!"
 
-#: ../src/wxMaximaFrame.cpp:1370
+#: ../src/wxMaximaFrame.cpp:1369
 msgid "Eta"
 msgstr "Η"
 
-#: ../src/wxMaximaFrame.cpp:909
+#: ../src/wxMaximaFrame.cpp:908
 msgid "Evaluate &Noun Forms"
 msgstr "Обчислити нео&бчислювані (noun) форми"
 
-#: ../src/wxMaximaFrame.cpp:589
+#: ../src/wxMaximaFrame.cpp:588
 msgid "Evaluate All Cells\tCtrl-Shift-R"
 msgstr "Обчислити усі комірки\tCtrl-Shift-R"
 
-#: ../src/wxMaximaFrame.cpp:587
+#: ../src/wxMaximaFrame.cpp:586
 msgid "Evaluate All Visible Cells\tCtrl-R"
 msgstr "Обчислити усі видимі комірки\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:585 ../src/MathCtrl.cpp:942
+#: ../src/MathCtrl.cpp:984 ../src/wxMaximaFrame.cpp:584
 msgid "Evaluate Cell(s)"
 msgstr "Обчислити комірки"
 
-#: ../src/wxMaximaFrame.cpp:591
+#: ../src/wxMaximaFrame.cpp:590
 msgid "Evaluate Cells Above\tCtrl-Shift-P"
 msgstr "Обчислити комірку вище\tCtrl-Shift-P"
 
-#: ../src/MathCtrl.cpp:956 ../src/MathCtrl.cpp:1051
+#: ../src/MathCtrl.cpp:998 ../src/MathCtrl.cpp:1093
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr "Обчислити частину\tShift+Ctrl+Enter"
 
-#: ../src/MathCtrl.cpp:961 ../src/MathCtrl.cpp:1053
+#: ../src/MathCtrl.cpp:1003 ../src/MathCtrl.cpp:1095
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr "Обчислити розділ\tShift+Ctrl+Enter"
 
-#: ../src/MathCtrl.cpp:971 ../src/MathCtrl.cpp:1057
+#: ../src/MathCtrl.cpp:1013 ../src/MathCtrl.cpp:1099
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr "Обчислити підпідрозділ\tShift+Ctrl+Enter"
 
-#: ../src/MathCtrl.cpp:966 ../src/MathCtrl.cpp:1055
+#: ../src/MathCtrl.cpp:1008 ../src/MathCtrl.cpp:1097
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr "Обчислити підрозділ\tShift+Ctrl+Enter"
 
-#: ../src/wxMaximaFrame.cpp:586
+#: ../src/wxMaximaFrame.cpp:585
 msgid "Evaluate active or selected cell(s)"
 msgstr "Виконати обчислення у активних або позначених комірках"
 
-#: ../src/wxMaximaFrame.cpp:590
+#: ../src/wxMaximaFrame.cpp:589
 msgid "Evaluate all cells in the document"
 msgstr "Виконати обчислення у всіх комірках документа"
 
-#: ../src/wxMaximaFrame.cpp:910
+#: ../src/wxMaximaFrame.cpp:909
 msgid "Evaluate all noun forms in expression"
 msgstr "Обчислити всі необчислювані (noun) форми у виразі"
 
-#: ../src/wxMaximaFrame.cpp:588
+#: ../src/wxMaximaFrame.cpp:587
 msgid "Evaluate all visible cells in the document"
 msgstr "Виконати обчислення у всіх видимих комірках документа"
 
@@ -1626,7 +1629,7 @@ msgstr "Виконати у файлі обчислення від початк�
 msgid "Evaluate to point"
 msgstr "Обчислити до пункту"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Example"
 msgstr "Приклад"
 
@@ -1638,31 +1641,31 @@ msgstr "Текст прикладу"
 msgid "Examples:"
 msgstr "Приклади:"
 
-#: ../src/wxMaximaFrame.cpp:488
+#: ../src/wxMaximaFrame.cpp:487
 msgid "Exit wxMaxima"
 msgstr "Вийти з wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:1214
+#: ../src/wxMaximaFrame.cpp:1213
 msgid "Expand"
 msgstr "Розкрити"
 
-#: ../src/wxMaximaFrame.cpp:1219
+#: ../src/wxMaximaFrame.cpp:1218
 msgid "Expand (tr)"
 msgstr "Розкрити (триг)"
 
-#: ../src/MathCtrl.cpp:997
+#: ../src/MathCtrl.cpp:1039
 msgid "Expand Expression"
 msgstr "Розкрити вираз"
 
-#: ../src/wxMaximaFrame.cpp:841
+#: ../src/wxMaximaFrame.cpp:840
 msgid "Expand Logarithms"
 msgstr "Розкрити логарифми"
 
-#: ../src/wxMaximaFrame.cpp:840
+#: ../src/wxMaximaFrame.cpp:839
 msgid "Expand an expression"
 msgstr "Розкрити вираз"
 
-#: ../src/wxMaximaFrame.cpp:874
+#: ../src/wxMaximaFrame.cpp:873
 msgid "Expand trigonometric expression"
 msgstr "Розкрити тригонометричний вираз"
 
@@ -1670,7 +1673,7 @@ msgstr "Розкрити тригонометричний вираз"
 msgid "Expected the icon files to be found at"
 msgstr "Очікувалося, що файли піктограм можна знайти у"
 
-#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2834
+#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2842
 msgid "Export"
 msgstr "Експортувати"
 
@@ -1681,31 +1684,31 @@ msgstr ""
 "Експортувати анімації до TeX (анімація зображень відбуватиметься, лише якщо "
 "у засобі перегляду її реалізовано)"
 
-#: ../src/wxMaximaFrame.cpp:481
+#: ../src/wxMaximaFrame.cpp:480
 msgid "Export document to a HTML or pdfLaTeX file"
 msgstr "Експортувати документ до файла HTML або pdfLaTeX"
 
-#: ../src/wxMaximaFrame.cpp:253
+#: ../src/wxMaximaFrame.cpp:252
 msgid "Export failed."
 msgstr "Помилка під час експортування."
 
-#: ../src/wxMaximaFrame.cpp:239
+#: ../src/wxMaximaFrame.cpp:238
 msgid "Export successful."
 msgstr "Успішно експортовано."
 
-#: ../src/wxMaxima.cpp:2913
+#: ../src/wxMaxima.cpp:2921
 msgid "Exporting to HTML failed!"
 msgstr "Спроба експортування даних до HTML завершилася невдало!"
 
-#: ../src/wxMaxima.cpp:2886
+#: ../src/wxMaxima.cpp:2894
 msgid "Exporting to TeX failed!"
 msgstr "Спроба експортування даних до TeX завершилася невдало!"
 
-#: ../src/wxMaxima.cpp:2900
+#: ../src/wxMaxima.cpp:2908
 msgid "Exporting to maxima batch file failed!"
 msgstr "Не вдалося експортувати до файла пакетної обробки maxima!"
 
-#: ../src/wxMaximaFrame.cpp:229
+#: ../src/wxMaximaFrame.cpp:228
 msgid "Exporting..."
 msgstr "Експортування…"
 
@@ -1718,42 +1721,42 @@ msgid "Expression(s):"
 msgstr "Вираз(и):"
 
 #: ../src/IntegrateWiz.cpp:30 ../src/LimitWiz.cpp:27 ../src/SeriesWiz.cpp:33
-#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3648
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:4205 ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5064
+#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3660
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:4217 ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5076
 msgid "Expression:"
 msgstr "Вираз:"
 
-#: ../src/wxMaximaFrame.cpp:1213
+#: ../src/wxMaximaFrame.cpp:1212
 msgid "Factor"
 msgstr "Розкласти на множники"
 
-#: ../src/wxMaximaFrame.cpp:836
+#: ../src/wxMaximaFrame.cpp:835
 msgid "Factor Complex"
 msgstr "Розкласти на комплексні множники"
 
-#: ../src/MathCtrl.cpp:996
+#: ../src/MathCtrl.cpp:1038
 msgid "Factor Expression"
 msgstr "Розкласти на множники вираз"
 
-#: ../src/wxMaximaFrame.cpp:835
+#: ../src/wxMaximaFrame.cpp:834
 msgid "Factor an expression"
 msgstr "Розкласти вираз на множники"
 
-#: ../src/wxMaximaFrame.cpp:837
+#: ../src/wxMaximaFrame.cpp:836
 msgid "Factor an expression in Gaussian numbers"
 msgstr "Розкласти на елементарні гаусові множники"
 
-#: ../src/wxMaximaFrame.cpp:862
+#: ../src/wxMaximaFrame.cpp:861
 msgid "Factorials and &Gamma"
 msgstr "Факторіали і &гамма-функція"
 
-#: ../src/wxMaxima.cpp:285
+#: ../src/wxMaxima.cpp:286
 msgid "Fatal error"
 msgstr "Критична помилка"
 
-#: ../src/GroupCell.cpp:1571
+#: ../src/GroupCell.cpp:1572
 #, c-format
 msgid "Figure %d:"
 msgstr "Рисунок %d:"
@@ -1762,20 +1765,20 @@ msgstr "Рисунок %d:"
 msgid "File"
 msgstr "Файл"
 
-#: ../src/wxMaxima.cpp:1457 ../src/wxMaxima.cpp:1623 ../src/wxMaxima.cpp:1636
-#: ../src/wxMaxima.cpp:1646 ../src/wxMaxima.cpp:1668
+#: ../src/wxMaxima.cpp:1462 ../src/wxMaxima.cpp:1628 ../src/wxMaxima.cpp:1641
+#: ../src/wxMaxima.cpp:1651 ../src/wxMaxima.cpp:1673
 msgid "File could not be opened"
 msgstr "Не вдалося відкрити файл"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File not found"
 msgstr "Файл не знайдено"
 
-#: ../src/wxMaxima.cpp:1511 ../src/wxMaxima.cpp:1729
+#: ../src/wxMaxima.cpp:1516 ../src/wxMaxima.cpp:1734
 msgid "File opened"
 msgstr "Файл відкрито"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File you tried to open does not exist."
 msgstr "Файла, який ви намагалися відкрити, не існує."
 
@@ -1787,67 +1790,67 @@ msgstr "Файл:"
 msgid "Find"
 msgstr "Знайти"
 
-#: ../src/wxMaximaFrame.cpp:523
+#: ../src/wxMaximaFrame.cpp:522
 msgid "Find\tCtrl-F"
 msgstr "Знайти\tCtrl+F"
 
-#: ../src/wxMaximaFrame.cpp:787
+#: ../src/wxMaximaFrame.cpp:786
 msgid "Find &Limit..."
 msgstr "Знайти &границю…"
 
-#: ../src/wxMaximaFrame.cpp:790
+#: ../src/wxMaximaFrame.cpp:789
 msgid "Find Minimum..."
 msgstr "Знайти мінімум…"
 
-#: ../src/MathCtrl.cpp:993
+#: ../src/MathCtrl.cpp:1035
 msgid "Find Root..."
 msgstr "Знайти корінь…"
 
-#: ../src/wxMaximaFrame.cpp:791
+#: ../src/wxMaximaFrame.cpp:790
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr "Знайти (абсолютний) мінімум виразу"
 
-#: ../src/wxMaximaFrame.cpp:788
+#: ../src/wxMaximaFrame.cpp:787
 msgid "Find a limit of an expression"
 msgstr "Знайти границю виразу"
 
-#: ../src/wxMaximaFrame.cpp:693
+#: ../src/wxMaximaFrame.cpp:692
 msgid "Find a root of an equation on an interval"
 msgstr "Знайти корінь рівняння на інтервалі"
 
-#: ../src/wxMaximaFrame.cpp:695
+#: ../src/wxMaximaFrame.cpp:694
 msgid "Find all roots of a polynomial"
 msgstr "Знайти всі корені полінома"
 
-#: ../src/wxMaximaFrame.cpp:698
+#: ../src/wxMaximaFrame.cpp:697
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr "Знайти всі корені полінома (підв. точність)"
 
-#: ../src/wxMaxima.cpp:3220
+#: ../src/wxMaxima.cpp:3215
 msgid "Find and Replace"
 msgstr "Знайти і замінити"
 
-#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:523
+#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:522
 msgid "Find and replace"
 msgstr "Знайти і замінити"
 
-#: ../src/wxMaximaFrame.cpp:756
+#: ../src/wxMaximaFrame.cpp:755
 msgid "Find eigenvalues of a matrix"
 msgstr "Знайти власні значення матриці"
 
-#: ../src/wxMaximaFrame.cpp:758
+#: ../src/wxMaximaFrame.cpp:757
 msgid "Find eigenvectors of a matrix"
 msgstr "Знайти власні вектори матриці"
 
-#: ../src/wxMaxima.cpp:4210
+#: ../src/wxMaxima.cpp:4222
 msgid "Find minimum"
 msgstr "Знайти мінімум"
 
-#: ../src/wxMaximaFrame.cpp:701
+#: ../src/wxMaximaFrame.cpp:700
 msgid "Find real roots of a polynomial"
 msgstr "Знайти дійсні корені полінома"
 
-#: ../src/wxMaxima.cpp:3493 ../src/wxMaxima.cpp:5036
+#: ../src/wxMaxima.cpp:3505 ../src/wxMaxima.cpp:5048
 msgid "Find root"
 msgstr "Знайти корінь"
 
@@ -1869,11 +1872,11 @@ msgstr "Виправити перевпорядковані індекси по�
 msgid "Fixed font in text controls"
 msgstr "Шрифт сталої ширини у текстових мітках"
 
-#: ../src/wxMaximaFrame.cpp:623
+#: ../src/wxMaximaFrame.cpp:622
 msgid "Fold All\tCtrl-Alt-["
 msgstr "Згорнути все\tCtrl-Alt-["
 
-#: ../src/wxMaximaFrame.cpp:624
+#: ../src/wxMaximaFrame.cpp:623
 msgid "Fold all sections"
 msgstr "Згорнути усі розділи"
 
@@ -1881,11 +1884,11 @@ msgstr "Згорнути усі розділи"
 msgid "Follow"
 msgstr "Перейти"
 
-#: ../src/ParenCell.cpp:319
+#: ../src/ParenCell.cpp:320
 msgid "Font issue: The Parenthesis sign is too small!"
 msgstr "Проблема зі шрифтом: знак дужки є надто малим!"
 
-#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:381
+#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:382
 msgid ""
 "Font issue: The char height is too small! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
@@ -1896,7 +1899,7 @@ msgstr ""
 "fonts.html і позначення пункту «Використовувати шрифти JSmath» у діалоговому "
 "вікні налаштовування."
 
-#: ../src/SqrtCell.cpp:199
+#: ../src/SqrtCell.cpp:202
 msgid ""
 "Font issue: The sqrt() sign has the size 0! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
@@ -1907,7 +1910,7 @@ msgstr ""
 "fonts.html і позначення пункту «Використовувати шрифти JSmath» у діалоговому "
 "вікні налаштовування."
 
-#: ../src/SqrtCell.cpp:198
+#: ../src/SqrtCell.cpp:201
 msgid "Font issue? The contents of a sqrt() has the size 0."
 msgstr "Проблеми зі шрифтом? Вміст sqrt() має розмір 0."
 
@@ -1938,15 +1941,15 @@ msgstr "французька"
 
 #: ../src/IntegrateWiz.cpp:37 ../src/Plot2dWiz.cpp:37 ../src/Plot2dWiz.cpp:47
 #: ../src/Plot2dWiz.cpp:536 ../src/Plot3dWiz.cpp:36 ../src/Plot3dWiz.cpp:45
-#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4240
+#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4252
 msgid "From:"
 msgstr "Від:"
 
-#: ../src/wxMaximaFrame.cpp:576
+#: ../src/wxMaximaFrame.cpp:575
 msgid "Full Screen\tAlt-Enter"
 msgstr "На весь екран\tAlt-Enter"
 
-#: ../src/wxMaxima.cpp:3342
+#: ../src/wxMaxima.cpp:3354
 msgid "Function"
 msgstr "Функція"
 
@@ -1954,32 +1957,32 @@ msgstr "Функція"
 msgid "Function names"
 msgstr "Назви функцій"
 
-#: ../src/wxMaxima.cpp:3633
+#: ../src/wxMaxima.cpp:3645
 msgid "Function(s):"
 msgstr "Функції:"
 
-#: ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3803
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3815
+#: ../src/wxMaxima.cpp:3848
 msgid "Function:"
 msgstr "Функція:"
 
-#: ../src/wxMaximaFrame.cpp:904
+#: ../src/wxMaximaFrame.cpp:903
 msgid "Functions for complex simplification"
 msgstr "Функції для спрощення комплексних чисел"
 
-#: ../src/wxMaximaFrame.cpp:864
+#: ../src/wxMaximaFrame.cpp:863
 msgid "Functions for simplifying factorials and gamma function"
 msgstr "Функції для спрощення факторіалів і гамма-функцій"
 
-#: ../src/wxMaximaFrame.cpp:881
+#: ../src/wxMaximaFrame.cpp:880
 msgid "Functions for simplifying trigonometric expressions"
 msgstr "Функції для спрощення тригонометричних виразів"
 
-#: ../src/wxMaxima.cpp:4046
+#: ../src/wxMaxima.cpp:4058
 msgid "GCD"
 msgstr "НСД"
 
-#: ../src/wxMaxima.cpp:5152
+#: ../src/wxMaxima.cpp:5164
 msgid "GIF image (*.gif)|*.gif"
 msgstr "зображення GIF (*.gif)|*.gif"
 
@@ -1987,31 +1990,31 @@ msgstr "зображення GIF (*.gif)|*.gif"
 msgid "Galician"
 msgstr "галісійська"
 
-#: ../src/wxMaximaFrame.cpp:1366
+#: ../src/wxMaximaFrame.cpp:1365
 msgid "Gamma"
 msgstr "Γ"
 
-#: ../src/wxMaximaFrame.cpp:391
+#: ../src/wxMaximaFrame.cpp:390
 msgid "General Math"
 msgstr "Математика"
 
-#: ../src/wxMaximaFrame.cpp:549
+#: ../src/wxMaximaFrame.cpp:548
 msgid "General Math\tAlt-Shift-M"
 msgstr "Математика\tAlt-Shift-M"
 
-#: ../src/wxMaxima.cpp:3766 ../src/wxMaxima.cpp:3785
+#: ../src/wxMaxima.cpp:3778 ../src/wxMaxima.cpp:3797
 msgid "Generate Matrix"
 msgstr "Створити матрицю"
 
-#: ../src/wxMaximaFrame.cpp:741
+#: ../src/wxMaximaFrame.cpp:740
 msgid "Generate Matrix from Expression..."
 msgstr "Створити матрицю за виразом…"
 
-#: ../src/wxMaximaFrame.cpp:739
+#: ../src/wxMaximaFrame.cpp:738
 msgid "Generate a matrix from a 2-dimensional array"
 msgstr "Створити матрицю з двовимірного масиву"
 
-#: ../src/wxMaximaFrame.cpp:742
+#: ../src/wxMaximaFrame.cpp:741
 msgid "Generate a matrix from a lambda expression"
 msgstr "Створити матрицю на основі лямбда-виразу"
 
@@ -2019,39 +2022,39 @@ msgstr "Створити матрицю на основі лямбда-вира�
 msgid "German"
 msgstr "німецька"
 
-#: ../src/wxMaximaFrame.cpp:893
+#: ../src/wxMaximaFrame.cpp:892
 msgid "Get &Imaginary Part"
 msgstr "Знайти у&явну частину"
 
-#: ../src/wxMaximaFrame.cpp:793
+#: ../src/wxMaximaFrame.cpp:792
 msgid "Get &Series..."
 msgstr "&Розкласти у ряд…"
 
-#: ../src/wxMaximaFrame.cpp:804
+#: ../src/wxMaximaFrame.cpp:803
 msgid "Get Laplace transformation of an expression"
 msgstr "Обчислити перетворення Лапласа від виразу"
 
-#: ../src/wxMaximaFrame.cpp:890
+#: ../src/wxMaximaFrame.cpp:889
 msgid "Get Real P&art"
 msgstr "Знайти &дійсну частину"
 
-#: ../src/wxMaximaFrame.cpp:807
+#: ../src/wxMaximaFrame.cpp:806
 msgid "Get inverse Laplace transformation of an expression"
 msgstr "Обчислити обернене перетворення Лапласа від виразу"
 
-#: ../src/wxMaximaFrame.cpp:794
+#: ../src/wxMaximaFrame.cpp:793
 msgid "Get the Taylor or power series of expression"
 msgstr "Знайти розклад виразу у степеневий ряд або ряд Тейлора"
 
-#: ../src/wxMaximaFrame.cpp:894
+#: ../src/wxMaximaFrame.cpp:893
 msgid "Get the imaginary part of complex expression"
 msgstr "Знайти уявну частину комплексного виразу"
 
-#: ../src/wxMaximaFrame.cpp:891
+#: ../src/wxMaximaFrame.cpp:890
 msgid "Get the real part of complex expression"
 msgstr "Знайти дійсну частину комплексного виразу"
 
-#: ../src/MathCtrl.cpp:5932
+#: ../src/MathCtrl.cpp:5984
 msgid ""
 "Got a request to undo an action that involves an delete which isn't possible "
 "at this moment."
@@ -2063,11 +2066,11 @@ msgstr ""
 msgid "Greek"
 msgstr "грецька"
 
-#: ../src/wxMaximaFrame.cpp:356
+#: ../src/wxMaximaFrame.cpp:355
 msgid "Greek Letters"
 msgstr "Грецькі літери"
 
-#: ../src/wxMaximaFrame.cpp:552
+#: ../src/wxMaximaFrame.cpp:551
 msgid "Greek Letters\tAlt-Shift-G"
 msgstr "Грецькі літери\tAlt-Shift-G"
 
@@ -2079,7 +2082,7 @@ msgstr "Грецькі сталі"
 msgid "Grid:"
 msgstr "Сітка:"
 
-#: ../src/wxMaxima.cpp:2836
+#: ../src/wxMaxima.cpp:2844
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|pdfLaTeX file (*."
 "tex)|*.tex"
@@ -2095,11 +2098,11 @@ msgstr "Комірки HTML/тексту: Експортувати усі роз
 msgid "Help"
 msgstr "Довідка"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide All Toolbars\tAlt-Shift--"
 msgstr "Приховати усі панелі інструментів\tAlt-Shift--"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide all panes"
 msgstr "Сховати усі панелі"
 
@@ -2107,19 +2110,19 @@ msgstr "Сховати усі панелі"
 msgid "Highlight (dpart)"
 msgstr "Позначити (dpart)"
 
-#: ../src/wxMaxima.cpp:4685
+#: ../src/wxMaxima.cpp:4697
 msgid "Histogram"
 msgstr "Гістограма"
 
-#: ../src/wxMaximaFrame.cpp:1270
+#: ../src/wxMaximaFrame.cpp:1269
 msgid "Histogram..."
 msgstr "Гістограма…"
 
-#: ../src/wxMaximaFrame.cpp:309
+#: ../src/wxMaximaFrame.cpp:308
 msgid "History"
 msgstr "Журнал"
 
-#: ../src/wxMaximaFrame.cpp:555
+#: ../src/wxMaximaFrame.cpp:554
 msgid "History\tAlt-Shift-I"
 msgstr "Журнал\tAlt-Shift-I"
 
@@ -2140,11 +2143,11 @@ msgstr ""
 msgid "Hungarian"
 msgstr "угорська"
 
-#: ../src/wxMaxima.cpp:3527
+#: ../src/wxMaxima.cpp:3539
 msgid "IC1"
 msgstr "НУ1"
 
-#: ../src/wxMaxima.cpp:3543
+#: ../src/wxMaxima.cpp:3555
 msgid "IC2"
 msgstr "НУ2"
 
@@ -2163,7 +2166,7 @@ msgstr ""
 "цю мітку а не мітку Maxima типу «%o», яку програма автоматично призначає для "
 "комірки виведення даних."
 
-#: ../src/wxMaximaFrame.cpp:683
+#: ../src/wxMaximaFrame.cpp:682
 msgid ""
 "If maxima ever finishes evaluating without wxMaxima realizing this this menu "
 "item can force wxMaxima to try to send commands to maxima again."
@@ -2245,11 +2248,11 @@ msgstr ""
 "допомогою пунктів меню «Maxima → Перервати» та «Maxima → Перезапустити "
 "Maxima»."
 
-#: ../src/wxMaximaFrame.cpp:1499
+#: ../src/wxMaximaFrame.cpp:1518
 msgid "Image"
 msgstr "Зображення"
 
-#: ../src/wxMaxima.cpp:5644
+#: ../src/wxMaxima.cpp:5659
 msgid "Image files (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 msgstr "файли зображень (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 
@@ -2279,7 +2282,7 @@ msgstr ""
 "індексу, а не над ним. Може зробити читання зручнішим для деяких шрифтів та "
 "коротких нижніх індексів."
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Include columns:"
 msgstr "Включити такі стовпці:"
 
@@ -2298,19 +2301,19 @@ msgstr ""
 msgid "Infinity"
 msgstr "Нескінченність"
 
-#: ../src/wxMaximaFrame.cpp:974
+#: ../src/wxMaximaFrame.cpp:973
 msgid "Info about Maxima build"
 msgstr "Дані щодо збирання Maxima"
 
-#: ../src/wxMaxima.cpp:4207
+#: ../src/wxMaxima.cpp:4219
 msgid "Initial Estimates:"
 msgstr "Початкові наближення:"
 
-#: ../src/wxMaximaFrame.cpp:718
+#: ../src/wxMaximaFrame.cpp:717
 msgid "Initial Value Problem (&1)..."
 msgstr "Задача Коші (&1)…"
 
-#: ../src/wxMaximaFrame.cpp:721
+#: ../src/wxMaximaFrame.cpp:720
 msgid "Initial Value Problem (&2)..."
 msgstr "Задача Коші (&2)…"
 
@@ -2318,7 +2321,7 @@ msgstr "Задача Коші (&2)…"
 msgid "Input labels"
 msgstr "Мітки введення"
 
-#: ../src/wxMaximaFrame.cpp:403
+#: ../src/wxMaximaFrame.cpp:402
 msgid "Insert"
 msgstr "Вставити"
 
@@ -2326,95 +2329,95 @@ msgstr "Вставити"
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr "Додавати % перед оператором на початку комірки"
 
-#: ../src/wxMaximaFrame.cpp:612
+#: ../src/wxMaximaFrame.cpp:611
 msgid "Insert &Section Cell\tCtrl-3"
 msgstr "Вставити комірку &розділу\tCtrl-3"
 
-#: ../src/wxMaximaFrame.cpp:608
+#: ../src/wxMaximaFrame.cpp:607
 msgid "Insert &Text Cell\tCtrl-1"
 msgstr "Вставити комірку &тексту\tCtrl-1"
 
-#: ../src/wxMaximaFrame.cpp:558
+#: ../src/wxMaximaFrame.cpp:557
 msgid "Insert Cell\tAlt-Shift-C"
 msgstr "Вставити комірку\tAlt-Shift-C"
 
-#: ../src/wxMaxima.cpp:5642
+#: ../src/wxMaxima.cpp:5657
 msgid "Insert Image"
 msgstr "Вставити зображення"
 
-#: ../src/wxMaximaFrame.cpp:620
+#: ../src/wxMaximaFrame.cpp:619
 msgid "Insert Image..."
 msgstr "Вставити зображення…"
 
-#: ../src/wxMaximaFrame.cpp:606
+#: ../src/wxMaximaFrame.cpp:605
 msgid "Insert Input &Cell"
 msgstr "Вставити комірку &введення"
 
-#: ../src/wxMaximaFrame.cpp:618
+#: ../src/wxMaximaFrame.cpp:617
 msgid "Insert Page Break"
 msgstr "Вставити розрив сторінки"
 
-#: ../src/wxMaximaFrame.cpp:614
+#: ../src/wxMaximaFrame.cpp:613
 msgid "Insert S&ubsection Cell\tCtrl-4"
 msgstr "Вставити комірку п&ідрозділу\tCtrl-4"
 
-#: ../src/wxMaximaFrame.cpp:616
+#: ../src/wxMaximaFrame.cpp:615
 msgid "Insert S&ubsubsection Cell\tCtrl-5"
 msgstr "Вставити комірку підпі&дрозділу\tCtrl-5"
 
-#: ../src/MathCtrl.cpp:1015
+#: ../src/MathCtrl.cpp:1057
 msgid "Insert Section Cell"
 msgstr "Вставити комірку розділу"
 
-#: ../src/MathCtrl.cpp:1016
+#: ../src/MathCtrl.cpp:1058
 msgid "Insert Subsection Cell"
 msgstr "Вставити комірку підрозділу"
 
-#: ../src/MathCtrl.cpp:1017
+#: ../src/MathCtrl.cpp:1059
 msgid "Insert Subsubsection Cell"
 msgstr "Вставити комірку підпідрозділу"
 
-#: ../src/wxMaximaFrame.cpp:610
+#: ../src/wxMaximaFrame.cpp:609
 msgid "Insert T&itle Cell\tCtrl-2"
 msgstr "Вставити комірку з&аголовка\tCtrl-2"
 
-#: ../src/MathCtrl.cpp:1013
+#: ../src/MathCtrl.cpp:1055
 msgid "Insert Text Cell"
 msgstr "Вставити текстову комірку (коментар)"
 
-#: ../src/MathCtrl.cpp:1014
+#: ../src/MathCtrl.cpp:1056
 msgid "Insert Title Cell"
 msgstr "Вставити комірку заголовка"
 
-#: ../src/wxMaximaFrame.cpp:607
+#: ../src/wxMaximaFrame.cpp:606
 msgid "Insert a new input cell"
 msgstr "Вставити нову комірку введення команди"
 
-#: ../src/wxMaximaFrame.cpp:613
+#: ../src/wxMaximaFrame.cpp:612
 msgid "Insert a new section cell"
 msgstr "Вставити нову комірку розділу"
 
-#: ../src/wxMaximaFrame.cpp:615
+#: ../src/wxMaximaFrame.cpp:614
 msgid "Insert a new subsection cell"
 msgstr "Вставити нову комірку підрозділу"
 
-#: ../src/wxMaximaFrame.cpp:617
+#: ../src/wxMaximaFrame.cpp:616
 msgid "Insert a new subsubsection cell"
 msgstr "Вставити нову комірку підпідрозділу"
 
-#: ../src/wxMaximaFrame.cpp:609
+#: ../src/wxMaximaFrame.cpp:608
 msgid "Insert a new text cell"
 msgstr "Вставити нову текстову комірку"
 
-#: ../src/wxMaximaFrame.cpp:611
+#: ../src/wxMaximaFrame.cpp:610
 msgid "Insert a new title cell"
 msgstr "Вставити нову комірку заголовка"
 
-#: ../src/wxMaximaFrame.cpp:619
+#: ../src/wxMaximaFrame.cpp:618
 msgid "Insert a page break"
 msgstr "Вставити розрив сторінки"
 
-#: ../src/wxMaximaFrame.cpp:621
+#: ../src/wxMaximaFrame.cpp:620
 msgid "Insert image"
 msgstr "Вставити зображення"
 
@@ -2426,27 +2429,27 @@ msgstr "Цілі числа і окремі літери"
 msgid "Integral sign"
 msgstr "Символ інтеграла"
 
-#: ../src/wxMaxima.cpp:3992
+#: ../src/wxMaxima.cpp:4004
 msgid "Integral/Sum:"
 msgstr "Інтеграл або сума:"
 
-#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4105 ../src/wxMaxima.cpp:5051
+#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4117 ../src/wxMaxima.cpp:5063
 msgid "Integrate"
 msgstr "Проінтегрувати"
 
-#: ../src/wxMaxima.cpp:4091
+#: ../src/wxMaxima.cpp:4103
 msgid "Integrate (risch)"
 msgstr "Проінтегрувати (Річ)"
 
-#: ../src/wxMaximaFrame.cpp:778
+#: ../src/wxMaximaFrame.cpp:777
 msgid "Integrate expression"
 msgstr "Проінтегрувати вираз"
 
-#: ../src/wxMaximaFrame.cpp:780
+#: ../src/wxMaximaFrame.cpp:779
 msgid "Integrate expression with Risch algorithm"
 msgstr "Проінтегрувати вираз за допомогою алгоритму Річа"
 
-#: ../src/wxMaximaFrame.cpp:1224 ../src/MathCtrl.cpp:1000
+#: ../src/MathCtrl.cpp:1042 ../src/wxMaximaFrame.cpp:1223
 msgid "Integrate..."
 msgstr "Проінтегрувати…"
 
@@ -2454,7 +2457,7 @@ msgstr "Проінтегрувати…"
 msgid "Interrupt"
 msgstr "Перервати"
 
-#: ../src/wxMaximaFrame.cpp:646 ../src/wxMaximaFrame.cpp:650
+#: ../src/wxMaximaFrame.cpp:645 ../src/wxMaximaFrame.cpp:649
 msgid "Interrupt current computation"
 msgstr "Перервати поточні обчислення"
 
@@ -2476,15 +2479,15 @@ msgstr ""
 "\n"
 "Будь ласка, вкажіть правильний шлях до програми Maxima."
 
-#: ../src/wxMaxima.cpp:4137
+#: ../src/wxMaxima.cpp:4149
 msgid "Inverse Laplace"
 msgstr "Обернене перетворення Лапласа"
 
-#: ../src/wxMaximaFrame.cpp:806
+#: ../src/wxMaximaFrame.cpp:805
 msgid "Inverse Laplace T&ransform..."
 msgstr "Обернене п&еретворення Лапласа…"
 
-#: ../src/wxMaximaFrame.cpp:1372
+#: ../src/wxMaximaFrame.cpp:1371
 msgid "Iota"
 msgstr "Ι"
 
@@ -2522,7 +2525,7 @@ msgstr "японська"
 msgid "Kabyle"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1373
+#: ../src/wxMaximaFrame.cpp:1372
 msgid "Kappa"
 msgstr "Κ"
 
@@ -2531,7 +2534,7 @@ msgstr "Κ"
 msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr "Додавати символ відсотків до спеціальних символів: %e, %i тощо"
 
-#: ../src/wxMaxima.cpp:4031
+#: ../src/wxMaxima.cpp:4043
 msgid "LCM"
 msgstr "НСК"
 
@@ -2547,7 +2550,7 @@ msgstr "LaTeX: використовувати символ частинної п
 msgid "Label width:"
 msgstr "Ширина мітки:"
 
-#: ../src/wxMaximaFrame.cpp:1374
+#: ../src/wxMaximaFrame.cpp:1373
 msgid "Lambda"
 msgstr "Λ"
 
@@ -2559,11 +2562,11 @@ msgstr "Мова інтерфейсу wxMaxima."
 msgid "Language:"
 msgstr "Мова:"
 
-#: ../src/wxMaxima.cpp:4120
+#: ../src/wxMaxima.cpp:4132
 msgid "Laplace"
 msgstr "Перетворення Лапласа"
 
-#: ../src/wxMaximaFrame.cpp:803
+#: ../src/wxMaximaFrame.cpp:802
 msgid "Laplace &Transform..."
 msgstr "&Перетворення Лапласа…"
 
@@ -2571,15 +2574,15 @@ msgstr "&Перетворення Лапласа…"
 msgid "Leads to"
 msgstr "Тобто"
 
-#: ../src/wxMaximaFrame.cpp:812
+#: ../src/wxMaximaFrame.cpp:811
 msgid "Least Common Multiple..."
 msgstr "Найменше спільне кратне…"
 
-#: ../src/wxMaxima.cpp:4809
+#: ../src/wxMaxima.cpp:4821
 msgid "Least Squares Fit"
 msgstr "Наближення за методом найменших квадратів"
 
-#: ../src/wxMaximaFrame.cpp:1266
+#: ../src/wxMaximaFrame.cpp:1265
 msgid "Least Squares Fit..."
 msgstr "Наближення за методом найменших квадратів…"
 
@@ -2594,23 +2597,23 @@ msgstr ""
 "користувача. Визначити потрібний каталог можна за допомогою команди "
 "maxima_userdir"
 
-#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4192
+#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4204
 msgid "Limit"
 msgstr "Границя"
 
-#: ../src/wxMaximaFrame.cpp:1225
+#: ../src/wxMaximaFrame.cpp:1224
 msgid "Limit..."
 msgstr "Границя…"
 
-#: ../src/wxMaximaFrame.cpp:1265
+#: ../src/wxMaximaFrame.cpp:1264
 msgid "Linear Regression..."
 msgstr "Лінійна регресія…"
 
-#: ../src/wxMaxima.cpp:3803
+#: ../src/wxMaxima.cpp:3815
 msgid "List(s):"
 msgstr "Списки:"
 
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3848
 msgid "List:"
 msgstr "Список:"
 
@@ -2618,15 +2621,15 @@ msgstr "Список:"
 msgid "Load"
 msgstr "Завантажити"
 
-#: ../src/wxMaxima.cpp:2932
+#: ../src/wxMaxima.cpp:2940
 msgid "Load Package"
 msgstr "Завантажити пакунок"
 
-#: ../src/wxMaximaFrame.cpp:479
+#: ../src/wxMaximaFrame.cpp:478
 msgid "Load a Maxima file using the batch command"
 msgstr "Завантажити файл програми Maxima за допомогою команди batch"
 
-#: ../src/wxMaximaFrame.cpp:477
+#: ../src/wxMaximaFrame.cpp:476
 msgid "Load a Maxima package file"
 msgstr "Завантажити файл пакунка Maxima"
 
@@ -2638,47 +2641,47 @@ msgstr "Завантажити стиль з файла"
 msgid "Long Right arrow"
 msgstr "Довга стрілка праворуч"
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Lower bound:"
 msgstr "Нижня межа:"
 
-#: ../src/wxMaximaFrame.cpp:771
+#: ../src/wxMaximaFrame.cpp:770
 msgid "Ma&p to Matrix..."
 msgstr "&Відобразити у матрицю…"
 
-#: ../src/wxMaximaFrame.cpp:547
+#: ../src/wxMaximaFrame.cpp:546
 msgid "Main Toolbar\tAlt-Shift-B"
 msgstr "Головна панель інструментів\tAlt-Shift-B"
 
-#: ../src/wxMaximaFrame.cpp:765
+#: ../src/wxMaximaFrame.cpp:764
 msgid "Make &List..."
 msgstr "С&творити список…"
 
-#: ../src/wxMaxima.cpp:3821
+#: ../src/wxMaxima.cpp:3833
 msgid "Make list"
 msgstr "Створити список"
 
-#: ../src/wxMaximaFrame.cpp:766
+#: ../src/wxMaximaFrame.cpp:765
 msgid "Make list from expression"
 msgstr "Створити список на основі виразу"
 
-#: ../src/wxMaximaFrame.cpp:907
+#: ../src/wxMaximaFrame.cpp:906
 msgid "Make substitution in expression"
 msgstr "Виконати заміну у виразі"
 
-#: ../src/wxMaximaFrame.cpp:682
+#: ../src/wxMaximaFrame.cpp:681
 msgid "Manually Trigger Evaluation"
 msgstr "Ініціювати обчислення вручну"
 
-#: ../src/wxMaxima.cpp:3805
+#: ../src/wxMaxima.cpp:3817
 msgid "Map"
 msgstr "Відобразити"
 
-#: ../src/wxMaximaFrame.cpp:770
+#: ../src/wxMaximaFrame.cpp:769
 msgid "Map function to a list"
 msgstr "Відобразити функцію на список"
 
-#: ../src/wxMaximaFrame.cpp:772
+#: ../src/wxMaximaFrame.cpp:771
 msgid "Map function to a matrix"
 msgstr "Відобразити функцію на матрицю"
 
@@ -2695,23 +2698,23 @@ msgstr "Перевіряти баланс дужок у тексті"
 msgid "Math font:"
 msgstr "Математичний шрифт:"
 
-#: ../src/wxMaximaFrame.cpp:374
+#: ../src/wxMaximaFrame.cpp:373
 msgid "Mathematical Symbols"
 msgstr "Математичні символи"
 
-#: ../src/wxMaxima.cpp:3716
+#: ../src/wxMaxima.cpp:3728
 msgid "Matrix"
 msgstr "Матриця"
 
-#: ../src/wxMaxima.cpp:3702
+#: ../src/wxMaxima.cpp:3714
 msgid "Matrix map"
 msgstr "Застосувати до матриці"
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Matrix name:"
 msgstr "Назва матриці:"
 
-#: ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3749
+#: ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3761
 msgid "Matrix:"
 msgstr "Матриця:"
 
@@ -2719,7 +2722,7 @@ msgstr "Матриця:"
 msgid "Maxima"
 msgstr "Maxima"
 
-#: ../src/wxMaximaFrame.cpp:137
+#: ../src/wxMaximaFrame.cpp:136
 msgid "Maxima has a question"
 msgstr "У Maxima є питання"
 
@@ -2727,24 +2730,24 @@ msgstr "У Maxima є питання"
 msgid "Maxima input"
 msgstr "Команда Maxima"
 
-#: ../src/wxMaximaFrame.cpp:166
+#: ../src/wxMaximaFrame.cpp:165
 msgid "Maxima is calculating"
 msgstr "Maxima виконує обчислення"
 
-#: ../src/wxMaximaFrame.cpp:111
+#: ../src/wxMaximaFrame.cpp:110
 #, fuzzy
 msgid "Maxima is ready for input."
 msgstr "Команда Maxima"
 
-#: ../src/wxMaxima.cpp:2945
+#: ../src/wxMaxima.cpp:2953
 msgid "Maxima package (*.mac)|*.mac"
 msgstr "пакунок Maxima (*.mac)|*.mac"
 
-#: ../src/wxMaxima.cpp:2934
+#: ../src/wxMaxima.cpp:2942
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr "пакунок Maxima (*.mac)|*.mac|пакунок Lisp (*.lisp)|*.lisp|усі файли|*"
 
-#: ../src/wxMaxima.cpp:1014
+#: ../src/wxMaxima.cpp:1019
 msgid "Maxima process terminated."
 msgstr "Роботу процесу Maxima перервано."
 
@@ -2756,7 +2759,7 @@ msgstr "Програма Maxima:"
 msgid "Maxima questions"
 msgstr "Питання Maxima"
 
-#: ../src/wxMaxima.cpp:942
+#: ../src/wxMaxima.cpp:947
 msgid "Maxima started. Waiting for connection..."
 msgstr "Maxima запущено. Очікуємо на встановлення з’єднання…"
 
@@ -2788,7 +2791,7 @@ msgstr ""
 "Maxima використовує «:» для присвоєння значень («a : 3;») і «:=» для "
 "визначення функцій («f(x) := x^2;»)."
 
-#: ../src/wxMaxima.cpp:4597
+#: ../src/wxMaxima.cpp:4609
 msgid "Maxima version: "
 msgstr "Версія Maxima: "
 
@@ -2825,40 +2828,40 @@ msgstr ""
 msgid "Maximum displayed number of digits:"
 msgstr "Максимальна показана кількість цифр:"
 
-#: ../src/wxMaximaFrame.cpp:1263
+#: ../src/wxMaximaFrame.cpp:1262
 msgid "Mean Difference Test..."
 msgstr "Перевірка рівності середніх значень…"
 
-#: ../src/wxMaximaFrame.cpp:1262
+#: ../src/wxMaximaFrame.cpp:1261
 msgid "Mean Test..."
 msgstr "Перевірка рівності середніх…"
 
-#: ../src/wxMaximaFrame.cpp:1255
+#: ../src/wxMaximaFrame.cpp:1254
 msgid "Mean..."
 msgstr "Середнє…"
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Mean:"
 msgstr "Середнє:"
 
-#: ../src/wxMaximaFrame.cpp:1256
+#: ../src/wxMaximaFrame.cpp:1255
 msgid "Median..."
 msgstr "Медіана…"
 
-#: ../src/MathCtrl.cpp:945
+#: ../src/MathCtrl.cpp:987
 msgid "Merge Cells"
 msgstr "Об’єднати комірки"
 
-#: ../src/wxMaximaFrame.cpp:633
+#: ../src/wxMaximaFrame.cpp:632
 #, fuzzy
 msgid "Merge Cells\tCtrl-M"
 msgstr "Об’єднати комірки"
 
-#: ../src/wxMaximaFrame.cpp:634
+#: ../src/wxMaximaFrame.cpp:633
 msgid "Merge the text from two input cells into one"
 msgstr "Об’єднати текст із двох комірок введення до однієї"
 
-#: ../src/wxMaxima.cpp:2668
+#: ../src/wxMaxima.cpp:2676
 msgid "Message from the stdout of Maxima: "
 msgstr "Повідомлення зі stdout Maxima: "
 
@@ -2866,19 +2869,19 @@ msgstr "Повідомлення зі stdout Maxima: "
 msgid "Method:"
 msgstr "Метод:"
 
-#: ../src/wxMaxima.cpp:5289
+#: ../src/wxMaxima.cpp:5301
 msgid "Mismatched parenthesis"
 msgstr "Незбалансована дужка"
 
-#: ../src/wxMaxima.cpp:3972
+#: ../src/wxMaxima.cpp:3984
 msgid "Modulus"
 msgstr "Модуль"
 
-#: ../src/wxMaximaFrame.cpp:1375
+#: ../src/wxMaximaFrame.cpp:1374
 msgid "Mu"
 msgstr "Μ"
 
-#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Name:"
 msgstr "Назва:"
 
@@ -2886,7 +2889,7 @@ msgstr "Назва:"
 msgid "New"
 msgstr "Створити"
 
-#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
+#: ../src/wxMaximaFrame.cpp:456 ../src/wxMaximaFrame.cpp:459
 msgid "New\tCtrl-N"
 msgstr "Створити\tCtrl-N"
 
@@ -2902,11 +2905,11 @@ msgstr "Нові рядки: перейти до тексту"
 msgid "New value:"
 msgstr "Нове значення:"
 
-#: ../src/wxMaxima.cpp:3993 ../src/wxMaxima.cpp:4119 ../src/wxMaxima.cpp:4136
+#: ../src/wxMaxima.cpp:4005 ../src/wxMaxima.cpp:4131 ../src/wxMaxima.cpp:4148
 msgid "New variable:"
 msgstr "Нова змінна:"
 
-#: ../src/wxMaximaFrame.cpp:630
+#: ../src/wxMaximaFrame.cpp:629
 msgid "Next Command\tAlt-Down"
 msgstr "Наступна команда\tAlt-↓"
 
@@ -2914,15 +2917,15 @@ msgstr "Наступна команда\tAlt-↓"
 msgid "No"
 msgstr "Ні"
 
-#: ../src/wxMaxima.cpp:5362
+#: ../src/wxMaxima.cpp:5378
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr "Наприкінці команди немає символу долара ($) або крапки з комою (;)"
 
-#: ../src/wxMaxima.cpp:3249 ../src/wxMaxima.cpp:3271
+#: ../src/wxMaxima.cpp:3260 ../src/wxMaxima.cpp:3283
 msgid "No matches found!"
 msgstr "Не знайдено відповідників."
 
-#: ../src/wxMaximaFrame.cpp:1264
+#: ../src/wxMaximaFrame.cpp:1263
 msgid "Normality Test..."
 msgstr "Перевірка нормальності…"
 
@@ -2953,31 +2956,31 @@ msgstr ""
 msgid "Norwegian"
 msgstr "норвезька"
 
-#: ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:3740
 msgid "Not a valid matrix dimension!"
 msgstr "Некоректна розмірність матриці."
 
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629
 msgid "Not a valid number of equations!"
 msgstr "Некоректна кількість рівнянь."
 
-#: ../src/wxMaximaFrame.cpp:197
+#: ../src/wxMaximaFrame.cpp:196
 msgid "Not connected to maxima"
 msgstr "Не з’єднано з maxima"
 
-#: ../src/wxMaxima.cpp:4599
+#: ../src/wxMaxima.cpp:4611
 msgid "Not connected."
 msgstr "Не з’єднано."
 
-#: ../src/wxMaximaFrame.cpp:1376
+#: ../src/wxMaximaFrame.cpp:1375
 msgid "Nu"
 msgstr "Ν"
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Num. deg:"
 msgstr "Степінь чисельника:"
 
-#: ../src/wxMaxima.cpp:3585 ../src/wxMaxima.cpp:3609
+#: ../src/wxMaxima.cpp:3597 ../src/wxMaxima.cpp:3621
 msgid "Number of equations:"
 msgstr "Кількість рівнянь:"
 
@@ -3004,15 +3007,15 @@ msgstr "Гаразд"
 msgid "Old value:"
 msgstr "Попереднє значення:"
 
-#: ../src/wxMaxima.cpp:3992 ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135
+#: ../src/wxMaxima.cpp:4004 ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147
 msgid "Old variable:"
 msgstr "Попередня змінна:"
 
-#: ../src/wxMaximaFrame.cpp:1387
+#: ../src/wxMaximaFrame.cpp:1386
 msgid "Omega"
 msgstr "Ω"
 
-#: ../src/wxMaximaFrame.cpp:1378
+#: ../src/wxMaximaFrame.cpp:1377
 msgid "Omicron"
 msgstr "Ο"
 
@@ -3033,20 +3036,20 @@ msgstr ""
 "позначено цей пункт, попри всі попередні зауваження, програма стежитиме за "
 "потоком stdout maxima, очікуючи на корисні повідомлення у ньому."
 
-#: ../src/wxMaxima.cpp:4763
+#: ../src/wxMaxima.cpp:4775
 msgid "One sample t-test"
 msgstr "Одновибіркова t-перевірка"
 
-#: ../src/wxMaximaFrame.cpp:971
+#: ../src/wxMaximaFrame.cpp:970
 msgid "Online tutorials"
 msgstr "Навчальні матеріали у інтернеті"
 
 #: ../src/ConfigDialogue.cpp:656 ../src/main.cpp:347 ../src/ToolBar.cpp:119
-#: ../src/wxMaxima.cpp:2797
+#: ../src/wxMaxima.cpp:2805
 msgid "Open"
 msgstr "Відкрити"
 
-#: ../src/wxMaximaFrame.cpp:466
+#: ../src/wxMaximaFrame.cpp:465
 msgid "Open Recent"
 msgstr "Відкрити недавні"
 
@@ -3054,11 +3057,11 @@ msgstr "Відкрити недавні"
 msgid "Open a cell when Maxima expects input"
 msgstr "Відкрити комірку, якщо Maxima очікує на вхідні дані"
 
-#: ../src/wxMaximaFrame.cpp:464
+#: ../src/wxMaximaFrame.cpp:463
 msgid "Open a document"
 msgstr "Відкрити документ"
 
-#: ../src/wxMaximaFrame.cpp:458 ../src/wxMaximaFrame.cpp:461
+#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
 msgid "Open a new window"
 msgstr "Відкрити нове вікно"
 
@@ -3066,11 +3069,11 @@ msgstr "Відкрити нове вікно"
 msgid "Open document"
 msgstr "Відкрити документ"
 
-#: ../src/wxMaxima.cpp:4824
+#: ../src/wxMaxima.cpp:4836
 msgid "Open matrix"
 msgstr "Відкрити матрицю"
 
-#: ../src/wxMaxima.cpp:1446 ../src/wxMaxima.cpp:1518
+#: ../src/wxMaxima.cpp:1451 ../src/wxMaxima.cpp:1523
 msgid "Opening file"
 msgstr "Відкриваємо файл"
 
@@ -3094,11 +3097,11 @@ msgstr "Застарілі комірки"
 msgid "Output labels"
 msgstr "Мітки результатів"
 
-#: ../src/wxMaximaFrame.cpp:796
+#: ../src/wxMaximaFrame.cpp:795
 msgid "P&ade Approximation..."
 msgstr "Ап&роксимація Паде…"
 
-#: ../src/wxMaxima.cpp:3132 ../src/wxMaxima.cpp:5133
+#: ../src/wxMaxima.cpp:3141 ../src/wxMaxima.cpp:5145
 msgid ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
 "bmp|Portable animap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X "
@@ -3108,15 +3111,15 @@ msgstr ""
 "bmp)|*.bmp|Portable animap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*."
 "tif|X pixmap (*.xpm)|*.xpm"
 
-#: ../src/wxMaxima.cpp:4012
+#: ../src/wxMaxima.cpp:4024
 msgid "Pade approximation"
 msgstr "Апроксимація Паде"
 
-#: ../src/wxMaximaFrame.cpp:797
+#: ../src/wxMaximaFrame.cpp:796
 msgid "Pade approximation of a Taylor series"
 msgstr "Паде-апроксимація ряду Тейлора"
 
-#: ../src/wxMaximaFrame.cpp:1500
+#: ../src/wxMaximaFrame.cpp:1519
 msgid "Pagebreak"
 msgstr "Розрив сторінки"
 
@@ -3128,19 +3131,19 @@ msgstr "Паралельно"
 msgid "Parametric plot"
 msgstr "Графік параметричної функції"
 
-#: ../src/wxMaximaFrame.cpp:188
+#: ../src/wxMaximaFrame.cpp:187
 msgid "Parsing output"
 msgstr "Аналіз результату"
 
-#: ../src/wxMaximaFrame.cpp:819
+#: ../src/wxMaximaFrame.cpp:818
 msgid "Partial &Fractions..."
 msgstr "Прості &дроби…"
 
-#: ../src/wxMaxima.cpp:4076
+#: ../src/wxMaxima.cpp:4088
 msgid "Partial fractions"
 msgstr "Прості дроби"
 
-#: ../src/wxMaxima.cpp:1769
+#: ../src/wxMaxima.cpp:1774
 msgid "Parts of the document will not be loaded correctly!"
 msgstr "Частину документа не вдалося завантажити!"
 
@@ -3152,11 +3155,11 @@ msgstr ""
 "Частину документа не вдалося завантажити:\n"
 "Виявлено невідомий теґ XML із назвою "
 
-#: ../src/ToolBar.cpp:143 ../src/MathCtrl.cpp:1010 ../src/MathCtrl.cpp:1025
+#: ../src/MathCtrl.cpp:1052 ../src/MathCtrl.cpp:1067 ../src/ToolBar.cpp:143
 msgid "Paste"
 msgstr "Вставити"
 
-#: ../src/wxMaximaFrame.cpp:518
+#: ../src/wxMaximaFrame.cpp:517
 msgid "Paste\tCtrl-V"
 msgstr "Вставити\tCtrl+V"
 
@@ -3164,7 +3167,7 @@ msgstr "Вставити\tCtrl+V"
 msgid "Paste from clipboard"
 msgstr "Вставити з буфера"
 
-#: ../src/wxMaximaFrame.cpp:519
+#: ../src/wxMaximaFrame.cpp:518
 msgid "Paste text from clipboard"
 msgstr "Вставити текст із буфера обміну даними"
 
@@ -3172,19 +3175,19 @@ msgstr "Вставити текст із буфера обміну даними"
 msgid "Perpendicular to"
 msgstr "Перпендикулярно"
 
-#: ../src/wxMaximaFrame.cpp:1384
+#: ../src/wxMaximaFrame.cpp:1383
 msgid "Phi"
 msgstr "Φ"
 
-#: ../src/wxMaximaFrame.cpp:1379
+#: ../src/wxMaximaFrame.cpp:1378
 msgid "Pi"
 msgstr "Π"
 
-#: ../src/wxMaximaFrame.cpp:1273
+#: ../src/wxMaximaFrame.cpp:1272
 msgid "Piechart..."
 msgstr "Кругова діаграма…"
 
-#: ../src/wxMaxima.cpp:1952
+#: ../src/wxMaxima.cpp:1957
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr "Налаштуйте wxMaxima за допомогою пункту меню «Зміни → Налаштувати»."
 
@@ -3192,52 +3195,52 @@ msgstr "Налаштуйте wxMaxima за допомогою пункту ме�
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr "Для набуття змінами чинності wxMaxima слід перезавантажити!"
 
-#: ../src/wxMaximaFrame.cpp:923
+#: ../src/wxMaximaFrame.cpp:922
 msgid "Plot &2d..."
 msgstr "&Двовимірний графік…"
 
-#: ../src/wxMaximaFrame.cpp:925
+#: ../src/wxMaximaFrame.cpp:924
 msgid "Plot &3d..."
 msgstr "&Тривимірний графік…"
 
-#: ../src/wxMaximaFrame.cpp:927
+#: ../src/wxMaximaFrame.cpp:926
 msgid "Plot &Format..."
 msgstr "&Формат графіка…"
 
 #: ../src/Plot2dWiz.cpp:104 ../src/Plot2dWiz.cpp:450 ../src/Plot2dWiz.cpp:464
-#: ../src/wxMaxima.cpp:4283 ../src/wxMaxima.cpp:5102
+#: ../src/wxMaxima.cpp:4295 ../src/wxMaxima.cpp:5114
 msgid "Plot 2D"
 msgstr "Двовимірний графік"
 
-#: ../src/wxMaximaFrame.cpp:1227
+#: ../src/wxMaximaFrame.cpp:1226
 msgid "Plot 2D..."
 msgstr "Двовимірний графік…"
 
-#: ../src/MathCtrl.cpp:1003
+#: ../src/MathCtrl.cpp:1045
 msgid "Plot 2d..."
 msgstr "Двовимірний графік…"
 
-#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4269 ../src/wxMaxima.cpp:5115
+#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4281 ../src/wxMaxima.cpp:5127
 msgid "Plot 3D"
 msgstr "Тривимірний графік"
 
-#: ../src/wxMaximaFrame.cpp:1228
+#: ../src/wxMaximaFrame.cpp:1227
 msgid "Plot 3D..."
 msgstr "Тривимірний графік…"
 
-#: ../src/MathCtrl.cpp:1004
+#: ../src/MathCtrl.cpp:1046
 msgid "Plot 3d..."
 msgstr "Тривимірний графік…"
 
-#: ../src/wxMaxima.cpp:4296
+#: ../src/wxMaxima.cpp:4308
 msgid "Plot format"
 msgstr "Формат графіка"
 
-#: ../src/wxMaximaFrame.cpp:924
+#: ../src/wxMaximaFrame.cpp:923
 msgid "Plot in 2 dimensions"
 msgstr "Двовимірний графік"
 
-#: ../src/wxMaximaFrame.cpp:926
+#: ../src/wxMaximaFrame.cpp:925
 msgid "Plot in 3 dimensions"
 msgstr "Тривимірний графік"
 
@@ -3246,8 +3249,8 @@ msgid "Plot to file:"
 msgstr "Вивести графік до файла:"
 
 #: ../src/BC2Wiz.cpp:30 ../src/BC2Wiz.cpp:36 ../src/LimitWiz.cpp:33
-#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
-#: ../src/wxMaxima.cpp:3648
+#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
+#: ../src/wxMaxima.cpp:3660
 msgid "Point:"
 msgstr "Точка:"
 
@@ -3255,11 +3258,11 @@ msgstr "Точка:"
 msgid "Polish"
 msgstr "польська"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 1:"
 msgstr "Поліном 1:"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 2:"
 msgstr "Поліном 2:"
 
@@ -3271,11 +3274,11 @@ msgstr "португальська (Бразилія)"
 msgid "Postscript file (*.eps)|*.eps|All|*"
 msgstr "файл Postscript (*.eps)|*.eps|усі файли|*"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Precision"
 msgstr "Точність"
 
-#: ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:536
 msgid "Preferences...\tCtrl+,"
 msgstr "Параметри…\tCtrl+,"
 
@@ -3292,7 +3295,7 @@ msgstr ""
 "доповнювати команди із поточних завантажених пакунків та функцій, визначених "
 "у поточному файлі."
 
-#: ../src/wxMaximaFrame.cpp:628
+#: ../src/wxMaximaFrame.cpp:627
 msgid "Previous Command\tAlt-Up"
 msgstr "Попередня команда\tAlt-↑"
 
@@ -3300,11 +3303,11 @@ msgstr "Попередня команда\tAlt-↑"
 msgid "Print"
 msgstr "Надрукувати"
 
-#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:484
+#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:483
 msgid "Print document"
 msgstr "Надрукувати документ"
 
-#: ../src/wxMaxima.cpp:4242
+#: ../src/wxMaxima.cpp:4254
 msgid "Product"
 msgstr "Добуток"
 
@@ -3312,35 +3315,35 @@ msgstr "Добуток"
 msgid "Product sign"
 msgstr "Знак добутку"
 
-#: ../src/wxMaximaFrame.cpp:1386
+#: ../src/wxMaximaFrame.cpp:1385
 msgid "Psi"
 msgstr "Ψ"
 
-#: ../src/wxMaximaFrame.cpp:331
+#: ../src/wxMaximaFrame.cpp:330
 msgid "Raw XML monitor"
 msgstr "Монітор коду XML"
 
-#: ../src/wxMaximaFrame.cpp:592
+#: ../src/wxMaximaFrame.cpp:591
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr "Виконати обчислення у всіх комірках над коміркою, де перебуває курсор"
 
-#: ../src/wxMaximaFrame.cpp:1278
+#: ../src/wxMaximaFrame.cpp:1277
 msgid "Read Matrix..."
 msgstr "Прочитати матрицю…"
 
-#: ../src/wxMaximaFrame.cpp:177
+#: ../src/wxMaximaFrame.cpp:176
 msgid "Reading Maxima output"
 msgstr "Читаємо результат обчислень Maxima"
 
-#: ../src/wxMaximaFrame.cpp:153
+#: ../src/wxMaximaFrame.cpp:152
 msgid "Ready for user input"
 msgstr "Готова до введення команди"
 
-#: ../src/wxMaximaFrame.cpp:631
+#: ../src/wxMaximaFrame.cpp:630
 msgid "Recall next command from history"
 msgstr "Нагадати наступну команду з журналу"
 
-#: ../src/wxMaximaFrame.cpp:629
+#: ../src/wxMaximaFrame.cpp:628
 msgid "Recall previous command from history"
 msgstr "Нагадати попередню команду з журналу"
 
@@ -3348,35 +3351,35 @@ msgstr "Нагадати попередню команду з журналу"
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1215
+#: ../src/wxMaximaFrame.cpp:1214
 msgid "Rectform"
 msgstr "Алгебраїчна форма"
 
-#: ../src/wxMaximaFrame.cpp:495
+#: ../src/wxMaximaFrame.cpp:494
 msgid "Redo\tCtrl-Y"
 msgstr "Повторити\tCtrl-Y"
 
-#: ../src/wxMaximaFrame.cpp:496
+#: ../src/wxMaximaFrame.cpp:495
 msgid "Redo last change"
 msgstr "Повторити останню зміну"
 
-#: ../src/wxMaximaFrame.cpp:1220
+#: ../src/wxMaximaFrame.cpp:1219
 msgid "Reduce (tr)"
 msgstr "Привести (триг)"
 
-#: ../src/wxMaximaFrame.cpp:871
+#: ../src/wxMaximaFrame.cpp:870
 msgid "Reduce trigonometric expression"
 msgstr "Привести тригонометричний вираз"
 
-#: ../src/wxMaxima.cpp:622 ../src/wxMaxima.cpp:5495
+#: ../src/wxMaxima.cpp:627 ../src/wxMaxima.cpp:5511
 msgid "Refusing to send cell to maxima: "
 msgstr "Відмовлено у надсиланні комірки до maxima: "
 
-#: ../src/wxMaximaFrame.cpp:594
+#: ../src/wxMaximaFrame.cpp:593
 msgid "Remove All Output"
 msgstr "Вилучити всі результати"
 
-#: ../src/wxMaximaFrame.cpp:595
+#: ../src/wxMaximaFrame.cpp:594
 msgid "Remove output from input cells"
 msgstr "Вилучити всі виведені дані з комірок для введення даних"
 
@@ -3385,7 +3388,7 @@ msgstr "Вилучити всі виведені дані з комірок дл
 msgid "Replace All"
 msgstr "Позначити все"
 
-#: ../src/wxMaxima.cpp:3282
+#: ../src/wxMaxima.cpp:3294
 #, c-format
 msgid "Replaced %d occurrences."
 msgstr "Замінено %d відповідників."
@@ -3394,11 +3397,11 @@ msgstr "Замінено %d відповідників."
 msgid "Replacement:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:976
+#: ../src/wxMaximaFrame.cpp:975
 msgid "Report bug"
 msgstr "Повідомити про ваду"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "Restart Maxima"
 msgstr "Перезапустити Maxima"
 
@@ -3406,7 +3409,7 @@ msgstr "Перезапустити Maxima"
 msgid "Restart maxima"
 msgstr "Перезапустити maxima"
 
-#: ../src/MathCtrl.cpp:4442
+#: ../src/MathCtrl.cpp:4497
 msgid "Result"
 msgstr "Результат"
 
@@ -3414,7 +3417,7 @@ msgstr "Результат"
 msgid "Return to the cell that is currently being evaluated"
 msgstr "Повернутися до комірки, у якій виконуються обчислення"
 
-#: ../src/wxMaximaFrame.cpp:1380
+#: ../src/wxMaximaFrame.cpp:1379
 msgid "Rho"
 msgstr "Ρ"
 
@@ -3422,19 +3425,19 @@ msgstr "Ρ"
 msgid "Right arrow"
 msgstr "Стрілка праворуч"
 
-#: ../src/wxMaximaFrame.cpp:779
+#: ../src/wxMaximaFrame.cpp:778
 msgid "Risch Integration..."
 msgstr "Інтегрування за Річем…"
 
-#: ../src/wxMaximaFrame.cpp:694
+#: ../src/wxMaximaFrame.cpp:693
 msgid "Roots of &Polynomial"
 msgstr "Корені &полінома"
 
-#: ../src/wxMaximaFrame.cpp:697
+#: ../src/wxMaximaFrame.cpp:696
 msgid "Roots of Polynomial (bfloat)"
 msgstr "Корені полінома (підв. точн.)"
 
-#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Rows:"
 msgstr "Рядків:"
 
@@ -3442,56 +3445,56 @@ msgstr "Рядків:"
 msgid "Russian"
 msgstr "російська"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 1:"
 msgstr "Вибірка 1:"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 2:"
 msgstr "Вибірка 2:"
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Sample:"
 msgstr "Вибірка:"
 
 #: ../src/ConfigDialogue.cpp:781 ../src/ToolBar.cpp:122
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Save"
 msgstr "Зберегти"
 
-#: ../src/MathCtrl.cpp:921
+#: ../src/MathCtrl.cpp:963
 msgid "Save Animation..."
 msgstr "Зберегти анімацію…"
 
-#: ../src/wxMaxima.cpp:2565
+#: ../src/wxMaxima.cpp:2572
 msgid "Save As"
 msgstr "Зберегти як"
 
-#: ../src/wxMaximaFrame.cpp:474
+#: ../src/wxMaximaFrame.cpp:473
 msgid "Save As...\tShift-Ctrl-S"
 msgstr "Зберегти як\tShift-Ctrl-S"
 
-#: ../src/MathCtrl.cpp:919
+#: ../src/MathCtrl.cpp:961
 msgid "Save Image..."
 msgstr "Зберегти зображення…"
 
-#: ../src/wxMaxima.cpp:3130
+#: ../src/wxMaxima.cpp:3139
 msgid "Save Selection to Image"
 msgstr "Зберегти позначене як зображення"
 
-#: ../src/wxMaximaFrame.cpp:528
+#: ../src/wxMaximaFrame.cpp:527
 msgid "Save Selection to Image..."
 msgstr "Зберегти позначене як зображення…"
 
-#: ../src/wxMaxima.cpp:5150
+#: ../src/wxMaxima.cpp:5162
 msgid "Save animation to file"
 msgstr "Зберегти анімацію до файла"
 
-#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:473
+#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:472
 msgid "Save document"
 msgstr "Зберегти документ"
 
-#: ../src/wxMaximaFrame.cpp:475
+#: ../src/wxMaximaFrame.cpp:474
 msgid "Save document as"
 msgstr "Зберегти документ як"
 
@@ -3515,11 +3518,11 @@ msgstr "Запам’ятовувати розташування панелей.
 msgid "Save plot to file"
 msgstr "Зберегти графік до файла"
 
-#: ../src/wxMaximaFrame.cpp:529
+#: ../src/wxMaximaFrame.cpp:528
 msgid "Save selection from document to an image file"
 msgstr "Зберегти позначене у документі до файла зображення"
 
-#: ../src/wxMaxima.cpp:5131
+#: ../src/wxMaxima.cpp:5143
 msgid "Save selection to file"
 msgstr "Зберегти позначене до файла"
 
@@ -3535,27 +3538,27 @@ msgstr "Зберігати розташування і розмір вікна w
 msgid "Save wxMaxima window size/position between sessions."
 msgstr "Зберігати розташування і розмір вікна wxMaxima."
 
-#: ../src/wxMaximaFrame.cpp:246
+#: ../src/wxMaximaFrame.cpp:245
 msgid "Saving failed."
 msgstr "Спроба збереження зазнала невдачі."
 
-#: ../src/wxMaximaFrame.cpp:222
+#: ../src/wxMaximaFrame.cpp:221
 msgid "Saving successful."
 msgstr "Успішно збережено."
 
-#: ../src/wxMaximaFrame.cpp:212
+#: ../src/wxMaximaFrame.cpp:211
 msgid "Saving..."
 msgstr "Зберігаємо…"
 
-#: ../src/wxMaxima.cpp:4699
+#: ../src/wxMaxima.cpp:4711
 msgid "Scatterplot"
 msgstr "Точкова діаграма"
 
-#: ../src/wxMaximaFrame.cpp:1271
+#: ../src/wxMaximaFrame.cpp:1270
 msgid "Scatterplot..."
 msgstr "Точкова діаграма…"
 
-#: ../src/wxMaximaFrame.cpp:1498
+#: ../src/wxMaximaFrame.cpp:1517
 msgid "Section"
 msgstr "Розділ"
 
@@ -3563,8 +3566,8 @@ msgstr "Розділ"
 msgid "Section cell"
 msgstr "Комірка розділу"
 
-#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:292 ../src/TextCell.cpp:306
-#: ../src/TextCell.cpp:322 ../src/TextCell.cpp:334
+#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:290 ../src/TextCell.cpp:304
+#: ../src/TextCell.cpp:320 ../src/TextCell.cpp:332
 msgid ""
 "Seems like something is broken with a font. Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
@@ -3575,7 +3578,7 @@ msgstr ""
 "позначення пункту «Використовувати шрифти JSmath» у діалоговому вікні "
 "налаштовування."
 
-#: ../src/TextCell.cpp:139
+#: ../src/TextCell.cpp:137
 msgid ""
 "Seems like something is broken with the maths font. Installing http://www."
 "math.union.edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use "
@@ -3586,11 +3589,11 @@ msgstr ""
 "fonts.html і позначення пункту «Використовувати шрифти JSmath» у діалоговому "
 "вікні налаштовування."
 
-#: ../src/MathCtrl.cpp:1011 ../src/MathCtrl.cpp:1027
+#: ../src/MathCtrl.cpp:1053 ../src/MathCtrl.cpp:1069
 msgid "Select All"
 msgstr "Позначити все"
 
-#: ../src/wxMaximaFrame.cpp:525
+#: ../src/wxMaximaFrame.cpp:524
 msgid "Select All\tCtrl-A"
 msgstr "Позначити все\tCtrl-A"
 
@@ -3598,7 +3601,7 @@ msgstr "Позначити все\tCtrl-A"
 msgid "Select Maxima program"
 msgstr "Виберіть адресу програми Maxima"
 
-#: ../src/wxMaxima.cpp:4860
+#: ../src/wxMaxima.cpp:4872
 msgid "Select Subsample"
 msgstr "Виберіть підвибірку"
 
@@ -3607,11 +3610,11 @@ msgstr "Виберіть підвибірку"
 msgid "Select a constant"
 msgstr "Виберіть сталу"
 
-#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:526
+#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:525
 msgid "Select all"
 msgstr "Позначити все"
 
-#: ../src/wxMaxima.cpp:3319
+#: ../src/wxMaxima.cpp:3331
 msgid "Select math display algorithm"
 msgstr "Виберіть спосіб показу математичних формул"
 
@@ -3628,23 +3631,23 @@ msgstr ""
 msgid "Selection"
 msgstr "Позначення"
 
-#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4178
+#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4190
 msgid "Series"
 msgstr "Ряд"
 
-#: ../src/wxMaximaFrame.cpp:1226
+#: ../src/wxMaximaFrame.cpp:1225
 msgid "Series..."
 msgstr "Ряд…"
 
-#: ../src/wxMaxima.cpp:863
+#: ../src/wxMaxima.cpp:868
 msgid "Server started"
 msgstr "Сервер запущено"
 
-#: ../src/wxMaximaFrame.cpp:575
+#: ../src/wxMaximaFrame.cpp:574
 msgid "Set Zoom"
 msgstr "Встановити масштаб"
 
-#: ../src/wxMaximaFrame.cpp:944
+#: ../src/wxMaximaFrame.cpp:943
 msgid "Set bigfloat &Precision..."
 msgstr "Встановити підвищену то&чність обчислень…"
 
@@ -3652,11 +3655,11 @@ msgstr "Встановити підвищену то&чність обчисле
 msgid "Set fixed font in text controls."
 msgstr "Встановити шрифт сталої ширини для текстових міток."
 
-#: ../src/wxMaximaFrame.cpp:928
+#: ../src/wxMaximaFrame.cpp:927
 msgid "Set plot format"
 msgstr "Встановити формат графіка"
 
-#: ../src/wxMaximaFrame.cpp:945
+#: ../src/wxMaximaFrame.cpp:944
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can "
 "be generated by entering 1.5b12 or as bfloat(1.234)"
@@ -3664,52 +3667,52 @@ msgstr ""
 "Встановити точність для чисел, які визначаються типом bigfloat. Такі числа "
 "можна вказати за допомогою такого коду: 1.5b12 або bfloat(1.234)"
 
-#: ../src/wxMaximaFrame.cpp:569
+#: ../src/wxMaximaFrame.cpp:568
 msgid "Set zoom to 100%"
 msgstr "Встановити масштаб у 100%"
 
-#: ../src/wxMaximaFrame.cpp:570
+#: ../src/wxMaximaFrame.cpp:569
 msgid "Set zoom to 120%"
 msgstr "Встановити масштаб у 120%"
 
-#: ../src/wxMaximaFrame.cpp:571
+#: ../src/wxMaximaFrame.cpp:570
 msgid "Set zoom to 150%"
 msgstr "Встановити масштаб у 150%"
 
-#: ../src/wxMaximaFrame.cpp:572
+#: ../src/wxMaximaFrame.cpp:571
 msgid "Set zoom to 200%"
 msgstr "Встановити масштаб у 200%"
 
-#: ../src/wxMaximaFrame.cpp:573
+#: ../src/wxMaximaFrame.cpp:572
 msgid "Set zoom to 300%"
 msgstr "Встановити масштаб у 300%"
 
-#: ../src/wxMaximaFrame.cpp:568
+#: ../src/wxMaximaFrame.cpp:567
 msgid "Set zoom to 80%"
 msgstr "Встановити масштаб у 80%"
 
-#: ../src/wxMaximaFrame.cpp:732
+#: ../src/wxMaximaFrame.cpp:731
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
 "Встановити значення для розвя’зання ЗДР за допомогою перетворення Лапласа"
 
-#: ../src/wxMaximaFrame.cpp:918
+#: ../src/wxMaximaFrame.cpp:917
 msgid "Setup modulus computation"
 msgstr "Встановити обчислення за модулем"
 
-#: ../src/wxMaximaFrame.cpp:662
+#: ../src/wxMaximaFrame.cpp:661
 msgid "Show &Definition..."
 msgstr "Показати ви&значення…"
 
-#: ../src/wxMaximaFrame.cpp:660
+#: ../src/wxMaximaFrame.cpp:659
 msgid "Show &Functions"
 msgstr "Показати &функції"
 
-#: ../src/wxMaximaFrame.cpp:967
+#: ../src/wxMaximaFrame.cpp:966
 msgid "Show &Tips..."
 msgstr "Показати п&ідказку…"
 
-#: ../src/wxMaximaFrame.cpp:665
+#: ../src/wxMaximaFrame.cpp:664
 msgid "Show &Variables"
 msgstr "Показати з&мінні"
 
@@ -3717,43 +3720,43 @@ msgstr "Показати з&мінні"
 msgid "Show Maxima help"
 msgstr "Показати довідку з Maxima"
 
-#: ../src/wxMaximaFrame.cpp:603
+#: ../src/wxMaximaFrame.cpp:602
 msgid "Show Template\tCtrl-Shift-K"
 msgstr "Показати шаблон\tCtrl-Shift-K"
 
-#: ../src/wxMaximaFrame.cpp:968
+#: ../src/wxMaximaFrame.cpp:967
 msgid "Show a tip"
 msgstr "Показати підказку"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Show all commands similar to:"
 msgstr "Показати всі команди, подібні до:"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Show an example for the command:"
 msgstr "Показати приклад для команди:"
 
-#: ../src/wxMaximaFrame.cpp:962
+#: ../src/wxMaximaFrame.cpp:961
 msgid "Show an example of usage"
 msgstr "Показати приклад використання"
 
-#: ../src/wxMaximaFrame.cpp:965
+#: ../src/wxMaximaFrame.cpp:964
 msgid "Show commands similar to"
 msgstr "Показати команди, подібні до"
 
-#: ../src/wxMaximaFrame.cpp:661
+#: ../src/wxMaximaFrame.cpp:660
 msgid "Show defined functions"
 msgstr "Показати визначені функції"
 
-#: ../src/wxMaximaFrame.cpp:666
+#: ../src/wxMaximaFrame.cpp:665
 msgid "Show defined variables"
 msgstr "Показати визначені змінні"
 
-#: ../src/wxMaximaFrame.cpp:663
+#: ../src/wxMaximaFrame.cpp:662
 msgid "Show definition of a function"
 msgstr "Показати визначення функції"
 
-#: ../src/wxMaximaFrame.cpp:604
+#: ../src/wxMaximaFrame.cpp:603
 msgid "Show function template"
 msgstr "Показати шаблон функції"
 
@@ -3765,7 +3768,7 @@ msgstr "Показувати довгі вирази у документі wxMax
 msgid "Show long expressions:"
 msgstr "Показувати довгі вирази:"
 
-#: ../src/wxMaxima.cpp:3341
+#: ../src/wxMaxima.cpp:3353
 msgid "Show the definition of function:"
 msgstr "Показати визначення функції:"
 
@@ -3774,43 +3777,43 @@ msgstr "Показати визначення функції:"
 msgid "Show user-defined labels instead of (%oxx)"
 msgstr "Показувати визначені користувачем мітки замість (%oxx)"
 
-#: ../src/wxMaximaFrame.cpp:953 ../src/wxMaximaFrame.cpp:956
+#: ../src/wxMaximaFrame.cpp:952 ../src/wxMaximaFrame.cpp:955
 msgid "Show wxMaxima help"
 msgstr "Показати довідку з wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:1381
+#: ../src/wxMaximaFrame.cpp:1380
 msgid "Sigma"
 msgstr "Σ"
 
-#: ../src/wxMaximaFrame.cpp:1211
+#: ../src/wxMaximaFrame.cpp:1210
 msgid "Simplify"
 msgstr "Спростити"
 
-#: ../src/wxMaximaFrame.cpp:831
+#: ../src/wxMaximaFrame.cpp:830
 msgid "Simplify &Radicals"
 msgstr "Спростити &радикали"
 
-#: ../src/wxMaximaFrame.cpp:1212
+#: ../src/wxMaximaFrame.cpp:1211
 msgid "Simplify (r)"
 msgstr "Спростити (рац)"
 
-#: ../src/wxMaximaFrame.cpp:1218
+#: ../src/wxMaximaFrame.cpp:1217
 msgid "Simplify (tr)"
 msgstr "Спростити (триг)"
 
-#: ../src/MathCtrl.cpp:995
+#: ../src/MathCtrl.cpp:1037
 msgid "Simplify Expression"
 msgstr "Спростити вираз"
 
-#: ../src/wxMaximaFrame.cpp:857
+#: ../src/wxMaximaFrame.cpp:856
 msgid "Simplify an expression containing factorials"
 msgstr "Спростити вираз, що містить факторіали"
 
-#: ../src/wxMaximaFrame.cpp:832
+#: ../src/wxMaximaFrame.cpp:831
 msgid "Simplify expression containing radicals"
 msgstr "Спростити вираз, що містить радикали"
 
-#: ../src/wxMaximaFrame.cpp:830
+#: ../src/wxMaximaFrame.cpp:829
 msgid "Simplify rational expression"
 msgstr "Спростити раціональний вираз"
 
@@ -3818,7 +3821,7 @@ msgstr "Спростити раціональний вираз"
 msgid "Simplify the sum"
 msgstr "Спростити суму"
 
-#: ../src/wxMaximaFrame.cpp:868
+#: ../src/wxMaximaFrame.cpp:867
 msgid "Simplify trigonometric expression"
 msgstr "Спростити тригонометричний вираз"
 
@@ -3835,88 +3838,88 @@ msgstr ""
 "збережено разом з вашим документом, під час збереження документа вам слід "
 "вибрати формат «XML-документ wxMaximaю."
 
-#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
+#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
 msgid "Solution:"
 msgstr "Розв’язок:"
 
-#: ../src/wxMaxima.cpp:3461 ../src/wxMaxima.cpp:3475 ../src/wxMaxima.cpp:5020
+#: ../src/wxMaxima.cpp:3473 ../src/wxMaxima.cpp:3487 ../src/wxMaxima.cpp:5032
 msgid "Solve"
 msgstr "Розв’язати"
 
-#: ../src/wxMaximaFrame.cpp:706
+#: ../src/wxMaximaFrame.cpp:705
 msgid "Solve &Algebraic System..."
 msgstr "Розв’язати систему &алгебраїчних рівнянь…"
 
-#: ../src/wxMaximaFrame.cpp:703
+#: ../src/wxMaximaFrame.cpp:702
 msgid "Solve &Linear System..."
 msgstr "Розв’язати систему &лінійних рівнянь…"
 
-#: ../src/wxMaximaFrame.cpp:714
+#: ../src/wxMaximaFrame.cpp:713
 msgid "Solve &ODE..."
 msgstr "Розв’язати &ЗДР…"
 
-#: ../src/wxMaximaFrame.cpp:690
+#: ../src/wxMaximaFrame.cpp:689
 msgid "Solve (to_poly)..."
 msgstr "Розв’язати (to_poly)…"
 
-#: ../src/wxMaxima.cpp:3511 ../src/wxMaxima.cpp:3635
+#: ../src/wxMaxima.cpp:3523 ../src/wxMaxima.cpp:3647
 msgid "Solve ODE"
 msgstr "Розв’язати ЗДР"
 
-#: ../src/wxMaximaFrame.cpp:728
+#: ../src/wxMaximaFrame.cpp:727
 msgid "Solve ODE with Lapla&ce..."
 msgstr "Розв’язати ЗДР за допомогою перетворення &Лапласа…"
 
-#: ../src/wxMaximaFrame.cpp:1222
+#: ../src/wxMaximaFrame.cpp:1221
 msgid "Solve ODE..."
 msgstr "Розв’язати ЗДР…"
 
-#: ../src/wxMaxima.cpp:3586 ../src/wxMaxima.cpp:3597
+#: ../src/wxMaxima.cpp:3598 ../src/wxMaxima.cpp:3609
 msgid "Solve algebraic system"
 msgstr "Розв’язати систему алгебраїчних рівнянь"
 
-#: ../src/wxMaximaFrame.cpp:707
+#: ../src/wxMaximaFrame.cpp:706
 msgid "Solve algebraic system of equations"
 msgstr "Розв’язати систему алгебраїчних рівнянь"
 
-#: ../src/wxMaximaFrame.cpp:725
+#: ../src/wxMaximaFrame.cpp:724
 msgid "Solve boundary value problem for second degree ODE"
 msgstr "Розв’язати крайову задачу для ЗДР другого порядку"
 
-#: ../src/wxMaximaFrame.cpp:689
+#: ../src/wxMaximaFrame.cpp:688
 msgid "Solve equation(s)"
 msgstr "Розв’язати рівняння"
 
-#: ../src/wxMaximaFrame.cpp:691
+#: ../src/wxMaximaFrame.cpp:690
 msgid "Solve equation(s) with to_poly_solve"
 msgstr "Розв’язати рівняння за допомогою to_poly_solve"
 
-#: ../src/wxMaximaFrame.cpp:719
+#: ../src/wxMaximaFrame.cpp:718
 msgid "Solve initial value problem for first degree ODE"
 msgstr "Розв’язати задачу Коші для ЗДР першого порядку"
 
-#: ../src/wxMaximaFrame.cpp:722
+#: ../src/wxMaximaFrame.cpp:721
 msgid "Solve initial value problem for second degree ODE"
 msgstr "Розв’язати задачу Коші для ЗДР другого порядку"
 
-#: ../src/wxMaxima.cpp:3610 ../src/wxMaxima.cpp:3621
+#: ../src/wxMaxima.cpp:3622 ../src/wxMaxima.cpp:3633
 msgid "Solve linear system"
 msgstr "Розв’язати систему лінійних рівнянь"
 
-#: ../src/wxMaximaFrame.cpp:704
+#: ../src/wxMaximaFrame.cpp:703
 msgid "Solve linear system of equations"
 msgstr "Розв’язати систему лінійних рівнянь"
 
-#: ../src/wxMaximaFrame.cpp:715
+#: ../src/wxMaximaFrame.cpp:714
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr "Розв’язати звичайне диференціальне рівняння не вище другого порядку"
 
-#: ../src/wxMaximaFrame.cpp:729
+#: ../src/wxMaximaFrame.cpp:728
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
 "Розв’язати звичайне диференціальне рівняння за допомогою перетворення Лапласа"
 
-#: ../src/wxMaximaFrame.cpp:1221 ../src/MathCtrl.cpp:992
+#: ../src/MathCtrl.cpp:1034 ../src/wxMaximaFrame.cpp:1220
 msgid "Solve..."
 msgstr "Розв’язати…"
 
@@ -3944,7 +3947,7 @@ msgstr "Додатково"
 msgid "Special constants"
 msgstr "Додаткові сталі"
 
-#: ../src/MathCtrl.cpp:922
+#: ../src/MathCtrl.cpp:964
 msgid "Start Animation"
 msgstr "Почати анімацію"
 
@@ -3964,28 +3967,28 @@ msgstr ""
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:294
+#: ../src/wxMaxima.cpp:295
 msgid "Starting Maxima process failed"
 msgstr "Спроба запустити процес Maxima завершилася невдало"
 
-#: ../src/wxMaxima.cpp:928
+#: ../src/wxMaxima.cpp:933
 msgid "Starting Maxima..."
 msgstr "Запускаємо Maxima…"
 
-#: ../src/wxMaxima.cpp:292 ../src/wxMaxima.cpp:860
+#: ../src/wxMaxima.cpp:293 ../src/wxMaxima.cpp:865
 msgid "Starting server failed"
 msgstr "Не вдалося запустити сервер"
 
-#: ../src/wxMaxima.cpp:841
+#: ../src/wxMaxima.cpp:846
 #, c-format
 msgid "Starting server on port %d"
 msgstr "Запуск сервера на порту %d"
 
-#: ../src/wxMaximaFrame.cpp:342
+#: ../src/wxMaximaFrame.cpp:341
 msgid "Statistics"
 msgstr "Статистика"
 
-#: ../src/wxMaximaFrame.cpp:550
+#: ../src/wxMaximaFrame.cpp:549
 msgid "Statistics\tAlt-Shift-S"
 msgstr "Статистика\tAlt-Shift-S"
 
@@ -4001,11 +4004,11 @@ msgstr "Стиль"
 msgid "Styles"
 msgstr "Стилі"
 
-#: ../src/wxMaximaFrame.cpp:1283
+#: ../src/wxMaximaFrame.cpp:1282
 msgid "Subsample..."
 msgstr "Підвибірка…"
 
-#: ../src/wxMaximaFrame.cpp:1496
+#: ../src/wxMaximaFrame.cpp:1515
 msgid "Subsection"
 msgstr "Підрозділ"
 
@@ -4013,20 +4016,20 @@ msgstr "Підрозділ"
 msgid "Subsection cell"
 msgstr "Комірка підрозділу"
 
-#: ../src/wxMaximaFrame.cpp:1216
+#: ../src/wxMaximaFrame.cpp:1215
 msgid "Subst..."
 msgstr "Підставити…"
 
-#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3423
-#: ../src/wxMaxima.cpp:5089
+#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3435
+#: ../src/wxMaxima.cpp:5101
 msgid "Substitute"
 msgstr "Підставити"
 
-#: ../src/wxMaximaFrame.cpp:906 ../src/MathCtrl.cpp:998
+#: ../src/MathCtrl.cpp:1040 ../src/wxMaximaFrame.cpp:905
 msgid "Substitute..."
 msgstr "Підставити…"
 
-#: ../src/wxMaximaFrame.cpp:1497
+#: ../src/wxMaximaFrame.cpp:1516
 msgid "Subsubsection"
 msgstr "Підпідрозділ"
 
@@ -4034,7 +4037,7 @@ msgstr "Підпідрозділ"
 msgid "Subsubsection cell"
 msgstr "Комірка підпідрозділу"
 
-#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4226
+#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4238
 msgid "Sum"
 msgstr "Сума"
 
@@ -4042,35 +4045,35 @@ msgstr "Сума"
 msgid "Sum sign"
 msgstr "Знак суми"
 
-#: ../src/wxMaximaFrame.cpp:553
+#: ../src/wxMaximaFrame.cpp:552
 msgid "Symbols\tAlt-Shift-Y"
 msgstr "Символи\tAlt-Shift-Y"
 
-#: ../src/wxMaxima.cpp:4456
+#: ../src/wxMaxima.cpp:4468
 msgid "System info"
 msgstr "Відомості щодо системи"
 
-#: ../src/wxMaximaFrame.cpp:320
+#: ../src/wxMaximaFrame.cpp:319
 msgid "Table of Contents"
 msgstr "Зміст"
 
-#: ../src/wxMaximaFrame.cpp:556
+#: ../src/wxMaximaFrame.cpp:555
 msgid "Table of Contents\tAlt-Shift-T"
 msgstr "Зміст\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:1382
+#: ../src/wxMaximaFrame.cpp:1381
 msgid "Tau"
 msgstr "Τ"
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Taylor series:"
 msgstr "Ряд Тейлора:"
 
-#: ../src/wxMaxima.cpp:3963
+#: ../src/wxMaxima.cpp:3975
 msgid "Tellrat"
 msgstr "Tellrat"
 
-#: ../src/wxMaximaFrame.cpp:1494
+#: ../src/wxMaximaFrame.cpp:1513
 msgid "Text"
 msgstr "Текст"
 
@@ -4119,7 +4122,7 @@ msgstr ""
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr "Клас документів LaTeX, який слід використовувати для наших документів."
 
-#: ../src/TextCell.cpp:136
+#: ../src/TextCell.cpp:134
 msgid ""
 "The letter \"X\" is of width zero. Installing http://www.math.union.edu/"
 "~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts\" in "
@@ -4140,7 +4143,7 @@ msgstr ""
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:959
+#: ../src/wxMaximaFrame.cpp:958
 msgid "The offline manual of maxima"
 msgstr "Автономний підручник з maxima"
 
@@ -4180,7 +4183,7 @@ msgstr ""
 "Відвідайте сторінку http://andrejv.github.com/wxmaxima/help.html, щоб "
 "дізнатися більше і пошукати підручники щодо користування wxMaxima та Maxima."
 
-#: ../src/SlideShowCell.cpp:332
+#: ../src/SlideShowCell.cpp:336
 msgid ""
 "There was an error during GIF export!\n"
 "\n"
@@ -4191,7 +4194,7 @@ msgstr ""
 "Переконайтеся, що у системі встановлено ImageMagick і що wxMaxima може "
 "знайти програму convert."
 
-#: ../src/wxMaxima.cpp:442
+#: ../src/wxMaxima.cpp:447
 msgid ""
 "There was an error in generated XML!\n"
 "\n"
@@ -4201,7 +4204,7 @@ msgstr ""
 "\n"
 "Будь ласка, повідомте про цю ваду розробника."
 
-#: ../src/wxMaximaFrame.cpp:1371
+#: ../src/wxMaximaFrame.cpp:1370
 msgid "Theta"
 msgstr "Θ"
 
@@ -4209,7 +4212,7 @@ msgstr "Θ"
 msgid "Ticks:"
 msgstr "Число точок:"
 
-#: ../src/wxMaxima.cpp:4153 ../src/wxMaxima.cpp:5065
+#: ../src/wxMaxima.cpp:4165 ../src/wxMaxima.cpp:5077
 msgid "Times:"
 msgstr "Порядок:"
 
@@ -4217,7 +4220,7 @@ msgstr "Порядок:"
 msgid "Tips not available, sorry!"
 msgstr "Підказки недоступні, вибачте!"
 
-#: ../src/wxMaximaFrame.cpp:1495
+#: ../src/wxMaximaFrame.cpp:1514
 msgid "Title"
 msgstr "Заголовок"
 
@@ -4237,19 +4240,19 @@ msgstr ""
 "Shift, буде згорнуто або розгорнуто вміст всіх підлеглих щодо основної "
 "комірки комірок."
 
-#: ../src/wxMaximaFrame.cpp:938
+#: ../src/wxMaximaFrame.cpp:937
 msgid "To &Bigfloat"
 msgstr "У число &підвищеної точності з рухомою крапкою"
 
-#: ../src/wxMaximaFrame.cpp:935
+#: ../src/wxMaximaFrame.cpp:934
 msgid "To &Float"
 msgstr "У число з &рухомою крапкою"
 
-#: ../src/MathCtrl.cpp:990
+#: ../src/MathCtrl.cpp:1032
 msgid "To Float"
 msgstr "У число з рухомою крапкою"
 
-#: ../src/wxMaximaFrame.cpp:941
+#: ../src/wxMaximaFrame.cpp:940
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr "У &число\tCtrl+Shift+N"
 
@@ -4290,51 +4293,51 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:41 ../src/Plot2dWiz.cpp:40 ../src/Plot2dWiz.cpp:50
 #: ../src/Plot2dWiz.cpp:539 ../src/Plot3dWiz.cpp:39 ../src/Plot3dWiz.cpp:48
-#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4241
+#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4253
 msgid "To:"
 msgstr "До:"
 
-#: ../src/wxMaximaFrame.cpp:912
+#: ../src/wxMaximaFrame.cpp:911
 msgid "Toggle &Algebraic Flag"
 msgstr "Пере&мкнути прапорець algebraic"
 
-#: ../src/wxMaximaFrame.cpp:933
+#: ../src/wxMaximaFrame.cpp:932
 msgid "Toggle &Numeric Output"
 msgstr "Пере&мкнути числове виведення"
 
-#: ../src/wxMaximaFrame.cpp:673
+#: ../src/wxMaximaFrame.cpp:672
 msgid "Toggle &Time Display"
 msgstr "Перемкнути показ витраченого &часу"
 
-#: ../src/wxMaximaFrame.cpp:913
+#: ../src/wxMaximaFrame.cpp:912
 msgid "Toggle algebraic flag"
 msgstr "Перемкнути прапорець algebraic"
 
-#: ../src/wxMaximaFrame.cpp:577
+#: ../src/wxMaximaFrame.cpp:576
 msgid "Toggle full screen editing"
 msgstr "Увімкнути або вимкнути режим повноекранного редагування"
 
-#: ../src/wxMaximaFrame.cpp:934
+#: ../src/wxMaximaFrame.cpp:933
 msgid "Toggle numeric output"
 msgstr "Увімкнути або вимкнути числове виведення"
 
-#: ../src/wxMaxima.cpp:4464
+#: ../src/wxMaxima.cpp:4476
 msgid "Toolbar icons"
 msgstr "Піктограми панелі інструментів"
 
-#: ../src/wxMaxima.cpp:4465
+#: ../src/wxMaxima.cpp:4477
 msgid "Translated by"
 msgstr "Переклад"
 
-#: ../src/wxMaximaFrame.cpp:763
+#: ../src/wxMaximaFrame.cpp:762
 msgid "Transpose a matrix"
 msgstr "Транспонувати матрицю"
 
-#: ../src/MathCtrl.cpp:5834
+#: ../src/MathCtrl.cpp:5886
 msgid "Trying to undo an action without starting cell."
 msgstr "Спроба скасування дії без визначення початкової комірки."
 
-#: ../src/MathCtrl.cpp:5901
+#: ../src/MathCtrl.cpp:5953
 msgid "Trying to undo something but the undo action is empty."
 msgstr "Намагаємося скасувати дію, але дія зі скасування є порожньою."
 
@@ -4342,11 +4345,11 @@ msgstr "Намагаємося скасувати дію, але дія зі с�
 msgid "Turkish"
 msgstr "турецька"
 
-#: ../src/wxMaximaFrame.cpp:970
+#: ../src/wxMaximaFrame.cpp:969
 msgid "Tutorials"
 msgstr "Настанови"
 
-#: ../src/wxMaxima.cpp:4778
+#: ../src/wxMaxima.cpp:4790
 msgid "Two sample t-test"
 msgstr "Двовибіркова t-перевірка"
 
@@ -4358,15 +4361,15 @@ msgstr "Тип:"
 msgid "Ukrainian"
 msgstr "українська"
 
-#: ../src/wxMaxima.cpp:5356
+#: ../src/wxMaxima.cpp:5372
 msgid "Un-closed parenthesis"
 msgstr "Незакрита дужка"
 
-#: ../src/wxMaxima.cpp:5323
+#: ../src/wxMaxima.cpp:5335
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr "Незакрита дужка до символу ; або $"
 
-#: ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5889
 msgid ""
 "Unable to interpret the version info I got from http://andrejv.github.io//"
 "wxmaxima/version.txt: "
@@ -4382,11 +4385,11 @@ msgstr "Підкреслення"
 msgid "Underscore converts to subscripts:"
 msgstr "Символ підкреслювання означає нижній індекс:"
 
-#: ../src/wxMaximaFrame.cpp:492
+#: ../src/wxMaximaFrame.cpp:491
 msgid "Undo\tCtrl-Z"
 msgstr "Вернути\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:493
+#: ../src/wxMaximaFrame.cpp:492
 msgid "Undo last change"
 msgstr "Скасувати останню зміну"
 
@@ -4394,23 +4397,23 @@ msgstr "Скасувати останню зміну"
 msgid "Undo limit (0 for none):"
 msgstr "Обмеження скасувань (0 — не обмежувати):"
 
-#: ../src/wxMaximaFrame.cpp:625
+#: ../src/wxMaximaFrame.cpp:624
 msgid "Unfold All\tCtrl-Alt-]"
 msgstr "Розгорнути всі\tCtrl-Alt-]"
 
-#: ../src/wxMaximaFrame.cpp:626
+#: ../src/wxMaximaFrame.cpp:625
 msgid "Unfold all folded sections"
 msgstr "Розгорнути всі згорнути розділи"
 
-#: ../src/wxMaxima.cpp:4458
+#: ../src/wxMaxima.cpp:4470
 msgid "Unicode Support"
 msgstr "Підтримка Unicode"
 
-#: ../src/wxMaxima.cpp:5335
+#: ../src/wxMaxima.cpp:5347
 msgid "Unterminated comment."
 msgstr "Незавершений коментар."
 
-#: ../src/wxMaxima.cpp:5309
+#: ../src/wxMaxima.cpp:5321
 msgid "Unterminated string."
 msgstr "Незавершений рядок."
 
@@ -4418,15 +4421,15 @@ msgstr "Незавершений рядок."
 msgid "Up"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5859 ../src/wxMaxima.cpp:5866 ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5874 ../src/wxMaxima.cpp:5881 ../src/wxMaxima.cpp:5889
 msgid "Upgrade"
 msgstr "Оновити"
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Upper bound:"
 msgstr "Верхня межа:"
 
-#: ../src/wxMaximaFrame.cpp:1383
+#: ../src/wxMaximaFrame.cpp:1382
 msgid "Upsilon"
 msgstr "Υ"
 
@@ -4478,22 +4481,22 @@ msgstr ""
 msgid "User-defined labels"
 msgstr "Визначені користувачем мітки"
 
-#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3525
-#: ../src/wxMaxima.cpp:3541 ../src/wxMaxima.cpp:3649
+#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3537
+#: ../src/wxMaxima.cpp:3553 ../src/wxMaxima.cpp:3661
 msgid "Value:"
 msgstr "Значення:"
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:5019 ../src/wxMaxima.cpp:5064
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:5031 ../src/wxMaxima.cpp:5076
 msgid "Variable(s):"
 msgstr "Змінні:"
 
 #: ../src/IntegrateWiz.cpp:33 ../src/LimitWiz.cpp:30 ../src/Plot2dWiz.cpp:34
 #: ../src/Plot2dWiz.cpp:44 ../src/Plot2dWiz.cpp:533 ../src/Plot3dWiz.cpp:33
 #: ../src/Plot3dWiz.cpp:42 ../src/SeriesWiz.cpp:36 ../src/SumWiz.cpp:30
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3749
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3761
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5045
 msgid "Variable:"
 msgstr "Змінна:"
 
@@ -4501,25 +4504,25 @@ msgstr "Змінна:"
 msgid "Variables"
 msgstr "Змінні"
 
-#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3571 ../src/wxMaxima.cpp:4206
-#: ../src/wxMaxima.cpp:4807
+#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3583 ../src/wxMaxima.cpp:4218
+#: ../src/wxMaxima.cpp:4819
 msgid "Variables:"
 msgstr "Змінні:"
 
-#: ../src/wxMaximaFrame.cpp:1257
+#: ../src/wxMaximaFrame.cpp:1256
 msgid "Variance..."
 msgstr "Дисперсія…"
 
-#: ../src/wxMaximaFrame.cpp:580
+#: ../src/wxMaximaFrame.cpp:579
 msgid "View"
 msgstr "Перегляд"
 
-#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1674 ../src/wxMaxima.cpp:1769
-#: ../src/wxMaxima.cpp:1950
+#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1679 ../src/wxMaxima.cpp:1774
+#: ../src/wxMaxima.cpp:1955
 msgid "Warning"
 msgstr "Попередження"
 
-#: ../src/wxMaximaFrame.cpp:109 ../src/wxMaximaFrame.cpp:295
+#: ../src/wxMaximaFrame.cpp:108 ../src/wxMaximaFrame.cpp:294
 msgid "Welcome to wxMaxima"
 msgstr "Ласкаво просимо до wxMaxima"
 
@@ -4547,7 +4550,7 @@ msgstr ""
 "аркуші. Якщо пункт не буде позначено, ви зможете вставляти розриви рядків "
 "вручну, додаючи порожній рядок."
 
-#: ../src/wxMaxima.cpp:2567
+#: ../src/wxMaxima.cpp:2574
 #, fuzzy
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) "
@@ -4567,7 +4570,7 @@ msgstr ""
 "Брати рівняння, експортовані за допомогою пункту «Копіювати як LaTeX», у "
 "позначення рівняння, \\[ на початку і \\] наприкінці"
 
-#: ../src/MathCtrl.cpp:6798
+#: ../src/MathCtrl.cpp:6856
 msgid "Wrapped search"
 msgstr "Циклічний пошук"
 
@@ -4575,15 +4578,15 @@ msgstr "Циклічний пошук"
 msgid "Write matching parenthesis in text controls."
 msgstr "Писати відповідні дужки в текстових елементах керування."
 
-#: ../src/wxMaxima.cpp:4461
+#: ../src/wxMaxima.cpp:4473
 msgid "Written by"
 msgstr "Автор"
 
-#: ../src/wxMaximaFrame.cpp:557
+#: ../src/wxMaximaFrame.cpp:556
 msgid "XML Inspector"
 msgstr "Аналізатор XML"
 
-#: ../src/wxMaximaFrame.cpp:1377
+#: ../src/wxMaximaFrame.cpp:1376
 msgid "Xi"
 msgstr "Ξ"
 
@@ -4659,7 +4662,7 @@ msgstr ""
 "корисним, якщо вам потрібно вилучити декілька комірок або виконати "
 "обчислення у декількох комірках одразу."
 
-#: ../src/wxMaxima.cpp:5856
+#: ../src/wxMaxima.cpp:5871
 #, c-format
 msgid ""
 "You have version %s. Current version is %s.\n"
@@ -4670,39 +4673,39 @@ msgstr ""
 "\n"
 "Натисніть кнопку «Гаразд», щоб відвідати сторінку wxMaxima у інтернеті."
 
-#: ../src/wxMaxima.cpp:5921
+#: ../src/wxMaxima.cpp:5936
 msgid "Your changes will be lost if you don't save them."
 msgstr "Внесені вами зміни буде втрачено, якщо ви не збережете їх."
 
-#: ../src/wxMaxima.cpp:5866
+#: ../src/wxMaxima.cpp:5881
 msgid "Your version of wxMaxima is up to date."
 msgstr "Ваша версія wxMaxima є актуальною."
 
-#: ../src/wxMaximaFrame.cpp:1369
+#: ../src/wxMaximaFrame.cpp:1368
 msgid "Zeta"
 msgstr "Ζ"
 
-#: ../src/wxMaximaFrame.cpp:562
+#: ../src/wxMaximaFrame.cpp:561
 msgid "Zoom &In\tCtrl-+"
 msgstr "З&більшити\tCtrl-+"
 
-#: ../src/wxMaximaFrame.cpp:564
+#: ../src/wxMaximaFrame.cpp:563
 msgid "Zoom Ou&t\tCtrl--"
 msgstr "З&меншити\tCtrl--"
 
-#: ../src/wxMaximaFrame.cpp:563
+#: ../src/wxMaximaFrame.cpp:562
 msgid "Zoom in 10%"
 msgstr "Збільшити на 10%"
 
-#: ../src/wxMaximaFrame.cpp:565
+#: ../src/wxMaximaFrame.cpp:564
 msgid "Zoom out 10%"
 msgstr "Зменшити на 10%"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaximaFrame.cpp:287
 msgid "[ unsaved ]"
 msgstr "[ не збережено ]"
 
-#: ../src/wxMaxima.cpp:5700
+#: ../src/wxMaxima.cpp:5715
 msgid "[ unsaved* ]"
 msgstr "[ не збережено* ]"
 
@@ -4711,17 +4714,17 @@ msgstr "[ не збережено* ]"
 msgid "[%i digits]"
 msgstr "[%i цифр]"
 
-#: ../src/MathCtrl.cpp:4392
+#: ../src/MathCtrl.cpp:4447
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" style=\"max-width:90%%;\" >\n"
 msgstr "_%d.gif\"  alt=\"Анімована діаграма\" style=\"max-width:90%%;\" >\n"
 
-#: ../src/MathCtrl.cpp:4517
+#: ../src/MathCtrl.cpp:4572
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" >"
 msgstr "_%d.gif\" alt=\"Анімована діаграма\" style=\"max-width:90%%;\" >"
 
-#: ../src/wxMaximaFrame.cpp:1333
+#: ../src/wxMaximaFrame.cpp:1332
 msgid "alpha"
 msgstr "α"
 
@@ -4733,7 +4736,7 @@ msgstr "і"
 msgid "antisymmetric"
 msgstr "антисиметрична"
 
-#: ../src/wxMaximaFrame.cpp:1334
+#: ../src/wxMaximaFrame.cpp:1333
 msgid "beta"
 msgstr "β"
 
@@ -4777,7 +4780,7 @@ msgstr "вада: некоректний теґ sum"
 msgid "bug:Invalid sup tag"
 msgstr "вада: некоректний теґ sup"
 
-#: ../src/wxMaximaFrame.cpp:1354
+#: ../src/wxMaximaFrame.cpp:1353
 msgid "chi"
 msgstr "χ"
 
@@ -4790,7 +4793,7 @@ msgstr "виберіть варіант lisp за допомогою якого 
 msgid "default"
 msgstr "типовий"
 
-#: ../src/wxMaximaFrame.cpp:1336
+#: ../src/wxMaximaFrame.cpp:1335
 msgid "delta"
 msgstr "δ"
 
@@ -4802,7 +4805,7 @@ msgstr "діагональна"
 msgid "empty"
 msgstr "порожня множина"
 
-#: ../src/wxMaximaFrame.cpp:1337
+#: ../src/wxMaximaFrame.cpp:1336
 msgid "epsilon"
 msgstr "ε"
 
@@ -4810,7 +4813,7 @@ msgstr "ε"
 msgid "equivalent"
 msgstr "еквівалентно"
 
-#: ../src/wxMaximaFrame.cpp:1339
+#: ../src/wxMaximaFrame.cpp:1338
 msgid "eta"
 msgstr "η"
 
@@ -4830,7 +4833,7 @@ msgstr ""
 "індексів, якщо таким індексом може стати цифра або літера\n"
 "all=_ позначає нижній індекс."
 
-#: ../src/wxMaximaFrame.cpp:1335
+#: ../src/wxMaximaFrame.cpp:1334
 msgid "gamma"
 msgstr "γ"
 
@@ -4856,15 +4859,15 @@ msgstr "вбудований"
 msgid "intersection"
 msgstr "перетин"
 
-#: ../src/wxMaximaFrame.cpp:1341
+#: ../src/wxMaximaFrame.cpp:1340
 msgid "iota"
 msgstr "ι"
 
-#: ../src/wxMaximaFrame.cpp:1342
+#: ../src/wxMaximaFrame.cpp:1341
 msgid "kappa"
 msgstr "ϰ"
 
-#: ../src/wxMaximaFrame.cpp:1343
+#: ../src/wxMaximaFrame.cpp:1342
 msgid "lambda"
 msgstr "λ"
 
@@ -4880,7 +4883,7 @@ msgstr "менше або дорівнює"
 msgid "logscale"
 msgstr "логарифмічна шкала"
 
-#: ../src/wxMaxima.cpp:3783
+#: ../src/wxMaxima.cpp:3795
 msgid "matrix[i,j]:"
 msgstr "матриця[i,j]:"
 
@@ -4888,7 +4891,7 @@ msgstr "матриця[i,j]:"
 msgid "maxima's pwd is path to document"
 msgstr "pwd maxima є шляхом до документа"
 
-#: ../src/wxMaximaFrame.cpp:1344
+#: ../src/wxMaximaFrame.cpp:1343
 msgid "mu"
 msgstr "μ"
 
@@ -4904,7 +4907,7 @@ msgstr "набагато менше"
 msgid "nand"
 msgstr "і-ні"
 
-#: ../src/wxMaxima.cpp:4524
+#: ../src/wxMaxima.cpp:4536
 msgid "no"
 msgstr "ні"
 
@@ -4928,15 +4931,15 @@ msgstr "не є підмножиною"
 msgid "not subset or equal"
 msgstr "не є підмножиною або тією самою множиною"
 
-#: ../src/wxMaximaFrame.cpp:1345
+#: ../src/wxMaximaFrame.cpp:1344
 msgid "nu"
 msgstr "ν"
 
-#: ../src/wxMaximaFrame.cpp:1356
+#: ../src/wxMaximaFrame.cpp:1355
 msgid "omega"
 msgstr "ω"
 
-#: ../src/wxMaximaFrame.cpp:1347
+#: ../src/wxMaximaFrame.cpp:1346
 msgid "omicron"
 msgstr "ο"
 
@@ -4948,11 +4951,11 @@ msgstr "або"
 msgid "partial sign"
 msgstr "символ частинної похідної"
 
-#: ../src/wxMaximaFrame.cpp:1353
+#: ../src/wxMaximaFrame.cpp:1352
 msgid "phi"
 msgstr "φ"
 
-#: ../src/wxMaximaFrame.cpp:1348
+#: ../src/wxMaximaFrame.cpp:1347
 msgid "pi"
 msgstr "π"
 
@@ -4964,11 +4967,11 @@ msgstr "плюс чи мінус"
 msgid "proportional to"
 msgstr "пропорційне"
 
-#: ../src/wxMaximaFrame.cpp:1355
+#: ../src/wxMaximaFrame.cpp:1354
 msgid "psi"
 msgstr "ψ"
 
-#: ../src/wxMaximaFrame.cpp:1349
+#: ../src/wxMaximaFrame.cpp:1348
 msgid "rho"
 msgstr "ρ"
 
@@ -4976,7 +4979,7 @@ msgstr "ρ"
 msgid "right"
 msgstr "праворуч"
 
-#: ../src/wxMaximaFrame.cpp:1350
+#: ../src/wxMaximaFrame.cpp:1349
 msgid "sigma"
 msgstr "σ"
 
@@ -4996,7 +4999,7 @@ msgstr "підмножина або та сама множина"
 msgid "symmetric"
 msgstr "симетрична"
 
-#: ../src/wxMaximaFrame.cpp:1351
+#: ../src/wxMaximaFrame.cpp:1350
 msgid "tau"
 msgstr "τ"
 
@@ -5008,7 +5011,7 @@ msgstr "повідомити sbcl, що для буфера слід викор�
 msgid "there is no"
 msgstr "немає"
 
-#: ../src/wxMaximaFrame.cpp:1340
+#: ../src/wxMaximaFrame.cpp:1339
 msgid "theta"
 msgstr "θ"
 
@@ -5024,12 +5027,12 @@ msgstr "у кубі"
 msgid "union"
 msgstr "об'єднання"
 
-#: ../src/wxMaxima.cpp:5903
+#: ../src/wxMaxima.cpp:5918
 msgid "unsaved"
 msgstr "не збережено"
 
-#: ../src/wxMaximaFrame.cpp:290 ../src/wxMaxima.cpp:2559
-#: ../src/wxMaxima.cpp:2826
+#: ../src/wxMaxima.cpp:2566 ../src/wxMaxima.cpp:2834
+#: ../src/wxMaximaFrame.cpp:289
 msgid "untitled"
 msgstr "без назви"
 
@@ -5038,25 +5041,25 @@ msgstr "без назви"
 msgid "untitled %d"
 msgstr "без назви %d"
 
-#: ../src/wxMaximaFrame.cpp:1352
+#: ../src/wxMaximaFrame.cpp:1351
 msgid "upsilon"
 msgstr "υ"
 
-#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4538
+#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4550
 msgid "wxMaxima"
 msgstr "wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
-#: ../src/wxMaxima.cpp:5700 ../src/wxMaxima.cpp:5709 ../src/wxMaxima.cpp:5712
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaxima.cpp:5715 ../src/wxMaxima.cpp:5724
+#: ../src/wxMaxima.cpp:5727 ../src/wxMaximaFrame.cpp:287
 #, c-format
 msgid "wxMaxima %s "
 msgstr "wxMaxima %s"
 
-#: ../src/wxMaximaFrame.cpp:952
+#: ../src/wxMaximaFrame.cpp:951
 msgid "wxMaxima &Help\tCtrl+?"
 msgstr "Д&овідка з wxMaxima\tCtrl+?"
 
-#: ../src/wxMaximaFrame.cpp:955
+#: ../src/wxMaximaFrame.cpp:954
 msgid "wxMaxima &Help\tF1"
 msgstr "Д&овідка з wxMaxima\tF1"
 
@@ -5071,11 +5074,11 @@ msgstr ""
 "домашньому каталозі користувача. Визначити адресу цього каталогу можна за "
 "допомогою команди maxima_userdir"
 
-#: ../src/wxMaxima.cpp:1619
+#: ../src/wxMaxima.cpp:1624
 msgid "wxMaxima cannot open content.xml in the .wxmx zip archive "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1633
+#: ../src/wxMaxima.cpp:1638
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
@@ -5083,7 +5086,7 @@ msgstr ""
 msgid "wxMaxima configuration"
 msgstr "Налаштування wxMaxima"
 
-#: ../src/wxMaxima.cpp:1947
+#: ../src/wxMaxima.cpp:1952
 msgid ""
 "wxMaxima could not find Maxima!\n"
 "\n"
@@ -5096,7 +5099,7 @@ msgstr ""
 "Після цього запустіть Maxima за допомогою пункту меню «Maxima → "
 "Перезапустити Maxima»."
 
-#: ../src/wxMaxima.cpp:2204
+#: ../src/wxMaxima.cpp:2209
 msgid ""
 "wxMaxima could not find help files.\n"
 "\n"
@@ -5106,7 +5109,7 @@ msgstr ""
 "\n"
 "Перевірте, чи належним чином встановлено програму."
 
-#: ../src/wxMaxima.cpp:2032
+#: ../src/wxMaxima.cpp:2037
 msgid ""
 "wxMaxima could not find tip files.\n"
 "\n"
@@ -5116,7 +5119,7 @@ msgstr ""
 "\n"
 "Перевірте, чи належним чином встановлено програму."
 
-#: ../src/wxMaxima.cpp:282
+#: ../src/wxMaxima.cpp:283
 msgid ""
 "wxMaxima could not start the server.\n"
 "\n"
@@ -5138,23 +5141,23 @@ msgstr ""
 "параметрів, одним з яких є «%». Якщо ви позначите якийсь з фрагментів у "
 "вашому документі, замість «%» буде використано цей фрагмент."
 
-#: ../src/wxMaxima.cpp:2330
+#: ../src/wxMaxima.cpp:2336
 msgid "wxMaxima document"
 msgstr "Документ wxMaxima"
 
-#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2799
+#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2807
 msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 msgstr "документ wxMaxima (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 
-#: ../src/wxMaxima.cpp:1455 ../src/wxMaxima.cpp:1469
+#: ../src/wxMaxima.cpp:1460 ../src/wxMaxima.cpp:1474
 msgid "wxMaxima encountered an error loading "
 msgstr "Під час спроби завантаження wxMaxima сталася помилка "
 
-#: ../src/wxMaxima.cpp:4463
+#: ../src/wxMaxima.cpp:4475
 msgid "wxMaxima icon"
 msgstr "Піктограма wxMaxima"
 
-#: ../src/wxMaxima.cpp:4455
+#: ../src/wxMaxima.cpp:4467
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "MAXIMA based on wxWidgets."
@@ -5162,7 +5165,7 @@ msgstr ""
 "wxMaxima — графічний інтерфейс до системи комп’ютерної алгебри MAXIMA на "
 "основі wxWidgets."
 
-#: ../src/wxMaxima.cpp:4516
+#: ../src/wxMaxima.cpp:4528
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "Maxima based on wxWidgets."
@@ -5182,11 +5185,11 @@ msgstr ""
 msgid "x"
 msgstr "x"
 
-#: ../src/wxMaximaFrame.cpp:1346
+#: ../src/wxMaximaFrame.cpp:1345
 msgid "xi"
 msgstr "χ"
 
-#: ../src/wxMaxima.cpp:1643
+#: ../src/wxMaxima.cpp:1648
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
@@ -5194,11 +5197,11 @@ msgstr ""
 msgid "xor"
 msgstr "викл. або"
 
-#: ../src/wxMaxima.cpp:4522
+#: ../src/wxMaxima.cpp:4534
 msgid "yes"
 msgstr "так"
 
-#: ../src/wxMaximaFrame.cpp:1338
+#: ../src/wxMaximaFrame.cpp:1337
 msgid "zeta"
 msgstr "ζ"
 

--- a/locales/wxMaxima.pot
+++ b/locales/wxMaxima.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-07 21:42+0200\n"
+"POT-Creation-Date: 2016-10-16 17:47+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../src/wxMaxima.cpp:4519
+#: ../src/wxMaxima.cpp:4531
 #, c-format
 msgid ""
 "\n"
@@ -26,25 +26,25 @@ msgid ""
 "Unicode support: %s"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4532
+#: ../src/wxMaxima.cpp:4544
 msgid ""
 "\n"
 "Lisp: "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4528
+#: ../src/wxMaxima.cpp:4540
 msgid ""
 "\n"
 "Maxima version: "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5381
+#: ../src/wxMaxima.cpp:5397
 msgid ""
 "\n"
 "Not connected to Maxima!\n"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4530
+#: ../src/wxMaxima.cpp:4542
 msgid ""
 "\n"
 "Not connected."
@@ -62,7 +62,7 @@ msgstr ""
 msgid " (Graphics) "
 msgstr ""
 
-#: ../src/EditorCell.cpp:3045 ../src/EditorCell.cpp:3227
+#: ../src/EditorCell.cpp:3088 ../src/EditorCell.cpp:3270
 #, c-format
 msgid " ... + %i hidden lines"
 msgstr ""
@@ -71,13 +71,13 @@ msgstr ""
 msgid " << Expression longer than allowed by the configuration setting! >>"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1673
+#: ../src/wxMaxima.cpp:1678
 msgid ""
 " was saved using a newer version of wxMaxima so it may not load correctly. "
 "Please update your wxMaxima."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1665
+#: ../src/wxMaxima.cpp:1670
 msgid ""
 " was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr ""
@@ -90,64 +90,64 @@ msgstr ""
 msgid "\"implies\" symbol"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:101
+#: ../src/wxMaximaFrame.cpp:100
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:773
+#: ../src/wxMaximaFrame.cpp:772
 msgid "&Algebra"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:767
+#: ../src/wxMaximaFrame.cpp:766
 msgid "&Apply to List..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:964
+#: ../src/wxMaximaFrame.cpp:963
 msgid "&Apropos..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:478
+#: ../src/wxMaximaFrame.cpp:477
 msgid "&Batch File...\tCtrl-B"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:724
+#: ../src/wxMaximaFrame.cpp:723
 msgid "&Boundary Value Problem..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:975
+#: ../src/wxMaximaFrame.cpp:974
 msgid "&Bug Report"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:825
+#: ../src/wxMaximaFrame.cpp:824
 msgid "&Calculus"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:876
+#: ../src/wxMaximaFrame.cpp:875
 msgid "&Canonical Form"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:749
+#: ../src/wxMaximaFrame.cpp:748
 msgid "&Characteristic Polynomial..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:654
+#: ../src/wxMaximaFrame.cpp:653
 msgid "&Clear Memory"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:859
+#: ../src/wxMaximaFrame.cpp:858
 msgid "&Combine Factorials"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:902
+#: ../src/wxMaximaFrame.cpp:901
 msgid "&Complex Simplification"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:822
+#: ../src/wxMaximaFrame.cpp:821
 msgid "&Continued Fraction"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:502
+#: ../src/wxMaximaFrame.cpp:501
 msgid "&Copy\tCtrl-C"
 msgstr ""
 
@@ -155,107 +155,107 @@ msgstr ""
 msgid "&Definite integration"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:896
+#: ../src/wxMaximaFrame.cpp:895
 msgid "&Demoivre"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:752
+#: ../src/wxMaximaFrame.cpp:751
 msgid "&Determinant"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:785
+#: ../src/wxMaximaFrame.cpp:784
 msgid "&Differentiate..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:543
+#: ../src/wxMaximaFrame.cpp:542
 msgid "&Edit"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:709
+#: ../src/wxMaximaFrame.cpp:708
 msgid "&Eliminate Variable..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:744
+#: ../src/wxMaximaFrame.cpp:743
 msgid "&Enter Matrix..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:961
+#: ../src/wxMaximaFrame.cpp:960
 msgid "&Example..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:839
+#: ../src/wxMaximaFrame.cpp:838
 msgid "&Expand Expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:873
+#: ../src/wxMaximaFrame.cpp:872
 msgid "&Expand Trigonometric"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:899
+#: ../src/wxMaximaFrame.cpp:898
 msgid "&Exponentialize"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:480
+#: ../src/wxMaximaFrame.cpp:479
 msgid "&Export..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:834
+#: ../src/wxMaximaFrame.cpp:833
 msgid "&Factor Expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:489
+#: ../src/wxMaximaFrame.cpp:488
 msgid "&File"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:692
+#: ../src/wxMaximaFrame.cpp:691
 msgid "&Find Root..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:738
+#: ../src/wxMaximaFrame.cpp:737
 msgid "&Generate Matrix..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:809
+#: ../src/wxMaximaFrame.cpp:808
 msgid "&Greatest Common Divisor..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:994
+#: ../src/wxMaximaFrame.cpp:993
 msgid "&Help"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:777
+#: ../src/wxMaximaFrame.cpp:776
 msgid "&Integrate..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:645
+#: ../src/wxMaximaFrame.cpp:644
 msgid "&Interrupt\tCtrl-."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:649
+#: ../src/wxMaximaFrame.cpp:648
 msgid "&Interrupt\tCtrl-G"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:746
+#: ../src/wxMaximaFrame.cpp:745
 msgid "&Invert Matrix"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:476
+#: ../src/wxMaximaFrame.cpp:475
 msgid "&Load Package...\tCtrl-L"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:769
+#: ../src/wxMaximaFrame.cpp:768
 msgid "&Map to List(s)..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:684
+#: ../src/wxMaximaFrame.cpp:683
 msgid "&Maxima"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:958
+#: ../src/wxMaximaFrame.cpp:957
 msgid "&Maxima help"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:917
+#: ../src/wxMaximaFrame.cpp:916
 msgid "&Modulus Computation..."
 msgstr ""
 
@@ -263,7 +263,7 @@ msgstr ""
 msgid "&New\tCtrl-N"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:947
+#: ../src/wxMaximaFrame.cpp:946
 msgid "&Numeric"
 msgstr ""
 
@@ -279,11 +279,11 @@ msgstr ""
 msgid "&Open\tCtrl-O"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:463
+#: ../src/wxMaximaFrame.cpp:462
 msgid "&Open...\tCtrl-O"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:929
+#: ../src/wxMaximaFrame.cpp:928
 msgid "&Plot"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgstr ""
 msgid "&Power series"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:483
+#: ../src/wxMaximaFrame.cpp:482
 msgid "&Print...\tCtrl-P"
 msgstr ""
 
@@ -299,39 +299,39 @@ msgstr ""
 msgid "&Rational"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:870
+#: ../src/wxMaximaFrame.cpp:869
 msgid "&Reduce Trigonometric"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "&Restart Maxima"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:700
+#: ../src/wxMaximaFrame.cpp:699
 msgid "&Roots of Polynomial (Real)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:472
+#: ../src/wxMaximaFrame.cpp:471
 msgid "&Save\tCtrl-S"
 msgstr ""
 
-#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:919
+#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:918
 msgid "&Simplify"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:829
+#: ../src/wxMaximaFrame.cpp:828
 msgid "&Simplify Expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:856
+#: ../src/wxMaximaFrame.cpp:855
 msgid "&Simplify Factorials"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:867
+#: ../src/wxMaximaFrame.cpp:866
 msgid "&Simplify Trigonometric"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:688
+#: ../src/wxMaximaFrame.cpp:687
 msgid "&Solve..."
 msgstr ""
 
@@ -343,11 +343,11 @@ msgstr ""
 msgid "&Taylor series"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:762
+#: ../src/wxMaximaFrame.cpp:761
 msgid "&Transpose Matrix"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:879
+#: ../src/wxMaximaFrame.cpp:878
 msgid "&Trigonometric Simplification"
 msgstr ""
 
@@ -365,7 +365,7 @@ msgstr ""
 msgid "- Infinity"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:351
+#: ../src/wxMaxima.cpp:356
 msgid ""
 "... [suppressed additional lines since the output is longer than allowed in "
 "the configuration] "
@@ -375,16 +375,16 @@ msgstr ""
 msgid "1/2"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:103
+#: ../src/wxMaximaFrame.cpp:102
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4601
+#: ../src/wxMaxima.cpp:4613
 msgid "<br>Lisp: "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5487
+#: ../src/wxMaxima.cpp:5503
 msgid ""
 "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
@@ -410,11 +410,11 @@ msgid ""
 "\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1472
+#: ../src/wxMaximaFrame.cpp:1495
 msgid "A symbol from the configuration dialogue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:731
+#: ../src/wxMaximaFrame.cpp:730
 msgid "A&t Value..."
 msgstr ""
 
@@ -422,12 +422,12 @@ msgstr ""
 msgid "Abort evaluation on error"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaxima.cpp:4603
+#: ../src/wxMaxima.cpp:4615 ../src/wxMaximaFrame.cpp:985
 msgid "About"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:987 ../src/wxMaximaFrame.cpp:990
-#: ../src/wxMaximaFrame.cpp:991
+#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaximaFrame.cpp:989
+#: ../src/wxMaximaFrame.cpp:990
 msgid "About wxMaxima"
 msgstr ""
 
@@ -435,23 +435,23 @@ msgstr ""
 msgid "Active cell bracket"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:760
+#: ../src/wxMaximaFrame.cpp:759
 msgid "Ad&joint Matrix"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:914
+#: ../src/wxMaximaFrame.cpp:913
 msgid "Add Algebraic E&quality..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:657
+#: ../src/wxMaximaFrame.cpp:656
 msgid "Add a directory to search path"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3353
+#: ../src/wxMaxima.cpp:3365
 msgid "Add dir to path:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:915
+#: ../src/wxMaximaFrame.cpp:914
 msgid "Add equality to the rational simplifier"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "Add the .wxmx file to the HTML export"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:656
+#: ../src/wxMaximaFrame.cpp:655
 msgid "Add to &Path..."
 msgstr ""
 
@@ -498,27 +498,27 @@ msgstr ""
 msgid "All|*"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1364
+#: ../src/wxMaximaFrame.cpp:1363
 msgid "Alpha"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3838
+#: ../src/wxMaxima.cpp:3850
 msgid "Apply"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:768
+#: ../src/wxMaximaFrame.cpp:767
 msgid "Apply function to a list"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Apropos"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3764
+#: ../src/wxMaxima.cpp:3776
 msgid "Array:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4462
+#: ../src/wxMaxima.cpp:4474
 msgid "Artwork by"
 msgstr ""
 
@@ -526,7 +526,7 @@ msgstr ""
 msgid "Ask to save untitled documents"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3650
+#: ../src/wxMaxima.cpp:3662
 msgid "At value"
 msgstr ""
 
@@ -547,11 +547,11 @@ msgstr ""
 msgid "Autosave interval (minutes, 0 means: off):"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3557
+#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3569
 msgid "BC2"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1272
+#: ../src/wxMaximaFrame.cpp:1271
 msgid "Barsplot..."
 msgstr ""
 
@@ -559,7 +559,7 @@ msgstr ""
 msgid "Bat files (*.bat)|*.bat|All|*"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2943
+#: ../src/wxMaxima.cpp:2951
 msgid "Batch File"
 msgstr ""
 
@@ -572,7 +572,7 @@ msgid ""
 "cells."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1365
+#: ../src/wxMaximaFrame.cpp:1364
 msgid "Beta"
 msgstr ""
 
@@ -584,11 +584,11 @@ msgstr ""
 msgid "Bold"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2359
+#: ../src/wxMaxima.cpp:2366
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1274
+#: ../src/wxMaximaFrame.cpp:1273
 msgid "Boxplot..."
 msgstr ""
 
@@ -600,15 +600,15 @@ msgstr ""
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2080
+#: ../src/MathCtrl.cpp:2127
 msgid "Bug: Cell left but not entered."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1178
+#: ../src/wxMaxima.cpp:1183
 msgid "Bug: Found a math end marker without any start marker."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1222
+#: ../src/wxMaxima.cpp:1227
 msgid "Bug: Found the end of autocompletion symbols but no beginning"
 msgstr ""
 
@@ -620,22 +620,22 @@ msgstr ""
 msgid "Bug: Fraction without enumerator"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2312
+#: ../src/MathCtrl.cpp:2359
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5839
+#: ../src/MathCtrl.cpp:5891
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of "
 "the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5913
+#: ../src/MathCtrl.cpp:5965
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5882
+#: ../src/MathCtrl.cpp:5934
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
@@ -645,49 +645,49 @@ msgstr ""
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
 msgstr ""
 
-#: ../src/GroupCell.cpp:780 ../src/GroupCell.cpp:951
+#: ../src/GroupCell.cpp:781 ../src/GroupCell.cpp:952
 msgid "Bug: No image counter to write to!"
 msgstr ""
 
-#: ../src/AbsCell.cpp:193
+#: ../src/AbsCell.cpp:199
 msgid "Bug: No last cell in an absCell!"
 msgstr ""
 
-#: ../src/ConjugateCell.cpp:185
+#: ../src/ConjugateCell.cpp:194
 msgid "Bug: No last cell in an conjugateCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:471
+#: ../src/FracCell.cpp:472
 msgid "Bug: No last cell in an denominator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:267
+#: ../src/ExptCell.cpp:270
 msgid "Bug: No last cell in an exponent of an exptCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:459
+#: ../src/FracCell.cpp:460
 msgid "Bug: No last cell in an numerator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:257
+#: ../src/ExptCell.cpp:260
 msgid "Bug: No last cell in the base of an exptCell!"
 msgstr ""
 
-#: ../src/ParenCell.cpp:534
+#: ../src/ParenCell.cpp:535
 msgid "Bug: No last cell inside a parenthesis!"
 msgstr ""
 
-#: ../src/SqrtCell.cpp:312
+#: ../src/SqrtCell.cpp:317
 msgid "Bug: No last cell inside a square root!"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2123
+#: ../src/MathCtrl.cpp:2170
 msgid ""
 "Bug: Start or end of merging of subsequent editing actions was requested two "
 "times in a row."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2090
+#: ../src/MathCtrl.cpp:2137
 msgid "Bug: Text changed, but no active cell."
 msgstr ""
 
@@ -695,39 +695,39 @@ msgstr ""
 msgid "Bug: Trying to append NULL to a group cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:555
+#: ../src/MathCtrl.cpp:600
 msgid "Bug: Trying to append maxima's output to a cell outside the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2014
+#: ../src/MathCtrl.cpp:2061
 msgid ""
 "Bug: Trying to merge individual cell adds to a region in the undo buffer but "
 "there are other cells between them."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6522
+#: ../src/MathCtrl.cpp:6577
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2092
+#: ../src/MathCtrl.cpp:2139
 msgid "Bug: Trying to record a cell contents change without a cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1495
+#: ../src/MathCtrl.cpp:1540
 msgid "Bug: Trying to select inside a cell without having a current cell"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5883
+#: ../src/MathCtrl.cpp:5935
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5844 ../src/MathCtrl.cpp:5918 ../src/MathCtrl.cpp:5952
+#: ../src/MathCtrl.cpp:5896 ../src/MathCtrl.cpp:5970 ../src/MathCtrl.cpp:6004
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:973
+#: ../src/wxMaximaFrame.cpp:972
 msgid "Build &Info"
 msgstr ""
 
@@ -739,51 +739,51 @@ msgid ""
 "two key commands."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:782
+#: ../src/wxMaximaFrame.cpp:781
 msgid "C&hange Variable..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:540
+#: ../src/wxMaximaFrame.cpp:539
 msgid "C&onfigure"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:801
+#: ../src/wxMaximaFrame.cpp:800
 msgid "Calculate &Product..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:799
+#: ../src/wxMaximaFrame.cpp:798
 msgid "Calculate Su&m..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:939
+#: ../src/wxMaximaFrame.cpp:938
 msgid "Calculate bigfloat value of the last result"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:936
+#: ../src/wxMaximaFrame.cpp:935
 msgid "Calculate float value of the last result"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3971
+#: ../src/wxMaxima.cpp:3983
 msgid "Calculate modulus:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:942
+#: ../src/wxMaximaFrame.cpp:941
 msgid "Calculate numeric value of the last result"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:802
+#: ../src/wxMaximaFrame.cpp:801
 msgid "Calculate products"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:800
+#: ../src/wxMaximaFrame.cpp:799
 msgid "Calculate sums"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5830
+#: ../src/wxMaxima.cpp:5845
 msgid "Can not connect to the web server."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5881
+#: ../src/wxMaxima.cpp:5896
 msgid "Can not download version info."
 msgstr ""
 
@@ -799,15 +799,15 @@ msgstr ""
 #: ../src/PlotFormatWiz.cpp:48 ../src/SeriesWiz.cpp:49 ../src/SeriesWiz.cpp:51
 #: ../src/SubstituteWiz.cpp:41 ../src/SubstituteWiz.cpp:43 ../src/SumWiz.cpp:44
 #: ../src/SumWiz.cpp:46 ../src/SystemWiz.cpp:38 ../src/SystemWiz.cpp:40
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Cancel"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:126 ../src/wxMaxima.cpp:932
+#: ../src/wxMaxima.cpp:937 ../src/wxMaximaFrame.cpp:125
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1217
+#: ../src/wxMaximaFrame.cpp:1216
 msgid "Canonical (tr)"
 msgstr ""
 
@@ -815,7 +815,7 @@ msgstr ""
 msgid "Catalan"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:638
+#: ../src/wxMaximaFrame.cpp:637
 msgid "Ce&ll"
 msgstr ""
 
@@ -823,39 +823,39 @@ msgstr ""
 msgid "Cell bracket"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5261
+#: ../src/wxMaxima.cpp:5273
 msgid "Cell ends in a backslash"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:676
+#: ../src/wxMaximaFrame.cpp:675
 msgid "Change &2d Display"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:677
+#: ../src/wxMaximaFrame.cpp:676
 msgid "Change the 2d display algorithm used to display math output"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3995
+#: ../src/wxMaxima.cpp:4007
 msgid "Change variable"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:783
+#: ../src/wxMaximaFrame.cpp:782
 msgid "Change variable in integral or sum"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3751
+#: ../src/wxMaxima.cpp:3763
 msgid "Char poly"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:978
+#: ../src/wxMaximaFrame.cpp:977
 msgid "Check for Updates"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:979
+#: ../src/wxMaximaFrame.cpp:978
 msgid "Check if a newer version of wxMaxima/Maxima exist."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1385
+#: ../src/wxMaximaFrame.cpp:1384
 msgid "Chi"
 msgstr ""
 
@@ -876,15 +876,15 @@ msgstr ""
 msgid "Choose new plot format:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710
 msgid "Classes:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:469
+#: ../src/wxMaximaFrame.cpp:468
 msgid "Close\tCtrl-W"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:470
+#: ../src/wxMaximaFrame.cpp:469
 msgid "Close window"
 msgstr ""
 
@@ -916,19 +916,19 @@ msgstr ""
 msgid "Code highlighting: Variables"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4806
+#: ../src/wxMaxima.cpp:4818
 msgid "Col. names:"
 msgstr ""
 
-#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Columns:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:860
+#: ../src/wxMaximaFrame.cpp:859
 msgid "Combine factorials in an expression"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5293
+#: ../src/wxMaxima.cpp:5305
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
@@ -940,23 +940,23 @@ msgstr ""
 msgid "Comma separated y coordinates"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1030
+#: ../src/MathCtrl.cpp:1072
 msgid "Comment Selection"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:533
+#: ../src/wxMaximaFrame.cpp:532
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:532
+#: ../src/wxMaximaFrame.cpp:531
 msgid "Comment selection\tCtrl-/"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:601
+#: ../src/wxMaximaFrame.cpp:600
 msgid "Complete Word\tCtrl-K"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:602
+#: ../src/wxMaximaFrame.cpp:601
 msgid "Complete word"
 msgstr ""
 
@@ -964,35 +964,35 @@ msgstr ""
 msgid "Completely stop maxima and restart it"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:823
+#: ../src/wxMaximaFrame.cpp:822
 msgid "Compute continued fraction of a value"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:761
+#: ../src/wxMaximaFrame.cpp:760
 msgid "Compute the adjoint matrix"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:750
+#: ../src/wxMaximaFrame.cpp:749
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:753
+#: ../src/wxMaximaFrame.cpp:752
 msgid "Compute the determinant of a matrix"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:810
+#: ../src/wxMaximaFrame.cpp:809
 msgid "Compute the greatest common divisor"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:747
+#: ../src/wxMaximaFrame.cpp:746
 msgid "Compute the inverse of a matrix"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:813
+#: ../src/wxMaximaFrame.cpp:812
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4868
 msgid "Condition:"
 msgstr ""
 
@@ -1004,8 +1004,8 @@ msgstr ""
 msgid "Configuration warning"
 msgstr ""
 
-#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:538
-#: ../src/wxMaximaFrame.cpp:541
+#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:540
 msgid "Configure wxMaxima"
 msgstr ""
 
@@ -1014,127 +1014,129 @@ msgstr ""
 msgid "Constant"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:844
+#: ../src/wxMaximaFrame.cpp:843
 msgid "Contract Logarithms"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:851
+#: ../src/wxMaximaFrame.cpp:850
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:854
+#: ../src/wxMaximaFrame.cpp:853
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:888
+#: ../src/wxMaximaFrame.cpp:887
 msgid "Convert complex expression to polar form"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:885
+#: ../src/wxMaximaFrame.cpp:884
 msgid "Convert complex expression to rect form"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:897
+#: ../src/wxMaximaFrame.cpp:896
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:842
+#: ../src/wxMaximaFrame.cpp:841
 msgid "Convert logarithm of product to sum of logarithms"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:845
+#: ../src/wxMaximaFrame.cpp:844
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:850
+#: ../src/wxMaximaFrame.cpp:849
 msgid "Convert to &Factorials"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:853
+#: ../src/wxMaximaFrame.cpp:852
 msgid "Convert to &Gamma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:887
+#: ../src/wxMaximaFrame.cpp:886
 msgid "Convert to &Polarform"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:884
+#: ../src/wxMaximaFrame.cpp:883
 msgid "Convert to &Rectform"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:877
+#: ../src/wxMaximaFrame.cpp:876
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:900
+#: ../src/wxMaximaFrame.cpp:899
 msgid "Convert trigonometric functions to exponential form"
 msgstr ""
 
-#: ../src/ToolBar.cpp:140 ../src/MathCtrl.cpp:918 ../src/MathCtrl.cpp:931
-#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1024
+#: ../src/MathCtrl.cpp:960 ../src/MathCtrl.cpp:973 ../src/MathCtrl.cpp:1019
+#: ../src/MathCtrl.cpp:1066 ../src/ToolBar.cpp:140
 msgid "Copy"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:597
+#: ../src/wxMaximaFrame.cpp:596
 msgid "Copy Previous Input\tCtrl-I"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:599
+#: ../src/wxMaximaFrame.cpp:598
 msgid "Copy Previous Output\tCtrl-U"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:514 ../src/MathCtrl.cpp:936 ../src/MathCtrl.cpp:982
+#: ../src/MathCtrl.cpp:978 ../src/MathCtrl.cpp:1024
+#: ../src/wxMaximaFrame.cpp:513
 msgid "Copy as Image"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:507 ../src/MathCtrl.cpp:932 ../src/MathCtrl.cpp:978
+#: ../src/MathCtrl.cpp:974 ../src/MathCtrl.cpp:1020
+#: ../src/wxMaximaFrame.cpp:506
 msgid "Copy as LaTeX"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:510
+#: ../src/wxMaximaFrame.cpp:509
 msgid "Copy as MathML"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:935 ../src/MathCtrl.cpp:980
+#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1022
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:504
+#: ../src/wxMaximaFrame.cpp:503
 msgid "Copy as Text\tCtrl-Shift-C"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:933 ../src/MathCtrl.cpp:979
+#: ../src/MathCtrl.cpp:975 ../src/MathCtrl.cpp:1021
 msgid "Copy as plain text"
 msgstr ""
 
-#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:503
+#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:502
 msgid "Copy selection"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:515
+#: ../src/wxMaximaFrame.cpp:514
 msgid "Copy selection from document as an image"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:505
+#: ../src/wxMaximaFrame.cpp:504
 msgid "Copy selection from document as text"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:508
+#: ../src/wxMaximaFrame.cpp:507
 msgid "Copy selection from document in LaTeX format"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:511
+#: ../src/wxMaximaFrame.cpp:510
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:598
+#: ../src/wxMaximaFrame.cpp:597
 msgid "Create a new cell with previous input"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:600
+#: ../src/wxMaximaFrame.cpp:599
 msgid "Create a new cell with previous output"
 msgstr ""
 
@@ -1142,15 +1144,15 @@ msgstr ""
 msgid "Cursor"
 msgstr ""
 
-#: ../src/ToolBar.cpp:137 ../src/MathCtrl.cpp:1023
+#: ../src/MathCtrl.cpp:1065 ../src/ToolBar.cpp:137
 msgid "Cut"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:499
+#: ../src/wxMaximaFrame.cpp:498
 msgid "Cut\tCtrl-X"
 msgstr ""
 
-#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:500
+#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:499
 msgid "Cut selection"
 msgstr ""
 
@@ -1162,18 +1164,18 @@ msgstr ""
 msgid "Danish"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4799 ../src/wxMaxima.cpp:4806 ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4811 ../src/wxMaxima.cpp:4818 ../src/wxMaxima.cpp:4868
 msgid "Data Matrix:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4826
+#: ../src/wxMaxima.cpp:4838
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698 ../src/wxMaxima.cpp:4712
-#: ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726 ../src/wxMaxima.cpp:4734
-#: ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748 ../src/wxMaxima.cpp:4755
-#: ../src/wxMaxima.cpp:4791
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710 ../src/wxMaxima.cpp:4724
+#: ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738 ../src/wxMaxima.cpp:4746
+#: ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760 ../src/wxMaxima.cpp:4767
+#: ../src/wxMaxima.cpp:4803
 msgid "Data:"
 msgstr ""
 
@@ -1181,7 +1183,7 @@ msgstr ""
 msgid "Debug: watch maxima's stdout stream"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:820
+#: ../src/wxMaximaFrame.cpp:819
 msgid "Decompose rational function to partial fractions"
 msgstr ""
 
@@ -1211,47 +1213,47 @@ msgid ""
 "with."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3403 ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3415 ../src/wxMaxima.cpp:3424
 msgid "Delete"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:667
+#: ../src/wxMaximaFrame.cpp:666
 msgid "Delete F&unction..."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:939 ../src/MathCtrl.cpp:985
+#: ../src/MathCtrl.cpp:981 ../src/MathCtrl.cpp:1027
 msgid "Delete Selection"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:669
+#: ../src/wxMaximaFrame.cpp:668
 msgid "Delete V&ariable..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:668
+#: ../src/wxMaximaFrame.cpp:667
 msgid "Delete a function"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:670
+#: ../src/wxMaximaFrame.cpp:669
 msgid "Delete a variable"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:655
+#: ../src/wxMaximaFrame.cpp:654
 msgid "Delete all values from memory"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3424
 msgid "Delete function(s):"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3403
+#: ../src/wxMaxima.cpp:3415
 msgid "Delete variable(s):"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1367
+#: ../src/wxMaximaFrame.cpp:1366
 msgid "Delta"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4011
+#: ../src/wxMaxima.cpp:4023
 msgid "Denom. deg:"
 msgstr ""
 
@@ -1259,35 +1261,35 @@ msgstr ""
 msgid "Depth:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3541
+#: ../src/wxMaxima.cpp:3553
 msgid "Derivative:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1258
+#: ../src/wxMaximaFrame.cpp:1257
 msgid "Deviation..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:816
+#: ../src/wxMaximaFrame.cpp:815
 msgid "Di&vide Polynomials..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1223
+#: ../src/wxMaximaFrame.cpp:1222
 msgid "Diff..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4154 ../src/wxMaxima.cpp:5066
+#: ../src/wxMaxima.cpp:4166 ../src/wxMaxima.cpp:5078
 msgid "Differentiate"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:786
+#: ../src/wxMaximaFrame.cpp:785
 msgid "Differentiate expression"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1001
+#: ../src/MathCtrl.cpp:1043
 msgid "Differentiate..."
 msgstr ""
 
-#: ../src/LimitWiz.cpp:37 ../src/FindReplacePane.cpp:76
+#: ../src/FindReplacePane.cpp:76 ../src/LimitWiz.cpp:37
 msgid "Direction:"
 msgstr ""
 
@@ -1295,47 +1297,48 @@ msgstr ""
 msgid "Discrete plot"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:679
+#: ../src/wxMaximaFrame.cpp:678
 msgid "Display Te&X Form"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3320
+#: ../src/wxMaxima.cpp:3332
 msgid "Display algorithm"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:680
+#: ../src/wxMaximaFrame.cpp:679
 msgid "Display last result in TeX form"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:674
+#: ../src/wxMaximaFrame.cpp:673
 msgid "Display time used for evaluation"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4061
+#: ../src/wxMaxima.cpp:4073
 msgid "Divide"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1032
+#: ../src/MathCtrl.cpp:1074
 msgid "Divide Cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:635
+#: ../src/wxMaximaFrame.cpp:634
 msgid "Divide Cell\tCtrl-D"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:817
+#: ../src/wxMaximaFrame.cpp:816
 msgid "Divide numbers or polynomials"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:636
+#: ../src/wxMaximaFrame.cpp:635
 msgid "Divide this input cell into two cells"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5917
-msgid "Do you want to save the changes you made in the document \""
+#: ../src/wxMaxima.cpp:5932
+#, c-format
+msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1664 ../src/wxMaxima.cpp:1672
+#: ../src/wxMaxima.cpp:1669 ../src/wxMaxima.cpp:1677
 msgid "Document "
 msgstr ""
 
@@ -1354,7 +1357,7 @@ msgid ""
 "differences."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Don't save"
 msgstr ""
 
@@ -1362,27 +1365,27 @@ msgstr ""
 msgid "Down"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:734
+#: ../src/wxMaximaFrame.cpp:733
 msgid "E&quations"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:487
+#: ../src/wxMaximaFrame.cpp:486
 msgid "E&xit\tCtrl-Q"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:757
+#: ../src/wxMaximaFrame.cpp:756
 msgid "Eige&nvectors"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:755
+#: ../src/wxMaximaFrame.cpp:754
 msgid "Eigen&values"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3572
+#: ../src/wxMaxima.cpp:3584
 msgid "Eliminate"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:710
+#: ../src/wxMaximaFrame.cpp:709
 msgid "Eliminate a variable from a system of equations"
 msgstr ""
 
@@ -1394,21 +1397,21 @@ msgstr ""
 msgid "English"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4712 ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726
-#: ../src/wxMaxima.cpp:4734 ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748
-#: ../src/wxMaxima.cpp:4755 ../src/wxMaxima.cpp:4791 ../src/wxMaxima.cpp:4799
+#: ../src/wxMaxima.cpp:4724 ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738
+#: ../src/wxMaxima.cpp:4746 ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760
+#: ../src/wxMaxima.cpp:4767 ../src/wxMaxima.cpp:4803 ../src/wxMaxima.cpp:4811
 msgid "Enter Data"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1279
+#: ../src/wxMaximaFrame.cpp:1278
 msgid "Enter Matrix..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:745
+#: ../src/wxMaximaFrame.cpp:744
 msgid "Enter a matrix"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3962
+#: ../src/wxMaxima.cpp:3974
 msgid "Enter an equation for rational simplification:"
 msgstr ""
 
@@ -1420,11 +1423,11 @@ msgstr ""
 msgid "Enter evaluates cells"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3734
+#: ../src/wxMaxima.cpp:3746
 msgid "Enter matrix"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Enter new precision for bigfloats:"
 msgstr ""
 
@@ -1432,11 +1435,11 @@ msgstr ""
 msgid "Enter the path to the Maxima executable."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1368
+#: ../src/wxMaximaFrame.cpp:1367
 msgid "Epsilon"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4208
+#: ../src/wxMaxima.cpp:4220
 msgid "Epsilon:"
 msgstr ""
 
@@ -1445,13 +1448,13 @@ msgstr ""
 msgid "Equation %d:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:3633
-#: ../src/wxMaxima.cpp:5019
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:3645
+#: ../src/wxMaxima.cpp:5031
 msgid "Equation(s):"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3993
-#: ../src/wxMaxima.cpp:4807 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:4005
+#: ../src/wxMaxima.cpp:4819 ../src/wxMaxima.cpp:5045
 msgid "Equation:"
 msgstr ""
 
@@ -1462,76 +1465,76 @@ msgid ""
 "be introduced one into another. Also they are always printed out as 2D maths."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3570
+#: ../src/wxMaxima.cpp:3582
 msgid "Equations:"
 msgstr ""
 
-#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1455
-#: ../src/wxMaxima.cpp:1469 ../src/wxMaxima.cpp:1620 ../src/wxMaxima.cpp:1633
-#: ../src/wxMaxima.cpp:1643 ../src/wxMaxima.cpp:1666 ../src/wxMaxima.cpp:2034
-#: ../src/wxMaxima.cpp:2206 ../src/wxMaxima.cpp:5381 ../src/wxMaxima.cpp:5830
-#: ../src/wxMaxima.cpp:5881
+#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1460
+#: ../src/wxMaxima.cpp:1474 ../src/wxMaxima.cpp:1625 ../src/wxMaxima.cpp:1638
+#: ../src/wxMaxima.cpp:1648 ../src/wxMaxima.cpp:1671 ../src/wxMaxima.cpp:2039
+#: ../src/wxMaxima.cpp:2211 ../src/wxMaxima.cpp:5397 ../src/wxMaxima.cpp:5845
+#: ../src/wxMaxima.cpp:5896
 msgid "Error"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2886 ../src/wxMaxima.cpp:2900 ../src/wxMaxima.cpp:2913
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617 ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:2894 ../src/wxMaxima.cpp:2908 ../src/wxMaxima.cpp:2921
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629 ../src/wxMaxima.cpp:3740
 msgid "Error!"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1370
+#: ../src/wxMaximaFrame.cpp:1369
 msgid "Eta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:909
+#: ../src/wxMaximaFrame.cpp:908
 msgid "Evaluate &Noun Forms"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:589
+#: ../src/wxMaximaFrame.cpp:588
 msgid "Evaluate All Cells\tCtrl-Shift-R"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:587
+#: ../src/wxMaximaFrame.cpp:586
 msgid "Evaluate All Visible Cells\tCtrl-R"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:585 ../src/MathCtrl.cpp:942
+#: ../src/MathCtrl.cpp:984 ../src/wxMaximaFrame.cpp:584
 msgid "Evaluate Cell(s)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:591
+#: ../src/wxMaximaFrame.cpp:590
 msgid "Evaluate Cells Above\tCtrl-Shift-P"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:956 ../src/MathCtrl.cpp:1051
+#: ../src/MathCtrl.cpp:998 ../src/MathCtrl.cpp:1093
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:961 ../src/MathCtrl.cpp:1053
+#: ../src/MathCtrl.cpp:1003 ../src/MathCtrl.cpp:1095
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:971 ../src/MathCtrl.cpp:1057
+#: ../src/MathCtrl.cpp:1013 ../src/MathCtrl.cpp:1099
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:966 ../src/MathCtrl.cpp:1055
+#: ../src/MathCtrl.cpp:1008 ../src/MathCtrl.cpp:1097
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:586
+#: ../src/wxMaximaFrame.cpp:585
 msgid "Evaluate active or selected cell(s)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:590
+#: ../src/wxMaximaFrame.cpp:589
 msgid "Evaluate all cells in the document"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:910
+#: ../src/wxMaximaFrame.cpp:909
 msgid "Evaluate all noun forms in expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:588
+#: ../src/wxMaximaFrame.cpp:587
 msgid "Evaluate all visible cells in the document"
 msgstr ""
 
@@ -1543,7 +1546,7 @@ msgstr ""
 msgid "Evaluate to point"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Example"
 msgstr ""
 
@@ -1555,31 +1558,31 @@ msgstr ""
 msgid "Examples:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:488
+#: ../src/wxMaximaFrame.cpp:487
 msgid "Exit wxMaxima"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1214
+#: ../src/wxMaximaFrame.cpp:1213
 msgid "Expand"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1219
+#: ../src/wxMaximaFrame.cpp:1218
 msgid "Expand (tr)"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:997
+#: ../src/MathCtrl.cpp:1039
 msgid "Expand Expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:841
+#: ../src/wxMaximaFrame.cpp:840
 msgid "Expand Logarithms"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:840
+#: ../src/wxMaximaFrame.cpp:839
 msgid "Expand an expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:874
+#: ../src/wxMaximaFrame.cpp:873
 msgid "Expand trigonometric expression"
 msgstr ""
 
@@ -1587,7 +1590,7 @@ msgstr ""
 msgid "Expected the icon files to be found at"
 msgstr ""
 
-#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2834
+#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2842
 msgid "Export"
 msgstr ""
 
@@ -1596,31 +1599,31 @@ msgid ""
 "Export animations to TeX (Images only move if the PDF viewer supports this)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:481
+#: ../src/wxMaximaFrame.cpp:480
 msgid "Export document to a HTML or pdfLaTeX file"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:253
+#: ../src/wxMaximaFrame.cpp:252
 msgid "Export failed."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:239
+#: ../src/wxMaximaFrame.cpp:238
 msgid "Export successful."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2913
+#: ../src/wxMaxima.cpp:2921
 msgid "Exporting to HTML failed!"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2886
+#: ../src/wxMaxima.cpp:2894
 msgid "Exporting to TeX failed!"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2900
+#: ../src/wxMaxima.cpp:2908
 msgid "Exporting to maxima batch file failed!"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:229
+#: ../src/wxMaximaFrame.cpp:228
 msgid "Exporting..."
 msgstr ""
 
@@ -1633,42 +1636,42 @@ msgid "Expression(s):"
 msgstr ""
 
 #: ../src/IntegrateWiz.cpp:30 ../src/LimitWiz.cpp:27 ../src/SeriesWiz.cpp:33
-#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3648
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:4205 ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5064
+#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3660
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:4217 ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5076
 msgid "Expression:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1213
+#: ../src/wxMaximaFrame.cpp:1212
 msgid "Factor"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:836
+#: ../src/wxMaximaFrame.cpp:835
 msgid "Factor Complex"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:996
+#: ../src/MathCtrl.cpp:1038
 msgid "Factor Expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:835
+#: ../src/wxMaximaFrame.cpp:834
 msgid "Factor an expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:837
+#: ../src/wxMaximaFrame.cpp:836
 msgid "Factor an expression in Gaussian numbers"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:862
+#: ../src/wxMaximaFrame.cpp:861
 msgid "Factorials and &Gamma"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:285
+#: ../src/wxMaxima.cpp:286
 msgid "Fatal error"
 msgstr ""
 
-#: ../src/GroupCell.cpp:1571
+#: ../src/GroupCell.cpp:1572
 #, c-format
 msgid "Figure %d:"
 msgstr ""
@@ -1677,20 +1680,20 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1457 ../src/wxMaxima.cpp:1623 ../src/wxMaxima.cpp:1636
-#: ../src/wxMaxima.cpp:1646 ../src/wxMaxima.cpp:1668
+#: ../src/wxMaxima.cpp:1462 ../src/wxMaxima.cpp:1628 ../src/wxMaxima.cpp:1641
+#: ../src/wxMaxima.cpp:1651 ../src/wxMaxima.cpp:1673
 msgid "File could not be opened"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File not found"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1511 ../src/wxMaxima.cpp:1729
+#: ../src/wxMaxima.cpp:1516 ../src/wxMaxima.cpp:1734
 msgid "File opened"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File you tried to open does not exist."
 msgstr ""
 
@@ -1702,67 +1705,67 @@ msgstr ""
 msgid "Find"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:523
+#: ../src/wxMaximaFrame.cpp:522
 msgid "Find\tCtrl-F"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:787
+#: ../src/wxMaximaFrame.cpp:786
 msgid "Find &Limit..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:790
+#: ../src/wxMaximaFrame.cpp:789
 msgid "Find Minimum..."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:993
+#: ../src/MathCtrl.cpp:1035
 msgid "Find Root..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:791
+#: ../src/wxMaximaFrame.cpp:790
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:788
+#: ../src/wxMaximaFrame.cpp:787
 msgid "Find a limit of an expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:693
+#: ../src/wxMaximaFrame.cpp:692
 msgid "Find a root of an equation on an interval"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:695
+#: ../src/wxMaximaFrame.cpp:694
 msgid "Find all roots of a polynomial"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:698
+#: ../src/wxMaximaFrame.cpp:697
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3220
+#: ../src/wxMaxima.cpp:3215
 msgid "Find and Replace"
 msgstr ""
 
-#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:523
+#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:522
 msgid "Find and replace"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:756
+#: ../src/wxMaximaFrame.cpp:755
 msgid "Find eigenvalues of a matrix"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:758
+#: ../src/wxMaximaFrame.cpp:757
 msgid "Find eigenvectors of a matrix"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4210
+#: ../src/wxMaxima.cpp:4222
 msgid "Find minimum"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:701
+#: ../src/wxMaximaFrame.cpp:700
 msgid "Find real roots of a polynomial"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3493 ../src/wxMaxima.cpp:5036
+#: ../src/wxMaxima.cpp:3505 ../src/wxMaxima.cpp:5048
 msgid "Find root"
 msgstr ""
 
@@ -1783,11 +1786,11 @@ msgstr ""
 msgid "Fixed font in text controls"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:623
+#: ../src/wxMaximaFrame.cpp:622
 msgid "Fold All\tCtrl-Alt-["
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:624
+#: ../src/wxMaximaFrame.cpp:623
 msgid "Fold all sections"
 msgstr ""
 
@@ -1795,25 +1798,25 @@ msgstr ""
 msgid "Follow"
 msgstr ""
 
-#: ../src/ParenCell.cpp:319
+#: ../src/ParenCell.cpp:320
 msgid "Font issue: The Parenthesis sign is too small!"
 msgstr ""
 
-#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:381
+#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:382
 msgid ""
 "Font issue: The char height is too small! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:199
+#: ../src/SqrtCell.cpp:202
 msgid ""
 "Font issue: The sqrt() sign has the size 0! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:198
+#: ../src/SqrtCell.cpp:201
 msgid "Font issue? The contents of a sqrt() has the size 0."
 msgstr ""
 
@@ -1844,15 +1847,15 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:37 ../src/Plot2dWiz.cpp:37 ../src/Plot2dWiz.cpp:47
 #: ../src/Plot2dWiz.cpp:536 ../src/Plot3dWiz.cpp:36 ../src/Plot3dWiz.cpp:45
-#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4240
+#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4252
 msgid "From:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:576
+#: ../src/wxMaximaFrame.cpp:575
 msgid "Full Screen\tAlt-Enter"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3342
+#: ../src/wxMaxima.cpp:3354
 msgid "Function"
 msgstr ""
 
@@ -1860,32 +1863,32 @@ msgstr ""
 msgid "Function names"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3633
+#: ../src/wxMaxima.cpp:3645
 msgid "Function(s):"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3803
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3815
+#: ../src/wxMaxima.cpp:3848
 msgid "Function:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:904
+#: ../src/wxMaximaFrame.cpp:903
 msgid "Functions for complex simplification"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:864
+#: ../src/wxMaximaFrame.cpp:863
 msgid "Functions for simplifying factorials and gamma function"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:881
+#: ../src/wxMaximaFrame.cpp:880
 msgid "Functions for simplifying trigonometric expressions"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4046
+#: ../src/wxMaxima.cpp:4058
 msgid "GCD"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5152
+#: ../src/wxMaxima.cpp:5164
 msgid "GIF image (*.gif)|*.gif"
 msgstr ""
 
@@ -1893,31 +1896,31 @@ msgstr ""
 msgid "Galician"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1366
+#: ../src/wxMaximaFrame.cpp:1365
 msgid "Gamma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:391
+#: ../src/wxMaximaFrame.cpp:390
 msgid "General Math"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:549
+#: ../src/wxMaximaFrame.cpp:548
 msgid "General Math\tAlt-Shift-M"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3766 ../src/wxMaxima.cpp:3785
+#: ../src/wxMaxima.cpp:3778 ../src/wxMaxima.cpp:3797
 msgid "Generate Matrix"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:741
+#: ../src/wxMaximaFrame.cpp:740
 msgid "Generate Matrix from Expression..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:739
+#: ../src/wxMaximaFrame.cpp:738
 msgid "Generate a matrix from a 2-dimensional array"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:742
+#: ../src/wxMaximaFrame.cpp:741
 msgid "Generate a matrix from a lambda expression"
 msgstr ""
 
@@ -1925,39 +1928,39 @@ msgstr ""
 msgid "German"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:893
+#: ../src/wxMaximaFrame.cpp:892
 msgid "Get &Imaginary Part"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:793
+#: ../src/wxMaximaFrame.cpp:792
 msgid "Get &Series..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:804
+#: ../src/wxMaximaFrame.cpp:803
 msgid "Get Laplace transformation of an expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:890
+#: ../src/wxMaximaFrame.cpp:889
 msgid "Get Real P&art"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:807
+#: ../src/wxMaximaFrame.cpp:806
 msgid "Get inverse Laplace transformation of an expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:794
+#: ../src/wxMaximaFrame.cpp:793
 msgid "Get the Taylor or power series of expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:894
+#: ../src/wxMaximaFrame.cpp:893
 msgid "Get the imaginary part of complex expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:891
+#: ../src/wxMaximaFrame.cpp:890
 msgid "Get the real part of complex expression"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5932
+#: ../src/MathCtrl.cpp:5984
 msgid ""
 "Got a request to undo an action that involves an delete which isn't possible "
 "at this moment."
@@ -1967,11 +1970,11 @@ msgstr ""
 msgid "Greek"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:356
+#: ../src/wxMaximaFrame.cpp:355
 msgid "Greek Letters"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:552
+#: ../src/wxMaximaFrame.cpp:551
 msgid "Greek Letters\tAlt-Shift-G"
 msgstr ""
 
@@ -1983,7 +1986,7 @@ msgstr ""
 msgid "Grid:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2836
+#: ../src/wxMaxima.cpp:2844
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|pdfLaTeX file (*."
 "tex)|*.tex"
@@ -1997,11 +2000,11 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide All Toolbars\tAlt-Shift--"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide all panes"
 msgstr ""
 
@@ -2009,19 +2012,19 @@ msgstr ""
 msgid "Highlight (dpart)"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4685
+#: ../src/wxMaxima.cpp:4697
 msgid "Histogram"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1270
+#: ../src/wxMaximaFrame.cpp:1269
 msgid "Histogram..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:309
+#: ../src/wxMaximaFrame.cpp:308
 msgid "History"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:555
+#: ../src/wxMaximaFrame.cpp:554
 msgid "History\tAlt-Shift-I"
 msgstr ""
 
@@ -2037,11 +2040,11 @@ msgstr ""
 msgid "Hungarian"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3527
+#: ../src/wxMaxima.cpp:3539
 msgid "IC1"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3543
+#: ../src/wxMaxima.cpp:3555
 msgid "IC2"
 msgstr ""
 
@@ -2057,7 +2060,7 @@ msgid ""
 "same output cell."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:683
+#: ../src/wxMaximaFrame.cpp:682
 msgid ""
 "If maxima ever finishes evaluating without wxMaxima realizing this this menu "
 "item can force wxMaxima to try to send commands to maxima again."
@@ -2117,11 +2120,11 @@ msgid ""
 ">Interrupt' or 'Maxima->Restart Maxima' menu commands."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1499
+#: ../src/wxMaximaFrame.cpp:1518
 msgid "Image"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5644
+#: ../src/wxMaxima.cpp:5659
 msgid "Image files (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 msgstr ""
 
@@ -2148,7 +2151,7 @@ msgid ""
 "above it. Might increase readability for some fonts and short subscripts."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Include columns:"
 msgstr ""
 
@@ -2167,19 +2170,19 @@ msgstr ""
 msgid "Infinity"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:974
+#: ../src/wxMaximaFrame.cpp:973
 msgid "Info about Maxima build"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4207
+#: ../src/wxMaxima.cpp:4219
 msgid "Initial Estimates:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:718
+#: ../src/wxMaximaFrame.cpp:717
 msgid "Initial Value Problem (&1)..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:721
+#: ../src/wxMaximaFrame.cpp:720
 msgid "Initial Value Problem (&2)..."
 msgstr ""
 
@@ -2187,7 +2190,7 @@ msgstr ""
 msgid "Input labels"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:403
+#: ../src/wxMaximaFrame.cpp:402
 msgid "Insert"
 msgstr ""
 
@@ -2195,95 +2198,95 @@ msgstr ""
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:612
+#: ../src/wxMaximaFrame.cpp:611
 msgid "Insert &Section Cell\tCtrl-3"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:608
+#: ../src/wxMaximaFrame.cpp:607
 msgid "Insert &Text Cell\tCtrl-1"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:558
+#: ../src/wxMaximaFrame.cpp:557
 msgid "Insert Cell\tAlt-Shift-C"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5642
+#: ../src/wxMaxima.cpp:5657
 msgid "Insert Image"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:620
+#: ../src/wxMaximaFrame.cpp:619
 msgid "Insert Image..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:606
+#: ../src/wxMaximaFrame.cpp:605
 msgid "Insert Input &Cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:618
+#: ../src/wxMaximaFrame.cpp:617
 msgid "Insert Page Break"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:614
+#: ../src/wxMaximaFrame.cpp:613
 msgid "Insert S&ubsection Cell\tCtrl-4"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:616
+#: ../src/wxMaximaFrame.cpp:615
 msgid "Insert S&ubsubsection Cell\tCtrl-5"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1015
+#: ../src/MathCtrl.cpp:1057
 msgid "Insert Section Cell"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1016
+#: ../src/MathCtrl.cpp:1058
 msgid "Insert Subsection Cell"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1017
+#: ../src/MathCtrl.cpp:1059
 msgid "Insert Subsubsection Cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:610
+#: ../src/wxMaximaFrame.cpp:609
 msgid "Insert T&itle Cell\tCtrl-2"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1013
+#: ../src/MathCtrl.cpp:1055
 msgid "Insert Text Cell"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1014
+#: ../src/MathCtrl.cpp:1056
 msgid "Insert Title Cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:607
+#: ../src/wxMaximaFrame.cpp:606
 msgid "Insert a new input cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:613
+#: ../src/wxMaximaFrame.cpp:612
 msgid "Insert a new section cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:615
+#: ../src/wxMaximaFrame.cpp:614
 msgid "Insert a new subsection cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:617
+#: ../src/wxMaximaFrame.cpp:616
 msgid "Insert a new subsubsection cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:609
+#: ../src/wxMaximaFrame.cpp:608
 msgid "Insert a new text cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:611
+#: ../src/wxMaximaFrame.cpp:610
 msgid "Insert a new title cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:619
+#: ../src/wxMaximaFrame.cpp:618
 msgid "Insert a page break"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:621
+#: ../src/wxMaximaFrame.cpp:620
 msgid "Insert image"
 msgstr ""
 
@@ -2295,27 +2298,27 @@ msgstr ""
 msgid "Integral sign"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3992
+#: ../src/wxMaxima.cpp:4004
 msgid "Integral/Sum:"
 msgstr ""
 
-#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4105 ../src/wxMaxima.cpp:5051
+#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4117 ../src/wxMaxima.cpp:5063
 msgid "Integrate"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4091
+#: ../src/wxMaxima.cpp:4103
 msgid "Integrate (risch)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:778
+#: ../src/wxMaximaFrame.cpp:777
 msgid "Integrate expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:780
+#: ../src/wxMaximaFrame.cpp:779
 msgid "Integrate expression with Risch algorithm"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1224 ../src/MathCtrl.cpp:1000
+#: ../src/MathCtrl.cpp:1042 ../src/wxMaximaFrame.cpp:1223
 msgid "Integrate..."
 msgstr ""
 
@@ -2323,7 +2326,7 @@ msgstr ""
 msgid "Interrupt"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:646 ../src/wxMaximaFrame.cpp:650
+#: ../src/wxMaximaFrame.cpp:645 ../src/wxMaximaFrame.cpp:649
 msgid "Interrupt current computation"
 msgstr ""
 
@@ -2340,15 +2343,15 @@ msgid ""
 "Please enter the path to Maxima program again."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4137
+#: ../src/wxMaxima.cpp:4149
 msgid "Inverse Laplace"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:806
+#: ../src/wxMaximaFrame.cpp:805
 msgid "Inverse Laplace T&ransform..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1372
+#: ../src/wxMaximaFrame.cpp:1371
 msgid "Iota"
 msgstr ""
 
@@ -2382,7 +2385,7 @@ msgstr ""
 msgid "Kabyle"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1373
+#: ../src/wxMaximaFrame.cpp:1372
 msgid "Kappa"
 msgstr ""
 
@@ -2391,7 +2394,7 @@ msgstr ""
 msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4031
+#: ../src/wxMaxima.cpp:4043
 msgid "LCM"
 msgstr ""
 
@@ -2407,7 +2410,7 @@ msgstr ""
 msgid "Label width:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1374
+#: ../src/wxMaximaFrame.cpp:1373
 msgid "Lambda"
 msgstr ""
 
@@ -2419,11 +2422,11 @@ msgstr ""
 msgid "Language:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4120
+#: ../src/wxMaxima.cpp:4132
 msgid "Laplace"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:803
+#: ../src/wxMaximaFrame.cpp:802
 msgid "Laplace &Transform..."
 msgstr ""
 
@@ -2431,15 +2434,15 @@ msgstr ""
 msgid "Leads to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:812
+#: ../src/wxMaximaFrame.cpp:811
 msgid "Least Common Multiple..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4809
+#: ../src/wxMaxima.cpp:4821
 msgid "Least Squares Fit"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1266
+#: ../src/wxMaximaFrame.cpp:1265
 msgid "Least Squares Fit..."
 msgstr ""
 
@@ -2450,23 +2453,23 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4192
+#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4204
 msgid "Limit"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1225
+#: ../src/wxMaximaFrame.cpp:1224
 msgid "Limit..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1265
+#: ../src/wxMaximaFrame.cpp:1264
 msgid "Linear Regression..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3803
+#: ../src/wxMaxima.cpp:3815
 msgid "List(s):"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3848
 msgid "List:"
 msgstr ""
 
@@ -2474,15 +2477,15 @@ msgstr ""
 msgid "Load"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2932
+#: ../src/wxMaxima.cpp:2940
 msgid "Load Package"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:479
+#: ../src/wxMaximaFrame.cpp:478
 msgid "Load a Maxima file using the batch command"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:477
+#: ../src/wxMaximaFrame.cpp:476
 msgid "Load a Maxima package file"
 msgstr ""
 
@@ -2494,47 +2497,47 @@ msgstr ""
 msgid "Long Right arrow"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Lower bound:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:771
+#: ../src/wxMaximaFrame.cpp:770
 msgid "Ma&p to Matrix..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:547
+#: ../src/wxMaximaFrame.cpp:546
 msgid "Main Toolbar\tAlt-Shift-B"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:765
+#: ../src/wxMaximaFrame.cpp:764
 msgid "Make &List..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3821
+#: ../src/wxMaxima.cpp:3833
 msgid "Make list"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:766
+#: ../src/wxMaximaFrame.cpp:765
 msgid "Make list from expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:907
+#: ../src/wxMaximaFrame.cpp:906
 msgid "Make substitution in expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:682
+#: ../src/wxMaximaFrame.cpp:681
 msgid "Manually Trigger Evaluation"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3805
+#: ../src/wxMaxima.cpp:3817
 msgid "Map"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:770
+#: ../src/wxMaximaFrame.cpp:769
 msgid "Map function to a list"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:772
+#: ../src/wxMaximaFrame.cpp:771
 msgid "Map function to a matrix"
 msgstr ""
 
@@ -2550,23 +2553,23 @@ msgstr ""
 msgid "Math font:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:374
+#: ../src/wxMaximaFrame.cpp:373
 msgid "Mathematical Symbols"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3716
+#: ../src/wxMaxima.cpp:3728
 msgid "Matrix"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3702
+#: ../src/wxMaxima.cpp:3714
 msgid "Matrix map"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Matrix name:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3749
+#: ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3761
 msgid "Matrix:"
 msgstr ""
 
@@ -2574,7 +2577,7 @@ msgstr ""
 msgid "Maxima"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:137
+#: ../src/wxMaximaFrame.cpp:136
 msgid "Maxima has a question"
 msgstr ""
 
@@ -2582,23 +2585,23 @@ msgstr ""
 msgid "Maxima input"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:166
+#: ../src/wxMaximaFrame.cpp:165
 msgid "Maxima is calculating"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:111
+#: ../src/wxMaximaFrame.cpp:110
 msgid "Maxima is ready for input."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2945
+#: ../src/wxMaxima.cpp:2953
 msgid "Maxima package (*.mac)|*.mac"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2934
+#: ../src/wxMaxima.cpp:2942
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1014
+#: ../src/wxMaxima.cpp:1019
 msgid "Maxima process terminated."
 msgstr ""
 
@@ -2610,7 +2613,7 @@ msgstr ""
 msgid "Maxima questions"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:942
+#: ../src/wxMaxima.cpp:947
 msgid "Maxima started. Waiting for connection..."
 msgstr ""
 
@@ -2632,7 +2635,7 @@ msgid ""
 "('f(x) := x^2;')."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4597
+#: ../src/wxMaxima.cpp:4609
 msgid "Maxima version: "
 msgstr ""
 
@@ -2669,39 +2672,39 @@ msgstr ""
 msgid "Maximum displayed number of digits:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1263
+#: ../src/wxMaximaFrame.cpp:1262
 msgid "Mean Difference Test..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1262
+#: ../src/wxMaximaFrame.cpp:1261
 msgid "Mean Test..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1255
+#: ../src/wxMaximaFrame.cpp:1254
 msgid "Mean..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Mean:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1256
+#: ../src/wxMaximaFrame.cpp:1255
 msgid "Median..."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:945
+#: ../src/MathCtrl.cpp:987
 msgid "Merge Cells"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:633
+#: ../src/wxMaximaFrame.cpp:632
 msgid "Merge Cells\tCtrl-M"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:634
+#: ../src/wxMaximaFrame.cpp:633
 msgid "Merge the text from two input cells into one"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2668
+#: ../src/wxMaxima.cpp:2676
 msgid "Message from the stdout of Maxima: "
 msgstr ""
 
@@ -2709,19 +2712,19 @@ msgstr ""
 msgid "Method:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5289
+#: ../src/wxMaxima.cpp:5301
 msgid "Mismatched parenthesis"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3972
+#: ../src/wxMaxima.cpp:3984
 msgid "Modulus"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1375
+#: ../src/wxMaximaFrame.cpp:1374
 msgid "Mu"
 msgstr ""
 
-#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Name:"
 msgstr ""
 
@@ -2729,7 +2732,7 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
+#: ../src/wxMaximaFrame.cpp:456 ../src/wxMaximaFrame.cpp:459
 msgid "New\tCtrl-N"
 msgstr ""
 
@@ -2745,11 +2748,11 @@ msgstr ""
 msgid "New value:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3993 ../src/wxMaxima.cpp:4119 ../src/wxMaxima.cpp:4136
+#: ../src/wxMaxima.cpp:4005 ../src/wxMaxima.cpp:4131 ../src/wxMaxima.cpp:4148
 msgid "New variable:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:630
+#: ../src/wxMaximaFrame.cpp:629
 msgid "Next Command\tAlt-Down"
 msgstr ""
 
@@ -2757,15 +2760,15 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5362
+#: ../src/wxMaxima.cpp:5378
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3249 ../src/wxMaxima.cpp:3271
+#: ../src/wxMaxima.cpp:3260 ../src/wxMaxima.cpp:3283
 msgid "No matches found!"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1264
+#: ../src/wxMaximaFrame.cpp:1263
 msgid "Normality Test..."
 msgstr ""
 
@@ -2788,31 +2791,31 @@ msgstr ""
 msgid "Norwegian"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:3740
 msgid "Not a valid matrix dimension!"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629
 msgid "Not a valid number of equations!"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:197
+#: ../src/wxMaximaFrame.cpp:196
 msgid "Not connected to maxima"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4599
+#: ../src/wxMaxima.cpp:4611
 msgid "Not connected."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1376
+#: ../src/wxMaximaFrame.cpp:1375
 msgid "Nu"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Num. deg:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3585 ../src/wxMaxima.cpp:3609
+#: ../src/wxMaxima.cpp:3597 ../src/wxMaxima.cpp:3621
 msgid "Number of equations:"
 msgstr ""
 
@@ -2839,15 +2842,15 @@ msgstr ""
 msgid "Old value:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3992 ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135
+#: ../src/wxMaxima.cpp:4004 ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147
 msgid "Old variable:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1387
+#: ../src/wxMaximaFrame.cpp:1386
 msgid "Omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1378
+#: ../src/wxMaximaFrame.cpp:1377
 msgid "Omicron"
 msgstr ""
 
@@ -2861,20 +2864,20 @@ msgid ""
 "stream for messages."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4763
+#: ../src/wxMaxima.cpp:4775
 msgid "One sample t-test"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:971
+#: ../src/wxMaximaFrame.cpp:970
 msgid "Online tutorials"
 msgstr ""
 
 #: ../src/ConfigDialogue.cpp:656 ../src/main.cpp:347 ../src/ToolBar.cpp:119
-#: ../src/wxMaxima.cpp:2797
+#: ../src/wxMaxima.cpp:2805
 msgid "Open"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:466
+#: ../src/wxMaximaFrame.cpp:465
 msgid "Open Recent"
 msgstr ""
 
@@ -2882,11 +2885,11 @@ msgstr ""
 msgid "Open a cell when Maxima expects input"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:464
+#: ../src/wxMaximaFrame.cpp:463
 msgid "Open a document"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:458 ../src/wxMaximaFrame.cpp:461
+#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
 msgid "Open a new window"
 msgstr ""
 
@@ -2894,11 +2897,11 @@ msgstr ""
 msgid "Open document"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4824
+#: ../src/wxMaxima.cpp:4836
 msgid "Open matrix"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1446 ../src/wxMaxima.cpp:1518
+#: ../src/wxMaxima.cpp:1451 ../src/wxMaxima.cpp:1523
 msgid "Opening file"
 msgstr ""
 
@@ -2922,26 +2925,26 @@ msgstr ""
 msgid "Output labels"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:796
+#: ../src/wxMaximaFrame.cpp:795
 msgid "P&ade Approximation..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3132 ../src/wxMaxima.cpp:5133
+#: ../src/wxMaxima.cpp:3141 ../src/wxMaxima.cpp:5145
 msgid ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
 "bmp|Portable animap (*.pnm)|*.pnm|Tagged image file format (*.tif)|*.tif|X "
 "pixmap (*.xpm)|*.xpm"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4012
+#: ../src/wxMaxima.cpp:4024
 msgid "Pade approximation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:797
+#: ../src/wxMaximaFrame.cpp:796
 msgid "Pade approximation of a Taylor series"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1500
+#: ../src/wxMaximaFrame.cpp:1519
 msgid "Pagebreak"
 msgstr ""
 
@@ -2953,19 +2956,19 @@ msgstr ""
 msgid "Parametric plot"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:188
+#: ../src/wxMaximaFrame.cpp:187
 msgid "Parsing output"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:819
+#: ../src/wxMaximaFrame.cpp:818
 msgid "Partial &Fractions..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4076
+#: ../src/wxMaxima.cpp:4088
 msgid "Partial fractions"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1769
+#: ../src/wxMaxima.cpp:1774
 msgid "Parts of the document will not be loaded correctly!"
 msgstr ""
 
@@ -2975,11 +2978,11 @@ msgid ""
 "Found unknown XML Tag name "
 msgstr ""
 
-#: ../src/ToolBar.cpp:143 ../src/MathCtrl.cpp:1010 ../src/MathCtrl.cpp:1025
+#: ../src/MathCtrl.cpp:1052 ../src/MathCtrl.cpp:1067 ../src/ToolBar.cpp:143
 msgid "Paste"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:518
+#: ../src/wxMaximaFrame.cpp:517
 msgid "Paste\tCtrl-V"
 msgstr ""
 
@@ -2987,7 +2990,7 @@ msgstr ""
 msgid "Paste from clipboard"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:519
+#: ../src/wxMaximaFrame.cpp:518
 msgid "Paste text from clipboard"
 msgstr ""
 
@@ -2995,19 +2998,19 @@ msgstr ""
 msgid "Perpendicular to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1384
+#: ../src/wxMaximaFrame.cpp:1383
 msgid "Phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1379
+#: ../src/wxMaximaFrame.cpp:1378
 msgid "Pi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1273
+#: ../src/wxMaximaFrame.cpp:1272
 msgid "Piechart..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1952
+#: ../src/wxMaxima.cpp:1957
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr ""
 
@@ -3015,52 +3018,52 @@ msgstr ""
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:923
+#: ../src/wxMaximaFrame.cpp:922
 msgid "Plot &2d..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:925
+#: ../src/wxMaximaFrame.cpp:924
 msgid "Plot &3d..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:927
+#: ../src/wxMaximaFrame.cpp:926
 msgid "Plot &Format..."
 msgstr ""
 
 #: ../src/Plot2dWiz.cpp:104 ../src/Plot2dWiz.cpp:450 ../src/Plot2dWiz.cpp:464
-#: ../src/wxMaxima.cpp:4283 ../src/wxMaxima.cpp:5102
+#: ../src/wxMaxima.cpp:4295 ../src/wxMaxima.cpp:5114
 msgid "Plot 2D"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1227
+#: ../src/wxMaximaFrame.cpp:1226
 msgid "Plot 2D..."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1003
+#: ../src/MathCtrl.cpp:1045
 msgid "Plot 2d..."
 msgstr ""
 
-#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4269 ../src/wxMaxima.cpp:5115
+#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4281 ../src/wxMaxima.cpp:5127
 msgid "Plot 3D"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1228
+#: ../src/wxMaximaFrame.cpp:1227
 msgid "Plot 3D..."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1004
+#: ../src/MathCtrl.cpp:1046
 msgid "Plot 3d..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4296
+#: ../src/wxMaxima.cpp:4308
 msgid "Plot format"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:924
+#: ../src/wxMaximaFrame.cpp:923
 msgid "Plot in 2 dimensions"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:926
+#: ../src/wxMaximaFrame.cpp:925
 msgid "Plot in 3 dimensions"
 msgstr ""
 
@@ -3069,8 +3072,8 @@ msgid "Plot to file:"
 msgstr ""
 
 #: ../src/BC2Wiz.cpp:30 ../src/BC2Wiz.cpp:36 ../src/LimitWiz.cpp:33
-#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
-#: ../src/wxMaxima.cpp:3648
+#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
+#: ../src/wxMaxima.cpp:3660
 msgid "Point:"
 msgstr ""
 
@@ -3078,11 +3081,11 @@ msgstr ""
 msgid "Polish"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 1:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 2:"
 msgstr ""
 
@@ -3094,11 +3097,11 @@ msgstr ""
 msgid "Postscript file (*.eps)|*.eps|All|*"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Precision"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:536
 msgid "Preferences...\tCtrl+,"
 msgstr ""
 
@@ -3110,7 +3113,7 @@ msgid ""
 "packages and from functions that are defined in the current file."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:628
+#: ../src/wxMaximaFrame.cpp:627
 msgid "Previous Command\tAlt-Up"
 msgstr ""
 
@@ -3118,11 +3121,11 @@ msgstr ""
 msgid "Print"
 msgstr ""
 
-#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:484
+#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:483
 msgid "Print document"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4242
+#: ../src/wxMaxima.cpp:4254
 msgid "Product"
 msgstr ""
 
@@ -3130,35 +3133,35 @@ msgstr ""
 msgid "Product sign"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1386
+#: ../src/wxMaximaFrame.cpp:1385
 msgid "Psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:331
+#: ../src/wxMaximaFrame.cpp:330
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:592
+#: ../src/wxMaximaFrame.cpp:591
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1278
+#: ../src/wxMaximaFrame.cpp:1277
 msgid "Read Matrix..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:177
+#: ../src/wxMaximaFrame.cpp:176
 msgid "Reading Maxima output"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:153
+#: ../src/wxMaximaFrame.cpp:152
 msgid "Ready for user input"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:631
+#: ../src/wxMaximaFrame.cpp:630
 msgid "Recall next command from history"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:629
+#: ../src/wxMaximaFrame.cpp:628
 msgid "Recall previous command from history"
 msgstr ""
 
@@ -3166,35 +3169,35 @@ msgstr ""
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1215
+#: ../src/wxMaximaFrame.cpp:1214
 msgid "Rectform"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:495
+#: ../src/wxMaximaFrame.cpp:494
 msgid "Redo\tCtrl-Y"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:496
+#: ../src/wxMaximaFrame.cpp:495
 msgid "Redo last change"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1220
+#: ../src/wxMaximaFrame.cpp:1219
 msgid "Reduce (tr)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:871
+#: ../src/wxMaximaFrame.cpp:870
 msgid "Reduce trigonometric expression"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:622 ../src/wxMaxima.cpp:5495
+#: ../src/wxMaxima.cpp:627 ../src/wxMaxima.cpp:5511
 msgid "Refusing to send cell to maxima: "
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:594
+#: ../src/wxMaximaFrame.cpp:593
 msgid "Remove All Output"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:595
+#: ../src/wxMaximaFrame.cpp:594
 msgid "Remove output from input cells"
 msgstr ""
 
@@ -3202,7 +3205,7 @@ msgstr ""
 msgid "Replace All"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3282
+#: ../src/wxMaxima.cpp:3294
 #, c-format
 msgid "Replaced %d occurrences."
 msgstr ""
@@ -3211,11 +3214,11 @@ msgstr ""
 msgid "Replacement:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:976
+#: ../src/wxMaximaFrame.cpp:975
 msgid "Report bug"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "Restart Maxima"
 msgstr ""
 
@@ -3223,7 +3226,7 @@ msgstr ""
 msgid "Restart maxima"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4442
+#: ../src/MathCtrl.cpp:4497
 msgid "Result"
 msgstr ""
 
@@ -3231,7 +3234,7 @@ msgstr ""
 msgid "Return to the cell that is currently being evaluated"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1380
+#: ../src/wxMaximaFrame.cpp:1379
 msgid "Rho"
 msgstr ""
 
@@ -3239,19 +3242,19 @@ msgstr ""
 msgid "Right arrow"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:779
+#: ../src/wxMaximaFrame.cpp:778
 msgid "Risch Integration..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:694
+#: ../src/wxMaximaFrame.cpp:693
 msgid "Roots of &Polynomial"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:697
+#: ../src/wxMaximaFrame.cpp:696
 msgid "Roots of Polynomial (bfloat)"
 msgstr ""
 
-#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Rows:"
 msgstr ""
 
@@ -3259,56 +3262,56 @@ msgstr ""
 msgid "Russian"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 1:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 2:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Sample:"
 msgstr ""
 
 #: ../src/ConfigDialogue.cpp:781 ../src/ToolBar.cpp:122
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Save"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:921
+#: ../src/MathCtrl.cpp:963
 msgid "Save Animation..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2565
+#: ../src/wxMaxima.cpp:2572
 msgid "Save As"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:474
+#: ../src/wxMaximaFrame.cpp:473
 msgid "Save As...\tShift-Ctrl-S"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:919
+#: ../src/MathCtrl.cpp:961
 msgid "Save Image..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3130
+#: ../src/wxMaxima.cpp:3139
 msgid "Save Selection to Image"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:528
+#: ../src/wxMaximaFrame.cpp:527
 msgid "Save Selection to Image..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5150
+#: ../src/wxMaxima.cpp:5162
 msgid "Save animation to file"
 msgstr ""
 
-#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:473
+#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:472
 msgid "Save document"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:475
+#: ../src/wxMaximaFrame.cpp:474
 msgid "Save document as"
 msgstr ""
 
@@ -3330,11 +3333,11 @@ msgstr ""
 msgid "Save plot to file"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:529
+#: ../src/wxMaximaFrame.cpp:528
 msgid "Save selection from document to an image file"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5131
+#: ../src/wxMaxima.cpp:5143
 msgid "Save selection to file"
 msgstr ""
 
@@ -3350,27 +3353,27 @@ msgstr ""
 msgid "Save wxMaxima window size/position between sessions."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:246
+#: ../src/wxMaximaFrame.cpp:245
 msgid "Saving failed."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:222
+#: ../src/wxMaximaFrame.cpp:221
 msgid "Saving successful."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:212
+#: ../src/wxMaximaFrame.cpp:211
 msgid "Saving..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4699
+#: ../src/wxMaxima.cpp:4711
 msgid "Scatterplot"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1271
+#: ../src/wxMaximaFrame.cpp:1270
 msgid "Scatterplot..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1498
+#: ../src/wxMaximaFrame.cpp:1517
 msgid "Section"
 msgstr ""
 
@@ -3378,26 +3381,26 @@ msgstr ""
 msgid "Section cell"
 msgstr ""
 
-#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:292 ../src/TextCell.cpp:306
-#: ../src/TextCell.cpp:322 ../src/TextCell.cpp:334
+#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:290 ../src/TextCell.cpp:304
+#: ../src/TextCell.cpp:320 ../src/TextCell.cpp:332
 msgid ""
 "Seems like something is broken with a font. Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/TextCell.cpp:139
+#: ../src/TextCell.cpp:137
 msgid ""
 "Seems like something is broken with the maths font. Installing http://www."
 "math.union.edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use "
 "JSmath fonts\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1011 ../src/MathCtrl.cpp:1027
+#: ../src/MathCtrl.cpp:1053 ../src/MathCtrl.cpp:1069
 msgid "Select All"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:525
+#: ../src/wxMaximaFrame.cpp:524
 msgid "Select All\tCtrl-A"
 msgstr ""
 
@@ -3405,7 +3408,7 @@ msgstr ""
 msgid "Select Maxima program"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4860
+#: ../src/wxMaxima.cpp:4872
 msgid "Select Subsample"
 msgstr ""
 
@@ -3414,11 +3417,11 @@ msgstr ""
 msgid "Select a constant"
 msgstr ""
 
-#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:526
+#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:525
 msgid "Select all"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3319
+#: ../src/wxMaxima.cpp:3331
 msgid "Select math display algorithm"
 msgstr ""
 
@@ -3432,23 +3435,23 @@ msgstr ""
 msgid "Selection"
 msgstr ""
 
-#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4178
+#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4190
 msgid "Series"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1226
+#: ../src/wxMaximaFrame.cpp:1225
 msgid "Series..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:863
+#: ../src/wxMaxima.cpp:868
 msgid "Server started"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:575
+#: ../src/wxMaximaFrame.cpp:574
 msgid "Set Zoom"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:944
+#: ../src/wxMaximaFrame.cpp:943
 msgid "Set bigfloat &Precision..."
 msgstr ""
 
@@ -3456,61 +3459,61 @@ msgstr ""
 msgid "Set fixed font in text controls."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:928
+#: ../src/wxMaximaFrame.cpp:927
 msgid "Set plot format"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:945
+#: ../src/wxMaximaFrame.cpp:944
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can "
 "be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:569
+#: ../src/wxMaximaFrame.cpp:568
 msgid "Set zoom to 100%"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:570
+#: ../src/wxMaximaFrame.cpp:569
 msgid "Set zoom to 120%"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:571
+#: ../src/wxMaximaFrame.cpp:570
 msgid "Set zoom to 150%"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:572
+#: ../src/wxMaximaFrame.cpp:571
 msgid "Set zoom to 200%"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:573
+#: ../src/wxMaximaFrame.cpp:572
 msgid "Set zoom to 300%"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:568
+#: ../src/wxMaximaFrame.cpp:567
 msgid "Set zoom to 80%"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:732
+#: ../src/wxMaximaFrame.cpp:731
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:918
+#: ../src/wxMaximaFrame.cpp:917
 msgid "Setup modulus computation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:662
+#: ../src/wxMaximaFrame.cpp:661
 msgid "Show &Definition..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:660
+#: ../src/wxMaximaFrame.cpp:659
 msgid "Show &Functions"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:967
+#: ../src/wxMaximaFrame.cpp:966
 msgid "Show &Tips..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:665
+#: ../src/wxMaximaFrame.cpp:664
 msgid "Show &Variables"
 msgstr ""
 
@@ -3518,43 +3521,43 @@ msgstr ""
 msgid "Show Maxima help"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:603
+#: ../src/wxMaximaFrame.cpp:602
 msgid "Show Template\tCtrl-Shift-K"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:968
+#: ../src/wxMaximaFrame.cpp:967
 msgid "Show a tip"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Show all commands similar to:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Show an example for the command:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:962
+#: ../src/wxMaximaFrame.cpp:961
 msgid "Show an example of usage"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:965
+#: ../src/wxMaximaFrame.cpp:964
 msgid "Show commands similar to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:661
+#: ../src/wxMaximaFrame.cpp:660
 msgid "Show defined functions"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:666
+#: ../src/wxMaximaFrame.cpp:665
 msgid "Show defined variables"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:663
+#: ../src/wxMaximaFrame.cpp:662
 msgid "Show definition of a function"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:604
+#: ../src/wxMaximaFrame.cpp:603
 msgid "Show function template"
 msgstr ""
 
@@ -3566,7 +3569,7 @@ msgstr ""
 msgid "Show long expressions:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3341
+#: ../src/wxMaxima.cpp:3353
 msgid "Show the definition of function:"
 msgstr ""
 
@@ -3575,43 +3578,43 @@ msgstr ""
 msgid "Show user-defined labels instead of (%oxx)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:953 ../src/wxMaximaFrame.cpp:956
+#: ../src/wxMaximaFrame.cpp:952 ../src/wxMaximaFrame.cpp:955
 msgid "Show wxMaxima help"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1381
+#: ../src/wxMaximaFrame.cpp:1380
 msgid "Sigma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1211
+#: ../src/wxMaximaFrame.cpp:1210
 msgid "Simplify"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:831
+#: ../src/wxMaximaFrame.cpp:830
 msgid "Simplify &Radicals"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1212
+#: ../src/wxMaximaFrame.cpp:1211
 msgid "Simplify (r)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1218
+#: ../src/wxMaximaFrame.cpp:1217
 msgid "Simplify (tr)"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:995
+#: ../src/MathCtrl.cpp:1037
 msgid "Simplify Expression"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:857
+#: ../src/wxMaximaFrame.cpp:856
 msgid "Simplify an expression containing factorials"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:832
+#: ../src/wxMaximaFrame.cpp:831
 msgid "Simplify expression containing radicals"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:830
+#: ../src/wxMaximaFrame.cpp:829
 msgid "Simplify rational expression"
 msgstr ""
 
@@ -3619,7 +3622,7 @@ msgstr ""
 msgid "Simplify the sum"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:868
+#: ../src/wxMaximaFrame.cpp:867
 msgid "Simplify trigonometric expression"
 msgstr ""
 
@@ -3631,87 +3634,87 @@ msgid ""
 "along with your document."
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
+#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
 msgid "Solution:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3461 ../src/wxMaxima.cpp:3475 ../src/wxMaxima.cpp:5020
+#: ../src/wxMaxima.cpp:3473 ../src/wxMaxima.cpp:3487 ../src/wxMaxima.cpp:5032
 msgid "Solve"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:706
+#: ../src/wxMaximaFrame.cpp:705
 msgid "Solve &Algebraic System..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:703
+#: ../src/wxMaximaFrame.cpp:702
 msgid "Solve &Linear System..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:714
+#: ../src/wxMaximaFrame.cpp:713
 msgid "Solve &ODE..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:690
+#: ../src/wxMaximaFrame.cpp:689
 msgid "Solve (to_poly)..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3511 ../src/wxMaxima.cpp:3635
+#: ../src/wxMaxima.cpp:3523 ../src/wxMaxima.cpp:3647
 msgid "Solve ODE"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:728
+#: ../src/wxMaximaFrame.cpp:727
 msgid "Solve ODE with Lapla&ce..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1222
+#: ../src/wxMaximaFrame.cpp:1221
 msgid "Solve ODE..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3586 ../src/wxMaxima.cpp:3597
+#: ../src/wxMaxima.cpp:3598 ../src/wxMaxima.cpp:3609
 msgid "Solve algebraic system"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:707
+#: ../src/wxMaximaFrame.cpp:706
 msgid "Solve algebraic system of equations"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:725
+#: ../src/wxMaximaFrame.cpp:724
 msgid "Solve boundary value problem for second degree ODE"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:689
+#: ../src/wxMaximaFrame.cpp:688
 msgid "Solve equation(s)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:691
+#: ../src/wxMaximaFrame.cpp:690
 msgid "Solve equation(s) with to_poly_solve"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:719
+#: ../src/wxMaximaFrame.cpp:718
 msgid "Solve initial value problem for first degree ODE"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:722
+#: ../src/wxMaximaFrame.cpp:721
 msgid "Solve initial value problem for second degree ODE"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3610 ../src/wxMaxima.cpp:3621
+#: ../src/wxMaxima.cpp:3622 ../src/wxMaxima.cpp:3633
 msgid "Solve linear system"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:704
+#: ../src/wxMaximaFrame.cpp:703
 msgid "Solve linear system of equations"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:715
+#: ../src/wxMaximaFrame.cpp:714
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:729
+#: ../src/wxMaximaFrame.cpp:728
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1221 ../src/MathCtrl.cpp:992
+#: ../src/MathCtrl.cpp:1034 ../src/wxMaximaFrame.cpp:1220
 msgid "Solve..."
 msgstr ""
 
@@ -3735,7 +3738,7 @@ msgstr ""
 msgid "Special constants"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:922
+#: ../src/MathCtrl.cpp:964
 msgid "Start Animation"
 msgstr ""
 
@@ -3753,28 +3756,28 @@ msgstr ""
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:294
+#: ../src/wxMaxima.cpp:295
 msgid "Starting Maxima process failed"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:928
+#: ../src/wxMaxima.cpp:933
 msgid "Starting Maxima..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:292 ../src/wxMaxima.cpp:860
+#: ../src/wxMaxima.cpp:293 ../src/wxMaxima.cpp:865
 msgid "Starting server failed"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:841
+#: ../src/wxMaxima.cpp:846
 #, c-format
 msgid "Starting server on port %d"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:342
+#: ../src/wxMaximaFrame.cpp:341
 msgid "Statistics"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:550
+#: ../src/wxMaximaFrame.cpp:549
 msgid "Statistics\tAlt-Shift-S"
 msgstr ""
 
@@ -3790,11 +3793,11 @@ msgstr ""
 msgid "Styles"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1283
+#: ../src/wxMaximaFrame.cpp:1282
 msgid "Subsample..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1496
+#: ../src/wxMaximaFrame.cpp:1515
 msgid "Subsection"
 msgstr ""
 
@@ -3802,20 +3805,20 @@ msgstr ""
 msgid "Subsection cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1216
+#: ../src/wxMaximaFrame.cpp:1215
 msgid "Subst..."
 msgstr ""
 
-#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3423
-#: ../src/wxMaxima.cpp:5089
+#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3435
+#: ../src/wxMaxima.cpp:5101
 msgid "Substitute"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:906 ../src/MathCtrl.cpp:998
+#: ../src/MathCtrl.cpp:1040 ../src/wxMaximaFrame.cpp:905
 msgid "Substitute..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1497
+#: ../src/wxMaximaFrame.cpp:1516
 msgid "Subsubsection"
 msgstr ""
 
@@ -3823,7 +3826,7 @@ msgstr ""
 msgid "Subsubsection cell"
 msgstr ""
 
-#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4226
+#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4238
 msgid "Sum"
 msgstr ""
 
@@ -3831,35 +3834,35 @@ msgstr ""
 msgid "Sum sign"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:553
+#: ../src/wxMaximaFrame.cpp:552
 msgid "Symbols\tAlt-Shift-Y"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4456
+#: ../src/wxMaxima.cpp:4468
 msgid "System info"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:320
+#: ../src/wxMaximaFrame.cpp:319
 msgid "Table of Contents"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:556
+#: ../src/wxMaximaFrame.cpp:555
 msgid "Table of Contents\tAlt-Shift-T"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1382
+#: ../src/wxMaximaFrame.cpp:1381
 msgid "Tau"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Taylor series:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3963
+#: ../src/wxMaxima.cpp:3975
 msgid "Tellrat"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1494
+#: ../src/wxMaximaFrame.cpp:1513
 msgid "Text"
 msgstr ""
 
@@ -3904,7 +3907,7 @@ msgstr ""
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr ""
 
-#: ../src/TextCell.cpp:136
+#: ../src/TextCell.cpp:134
 msgid ""
 "The letter \"X\" is of width zero. Installing http://www.math.union.edu/"
 "~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts\" in "
@@ -3921,7 +3924,7 @@ msgstr ""
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:959
+#: ../src/wxMaximaFrame.cpp:958
 msgid "The offline manual of maxima"
 msgstr ""
 
@@ -3955,21 +3958,21 @@ msgid ""
 "find tutorials on using wxMaxima and Maxima."
 msgstr ""
 
-#: ../src/SlideShowCell.cpp:332
+#: ../src/SlideShowCell.cpp:336
 msgid ""
 "There was an error during GIF export!\n"
 "\n"
 "Make sure ImageMagick is installed and wxMaxima can find the convert program."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:442
+#: ../src/wxMaxima.cpp:447
 msgid ""
 "There was an error in generated XML!\n"
 "\n"
 "Please report this as a bug."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1371
+#: ../src/wxMaximaFrame.cpp:1370
 msgid "Theta"
 msgstr ""
 
@@ -3977,7 +3980,7 @@ msgstr ""
 msgid "Ticks:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4153 ../src/wxMaxima.cpp:5065
+#: ../src/wxMaxima.cpp:4165 ../src/wxMaxima.cpp:5077
 msgid "Times:"
 msgstr ""
 
@@ -3985,7 +3988,7 @@ msgstr ""
 msgid "Tips not available, sorry!"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1495
+#: ../src/wxMaximaFrame.cpp:1514
 msgid "Title"
 msgstr ""
 
@@ -4000,19 +4003,19 @@ msgid ""
 "all sublevels of that cell will also fold/unfold."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:938
+#: ../src/wxMaximaFrame.cpp:937
 msgid "To &Bigfloat"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:935
+#: ../src/wxMaximaFrame.cpp:934
 msgid "To &Float"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:990
+#: ../src/MathCtrl.cpp:1032
 msgid "To Float"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:941
+#: ../src/wxMaximaFrame.cpp:940
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr ""
 
@@ -4043,51 +4046,51 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:41 ../src/Plot2dWiz.cpp:40 ../src/Plot2dWiz.cpp:50
 #: ../src/Plot2dWiz.cpp:539 ../src/Plot3dWiz.cpp:39 ../src/Plot3dWiz.cpp:48
-#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4241
+#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4253
 msgid "To:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:912
+#: ../src/wxMaximaFrame.cpp:911
 msgid "Toggle &Algebraic Flag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:933
+#: ../src/wxMaximaFrame.cpp:932
 msgid "Toggle &Numeric Output"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:673
+#: ../src/wxMaximaFrame.cpp:672
 msgid "Toggle &Time Display"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:913
+#: ../src/wxMaximaFrame.cpp:912
 msgid "Toggle algebraic flag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:577
+#: ../src/wxMaximaFrame.cpp:576
 msgid "Toggle full screen editing"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:934
+#: ../src/wxMaximaFrame.cpp:933
 msgid "Toggle numeric output"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4464
+#: ../src/wxMaxima.cpp:4476
 msgid "Toolbar icons"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4465
+#: ../src/wxMaxima.cpp:4477
 msgid "Translated by"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:763
+#: ../src/wxMaximaFrame.cpp:762
 msgid "Transpose a matrix"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5834
+#: ../src/MathCtrl.cpp:5886
 msgid "Trying to undo an action without starting cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5901
+#: ../src/MathCtrl.cpp:5953
 msgid "Trying to undo something but the undo action is empty."
 msgstr ""
 
@@ -4095,11 +4098,11 @@ msgstr ""
 msgid "Turkish"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:970
+#: ../src/wxMaximaFrame.cpp:969
 msgid "Tutorials"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4778
+#: ../src/wxMaxima.cpp:4790
 msgid "Two sample t-test"
 msgstr ""
 
@@ -4111,15 +4114,15 @@ msgstr ""
 msgid "Ukrainian"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5356
+#: ../src/wxMaxima.cpp:5372
 msgid "Un-closed parenthesis"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5323
+#: ../src/wxMaxima.cpp:5335
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5889
 msgid ""
 "Unable to interpret the version info I got from http://andrejv.github.io//"
 "wxmaxima/version.txt: "
@@ -4133,11 +4136,11 @@ msgstr ""
 msgid "Underscore converts to subscripts:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:492
+#: ../src/wxMaximaFrame.cpp:491
 msgid "Undo\tCtrl-Z"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:493
+#: ../src/wxMaximaFrame.cpp:492
 msgid "Undo last change"
 msgstr ""
 
@@ -4145,23 +4148,23 @@ msgstr ""
 msgid "Undo limit (0 for none):"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:625
+#: ../src/wxMaximaFrame.cpp:624
 msgid "Unfold All\tCtrl-Alt-]"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:626
+#: ../src/wxMaximaFrame.cpp:625
 msgid "Unfold all folded sections"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4458
+#: ../src/wxMaxima.cpp:4470
 msgid "Unicode Support"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5335
+#: ../src/wxMaxima.cpp:5347
 msgid "Unterminated comment."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5309
+#: ../src/wxMaxima.cpp:5321
 msgid "Unterminated string."
 msgstr ""
 
@@ -4169,15 +4172,15 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5859 ../src/wxMaxima.cpp:5866 ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5874 ../src/wxMaxima.cpp:5881 ../src/wxMaxima.cpp:5889
 msgid "Upgrade"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Upper bound:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1383
+#: ../src/wxMaximaFrame.cpp:1382
 msgid "Upsilon"
 msgstr ""
 
@@ -4221,22 +4224,22 @@ msgstr ""
 msgid "User-defined labels"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3525
-#: ../src/wxMaxima.cpp:3541 ../src/wxMaxima.cpp:3649
+#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3537
+#: ../src/wxMaxima.cpp:3553 ../src/wxMaxima.cpp:3661
 msgid "Value:"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:5019 ../src/wxMaxima.cpp:5064
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:5031 ../src/wxMaxima.cpp:5076
 msgid "Variable(s):"
 msgstr ""
 
 #: ../src/IntegrateWiz.cpp:33 ../src/LimitWiz.cpp:30 ../src/Plot2dWiz.cpp:34
 #: ../src/Plot2dWiz.cpp:44 ../src/Plot2dWiz.cpp:533 ../src/Plot3dWiz.cpp:33
 #: ../src/Plot3dWiz.cpp:42 ../src/SeriesWiz.cpp:36 ../src/SumWiz.cpp:30
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3749
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3761
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5045
 msgid "Variable:"
 msgstr ""
 
@@ -4244,25 +4247,25 @@ msgstr ""
 msgid "Variables"
 msgstr ""
 
-#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3571 ../src/wxMaxima.cpp:4206
-#: ../src/wxMaxima.cpp:4807
+#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3583 ../src/wxMaxima.cpp:4218
+#: ../src/wxMaxima.cpp:4819
 msgid "Variables:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1257
+#: ../src/wxMaximaFrame.cpp:1256
 msgid "Variance..."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:580
+#: ../src/wxMaximaFrame.cpp:579
 msgid "View"
 msgstr ""
 
-#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1674 ../src/wxMaxima.cpp:1769
-#: ../src/wxMaxima.cpp:1950
+#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1679 ../src/wxMaxima.cpp:1774
+#: ../src/wxMaxima.cpp:1955
 msgid "Warning"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:109 ../src/wxMaximaFrame.cpp:295
+#: ../src/wxMaximaFrame.cpp:108 ../src/wxMaximaFrame.cpp:294
 msgid "Welcome to wxMaxima"
 msgstr ""
 
@@ -4282,7 +4285,7 @@ msgid ""
 "introducing an empty line."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2567
+#: ../src/wxMaxima.cpp:2574
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) "
 "(*.wxm)|*.wxm"
@@ -4298,7 +4301,7 @@ msgid ""
 "as equation markers"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6798
+#: ../src/MathCtrl.cpp:6856
 msgid "Wrapped search"
 msgstr ""
 
@@ -4306,15 +4309,15 @@ msgstr ""
 msgid "Write matching parenthesis in text controls."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4461
+#: ../src/wxMaxima.cpp:4473
 msgid "Written by"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:557
+#: ../src/wxMaximaFrame.cpp:556
 msgid "XML Inspector"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1377
+#: ../src/wxMaximaFrame.cpp:1376
 msgid "Xi"
 msgstr ""
 
@@ -4365,7 +4368,7 @@ msgid ""
 "cells."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5856
+#: ../src/wxMaxima.cpp:5871
 #, c-format
 msgid ""
 "You have version %s. Current version is %s.\n"
@@ -4373,39 +4376,39 @@ msgid ""
 "Select OK to visit the wxMaxima webpage."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5921
+#: ../src/wxMaxima.cpp:5936
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5866
+#: ../src/wxMaxima.cpp:5881
 msgid "Your version of wxMaxima is up to date."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1369
+#: ../src/wxMaximaFrame.cpp:1368
 msgid "Zeta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:562
+#: ../src/wxMaximaFrame.cpp:561
 msgid "Zoom &In\tCtrl-+"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:564
+#: ../src/wxMaximaFrame.cpp:563
 msgid "Zoom Ou&t\tCtrl--"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:563
+#: ../src/wxMaximaFrame.cpp:562
 msgid "Zoom in 10%"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:565
+#: ../src/wxMaximaFrame.cpp:564
 msgid "Zoom out 10%"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaximaFrame.cpp:287
 msgid "[ unsaved ]"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5700
+#: ../src/wxMaxima.cpp:5715
 msgid "[ unsaved* ]"
 msgstr ""
 
@@ -4414,17 +4417,17 @@ msgstr ""
 msgid "[%i digits]"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4392
+#: ../src/MathCtrl.cpp:4447
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" style=\"max-width:90%%;\" >\n"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4517
+#: ../src/MathCtrl.cpp:4572
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" >"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1333
+#: ../src/wxMaximaFrame.cpp:1332
 msgid "alpha"
 msgstr ""
 
@@ -4436,7 +4439,7 @@ msgstr ""
 msgid "antisymmetric"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1334
+#: ../src/wxMaximaFrame.cpp:1333
 msgid "beta"
 msgstr ""
 
@@ -4480,7 +4483,7 @@ msgstr ""
 msgid "bug:Invalid sup tag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1354
+#: ../src/wxMaximaFrame.cpp:1353
 msgid "chi"
 msgstr ""
 
@@ -4493,7 +4496,7 @@ msgstr ""
 msgid "default"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1336
+#: ../src/wxMaximaFrame.cpp:1335
 msgid "delta"
 msgstr ""
 
@@ -4505,7 +4508,7 @@ msgstr ""
 msgid "empty"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1337
+#: ../src/wxMaximaFrame.cpp:1336
 msgid "epsilon"
 msgstr ""
 
@@ -4513,7 +4516,7 @@ msgstr ""
 msgid "equivalent"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1339
+#: ../src/wxMaximaFrame.cpp:1338
 msgid "eta"
 msgstr ""
 
@@ -4529,7 +4532,7 @@ msgid ""
 "all=_ marks subscripts."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1335
+#: ../src/wxMaximaFrame.cpp:1334
 msgid "gamma"
 msgstr ""
 
@@ -4555,15 +4558,15 @@ msgstr ""
 msgid "intersection"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1341
+#: ../src/wxMaximaFrame.cpp:1340
 msgid "iota"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1342
+#: ../src/wxMaximaFrame.cpp:1341
 msgid "kappa"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1343
+#: ../src/wxMaximaFrame.cpp:1342
 msgid "lambda"
 msgstr ""
 
@@ -4579,7 +4582,7 @@ msgstr ""
 msgid "logscale"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3783
+#: ../src/wxMaxima.cpp:3795
 msgid "matrix[i,j]:"
 msgstr ""
 
@@ -4587,7 +4590,7 @@ msgstr ""
 msgid "maxima's pwd is path to document"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1344
+#: ../src/wxMaximaFrame.cpp:1343
 msgid "mu"
 msgstr ""
 
@@ -4603,7 +4606,7 @@ msgstr ""
 msgid "nand"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4524
+#: ../src/wxMaxima.cpp:4536
 msgid "no"
 msgstr ""
 
@@ -4627,15 +4630,15 @@ msgstr ""
 msgid "not subset or equal"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1345
+#: ../src/wxMaximaFrame.cpp:1344
 msgid "nu"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1356
+#: ../src/wxMaximaFrame.cpp:1355
 msgid "omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1347
+#: ../src/wxMaximaFrame.cpp:1346
 msgid "omicron"
 msgstr ""
 
@@ -4647,11 +4650,11 @@ msgstr ""
 msgid "partial sign"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1353
+#: ../src/wxMaximaFrame.cpp:1352
 msgid "phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1348
+#: ../src/wxMaximaFrame.cpp:1347
 msgid "pi"
 msgstr ""
 
@@ -4663,11 +4666,11 @@ msgstr ""
 msgid "proportional to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1355
+#: ../src/wxMaximaFrame.cpp:1354
 msgid "psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1349
+#: ../src/wxMaximaFrame.cpp:1348
 msgid "rho"
 msgstr ""
 
@@ -4675,7 +4678,7 @@ msgstr ""
 msgid "right"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1350
+#: ../src/wxMaximaFrame.cpp:1349
 msgid "sigma"
 msgstr ""
 
@@ -4695,7 +4698,7 @@ msgstr ""
 msgid "symmetric"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1351
+#: ../src/wxMaximaFrame.cpp:1350
 msgid "tau"
 msgstr ""
 
@@ -4707,7 +4710,7 @@ msgstr ""
 msgid "there is no"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1340
+#: ../src/wxMaximaFrame.cpp:1339
 msgid "theta"
 msgstr ""
 
@@ -4723,12 +4726,12 @@ msgstr ""
 msgid "union"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5903
+#: ../src/wxMaxima.cpp:5918
 msgid "unsaved"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:290 ../src/wxMaxima.cpp:2559
-#: ../src/wxMaxima.cpp:2826
+#: ../src/wxMaxima.cpp:2566 ../src/wxMaxima.cpp:2834
+#: ../src/wxMaximaFrame.cpp:289
 msgid "untitled"
 msgstr ""
 
@@ -4737,25 +4740,25 @@ msgstr ""
 msgid "untitled %d"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1352
+#: ../src/wxMaximaFrame.cpp:1351
 msgid "upsilon"
 msgstr ""
 
-#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4538
+#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4550
 msgid "wxMaxima"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
-#: ../src/wxMaxima.cpp:5700 ../src/wxMaxima.cpp:5709 ../src/wxMaxima.cpp:5712
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaxima.cpp:5715 ../src/wxMaxima.cpp:5724
+#: ../src/wxMaxima.cpp:5727 ../src/wxMaximaFrame.cpp:287
 #, c-format
 msgid "wxMaxima %s "
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:952
+#: ../src/wxMaximaFrame.cpp:951
 msgid "wxMaxima &Help\tCtrl+?"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:955
+#: ../src/wxMaximaFrame.cpp:954
 msgid "wxMaxima &Help\tF1"
 msgstr ""
 
@@ -4766,11 +4769,11 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1619
+#: ../src/wxMaxima.cpp:1624
 msgid "wxMaxima cannot open content.xml in the .wxmx zip archive "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1633
+#: ../src/wxMaxima.cpp:1638
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
@@ -4778,7 +4781,7 @@ msgstr ""
 msgid "wxMaxima configuration"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1947
+#: ../src/wxMaxima.cpp:1952
 msgid ""
 "wxMaxima could not find Maxima!\n"
 "\n"
@@ -4786,21 +4789,21 @@ msgid ""
 "Then start Maxima with 'Maxima->Restart Maxima'."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2204
+#: ../src/wxMaxima.cpp:2209
 msgid ""
 "wxMaxima could not find help files.\n"
 "\n"
 "Please check your installation."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2032
+#: ../src/wxMaxima.cpp:2037
 msgid ""
 "wxMaxima could not find tip files.\n"
 "\n"
 "Please check your installation."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:282
+#: ../src/wxMaxima.cpp:283
 msgid ""
 "wxMaxima could not start the server.\n"
 "\n"
@@ -4815,29 +4818,29 @@ msgid ""
 "instead of '%'."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2330
+#: ../src/wxMaxima.cpp:2336
 msgid "wxMaxima document"
 msgstr ""
 
-#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2799
+#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2807
 msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1455 ../src/wxMaxima.cpp:1469
+#: ../src/wxMaxima.cpp:1460 ../src/wxMaxima.cpp:1474
 msgid "wxMaxima encountered an error loading "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4463
+#: ../src/wxMaxima.cpp:4475
 msgid "wxMaxima icon"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4455
+#: ../src/wxMaxima.cpp:4467
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "MAXIMA based on wxWidgets."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4516
+#: ../src/wxMaxima.cpp:4528
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "Maxima based on wxWidgets."
@@ -4855,11 +4858,11 @@ msgstr ""
 msgid "x"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1346
+#: ../src/wxMaximaFrame.cpp:1345
 msgid "xi"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1643
+#: ../src/wxMaxima.cpp:1648
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
@@ -4867,10 +4870,10 @@ msgstr ""
 msgid "xor"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4522
+#: ../src/wxMaxima.cpp:4534
 msgid "yes"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1338
+#: ../src/wxMaximaFrame.cpp:1337
 msgid "zeta"
 msgstr ""

--- a/locales/zh_CN.po
+++ b/locales/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxMaxima HEAD\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-07 21:42+0200\n"
+"POT-Creation-Date: 2016-10-16 17:47+0900\n"
 "PO-Revision-Date: 2013-01-04 00:31+0800\n"
 "Last-Translator: crickzhang1 <crickzhang1@gmail.com>\n"
 "Language-Team: amateur\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../src/wxMaxima.cpp:4519
+#: ../src/wxMaxima.cpp:4531
 #, c-format
 msgid ""
 "\n"
@@ -29,7 +29,7 @@ msgstr ""
 "wxWidgets 版本：%d.%d.%d.\n"
 "支持 Unicode： %s"
 
-#: ../src/wxMaxima.cpp:4532
+#: ../src/wxMaxima.cpp:4544
 msgid ""
 "\n"
 "Lisp: "
@@ -37,7 +37,7 @@ msgstr ""
 "\n"
 "Lisp 版本："
 
-#: ../src/wxMaxima.cpp:4528
+#: ../src/wxMaxima.cpp:4540
 msgid ""
 "\n"
 "Maxima version: "
@@ -45,7 +45,7 @@ msgstr ""
 "\n"
 "Maxima 版本："
 
-#: ../src/wxMaxima.cpp:5381
+#: ../src/wxMaxima.cpp:5397
 msgid ""
 "\n"
 "Not connected to Maxima!\n"
@@ -53,7 +53,7 @@ msgstr ""
 "\n"
 "未连接到 Maxima！\n"
 
-#: ../src/wxMaxima.cpp:4530
+#: ../src/wxMaxima.cpp:4542
 msgid ""
 "\n"
 "Not connected."
@@ -73,7 +73,7 @@ msgstr ""
 msgid " (Graphics) "
 msgstr ""
 
-#: ../src/EditorCell.cpp:3045 ../src/EditorCell.cpp:3227
+#: ../src/EditorCell.cpp:3088 ../src/EditorCell.cpp:3270
 #, c-format
 msgid " ... + %i hidden lines"
 msgstr ""
@@ -82,13 +82,13 @@ msgstr ""
 msgid " << Expression longer than allowed by the configuration setting! >>"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1673
+#: ../src/wxMaxima.cpp:1678
 msgid ""
 " was saved using a newer version of wxMaxima so it may not load correctly. "
 "Please update your wxMaxima."
 msgstr " 是以新版本 wxMaxima 保存的，无法正确载入。请更新您的 wxMaxima。 "
 
-#: ../src/wxMaxima.cpp:1665
+#: ../src/wxMaxima.cpp:1670
 msgid ""
 " was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr " 是以新版本 wxMaxima 保存的。请更新您的 wxMaxima。"
@@ -101,64 +101,64 @@ msgstr ""
 msgid "\"implies\" symbol"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:101
+#: ../src/wxMaximaFrame.cpp:100
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:773
+#: ../src/wxMaximaFrame.cpp:772
 msgid "&Algebra"
 msgstr "代数(&A)"
 
-#: ../src/wxMaximaFrame.cpp:767
+#: ../src/wxMaximaFrame.cpp:766
 msgid "&Apply to List..."
 msgstr "应用到列表(&A)..."
 
-#: ../src/wxMaximaFrame.cpp:964
+#: ../src/wxMaximaFrame.cpp:963
 msgid "&Apropos..."
 msgstr "查找命令(&A)..."
 
-#: ../src/wxMaximaFrame.cpp:478
+#: ../src/wxMaximaFrame.cpp:477
 msgid "&Batch File...\tCtrl-B"
 msgstr "载入批处理文件(&B)...   Ctrl-B"
 
-#: ../src/wxMaximaFrame.cpp:724
+#: ../src/wxMaximaFrame.cpp:723
 msgid "&Boundary Value Problem..."
 msgstr "边界值问题(&B)..."
 
-#: ../src/wxMaximaFrame.cpp:975
+#: ../src/wxMaximaFrame.cpp:974
 msgid "&Bug Report"
 msgstr "错误报告(&B)"
 
-#: ../src/wxMaximaFrame.cpp:825
+#: ../src/wxMaximaFrame.cpp:824
 msgid "&Calculus"
 msgstr "微积分(&C)"
 
-#: ../src/wxMaximaFrame.cpp:876
+#: ../src/wxMaximaFrame.cpp:875
 msgid "&Canonical Form"
 msgstr "标准形(&C)"
 
-#: ../src/wxMaximaFrame.cpp:749
+#: ../src/wxMaximaFrame.cpp:748
 msgid "&Characteristic Polynomial..."
 msgstr "特征多项式(&C)..."
 
-#: ../src/wxMaximaFrame.cpp:654
+#: ../src/wxMaximaFrame.cpp:653
 msgid "&Clear Memory"
 msgstr "清除内存(&C)"
 
-#: ../src/wxMaximaFrame.cpp:859
+#: ../src/wxMaximaFrame.cpp:858
 msgid "&Combine Factorials"
 msgstr "合并阶乘(&C)"
 
-#: ../src/wxMaximaFrame.cpp:902
+#: ../src/wxMaximaFrame.cpp:901
 msgid "&Complex Simplification"
 msgstr "复数化简(&C)"
 
-#: ../src/wxMaximaFrame.cpp:822
+#: ../src/wxMaximaFrame.cpp:821
 msgid "&Continued Fraction"
 msgstr "连分数(&C)"
 
-#: ../src/wxMaximaFrame.cpp:502
+#: ../src/wxMaximaFrame.cpp:501
 msgid "&Copy\tCtrl-C"
 msgstr "复制(&C)\tCtrl-C"
 
@@ -166,109 +166,109 @@ msgstr "复制(&C)\tCtrl-C"
 msgid "&Definite integration"
 msgstr "定积分(&D)"
 
-#: ../src/wxMaximaFrame.cpp:896
+#: ../src/wxMaximaFrame.cpp:895
 msgid "&Demoivre"
 msgstr "德莫佛公式(&D)"
 
-#: ../src/wxMaximaFrame.cpp:752
+#: ../src/wxMaximaFrame.cpp:751
 msgid "&Determinant"
 msgstr "行列式(&D)"
 
-#: ../src/wxMaximaFrame.cpp:785
+#: ../src/wxMaximaFrame.cpp:784
 msgid "&Differentiate..."
 msgstr "微分(&D)..."
 
-#: ../src/wxMaximaFrame.cpp:543
+#: ../src/wxMaximaFrame.cpp:542
 msgid "&Edit"
 msgstr "编辑(&E)"
 
-#: ../src/wxMaximaFrame.cpp:709
+#: ../src/wxMaximaFrame.cpp:708
 msgid "&Eliminate Variable..."
 msgstr "消元(&E)..."
 
-#: ../src/wxMaximaFrame.cpp:744
+#: ../src/wxMaximaFrame.cpp:743
 msgid "&Enter Matrix..."
 msgstr "输入矩阵(&E)..."
 
-#: ../src/wxMaximaFrame.cpp:961
+#: ../src/wxMaximaFrame.cpp:960
 msgid "&Example..."
 msgstr "示例(&E)..."
 
-#: ../src/wxMaximaFrame.cpp:839
+#: ../src/wxMaximaFrame.cpp:838
 msgid "&Expand Expression"
 msgstr "表达式展开(&E)"
 
-#: ../src/wxMaximaFrame.cpp:873
+#: ../src/wxMaximaFrame.cpp:872
 msgid "&Expand Trigonometric"
 msgstr "三角函数展开(&E)"
 
-#: ../src/wxMaximaFrame.cpp:899
+#: ../src/wxMaximaFrame.cpp:898
 msgid "&Exponentialize"
 msgstr "指数化(&E)"
 
-#: ../src/wxMaximaFrame.cpp:480
+#: ../src/wxMaximaFrame.cpp:479
 msgid "&Export..."
 msgstr "导出(&E)..."
 
-#: ../src/wxMaximaFrame.cpp:834
+#: ../src/wxMaximaFrame.cpp:833
 msgid "&Factor Expression"
 msgstr "因式分解式(&F)"
 
-#: ../src/wxMaximaFrame.cpp:489
+#: ../src/wxMaximaFrame.cpp:488
 msgid "&File"
 msgstr "文件(&F)"
 
-#: ../src/wxMaximaFrame.cpp:692
+#: ../src/wxMaximaFrame.cpp:691
 msgid "&Find Root..."
 msgstr "寻根(&F)..."
 
-#: ../src/wxMaximaFrame.cpp:738
+#: ../src/wxMaximaFrame.cpp:737
 msgid "&Generate Matrix..."
 msgstr "生成矩阵(&G)..."
 
-#: ../src/wxMaximaFrame.cpp:809
+#: ../src/wxMaximaFrame.cpp:808
 msgid "&Greatest Common Divisor..."
 msgstr "最大公因子(&G)..."
 
-#: ../src/wxMaximaFrame.cpp:994
+#: ../src/wxMaximaFrame.cpp:993
 msgid "&Help"
 msgstr "帮助(&H)"
 
-#: ../src/wxMaximaFrame.cpp:777
+#: ../src/wxMaximaFrame.cpp:776
 msgid "&Integrate..."
 msgstr "积分(&I)..."
 
-#: ../src/wxMaximaFrame.cpp:645
+#: ../src/wxMaximaFrame.cpp:644
 msgid "&Interrupt\tCtrl-."
 msgstr "中断(&I)\tCtrl-."
 
-#: ../src/wxMaximaFrame.cpp:649
+#: ../src/wxMaximaFrame.cpp:648
 msgid "&Interrupt\tCtrl-G"
 msgstr "中断(&I)\tCtrl-G"
 
-#: ../src/wxMaximaFrame.cpp:746
+#: ../src/wxMaximaFrame.cpp:745
 msgid "&Invert Matrix"
 msgstr "矩阵求逆(&I)"
 
-#: ../src/wxMaximaFrame.cpp:476
+#: ../src/wxMaximaFrame.cpp:475
 msgid "&Load Package...\tCtrl-L"
 msgstr "载入包(&L)...     Ctrl-L"
 
-#: ../src/wxMaximaFrame.cpp:769
+#: ../src/wxMaximaFrame.cpp:768
 #, fuzzy
 msgid "&Map to List(s)..."
 msgstr "映射至列表(&M)..."
 
-#: ../src/wxMaximaFrame.cpp:684
+#: ../src/wxMaximaFrame.cpp:683
 msgid "&Maxima"
 msgstr "Maxima(&M)"
 
-#: ../src/wxMaximaFrame.cpp:958
+#: ../src/wxMaximaFrame.cpp:957
 #, fuzzy
 msgid "&Maxima help"
 msgstr "显示 Maxima 帮助"
 
-#: ../src/wxMaximaFrame.cpp:917
+#: ../src/wxMaximaFrame.cpp:916
 msgid "&Modulus Computation..."
 msgstr "设置模运算(&M)..."
 
@@ -276,7 +276,7 @@ msgstr "设置模运算(&M)..."
 msgid "&New\tCtrl-N"
 msgstr "新建(&N)\tCtrl-N"
 
-#: ../src/wxMaximaFrame.cpp:947
+#: ../src/wxMaximaFrame.cpp:946
 msgid "&Numeric"
 msgstr "数值(&N)"
 
@@ -292,11 +292,11 @@ msgstr "使用 Nusum(&N)"
 msgid "&Open\tCtrl-O"
 msgstr "打开(&O)\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:463
+#: ../src/wxMaximaFrame.cpp:462
 msgid "&Open...\tCtrl-O"
 msgstr "打开(&O)...\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:929
+#: ../src/wxMaximaFrame.cpp:928
 msgid "&Plot"
 msgstr "绘图(&P)"
 
@@ -304,7 +304,7 @@ msgstr "绘图(&P)"
 msgid "&Power series"
 msgstr "幂级数(&P)"
 
-#: ../src/wxMaximaFrame.cpp:483
+#: ../src/wxMaximaFrame.cpp:482
 msgid "&Print...\tCtrl-P"
 msgstr "打印(&P)...\tCtrl-P"
 
@@ -312,39 +312,39 @@ msgstr "打印(&P)...\tCtrl-P"
 msgid "&Rational"
 msgstr "有理式(&R)"
 
-#: ../src/wxMaximaFrame.cpp:870
+#: ../src/wxMaximaFrame.cpp:869
 msgid "&Reduce Trigonometric"
 msgstr "三角函数化简(&R)"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "&Restart Maxima"
 msgstr "重启 Maxima(&R)"
 
-#: ../src/wxMaximaFrame.cpp:700
+#: ../src/wxMaximaFrame.cpp:699
 msgid "&Roots of Polynomial (Real)"
 msgstr "多项式求根（实根）(&R)"
 
-#: ../src/wxMaximaFrame.cpp:472
+#: ../src/wxMaximaFrame.cpp:471
 msgid "&Save\tCtrl-S"
 msgstr "保存(&S)\tCtrl-S"
 
-#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:919
+#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:918
 msgid "&Simplify"
 msgstr "化简(&S)"
 
-#: ../src/wxMaximaFrame.cpp:829
+#: ../src/wxMaximaFrame.cpp:828
 msgid "&Simplify Expression"
 msgstr "表达式化简(&S)"
 
-#: ../src/wxMaximaFrame.cpp:856
+#: ../src/wxMaximaFrame.cpp:855
 msgid "&Simplify Factorials"
 msgstr "阶乘化简(&S)"
 
-#: ../src/wxMaximaFrame.cpp:867
+#: ../src/wxMaximaFrame.cpp:866
 msgid "&Simplify Trigonometric"
 msgstr "三角函数化简(&S)"
 
-#: ../src/wxMaximaFrame.cpp:688
+#: ../src/wxMaximaFrame.cpp:687
 msgid "&Solve..."
 msgstr "求解(&S)..."
 
@@ -356,11 +356,11 @@ msgstr "特殊(&S)"
 msgid "&Taylor series"
 msgstr "泰勒级数(&T)"
 
-#: ../src/wxMaximaFrame.cpp:762
+#: ../src/wxMaximaFrame.cpp:761
 msgid "&Transpose Matrix"
 msgstr "矩阵转置(&T)"
 
-#: ../src/wxMaximaFrame.cpp:879
+#: ../src/wxMaximaFrame.cpp:878
 msgid "&Trigonometric Simplification"
 msgstr "三角函数化简(&T)"
 
@@ -378,7 +378,7 @@ msgstr "（使用默认语言）"
 msgid "- Infinity"
 msgstr "负无穷"
 
-#: ../src/wxMaxima.cpp:351
+#: ../src/wxMaxima.cpp:356
 msgid ""
 "... [suppressed additional lines since the output is longer than allowed in "
 "the configuration] "
@@ -388,16 +388,16 @@ msgstr ""
 msgid "1/2"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:103
+#: ../src/wxMaximaFrame.cpp:102
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4601
+#: ../src/wxMaxima.cpp:4613
 msgid "<br>Lisp: "
 msgstr "<br>Lisp 版本："
 
-#: ../src/wxMaxima.cpp:5487
+#: ../src/wxMaxima.cpp:5503
 msgid ""
 "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
@@ -427,11 +427,11 @@ msgid ""
 "\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1472
+#: ../src/wxMaximaFrame.cpp:1495
 msgid "A symbol from the configuration dialogue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:731
+#: ../src/wxMaximaFrame.cpp:730
 msgid "A&t Value..."
 msgstr "设定值(&A)..."
 
@@ -439,12 +439,12 @@ msgstr "设定值(&A)..."
 msgid "Abort evaluation on error"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaxima.cpp:4603
+#: ../src/wxMaxima.cpp:4615 ../src/wxMaximaFrame.cpp:985
 msgid "About"
 msgstr "关于"
 
-#: ../src/wxMaximaFrame.cpp:987 ../src/wxMaximaFrame.cpp:990
-#: ../src/wxMaximaFrame.cpp:991
+#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaximaFrame.cpp:989
+#: ../src/wxMaximaFrame.cpp:990
 msgid "About wxMaxima"
 msgstr "关于　wxMaxima"
 
@@ -452,23 +452,23 @@ msgstr "关于　wxMaxima"
 msgid "Active cell bracket"
 msgstr "活动单元的括号"
 
-#: ../src/wxMaximaFrame.cpp:760
+#: ../src/wxMaximaFrame.cpp:759
 msgid "Ad&joint Matrix"
 msgstr "伴随矩阵(&J)"
 
-#: ../src/wxMaximaFrame.cpp:914
+#: ../src/wxMaximaFrame.cpp:913
 msgid "Add Algebraic E&quality..."
 msgstr "添加代数恒等式(&Q)..."
 
-#: ../src/wxMaximaFrame.cpp:657
+#: ../src/wxMaximaFrame.cpp:656
 msgid "Add a directory to search path"
 msgstr "添加目录至搜索路径"
 
-#: ../src/wxMaxima.cpp:3353
+#: ../src/wxMaxima.cpp:3365
 msgid "Add dir to path:"
 msgstr "添加目录至搜索路径："
 
-#: ../src/wxMaximaFrame.cpp:915
+#: ../src/wxMaximaFrame.cpp:914
 msgid "Add equality to the rational simplifier"
 msgstr "添加恒等式至有理式化简因子"
 
@@ -476,7 +476,7 @@ msgstr "添加恒等式至有理式化简因子"
 msgid "Add the .wxmx file to the HTML export"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:656
+#: ../src/wxMaximaFrame.cpp:655
 msgid "Add to &Path..."
 msgstr "添加至搜索路径(&P)"
 
@@ -517,27 +517,27 @@ msgstr "旧变量："
 msgid "All|*"
 msgstr "所有类型|*"
 
-#: ../src/wxMaximaFrame.cpp:1364
+#: ../src/wxMaximaFrame.cpp:1363
 msgid "Alpha"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3838
+#: ../src/wxMaxima.cpp:3850
 msgid "Apply"
 msgstr "应用"
 
-#: ../src/wxMaximaFrame.cpp:768
+#: ../src/wxMaximaFrame.cpp:767
 msgid "Apply function to a list"
 msgstr "应用函数至列表"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Apropos"
 msgstr "命令查找"
 
-#: ../src/wxMaxima.cpp:3764
+#: ../src/wxMaxima.cpp:3776
 msgid "Array:"
 msgstr "数组："
 
-#: ../src/wxMaxima.cpp:4462
+#: ../src/wxMaxima.cpp:4474
 msgid "Artwork by"
 msgstr "美工："
 
@@ -545,7 +545,7 @@ msgstr "美工："
 msgid "Ask to save untitled documents"
 msgstr "询问是否保存未命名文档"
 
-#: ../src/wxMaxima.cpp:3650
+#: ../src/wxMaxima.cpp:3662
 msgid "At value"
 msgstr "设定值"
 
@@ -566,11 +566,11 @@ msgstr ""
 msgid "Autosave interval (minutes, 0 means: off):"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3557
+#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3569
 msgid "BC2"
 msgstr "边界条件(二阶)"
 
-#: ../src/wxMaximaFrame.cpp:1272
+#: ../src/wxMaximaFrame.cpp:1271
 msgid "Barsplot..."
 msgstr "直方图..."
 
@@ -578,7 +578,7 @@ msgstr "直方图..."
 msgid "Bat files (*.bat)|*.bat|All|*"
 msgstr "批处理文件 (*.bat)|*.bat|所有类型|*"
 
-#: ../src/wxMaxima.cpp:2943
+#: ../src/wxMaxima.cpp:2951
 msgid "Batch File"
 msgstr "载入批处理文件"
 
@@ -591,7 +591,7 @@ msgid ""
 "cells."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1365
+#: ../src/wxMaximaFrame.cpp:1364
 msgid "Beta"
 msgstr ""
 
@@ -603,11 +603,11 @@ msgstr ""
 msgid "Bold"
 msgstr "黑体"
 
-#: ../src/wxMaxima.cpp:2359
+#: ../src/wxMaxima.cpp:2366
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1274
+#: ../src/wxMaximaFrame.cpp:1273
 msgid "Boxplot..."
 msgstr "箱线图..."
 
@@ -619,15 +619,15 @@ msgstr "浏览"
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2080
+#: ../src/MathCtrl.cpp:2127
 msgid "Bug: Cell left but not entered."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1178
+#: ../src/wxMaxima.cpp:1183
 msgid "Bug: Found a math end marker without any start marker."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1222
+#: ../src/wxMaxima.cpp:1227
 msgid "Bug: Found the end of autocompletion symbols but no beginning"
 msgstr ""
 
@@ -639,22 +639,22 @@ msgstr ""
 msgid "Bug: Fraction without enumerator"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2312
+#: ../src/MathCtrl.cpp:2359
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5839
+#: ../src/MathCtrl.cpp:5891
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of "
 "the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5913
+#: ../src/MathCtrl.cpp:5965
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5882
+#: ../src/MathCtrl.cpp:5934
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
@@ -664,49 +664,49 @@ msgstr ""
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
 msgstr ""
 
-#: ../src/GroupCell.cpp:780 ../src/GroupCell.cpp:951
+#: ../src/GroupCell.cpp:781 ../src/GroupCell.cpp:952
 msgid "Bug: No image counter to write to!"
 msgstr ""
 
-#: ../src/AbsCell.cpp:193
+#: ../src/AbsCell.cpp:199
 msgid "Bug: No last cell in an absCell!"
 msgstr ""
 
-#: ../src/ConjugateCell.cpp:185
+#: ../src/ConjugateCell.cpp:194
 msgid "Bug: No last cell in an conjugateCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:471
+#: ../src/FracCell.cpp:472
 msgid "Bug: No last cell in an denominator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:267
+#: ../src/ExptCell.cpp:270
 msgid "Bug: No last cell in an exponent of an exptCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:459
+#: ../src/FracCell.cpp:460
 msgid "Bug: No last cell in an numerator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:257
+#: ../src/ExptCell.cpp:260
 msgid "Bug: No last cell in the base of an exptCell!"
 msgstr ""
 
-#: ../src/ParenCell.cpp:534
+#: ../src/ParenCell.cpp:535
 msgid "Bug: No last cell inside a parenthesis!"
 msgstr ""
 
-#: ../src/SqrtCell.cpp:312
+#: ../src/SqrtCell.cpp:317
 msgid "Bug: No last cell inside a square root!"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2123
+#: ../src/MathCtrl.cpp:2170
 msgid ""
 "Bug: Start or end of merging of subsequent editing actions was requested two "
 "times in a row."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2090
+#: ../src/MathCtrl.cpp:2137
 msgid "Bug: Text changed, but no active cell."
 msgstr ""
 
@@ -714,39 +714,39 @@ msgstr ""
 msgid "Bug: Trying to append NULL to a group cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:555
+#: ../src/MathCtrl.cpp:600
 msgid "Bug: Trying to append maxima's output to a cell outside the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2014
+#: ../src/MathCtrl.cpp:2061
 msgid ""
 "Bug: Trying to merge individual cell adds to a region in the undo buffer but "
 "there are other cells between them."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6522
+#: ../src/MathCtrl.cpp:6577
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2092
+#: ../src/MathCtrl.cpp:2139
 msgid "Bug: Trying to record a cell contents change without a cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1495
+#: ../src/MathCtrl.cpp:1540
 msgid "Bug: Trying to select inside a cell without having a current cell"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5883
+#: ../src/MathCtrl.cpp:5935
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5844 ../src/MathCtrl.cpp:5918 ../src/MathCtrl.cpp:5952
+#: ../src/MathCtrl.cpp:5896 ../src/MathCtrl.cpp:5970 ../src/MathCtrl.cpp:6004
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:973
+#: ../src/wxMaximaFrame.cpp:972
 msgid "Build &Info"
 msgstr "构建信息(&I)"
 
@@ -761,52 +761,52 @@ msgstr ""
 "默认使用 Shift-Enter 对命令求值，Enter 则用于进行多行输入。通过在“编辑->配"
 "置”对话框中选中”使用 Enter 对单元求值“可以对此进行更改，交换两组按键的功能。"
 
-#: ../src/wxMaximaFrame.cpp:782
+#: ../src/wxMaximaFrame.cpp:781
 msgid "C&hange Variable..."
 msgstr "修改变量(&H)..."
 
-#: ../src/wxMaximaFrame.cpp:540
+#: ../src/wxMaximaFrame.cpp:539
 msgid "C&onfigure"
 msgstr "配置(&O)"
 
-#: ../src/wxMaximaFrame.cpp:801
+#: ../src/wxMaximaFrame.cpp:800
 msgid "Calculate &Product..."
 msgstr "计算乘积(&P)..."
 
-#: ../src/wxMaximaFrame.cpp:799
+#: ../src/wxMaximaFrame.cpp:798
 msgid "Calculate Su&m..."
 msgstr "求和(&M)..."
 
-#: ../src/wxMaximaFrame.cpp:939
+#: ../src/wxMaximaFrame.cpp:938
 msgid "Calculate bigfloat value of the last result"
 msgstr "将最后的计算结果以长浮点数(bigfloat)表示"
 
-#: ../src/wxMaximaFrame.cpp:936
+#: ../src/wxMaximaFrame.cpp:935
 msgid "Calculate float value of the last result"
 msgstr "将最后的计算结果以浮点数(float)表示"
 
-#: ../src/wxMaxima.cpp:3971
+#: ../src/wxMaxima.cpp:3983
 msgid "Calculate modulus:"
 msgstr "求模："
 
-#: ../src/wxMaximaFrame.cpp:942
+#: ../src/wxMaximaFrame.cpp:941
 #, fuzzy
 msgid "Calculate numeric value of the last result"
 msgstr "将最后的计算结果以浮点数(float)表示"
 
-#: ../src/wxMaximaFrame.cpp:802
+#: ../src/wxMaximaFrame.cpp:801
 msgid "Calculate products"
 msgstr "求乘积"
 
-#: ../src/wxMaximaFrame.cpp:800
+#: ../src/wxMaximaFrame.cpp:799
 msgid "Calculate sums"
 msgstr "求和"
 
-#: ../src/wxMaxima.cpp:5830
+#: ../src/wxMaxima.cpp:5845
 msgid "Can not connect to the web server."
 msgstr "无法连接到网页服务器。"
 
-#: ../src/wxMaxima.cpp:5881
+#: ../src/wxMaxima.cpp:5896
 msgid "Can not download version info."
 msgstr "无法下载版本信息。"
 
@@ -822,15 +822,15 @@ msgstr "无法下载版本信息。"
 #: ../src/PlotFormatWiz.cpp:48 ../src/SeriesWiz.cpp:49 ../src/SeriesWiz.cpp:51
 #: ../src/SubstituteWiz.cpp:41 ../src/SubstituteWiz.cpp:43 ../src/SumWiz.cpp:44
 #: ../src/SumWiz.cpp:46 ../src/SystemWiz.cpp:38 ../src/SystemWiz.cpp:40
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Cancel"
 msgstr "取消"
 
-#: ../src/wxMaximaFrame.cpp:126 ../src/wxMaxima.cpp:932
+#: ../src/wxMaxima.cpp:937 ../src/wxMaximaFrame.cpp:125
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1217
+#: ../src/wxMaximaFrame.cpp:1216
 msgid "Canonical (tr)"
 msgstr "标准形式(三角)"
 
@@ -838,7 +838,7 @@ msgstr "标准形式(三角)"
 msgid "Catalan"
 msgstr "加泰罗尼亚语"
 
-#: ../src/wxMaximaFrame.cpp:638
+#: ../src/wxMaximaFrame.cpp:637
 msgid "Ce&ll"
 msgstr "单元(&L)"
 
@@ -846,39 +846,39 @@ msgstr "单元(&L)"
 msgid "Cell bracket"
 msgstr "单元括号"
 
-#: ../src/wxMaxima.cpp:5261
+#: ../src/wxMaxima.cpp:5273
 msgid "Cell ends in a backslash"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:676
+#: ../src/wxMaximaFrame.cpp:675
 msgid "Change &2d Display"
 msgstr "修改2D显示方式(&2)"
 
-#: ../src/wxMaximaFrame.cpp:677
+#: ../src/wxMaximaFrame.cpp:676
 msgid "Change the 2d display algorithm used to display math output"
 msgstr "修改用于显示数学输出的2D显示算法"
 
-#: ../src/wxMaxima.cpp:3995
+#: ../src/wxMaxima.cpp:4007
 msgid "Change variable"
 msgstr "修改变量"
 
-#: ../src/wxMaximaFrame.cpp:783
+#: ../src/wxMaximaFrame.cpp:782
 msgid "Change variable in integral or sum"
 msgstr "修改积分或求和中的变量"
 
-#: ../src/wxMaxima.cpp:3751
+#: ../src/wxMaxima.cpp:3763
 msgid "Char poly"
 msgstr "特征多项式"
 
-#: ../src/wxMaximaFrame.cpp:978
+#: ../src/wxMaximaFrame.cpp:977
 msgid "Check for Updates"
 msgstr "检查更新"
 
-#: ../src/wxMaximaFrame.cpp:979
+#: ../src/wxMaximaFrame.cpp:978
 msgid "Check if a newer version of wxMaxima/Maxima exist."
 msgstr "检查是否存在新版本 wxMaxima/Maxima。"
 
-#: ../src/wxMaximaFrame.cpp:1385
+#: ../src/wxMaximaFrame.cpp:1384
 msgid "Chi"
 msgstr ""
 
@@ -899,15 +899,15 @@ msgstr "选择字体"
 msgid "Choose new plot format:"
 msgstr "选择新的绘图格式："
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710
 msgid "Classes:"
 msgstr "类型："
 
-#: ../src/wxMaximaFrame.cpp:469
+#: ../src/wxMaximaFrame.cpp:468
 msgid "Close\tCtrl-W"
 msgstr "关闭\tCtrl-W"
 
-#: ../src/wxMaximaFrame.cpp:470
+#: ../src/wxMaximaFrame.cpp:469
 msgid "Close window"
 msgstr "关闭窗口"
 
@@ -939,19 +939,19 @@ msgstr ""
 msgid "Code highlighting: Variables"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4806
+#: ../src/wxMaxima.cpp:4818
 msgid "Col. names:"
 msgstr "列名称："
 
-#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Columns:"
 msgstr "列："
 
-#: ../src/wxMaximaFrame.cpp:860
+#: ../src/wxMaximaFrame.cpp:859
 msgid "Combine factorials in an expression"
 msgstr "合并表达式中的阶乘"
 
-#: ../src/wxMaxima.cpp:5293
+#: ../src/wxMaxima.cpp:5305
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
@@ -963,24 +963,24 @@ msgstr "x坐标，以逗号分割"
 msgid "Comma separated y coordinates"
 msgstr "y 坐标，以逗号分割"
 
-#: ../src/MathCtrl.cpp:1030
+#: ../src/MathCtrl.cpp:1072
 msgid "Comment Selection"
 msgstr "注释掉所选内容"
 
-#: ../src/wxMaximaFrame.cpp:533
+#: ../src/wxMaximaFrame.cpp:532
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:532
+#: ../src/wxMaximaFrame.cpp:531
 #, fuzzy
 msgid "Comment selection\tCtrl-/"
 msgstr "注释掉所选内容"
 
-#: ../src/wxMaximaFrame.cpp:601
+#: ../src/wxMaximaFrame.cpp:600
 msgid "Complete Word\tCtrl-K"
 msgstr "自动补齐\tCtrl-K"
 
-#: ../src/wxMaximaFrame.cpp:602
+#: ../src/wxMaximaFrame.cpp:601
 msgid "Complete word"
 msgstr "自动补齐"
 
@@ -988,35 +988,35 @@ msgstr "自动补齐"
 msgid "Completely stop maxima and restart it"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:823
+#: ../src/wxMaximaFrame.cpp:822
 msgid "Compute continued fraction of a value"
 msgstr "计算数值的连分数表示"
 
-#: ../src/wxMaximaFrame.cpp:761
+#: ../src/wxMaximaFrame.cpp:760
 msgid "Compute the adjoint matrix"
 msgstr "计算伴随矩阵"
 
-#: ../src/wxMaximaFrame.cpp:750
+#: ../src/wxMaximaFrame.cpp:749
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr "计算矩阵的特征多项式"
 
-#: ../src/wxMaximaFrame.cpp:753
+#: ../src/wxMaximaFrame.cpp:752
 msgid "Compute the determinant of a matrix"
 msgstr "计算矩阵的行列式"
 
-#: ../src/wxMaximaFrame.cpp:810
+#: ../src/wxMaximaFrame.cpp:809
 msgid "Compute the greatest common divisor"
 msgstr "计算最大公因子"
 
-#: ../src/wxMaximaFrame.cpp:747
+#: ../src/wxMaximaFrame.cpp:746
 msgid "Compute the inverse of a matrix"
 msgstr "矩阵求逆"
 
-#: ../src/wxMaximaFrame.cpp:813
+#: ../src/wxMaximaFrame.cpp:812
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr "计算最小公倍式（在使用前先执行 load(functs)）"
 
-#: ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4868
 msgid "Condition:"
 msgstr "条件："
 
@@ -1028,8 +1028,8 @@ msgstr "配置文件 (*.ini)|*.ini"
 msgid "Configuration warning"
 msgstr "配置警告"
 
-#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:538
-#: ../src/wxMaximaFrame.cpp:541
+#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:540
 msgid "Configure wxMaxima"
 msgstr "配置 wxMaxima"
 
@@ -1038,129 +1038,131 @@ msgstr "配置 wxMaxima"
 msgid "Constant"
 msgstr "常量"
 
-#: ../src/wxMaximaFrame.cpp:844
+#: ../src/wxMaximaFrame.cpp:843
 msgid "Contract Logarithms"
 msgstr "合并对数式"
 
-#: ../src/wxMaximaFrame.cpp:851
+#: ../src/wxMaximaFrame.cpp:850
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr "转换二项式、beta 函数及 gamma 函数为阶乘形式"
 
-#: ../src/wxMaximaFrame.cpp:854
+#: ../src/wxMaximaFrame.cpp:853
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr "转换二项式、阶乘及 beta 函数为 gamma 函数"
 
-#: ../src/wxMaximaFrame.cpp:888
+#: ../src/wxMaximaFrame.cpp:887
 msgid "Convert complex expression to polar form"
 msgstr "转换复数表达式为极坐标形式"
 
-#: ../src/wxMaximaFrame.cpp:885
+#: ../src/wxMaximaFrame.cpp:884
 msgid "Convert complex expression to rect form"
 msgstr "转换复数表达式为直角坐标形式"
 
-#: ../src/wxMaximaFrame.cpp:897
+#: ../src/wxMaximaFrame.cpp:896
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr "转换虚数的指数函数为三角函数形式"
 
-#: ../src/wxMaximaFrame.cpp:842
+#: ../src/wxMaximaFrame.cpp:841
 msgid "Convert logarithm of product to sum of logarithms"
 msgstr "转换乘积的对数为对数的和"
 
-#: ../src/wxMaximaFrame.cpp:845
+#: ../src/wxMaximaFrame.cpp:844
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "转换对数的和为乘积的对数"
 
-#: ../src/wxMaximaFrame.cpp:850
+#: ../src/wxMaximaFrame.cpp:849
 msgid "Convert to &Factorials"
 msgstr "转换为阶乘(&F)"
 
-#: ../src/wxMaximaFrame.cpp:853
+#: ../src/wxMaximaFrame.cpp:852
 msgid "Convert to &Gamma"
 msgstr "转换为 Gamma 函数(&G)"
 
-#: ../src/wxMaximaFrame.cpp:887
+#: ../src/wxMaximaFrame.cpp:886
 msgid "Convert to &Polarform"
 msgstr "转换为极坐标形式(&P)"
 
-#: ../src/wxMaximaFrame.cpp:884
+#: ../src/wxMaximaFrame.cpp:883
 msgid "Convert to &Rectform"
 msgstr "转换为直角坐标形式(&R)"
 
-#: ../src/wxMaximaFrame.cpp:877
+#: ../src/wxMaximaFrame.cpp:876
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr "转换三角函数表达式为标准拟线性形式"
 
-#: ../src/wxMaximaFrame.cpp:900
+#: ../src/wxMaximaFrame.cpp:899
 msgid "Convert trigonometric functions to exponential form"
 msgstr "转换三角函数为指数形式"
 
-#: ../src/ToolBar.cpp:140 ../src/MathCtrl.cpp:918 ../src/MathCtrl.cpp:931
-#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1024
+#: ../src/MathCtrl.cpp:960 ../src/MathCtrl.cpp:973 ../src/MathCtrl.cpp:1019
+#: ../src/MathCtrl.cpp:1066 ../src/ToolBar.cpp:140
 msgid "Copy"
 msgstr "复制"
 
-#: ../src/wxMaximaFrame.cpp:597
+#: ../src/wxMaximaFrame.cpp:596
 msgid "Copy Previous Input\tCtrl-I"
 msgstr "复制前一次输入\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:599
+#: ../src/wxMaximaFrame.cpp:598
 msgid "Copy Previous Output\tCtrl-U"
 msgstr "复制前一次输出\tCtrl-U"
 
-#: ../src/wxMaximaFrame.cpp:514 ../src/MathCtrl.cpp:936 ../src/MathCtrl.cpp:982
+#: ../src/MathCtrl.cpp:978 ../src/MathCtrl.cpp:1024
+#: ../src/wxMaximaFrame.cpp:513
 msgid "Copy as Image"
 msgstr "复制为图片"
 
-#: ../src/wxMaximaFrame.cpp:507 ../src/MathCtrl.cpp:932 ../src/MathCtrl.cpp:978
+#: ../src/MathCtrl.cpp:974 ../src/MathCtrl.cpp:1020
+#: ../src/wxMaximaFrame.cpp:506
 msgid "Copy as LaTeX"
 msgstr "复制为 LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:510
+#: ../src/wxMaximaFrame.cpp:509
 #, fuzzy
 msgid "Copy as MathML"
 msgstr "复制为图片"
 
-#: ../src/MathCtrl.cpp:935 ../src/MathCtrl.cpp:980
+#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1022
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:504
+#: ../src/wxMaximaFrame.cpp:503
 msgid "Copy as Text\tCtrl-Shift-C"
 msgstr "复制为纯文本\tCtrl-Shift-C"
 
-#: ../src/MathCtrl.cpp:933 ../src/MathCtrl.cpp:979
+#: ../src/MathCtrl.cpp:975 ../src/MathCtrl.cpp:1021
 #, fuzzy
 msgid "Copy as plain text"
 msgstr "复制为图片"
 
-#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:503
+#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:502
 msgid "Copy selection"
 msgstr "复制所选区域"
 
-#: ../src/wxMaximaFrame.cpp:515
+#: ../src/wxMaximaFrame.cpp:514
 msgid "Copy selection from document as an image"
 msgstr "复制文档中所选区域为图片"
 
-#: ../src/wxMaximaFrame.cpp:505
+#: ../src/wxMaximaFrame.cpp:504
 msgid "Copy selection from document as text"
 msgstr "复制文档中所选区域为纯文本"
 
-#: ../src/wxMaximaFrame.cpp:508
+#: ../src/wxMaximaFrame.cpp:507
 msgid "Copy selection from document in LaTeX format"
 msgstr "复制文档中所选区域为 LaTeX"
 
-#: ../src/wxMaximaFrame.cpp:511
+#: ../src/wxMaximaFrame.cpp:510
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:598
+#: ../src/wxMaximaFrame.cpp:597
 msgid "Create a new cell with previous input"
 msgstr "使用前一次输入新建单元"
 
-#: ../src/wxMaximaFrame.cpp:600
+#: ../src/wxMaximaFrame.cpp:599
 msgid "Create a new cell with previous output"
 msgstr "使用前一次输出新建单元"
 
@@ -1168,15 +1170,15 @@ msgstr "使用前一次输出新建单元"
 msgid "Cursor"
 msgstr "光标"
 
-#: ../src/ToolBar.cpp:137 ../src/MathCtrl.cpp:1023
+#: ../src/MathCtrl.cpp:1065 ../src/ToolBar.cpp:137
 msgid "Cut"
 msgstr "剪切"
 
-#: ../src/wxMaximaFrame.cpp:499
+#: ../src/wxMaximaFrame.cpp:498
 msgid "Cut\tCtrl-X"
 msgstr "剪切\tCtrl-X"
 
-#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:500
+#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:499
 msgid "Cut selection"
 msgstr "剪切所选区域"
 
@@ -1188,18 +1190,18 @@ msgstr "捷克语"
 msgid "Danish"
 msgstr "丹麦语"
 
-#: ../src/wxMaxima.cpp:4799 ../src/wxMaxima.cpp:4806 ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4811 ../src/wxMaxima.cpp:4818 ../src/wxMaxima.cpp:4868
 msgid "Data Matrix:"
 msgstr "数据矩阵："
 
-#: ../src/wxMaxima.cpp:4826
+#: ../src/wxMaxima.cpp:4838
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr "数据文件 (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698 ../src/wxMaxima.cpp:4712
-#: ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726 ../src/wxMaxima.cpp:4734
-#: ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748 ../src/wxMaxima.cpp:4755
-#: ../src/wxMaxima.cpp:4791
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710 ../src/wxMaxima.cpp:4724
+#: ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738 ../src/wxMaxima.cpp:4746
+#: ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760 ../src/wxMaxima.cpp:4767
+#: ../src/wxMaxima.cpp:4803
 msgid "Data:"
 msgstr "数据："
 
@@ -1207,7 +1209,7 @@ msgstr "数据："
 msgid "Debug: watch maxima's stdout stream"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:820
+#: ../src/wxMaximaFrame.cpp:819
 msgid "Decompose rational function to partial fractions"
 msgstr "分解有理函数为部分分式"
 
@@ -1238,47 +1240,47 @@ msgid ""
 "with."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3403 ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3415 ../src/wxMaxima.cpp:3424
 msgid "Delete"
 msgstr "删除"
 
-#: ../src/wxMaximaFrame.cpp:667
+#: ../src/wxMaximaFrame.cpp:666
 msgid "Delete F&unction..."
 msgstr "删除函数(&U)..."
 
-#: ../src/MathCtrl.cpp:939 ../src/MathCtrl.cpp:985
+#: ../src/MathCtrl.cpp:981 ../src/MathCtrl.cpp:1027
 msgid "Delete Selection"
 msgstr "删除所选区域"
 
-#: ../src/wxMaximaFrame.cpp:669
+#: ../src/wxMaximaFrame.cpp:668
 msgid "Delete V&ariable..."
 msgstr "删除变量(&A)..."
 
-#: ../src/wxMaximaFrame.cpp:668
+#: ../src/wxMaximaFrame.cpp:667
 msgid "Delete a function"
 msgstr "删除函数"
 
-#: ../src/wxMaximaFrame.cpp:670
+#: ../src/wxMaximaFrame.cpp:669
 msgid "Delete a variable"
 msgstr "删除变量"
 
-#: ../src/wxMaximaFrame.cpp:655
+#: ../src/wxMaximaFrame.cpp:654
 msgid "Delete all values from memory"
 msgstr "删除内存中所有值"
 
-#: ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3424
 msgid "Delete function(s):"
 msgstr "删除函数："
 
-#: ../src/wxMaxima.cpp:3403
+#: ../src/wxMaxima.cpp:3415
 msgid "Delete variable(s):"
 msgstr "删除变量："
 
-#: ../src/wxMaximaFrame.cpp:1367
+#: ../src/wxMaximaFrame.cpp:1366
 msgid "Delta"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4011
+#: ../src/wxMaxima.cpp:4023
 msgid "Denom. deg:"
 msgstr "分母次数："
 
@@ -1286,35 +1288,35 @@ msgstr "分母次数："
 msgid "Depth:"
 msgstr "深度："
 
-#: ../src/wxMaxima.cpp:3541
+#: ../src/wxMaxima.cpp:3553
 msgid "Derivative:"
 msgstr "导数："
 
-#: ../src/wxMaximaFrame.cpp:1258
+#: ../src/wxMaximaFrame.cpp:1257
 msgid "Deviation..."
 msgstr "偏差..."
 
-#: ../src/wxMaximaFrame.cpp:816
+#: ../src/wxMaximaFrame.cpp:815
 msgid "Di&vide Polynomials..."
 msgstr "多项式相除(&V)..."
 
-#: ../src/wxMaximaFrame.cpp:1223
+#: ../src/wxMaximaFrame.cpp:1222
 msgid "Diff..."
 msgstr "微分..."
 
-#: ../src/wxMaxima.cpp:4154 ../src/wxMaxima.cpp:5066
+#: ../src/wxMaxima.cpp:4166 ../src/wxMaxima.cpp:5078
 msgid "Differentiate"
 msgstr "微分"
 
-#: ../src/wxMaximaFrame.cpp:786
+#: ../src/wxMaximaFrame.cpp:785
 msgid "Differentiate expression"
 msgstr "对表达式求微分"
 
-#: ../src/MathCtrl.cpp:1001
+#: ../src/MathCtrl.cpp:1043
 msgid "Differentiate..."
 msgstr "微分..."
 
-#: ../src/LimitWiz.cpp:37 ../src/FindReplacePane.cpp:76
+#: ../src/FindReplacePane.cpp:76 ../src/LimitWiz.cpp:37
 msgid "Direction:"
 msgstr "方向："
 
@@ -1322,48 +1324,49 @@ msgstr "方向："
 msgid "Discrete plot"
 msgstr "离散绘图"
 
-#: ../src/wxMaximaFrame.cpp:679
+#: ../src/wxMaximaFrame.cpp:678
 msgid "Display Te&X Form"
 msgstr "以 TeX 格式显示(&X)"
 
-#: ../src/wxMaxima.cpp:3320
+#: ../src/wxMaxima.cpp:3332
 msgid "Display algorithm"
 msgstr "显示算法"
 
-#: ../src/wxMaximaFrame.cpp:680
+#: ../src/wxMaximaFrame.cpp:679
 msgid "Display last result in TeX form"
 msgstr "以 TeX 格式显示最后一次结果"
 
-#: ../src/wxMaximaFrame.cpp:674
+#: ../src/wxMaximaFrame.cpp:673
 msgid "Display time used for evaluation"
 msgstr "显示求值时间"
 
-#: ../src/wxMaxima.cpp:4061
+#: ../src/wxMaxima.cpp:4073
 msgid "Divide"
 msgstr "数字/多项式相除"
 
-#: ../src/MathCtrl.cpp:1032
+#: ../src/MathCtrl.cpp:1074
 msgid "Divide Cell"
 msgstr "分割单元"
 
-#: ../src/wxMaximaFrame.cpp:635
+#: ../src/wxMaximaFrame.cpp:634
 #, fuzzy
 msgid "Divide Cell\tCtrl-D"
 msgstr "分割单元"
 
-#: ../src/wxMaximaFrame.cpp:817
+#: ../src/wxMaximaFrame.cpp:816
 msgid "Divide numbers or polynomials"
 msgstr "将数字或多项式相除"
 
-#: ../src/wxMaximaFrame.cpp:636
+#: ../src/wxMaximaFrame.cpp:635
 msgid "Divide this input cell into two cells"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5917
-msgid "Do you want to save the changes you made in the document \""
+#: ../src/wxMaxima.cpp:5932
+#, fuzzy, c-format
+msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr "您是否想保存文档中的更改:“"
 
-#: ../src/wxMaxima.cpp:1664 ../src/wxMaxima.cpp:1672
+#: ../src/wxMaxima.cpp:1669 ../src/wxMaxima.cpp:1677
 msgid "Document "
 msgstr "文档"
 
@@ -1382,7 +1385,7 @@ msgid ""
 "differences."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Don't save"
 msgstr "不保存"
 
@@ -1390,27 +1393,27 @@ msgstr "不保存"
 msgid "Down"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:734
+#: ../src/wxMaximaFrame.cpp:733
 msgid "E&quations"
 msgstr "方程(&Q)"
 
-#: ../src/wxMaximaFrame.cpp:487
+#: ../src/wxMaximaFrame.cpp:486
 msgid "E&xit\tCtrl-Q"
 msgstr "退出(&X)\tCtrl-Q"
 
-#: ../src/wxMaximaFrame.cpp:757
+#: ../src/wxMaximaFrame.cpp:756
 msgid "Eige&nvectors"
 msgstr "特征向量(&N)"
 
-#: ../src/wxMaximaFrame.cpp:755
+#: ../src/wxMaximaFrame.cpp:754
 msgid "Eigen&values"
 msgstr "e特征值(&V)"
 
-#: ../src/wxMaxima.cpp:3572
+#: ../src/wxMaxima.cpp:3584
 msgid "Eliminate"
 msgstr "消元"
 
-#: ../src/wxMaximaFrame.cpp:710
+#: ../src/wxMaximaFrame.cpp:709
 msgid "Eliminate a variable from a system of equations"
 msgstr "消去方程组中一个变量"
 
@@ -1422,21 +1425,21 @@ msgstr ""
 msgid "English"
 msgstr "英语"
 
-#: ../src/wxMaxima.cpp:4712 ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726
-#: ../src/wxMaxima.cpp:4734 ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748
-#: ../src/wxMaxima.cpp:4755 ../src/wxMaxima.cpp:4791 ../src/wxMaxima.cpp:4799
+#: ../src/wxMaxima.cpp:4724 ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738
+#: ../src/wxMaxima.cpp:4746 ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760
+#: ../src/wxMaxima.cpp:4767 ../src/wxMaxima.cpp:4803 ../src/wxMaxima.cpp:4811
 msgid "Enter Data"
 msgstr "输入数据"
 
-#: ../src/wxMaximaFrame.cpp:1279
+#: ../src/wxMaximaFrame.cpp:1278
 msgid "Enter Matrix..."
 msgstr "输入矩阵..."
 
-#: ../src/wxMaximaFrame.cpp:745
+#: ../src/wxMaximaFrame.cpp:744
 msgid "Enter a matrix"
 msgstr "输入一个矩阵"
 
-#: ../src/wxMaxima.cpp:3962
+#: ../src/wxMaxima.cpp:3974
 msgid "Enter an equation for rational simplification:"
 msgstr "输入一个用于有理式化简的方程"
 
@@ -1448,11 +1451,11 @@ msgstr "输入变量列表，以逗号分割。"
 msgid "Enter evaluates cells"
 msgstr "使用回车对单元求值"
 
-#: ../src/wxMaxima.cpp:3734
+#: ../src/wxMaxima.cpp:3746
 msgid "Enter matrix"
 msgstr "输入矩阵"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 #, fuzzy
 msgid "Enter new precision for bigfloats:"
 msgstr "输入新的精度："
@@ -1461,12 +1464,12 @@ msgstr "输入新的精度："
 msgid "Enter the path to the Maxima executable."
 msgstr "输入 Maxima 程序（可执行文件）的路径。"
 
-#: ../src/wxMaximaFrame.cpp:1368
+#: ../src/wxMaximaFrame.cpp:1367
 #, fuzzy
 msgid "Epsilon"
 msgstr "Epsilon："
 
-#: ../src/wxMaxima.cpp:4208
+#: ../src/wxMaxima.cpp:4220
 msgid "Epsilon:"
 msgstr "Epsilon："
 
@@ -1475,13 +1478,13 @@ msgstr "Epsilon："
 msgid "Equation %d:"
 msgstr "方程 %d："
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:3633
-#: ../src/wxMaxima.cpp:5019
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:3645
+#: ../src/wxMaxima.cpp:5031
 msgid "Equation(s):"
 msgstr "方程："
 
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3993
-#: ../src/wxMaxima.cpp:4807 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:4005
+#: ../src/wxMaxima.cpp:4819 ../src/wxMaxima.cpp:5045
 msgid "Equation:"
 msgstr "方程："
 
@@ -1492,77 +1495,77 @@ msgid ""
 "be introduced one into another. Also they are always printed out as 2D maths."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3570
+#: ../src/wxMaxima.cpp:3582
 msgid "Equations:"
 msgstr "方程"
 
-#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1455
-#: ../src/wxMaxima.cpp:1469 ../src/wxMaxima.cpp:1620 ../src/wxMaxima.cpp:1633
-#: ../src/wxMaxima.cpp:1643 ../src/wxMaxima.cpp:1666 ../src/wxMaxima.cpp:2034
-#: ../src/wxMaxima.cpp:2206 ../src/wxMaxima.cpp:5381 ../src/wxMaxima.cpp:5830
-#: ../src/wxMaxima.cpp:5881
+#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1460
+#: ../src/wxMaxima.cpp:1474 ../src/wxMaxima.cpp:1625 ../src/wxMaxima.cpp:1638
+#: ../src/wxMaxima.cpp:1648 ../src/wxMaxima.cpp:1671 ../src/wxMaxima.cpp:2039
+#: ../src/wxMaxima.cpp:2211 ../src/wxMaxima.cpp:5397 ../src/wxMaxima.cpp:5845
+#: ../src/wxMaxima.cpp:5896
 msgid "Error"
 msgstr "错误"
 
-#: ../src/wxMaxima.cpp:2886 ../src/wxMaxima.cpp:2900 ../src/wxMaxima.cpp:2913
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617 ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:2894 ../src/wxMaxima.cpp:2908 ../src/wxMaxima.cpp:2921
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629 ../src/wxMaxima.cpp:3740
 msgid "Error!"
 msgstr "错误！"
 
-#: ../src/wxMaximaFrame.cpp:1370
+#: ../src/wxMaximaFrame.cpp:1369
 msgid "Eta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:909
+#: ../src/wxMaximaFrame.cpp:908
 msgid "Evaluate &Noun Forms"
 msgstr "对名词形式求值"
 
-#: ../src/wxMaximaFrame.cpp:589
+#: ../src/wxMaximaFrame.cpp:588
 msgid "Evaluate All Cells\tCtrl-Shift-R"
 msgstr "对所有单元求值\tCtrl-Shift-R"
 
-#: ../src/wxMaximaFrame.cpp:587
+#: ../src/wxMaximaFrame.cpp:586
 msgid "Evaluate All Visible Cells\tCtrl-R"
 msgstr "对所有可见单元求值\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:585 ../src/MathCtrl.cpp:942
+#: ../src/MathCtrl.cpp:984 ../src/wxMaximaFrame.cpp:584
 msgid "Evaluate Cell(s)"
 msgstr "对单元求值"
 
-#: ../src/wxMaximaFrame.cpp:591
+#: ../src/wxMaximaFrame.cpp:590
 #, fuzzy
 msgid "Evaluate Cells Above\tCtrl-Shift-P"
 msgstr "对所有单元求值\tCtrl-Shift-R"
 
-#: ../src/MathCtrl.cpp:956 ../src/MathCtrl.cpp:1051
+#: ../src/MathCtrl.cpp:998 ../src/MathCtrl.cpp:1093
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:961 ../src/MathCtrl.cpp:1053
+#: ../src/MathCtrl.cpp:1003 ../src/MathCtrl.cpp:1095
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:971 ../src/MathCtrl.cpp:1057
+#: ../src/MathCtrl.cpp:1013 ../src/MathCtrl.cpp:1099
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:966 ../src/MathCtrl.cpp:1055
+#: ../src/MathCtrl.cpp:1008 ../src/MathCtrl.cpp:1097
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:586
+#: ../src/wxMaximaFrame.cpp:585
 msgid "Evaluate active or selected cell(s)"
 msgstr "对活动单元或所选单元求值"
 
-#: ../src/wxMaximaFrame.cpp:590
+#: ../src/wxMaximaFrame.cpp:589
 msgid "Evaluate all cells in the document"
 msgstr "对文档中所有单元求值"
 
-#: ../src/wxMaximaFrame.cpp:910
+#: ../src/wxMaximaFrame.cpp:909
 msgid "Evaluate all noun forms in expression"
 msgstr "对表达式中所有名词形式求值"
 
-#: ../src/wxMaximaFrame.cpp:588
+#: ../src/wxMaximaFrame.cpp:587
 msgid "Evaluate all visible cells in the document"
 msgstr "对文档中所有可见单元求值"
 
@@ -1575,7 +1578,7 @@ msgstr ""
 msgid "Evaluate to point"
 msgstr "对名词形式求值"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Example"
 msgstr "示例"
 
@@ -1588,31 +1591,31 @@ msgstr "示例文本"
 msgid "Examples:"
 msgstr "示例"
 
-#: ../src/wxMaximaFrame.cpp:488
+#: ../src/wxMaximaFrame.cpp:487
 msgid "Exit wxMaxima"
 msgstr "退出 wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:1214
+#: ../src/wxMaximaFrame.cpp:1213
 msgid "Expand"
 msgstr "展开"
 
-#: ../src/wxMaximaFrame.cpp:1219
+#: ../src/wxMaximaFrame.cpp:1218
 msgid "Expand (tr)"
 msgstr "展开（三角）"
 
-#: ../src/MathCtrl.cpp:997
+#: ../src/MathCtrl.cpp:1039
 msgid "Expand Expression"
 msgstr "展开表达式"
 
-#: ../src/wxMaximaFrame.cpp:841
+#: ../src/wxMaximaFrame.cpp:840
 msgid "Expand Logarithms"
 msgstr "展开对数式"
 
-#: ../src/wxMaximaFrame.cpp:840
+#: ../src/wxMaximaFrame.cpp:839
 msgid "Expand an expression"
 msgstr "展开一个表达式"
 
-#: ../src/wxMaximaFrame.cpp:874
+#: ../src/wxMaximaFrame.cpp:873
 msgid "Expand trigonometric expression"
 msgstr "展开三角表达式"
 
@@ -1620,7 +1623,7 @@ msgstr "展开三角表达式"
 msgid "Expected the icon files to be found at"
 msgstr ""
 
-#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2834
+#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2842
 msgid "Export"
 msgstr "导出"
 
@@ -1629,33 +1632,33 @@ msgid ""
 "Export animations to TeX (Images only move if the PDF viewer supports this)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:481
+#: ../src/wxMaximaFrame.cpp:480
 msgid "Export document to a HTML or pdfLaTeX file"
 msgstr "将文档导出为 HTML 文件或 pdfLaTeX 文件"
 
-#: ../src/wxMaximaFrame.cpp:253
+#: ../src/wxMaximaFrame.cpp:252
 #, fuzzy
 msgid "Export failed."
 msgstr "导出到 TeX 失败！"
 
-#: ../src/wxMaximaFrame.cpp:239
+#: ../src/wxMaximaFrame.cpp:238
 msgid "Export successful."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2913
+#: ../src/wxMaxima.cpp:2921
 msgid "Exporting to HTML failed!"
 msgstr "导出到 HTML 失败！"
 
-#: ../src/wxMaxima.cpp:2886
+#: ../src/wxMaxima.cpp:2894
 msgid "Exporting to TeX failed!"
 msgstr "导出到 TeX 失败！"
 
-#: ../src/wxMaxima.cpp:2900
+#: ../src/wxMaxima.cpp:2908
 #, fuzzy
 msgid "Exporting to maxima batch file failed!"
 msgstr "导出到 TeX 失败！"
 
-#: ../src/wxMaximaFrame.cpp:229
+#: ../src/wxMaximaFrame.cpp:228
 #, fuzzy
 msgid "Exporting..."
 msgstr "导出(&E)..."
@@ -1669,42 +1672,42 @@ msgid "Expression(s):"
 msgstr "表达式："
 
 #: ../src/IntegrateWiz.cpp:30 ../src/LimitWiz.cpp:27 ../src/SeriesWiz.cpp:33
-#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3648
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:4205 ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5064
+#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3660
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:4217 ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5076
 msgid "Expression:"
 msgstr "表达式："
 
-#: ../src/wxMaximaFrame.cpp:1213
+#: ../src/wxMaximaFrame.cpp:1212
 msgid "Factor"
 msgstr "因式分解"
 
-#: ../src/wxMaximaFrame.cpp:836
+#: ../src/wxMaximaFrame.cpp:835
 msgid "Factor Complex"
 msgstr "复数因式分解"
 
-#: ../src/MathCtrl.cpp:996
+#: ../src/MathCtrl.cpp:1038
 msgid "Factor Expression"
 msgstr "对表达式因式分解"
 
-#: ../src/wxMaximaFrame.cpp:835
+#: ../src/wxMaximaFrame.cpp:834
 msgid "Factor an expression"
 msgstr "对表达式因式分解"
 
-#: ../src/wxMaximaFrame.cpp:837
+#: ../src/wxMaximaFrame.cpp:836
 msgid "Factor an expression in Gaussian numbers"
 msgstr "对含 Gaussian 数的表达式因式分解"
 
-#: ../src/wxMaximaFrame.cpp:862
+#: ../src/wxMaximaFrame.cpp:861
 msgid "Factorials and &Gamma"
 msgstr "阶乘和 Gamma 函数(&G)"
 
-#: ../src/wxMaxima.cpp:285
+#: ../src/wxMaxima.cpp:286
 msgid "Fatal error"
 msgstr "致命错误"
 
-#: ../src/GroupCell.cpp:1571
+#: ../src/GroupCell.cpp:1572
 #, c-format
 msgid "Figure %d:"
 msgstr "图 %d："
@@ -1713,22 +1716,22 @@ msgstr "图 %d："
 msgid "File"
 msgstr "文件"
 
-#: ../src/wxMaxima.cpp:1457 ../src/wxMaxima.cpp:1623 ../src/wxMaxima.cpp:1636
-#: ../src/wxMaxima.cpp:1646 ../src/wxMaxima.cpp:1668
+#: ../src/wxMaxima.cpp:1462 ../src/wxMaxima.cpp:1628 ../src/wxMaxima.cpp:1641
+#: ../src/wxMaxima.cpp:1651 ../src/wxMaxima.cpp:1673
 #, fuzzy
 msgid "File could not be opened"
 msgstr "无法找到文件"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File not found"
 msgstr "无法找到文件"
 
-#: ../src/wxMaxima.cpp:1511 ../src/wxMaxima.cpp:1729
+#: ../src/wxMaxima.cpp:1516 ../src/wxMaxima.cpp:1734
 #, fuzzy
 msgid "File opened"
 msgstr "无法找到文件"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File you tried to open does not exist."
 msgstr "您想打开的文件不存在。"
 
@@ -1740,67 +1743,67 @@ msgstr "文件："
 msgid "Find"
 msgstr "查找"
 
-#: ../src/wxMaximaFrame.cpp:523
+#: ../src/wxMaximaFrame.cpp:522
 msgid "Find\tCtrl-F"
 msgstr "查找\tCtrl-F"
 
-#: ../src/wxMaximaFrame.cpp:787
+#: ../src/wxMaximaFrame.cpp:786
 msgid "Find &Limit..."
 msgstr "求极限(&L)..."
 
-#: ../src/wxMaximaFrame.cpp:790
+#: ../src/wxMaximaFrame.cpp:789
 msgid "Find Minimum..."
 msgstr "求极小值..."
 
-#: ../src/MathCtrl.cpp:993
+#: ../src/MathCtrl.cpp:1035
 msgid "Find Root..."
 msgstr "求根..."
 
-#: ../src/wxMaximaFrame.cpp:791
+#: ../src/wxMaximaFrame.cpp:790
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr "求表达式的极小值（无约束）"
 
-#: ../src/wxMaximaFrame.cpp:788
+#: ../src/wxMaximaFrame.cpp:787
 msgid "Find a limit of an expression"
 msgstr "求表达式的极限"
 
-#: ../src/wxMaximaFrame.cpp:693
+#: ../src/wxMaximaFrame.cpp:692
 msgid "Find a root of an equation on an interval"
 msgstr "求方程在在区间内的根"
 
-#: ../src/wxMaximaFrame.cpp:695
+#: ../src/wxMaximaFrame.cpp:694
 msgid "Find all roots of a polynomial"
 msgstr "求多项式所有的根"
 
-#: ../src/wxMaximaFrame.cpp:698
+#: ../src/wxMaximaFrame.cpp:697
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr "求多项式所有的根（以长浮点数表示）"
 
-#: ../src/wxMaxima.cpp:3220
+#: ../src/wxMaxima.cpp:3215
 msgid "Find and Replace"
 msgstr "查找并替换"
 
-#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:523
+#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:522
 msgid "Find and replace"
 msgstr "查找并替换"
 
-#: ../src/wxMaximaFrame.cpp:756
+#: ../src/wxMaximaFrame.cpp:755
 msgid "Find eigenvalues of a matrix"
 msgstr "求矩阵特征值"
 
-#: ../src/wxMaximaFrame.cpp:758
+#: ../src/wxMaximaFrame.cpp:757
 msgid "Find eigenvectors of a matrix"
 msgstr "求矩阵特征向量"
 
-#: ../src/wxMaxima.cpp:4210
+#: ../src/wxMaxima.cpp:4222
 msgid "Find minimum"
 msgstr "求最小值"
 
-#: ../src/wxMaximaFrame.cpp:701
+#: ../src/wxMaximaFrame.cpp:700
 msgid "Find real roots of a polynomial"
 msgstr "求多项式的实数根"
 
-#: ../src/wxMaxima.cpp:3493 ../src/wxMaxima.cpp:5036
+#: ../src/wxMaxima.cpp:3505 ../src/wxMaxima.cpp:5048
 msgid "Find root"
 msgstr "求根"
 
@@ -1823,11 +1826,11 @@ msgstr ""
 msgid "Fixed font in text controls"
 msgstr "文本控件中使用等宽字体"
 
-#: ../src/wxMaximaFrame.cpp:623
+#: ../src/wxMaximaFrame.cpp:622
 msgid "Fold All\tCtrl-Alt-["
 msgstr "折叠所有的\tCtrl-Alt-["
 
-#: ../src/wxMaximaFrame.cpp:624
+#: ../src/wxMaximaFrame.cpp:623
 msgid "Fold all sections"
 msgstr "折叠所有节"
 
@@ -1835,25 +1838,25 @@ msgstr "折叠所有节"
 msgid "Follow"
 msgstr ""
 
-#: ../src/ParenCell.cpp:319
+#: ../src/ParenCell.cpp:320
 msgid "Font issue: The Parenthesis sign is too small!"
 msgstr ""
 
-#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:381
+#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:382
 msgid ""
 "Font issue: The char height is too small! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:199
+#: ../src/SqrtCell.cpp:202
 msgid ""
 "Font issue: The sqrt() sign has the size 0! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:198
+#: ../src/SqrtCell.cpp:201
 msgid "Font issue? The contents of a sqrt() has the size 0."
 msgstr ""
 
@@ -1884,15 +1887,15 @@ msgstr "法语"
 
 #: ../src/IntegrateWiz.cpp:37 ../src/Plot2dWiz.cpp:37 ../src/Plot2dWiz.cpp:47
 #: ../src/Plot2dWiz.cpp:536 ../src/Plot3dWiz.cpp:36 ../src/Plot3dWiz.cpp:45
-#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4240
+#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4252
 msgid "From:"
 msgstr "从："
 
-#: ../src/wxMaximaFrame.cpp:576
+#: ../src/wxMaximaFrame.cpp:575
 msgid "Full Screen\tAlt-Enter"
 msgstr "全屏\tAlt-Enter"
 
-#: ../src/wxMaxima.cpp:3342
+#: ../src/wxMaxima.cpp:3354
 msgid "Function"
 msgstr "函数"
 
@@ -1900,32 +1903,32 @@ msgstr "函数"
 msgid "Function names"
 msgstr "函数名"
 
-#: ../src/wxMaxima.cpp:3633
+#: ../src/wxMaxima.cpp:3645
 msgid "Function(s):"
 msgstr "函数："
 
-#: ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3803
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3815
+#: ../src/wxMaxima.cpp:3848
 msgid "Function:"
 msgstr "函数："
 
-#: ../src/wxMaximaFrame.cpp:904
+#: ../src/wxMaximaFrame.cpp:903
 msgid "Functions for complex simplification"
 msgstr "用于复数化简的函数"
 
-#: ../src/wxMaximaFrame.cpp:864
+#: ../src/wxMaximaFrame.cpp:863
 msgid "Functions for simplifying factorials and gamma function"
 msgstr "用于阶乘和 gamma 函数化简的函数"
 
-#: ../src/wxMaximaFrame.cpp:881
+#: ../src/wxMaximaFrame.cpp:880
 msgid "Functions for simplifying trigonometric expressions"
 msgstr "用于三角函数表达式化简的函数"
 
-#: ../src/wxMaxima.cpp:4046
+#: ../src/wxMaxima.cpp:4058
 msgid "GCD"
 msgstr "最大公因式"
 
-#: ../src/wxMaxima.cpp:5152
+#: ../src/wxMaxima.cpp:5164
 msgid "GIF image (*.gif)|*.gif"
 msgstr "GIF 图片 (*.gif)|*.gif"
 
@@ -1933,31 +1936,31 @@ msgstr "GIF 图片 (*.gif)|*.gif"
 msgid "Galician"
 msgstr "加里西亚语"
 
-#: ../src/wxMaximaFrame.cpp:1366
+#: ../src/wxMaximaFrame.cpp:1365
 msgid "Gamma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:391
+#: ../src/wxMaximaFrame.cpp:390
 msgid "General Math"
 msgstr "常用数学"
 
-#: ../src/wxMaximaFrame.cpp:549
+#: ../src/wxMaximaFrame.cpp:548
 msgid "General Math\tAlt-Shift-M"
 msgstr "常用数学\tAlt-Shift-M"
 
-#: ../src/wxMaxima.cpp:3766 ../src/wxMaxima.cpp:3785
+#: ../src/wxMaxima.cpp:3778 ../src/wxMaxima.cpp:3797
 msgid "Generate Matrix"
 msgstr "创建矩阵"
 
-#: ../src/wxMaximaFrame.cpp:741
+#: ../src/wxMaximaFrame.cpp:740
 msgid "Generate Matrix from Expression..."
 msgstr "从表达式创建矩阵..."
 
-#: ../src/wxMaximaFrame.cpp:739
+#: ../src/wxMaximaFrame.cpp:738
 msgid "Generate a matrix from a 2-dimensional array"
 msgstr "从二维数组产生一个矩阵"
 
-#: ../src/wxMaximaFrame.cpp:742
+#: ../src/wxMaximaFrame.cpp:741
 msgid "Generate a matrix from a lambda expression"
 msgstr "从 lambda 表达式产生一个矩阵"
 
@@ -1965,39 +1968,39 @@ msgstr "从 lambda 表达式产生一个矩阵"
 msgid "German"
 msgstr "德语"
 
-#: ../src/wxMaximaFrame.cpp:893
+#: ../src/wxMaximaFrame.cpp:892
 msgid "Get &Imaginary Part"
 msgstr "取虚部(&I)"
 
-#: ../src/wxMaximaFrame.cpp:793
+#: ../src/wxMaximaFrame.cpp:792
 msgid "Get &Series..."
 msgstr "取级数(&S)..."
 
-#: ../src/wxMaximaFrame.cpp:804
+#: ../src/wxMaximaFrame.cpp:803
 msgid "Get Laplace transformation of an expression"
 msgstr "计算表达式的 Laplace 变换"
 
-#: ../src/wxMaximaFrame.cpp:890
+#: ../src/wxMaximaFrame.cpp:889
 msgid "Get Real P&art"
 msgstr "取实部(&A)"
 
-#: ../src/wxMaximaFrame.cpp:807
+#: ../src/wxMaximaFrame.cpp:806
 msgid "Get inverse Laplace transformation of an expression"
 msgstr "计算表达式的 Laplace 逆变换"
 
-#: ../src/wxMaximaFrame.cpp:794
+#: ../src/wxMaximaFrame.cpp:793
 msgid "Get the Taylor or power series of expression"
 msgstr "计算表达式的泰勒级数或幂级数"
 
-#: ../src/wxMaximaFrame.cpp:894
+#: ../src/wxMaximaFrame.cpp:893
 msgid "Get the imaginary part of complex expression"
 msgstr "取复数表达式的虚部"
 
-#: ../src/wxMaximaFrame.cpp:891
+#: ../src/wxMaximaFrame.cpp:890
 msgid "Get the real part of complex expression"
 msgstr "取复数表达式的实部"
 
-#: ../src/MathCtrl.cpp:5932
+#: ../src/MathCtrl.cpp:5984
 msgid ""
 "Got a request to undo an action that involves an delete which isn't possible "
 "at this moment."
@@ -2007,12 +2010,12 @@ msgstr ""
 msgid "Greek"
 msgstr "希腊语"
 
-#: ../src/wxMaximaFrame.cpp:356
+#: ../src/wxMaximaFrame.cpp:355
 #, fuzzy
 msgid "Greek Letters"
 msgstr "希腊字母常量"
 
-#: ../src/wxMaximaFrame.cpp:552
+#: ../src/wxMaximaFrame.cpp:551
 #, fuzzy
 msgid "Greek Letters\tAlt-Shift-G"
 msgstr "常用数学\tAlt-Shift-M"
@@ -2025,7 +2028,7 @@ msgstr "希腊字母常量"
 msgid "Grid:"
 msgstr "网格："
 
-#: ../src/wxMaxima.cpp:2836
+#: ../src/wxMaxima.cpp:2844
 #, fuzzy
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|pdfLaTeX file (*."
@@ -2040,12 +2043,12 @@ msgstr ""
 msgid "Help"
 msgstr "帮助"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 #, fuzzy
 msgid "Hide All Toolbars\tAlt-Shift--"
 msgstr "隐藏所有\tAlt-Shift--"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide all panes"
 msgstr "隐藏所有面板"
 
@@ -2053,19 +2056,19 @@ msgstr "隐藏所有面板"
 msgid "Highlight (dpart)"
 msgstr "高亮显示标记（在dpart函数中）"
 
-#: ../src/wxMaxima.cpp:4685
+#: ../src/wxMaxima.cpp:4697
 msgid "Histogram"
 msgstr "柱状图"
 
-#: ../src/wxMaximaFrame.cpp:1270
+#: ../src/wxMaximaFrame.cpp:1269
 msgid "Histogram..."
 msgstr "柱状图..."
 
-#: ../src/wxMaximaFrame.cpp:309
+#: ../src/wxMaximaFrame.cpp:308
 msgid "History"
 msgstr "历史"
 
-#: ../src/wxMaximaFrame.cpp:555
+#: ../src/wxMaximaFrame.cpp:554
 #, fuzzy
 msgid "History\tAlt-Shift-I"
 msgstr "历史\tAlt-Shift-H"
@@ -2085,11 +2088,11 @@ msgstr ""
 msgid "Hungarian"
 msgstr "匈牙利语"
 
-#: ../src/wxMaxima.cpp:3527
+#: ../src/wxMaxima.cpp:3539
 msgid "IC1"
 msgstr "初始条件（一阶）"
 
-#: ../src/wxMaxima.cpp:3543
+#: ../src/wxMaxima.cpp:3555
 msgid "IC2"
 msgstr "初始条件（二阶）"
 
@@ -2105,7 +2108,7 @@ msgid ""
 "same output cell."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:683
+#: ../src/wxMaximaFrame.cpp:682
 msgid ""
 "If maxima ever finishes evaluating without wxMaxima realizing this this menu "
 "item can force wxMaxima to try to send commands to maxima again."
@@ -2166,11 +2169,11 @@ msgid ""
 msgstr ""
 "若您的计算耗时过长，可以尝试菜单命令“Maxima->中断”或“Maxima->重启 Maxima”"
 
-#: ../src/wxMaximaFrame.cpp:1499
+#: ../src/wxMaximaFrame.cpp:1518
 msgid "Image"
 msgstr "图片"
 
-#: ../src/wxMaxima.cpp:5644
+#: ../src/wxMaxima.cpp:5659
 msgid "Image files (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 msgstr "图片文件 (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 
@@ -2197,7 +2200,7 @@ msgid ""
 "above it. Might increase readability for some fonts and short subscripts."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Include columns:"
 msgstr "包含列："
 
@@ -2216,19 +2219,19 @@ msgstr ""
 msgid "Infinity"
 msgstr "无穷大"
 
-#: ../src/wxMaximaFrame.cpp:974
+#: ../src/wxMaximaFrame.cpp:973
 msgid "Info about Maxima build"
 msgstr "关于 Maxima 的构建信息"
 
-#: ../src/wxMaxima.cpp:4207
+#: ../src/wxMaxima.cpp:4219
 msgid "Initial Estimates:"
 msgstr "初始估计值："
 
-#: ../src/wxMaximaFrame.cpp:718
+#: ../src/wxMaximaFrame.cpp:717
 msgid "Initial Value Problem (&1)..."
 msgstr "一阶常微分方程初始值问题(&1)..."
 
-#: ../src/wxMaximaFrame.cpp:721
+#: ../src/wxMaximaFrame.cpp:720
 msgid "Initial Value Problem (&2)..."
 msgstr "二阶常微分方程初始值问题(&2)..."
 
@@ -2236,7 +2239,7 @@ msgstr "二阶常微分方程初始值问题(&2)..."
 msgid "Input labels"
 msgstr "输入标签"
 
-#: ../src/wxMaximaFrame.cpp:403
+#: ../src/wxMaximaFrame.cpp:402
 msgid "Insert"
 msgstr "插入"
 
@@ -2244,98 +2247,98 @@ msgstr "插入"
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:612
+#: ../src/wxMaximaFrame.cpp:611
 msgid "Insert &Section Cell\tCtrl-3"
 msgstr "插入节单元(&S)\tCtrl-3"
 
-#: ../src/wxMaximaFrame.cpp:608
+#: ../src/wxMaximaFrame.cpp:607
 msgid "Insert &Text Cell\tCtrl-1"
 msgstr "插入文本单元(&T)\tCtrl-1"
 
-#: ../src/wxMaximaFrame.cpp:558
+#: ../src/wxMaximaFrame.cpp:557
 msgid "Insert Cell\tAlt-Shift-C"
 msgstr "插入单元\tAlt-Shift-C"
 
-#: ../src/wxMaxima.cpp:5642
+#: ../src/wxMaxima.cpp:5657
 msgid "Insert Image"
 msgstr "插入图片"
 
-#: ../src/wxMaximaFrame.cpp:620
+#: ../src/wxMaximaFrame.cpp:619
 msgid "Insert Image..."
 msgstr "插入图片..."
 
-#: ../src/wxMaximaFrame.cpp:606
+#: ../src/wxMaximaFrame.cpp:605
 msgid "Insert Input &Cell"
 msgstr "插入输入单元(&C)"
 
-#: ../src/wxMaximaFrame.cpp:618
+#: ../src/wxMaximaFrame.cpp:617
 msgid "Insert Page Break"
 msgstr "插入分页符"
 
-#: ../src/wxMaximaFrame.cpp:614
+#: ../src/wxMaximaFrame.cpp:613
 msgid "Insert S&ubsection Cell\tCtrl-4"
 msgstr "插入小节单元(&U)\tCtrl-4"
 
-#: ../src/wxMaximaFrame.cpp:616
+#: ../src/wxMaximaFrame.cpp:615
 #, fuzzy
 msgid "Insert S&ubsubsection Cell\tCtrl-5"
 msgstr "插入小节单元(&U)\tCtrl-4"
 
-#: ../src/MathCtrl.cpp:1015
+#: ../src/MathCtrl.cpp:1057
 msgid "Insert Section Cell"
 msgstr "插入节单元"
 
-#: ../src/MathCtrl.cpp:1016
+#: ../src/MathCtrl.cpp:1058
 msgid "Insert Subsection Cell"
 msgstr "插入小节单元"
 
-#: ../src/MathCtrl.cpp:1017
+#: ../src/MathCtrl.cpp:1059
 #, fuzzy
 msgid "Insert Subsubsection Cell"
 msgstr "插入小节单元"
 
-#: ../src/wxMaximaFrame.cpp:610
+#: ../src/wxMaximaFrame.cpp:609
 msgid "Insert T&itle Cell\tCtrl-2"
 msgstr "插入标题单元(&I)\tCtrl-2"
 
-#: ../src/MathCtrl.cpp:1013
+#: ../src/MathCtrl.cpp:1055
 msgid "Insert Text Cell"
 msgstr "插入文本单元"
 
-#: ../src/MathCtrl.cpp:1014
+#: ../src/MathCtrl.cpp:1056
 msgid "Insert Title Cell"
 msgstr "插入标题单元"
 
-#: ../src/wxMaximaFrame.cpp:607
+#: ../src/wxMaximaFrame.cpp:606
 msgid "Insert a new input cell"
 msgstr "插入新的输入单元"
 
-#: ../src/wxMaximaFrame.cpp:613
+#: ../src/wxMaximaFrame.cpp:612
 msgid "Insert a new section cell"
 msgstr "插入新的节单元"
 
-#: ../src/wxMaximaFrame.cpp:615
+#: ../src/wxMaximaFrame.cpp:614
 msgid "Insert a new subsection cell"
 msgstr "插入新的小节单元"
 
-#: ../src/wxMaximaFrame.cpp:617
+#: ../src/wxMaximaFrame.cpp:616
 #, fuzzy
 msgid "Insert a new subsubsection cell"
 msgstr "插入新的小节单元"
 
-#: ../src/wxMaximaFrame.cpp:609
+#: ../src/wxMaximaFrame.cpp:608
 msgid "Insert a new text cell"
 msgstr "插入新的文本单元"
 
-#: ../src/wxMaximaFrame.cpp:611
+#: ../src/wxMaximaFrame.cpp:610
 msgid "Insert a new title cell"
 msgstr "插入新的标题单元"
 
-#: ../src/wxMaximaFrame.cpp:619
+#: ../src/wxMaximaFrame.cpp:618
 msgid "Insert a page break"
 msgstr "插入一个换夜符"
 
-#: ../src/wxMaximaFrame.cpp:621
+#: ../src/wxMaximaFrame.cpp:620
 msgid "Insert image"
 msgstr "插入图片"
 
@@ -2348,27 +2351,27 @@ msgstr ""
 msgid "Integral sign"
 msgstr "对表达式求积分"
 
-#: ../src/wxMaxima.cpp:3992
+#: ../src/wxMaxima.cpp:4004
 msgid "Integral/Sum:"
 msgstr "积分/求和："
 
-#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4105 ../src/wxMaxima.cpp:5051
+#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4117 ../src/wxMaxima.cpp:5063
 msgid "Integrate"
 msgstr "积分"
 
-#: ../src/wxMaxima.cpp:4091
+#: ../src/wxMaxima.cpp:4103
 msgid "Integrate (risch)"
 msgstr "Risch 积分"
 
-#: ../src/wxMaximaFrame.cpp:778
+#: ../src/wxMaximaFrame.cpp:777
 msgid "Integrate expression"
 msgstr "对表达式求积分"
 
-#: ../src/wxMaximaFrame.cpp:780
+#: ../src/wxMaximaFrame.cpp:779
 msgid "Integrate expression with Risch algorithm"
 msgstr "使用 Risch 算法对表达式求积分"
 
-#: ../src/wxMaximaFrame.cpp:1224 ../src/MathCtrl.cpp:1000
+#: ../src/MathCtrl.cpp:1042 ../src/wxMaximaFrame.cpp:1223
 msgid "Integrate..."
 msgstr "积分..."
 
@@ -2376,7 +2379,7 @@ msgstr "积分..."
 msgid "Interrupt"
 msgstr "中断"
 
-#: ../src/wxMaximaFrame.cpp:646 ../src/wxMaximaFrame.cpp:650
+#: ../src/wxMaximaFrame.cpp:645 ../src/wxMaximaFrame.cpp:649
 msgid "Interrupt current computation"
 msgstr "中断当前计算"
 
@@ -2396,15 +2399,15 @@ msgstr ""
 "\n"
 "请再次输入 Maxima 程序所在路径。"
 
-#: ../src/wxMaxima.cpp:4137
+#: ../src/wxMaxima.cpp:4149
 msgid "Inverse Laplace"
 msgstr "Laplace 逆变换"
 
-#: ../src/wxMaximaFrame.cpp:806
+#: ../src/wxMaximaFrame.cpp:805
 msgid "Inverse Laplace T&ransform..."
 msgstr "Laplace 逆变换(&R)..."
 
-#: ../src/wxMaximaFrame.cpp:1372
+#: ../src/wxMaximaFrame.cpp:1371
 msgid "Iota"
 msgstr ""
 
@@ -2438,7 +2441,7 @@ msgstr "日本语"
 msgid "Kabyle"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1373
+#: ../src/wxMaximaFrame.cpp:1372
 msgid "Kappa"
 msgstr ""
 
@@ -2447,7 +2450,7 @@ msgstr ""
 msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr "保留下列特殊符号前的百分号(%)：%e, %i 等。"
 
-#: ../src/wxMaxima.cpp:4031
+#: ../src/wxMaxima.cpp:4043
 msgid "LCM"
 msgstr "最小公倍式"
 
@@ -2463,7 +2466,7 @@ msgstr ""
 msgid "Label width:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1374
+#: ../src/wxMaximaFrame.cpp:1373
 msgid "Lambda"
 msgstr ""
 
@@ -2475,11 +2478,11 @@ msgstr "wxMaxima 图形界面语言。"
 msgid "Language:"
 msgstr "语言："
 
-#: ../src/wxMaxima.cpp:4120
+#: ../src/wxMaxima.cpp:4132
 msgid "Laplace"
 msgstr "Laplace 变换"
 
-#: ../src/wxMaximaFrame.cpp:803
+#: ../src/wxMaximaFrame.cpp:802
 msgid "Laplace &Transform..."
 msgstr "Laplace 变换(&T)..."
 
@@ -2487,15 +2490,15 @@ msgstr "Laplace 变换(&T)..."
 msgid "Leads to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:812
+#: ../src/wxMaximaFrame.cpp:811
 msgid "Least Common Multiple..."
 msgstr "最小公倍式..."
 
-#: ../src/wxMaxima.cpp:4809
+#: ../src/wxMaxima.cpp:4821
 msgid "Least Squares Fit"
 msgstr " 最小二乘拟合"
 
-#: ../src/wxMaximaFrame.cpp:1266
+#: ../src/wxMaximaFrame.cpp:1265
 msgid "Least Squares Fit..."
 msgstr "最小二乘拟合..."
 
@@ -2506,24 +2509,24 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4192
+#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4204
 msgid "Limit"
 msgstr "极限"
 
-#: ../src/wxMaximaFrame.cpp:1225
+#: ../src/wxMaximaFrame.cpp:1224
 msgid "Limit..."
 msgstr "极限..."
 
-#: ../src/wxMaximaFrame.cpp:1265
+#: ../src/wxMaximaFrame.cpp:1264
 msgid "Linear Regression..."
 msgstr "线性回归..."
 
-#: ../src/wxMaxima.cpp:3803
+#: ../src/wxMaxima.cpp:3815
 #, fuzzy
 msgid "List(s):"
 msgstr "列表："
 
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3848
 msgid "List:"
 msgstr "列表："
 
@@ -2531,15 +2534,15 @@ msgstr "列表："
 msgid "Load"
 msgstr "载入"
 
-#: ../src/wxMaxima.cpp:2932
+#: ../src/wxMaxima.cpp:2940
 msgid "Load Package"
 msgstr "载入包"
 
-#: ../src/wxMaximaFrame.cpp:479
+#: ../src/wxMaximaFrame.cpp:478
 msgid "Load a Maxima file using the batch command"
 msgstr "使用批处理命令载入 Maxima 文件"
 
-#: ../src/wxMaximaFrame.cpp:477
+#: ../src/wxMaximaFrame.cpp:476
 msgid "Load a Maxima package file"
 msgstr "载入 Maxima 包文件"
 
@@ -2551,49 +2554,49 @@ msgstr "从文件载入样式"
 msgid "Long Right arrow"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Lower bound:"
 msgstr "下限："
 
-#: ../src/wxMaximaFrame.cpp:771
+#: ../src/wxMaximaFrame.cpp:770
 msgid "Ma&p to Matrix..."
 msgstr "映射至矩阵(&P)..."
 
-#: ../src/wxMaximaFrame.cpp:547
+#: ../src/wxMaximaFrame.cpp:546
 #, fuzzy
 msgid "Main Toolbar\tAlt-Shift-B"
 msgstr "工具栏\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:765
+#: ../src/wxMaximaFrame.cpp:764
 msgid "Make &List..."
 msgstr "创建列表(&L)..."
 
-#: ../src/wxMaxima.cpp:3821
+#: ../src/wxMaxima.cpp:3833
 msgid "Make list"
 msgstr "创建列表"
 
-#: ../src/wxMaximaFrame.cpp:766
+#: ../src/wxMaximaFrame.cpp:765
 msgid "Make list from expression"
 msgstr "从表达式创建列表"
 
-#: ../src/wxMaximaFrame.cpp:907
+#: ../src/wxMaximaFrame.cpp:906
 msgid "Make substitution in expression"
 msgstr "在表达式中进行替换"
 
-#: ../src/wxMaximaFrame.cpp:682
+#: ../src/wxMaximaFrame.cpp:681
 #, fuzzy
 msgid "Manually Trigger Evaluation"
 msgstr "显示求值时间"
 
-#: ../src/wxMaxima.cpp:3805
+#: ../src/wxMaxima.cpp:3817
 msgid "Map"
 msgstr "映射"
 
-#: ../src/wxMaximaFrame.cpp:770
+#: ../src/wxMaximaFrame.cpp:769
 msgid "Map function to a list"
 msgstr "映射函数至列表"
 
-#: ../src/wxMaximaFrame.cpp:772
+#: ../src/wxMaximaFrame.cpp:771
 msgid "Map function to a matrix"
 msgstr "映射函数至矩阵"
 
@@ -2610,23 +2613,23 @@ msgstr "在文本控件中输入时匹配括号"
 msgid "Math font:"
 msgstr "数学字体："
 
-#: ../src/wxMaximaFrame.cpp:374
+#: ../src/wxMaximaFrame.cpp:373
 msgid "Mathematical Symbols"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3716
+#: ../src/wxMaxima.cpp:3728
 msgid "Matrix"
 msgstr "矩阵"
 
-#: ../src/wxMaxima.cpp:3702
+#: ../src/wxMaxima.cpp:3714
 msgid "Matrix map"
 msgstr "矩阵映射"
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Matrix name:"
 msgstr "矩阵名："
 
-#: ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3749
+#: ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3761
 msgid "Matrix:"
 msgstr "矩阵："
 
@@ -2634,7 +2637,7 @@ msgstr "矩阵："
 msgid "Maxima"
 msgstr "Maxima"
 
-#: ../src/wxMaximaFrame.cpp:137
+#: ../src/wxMaximaFrame.cpp:136
 #, fuzzy
 msgid "Maxima has a question"
 msgstr "Maxima 问题"
@@ -2643,24 +2646,24 @@ msgstr "Maxima 问题"
 msgid "Maxima input"
 msgstr "Maxima 输入"
 
-#: ../src/wxMaximaFrame.cpp:166
+#: ../src/wxMaximaFrame.cpp:165
 msgid "Maxima is calculating"
 msgstr "Maxima 正在计算"
 
-#: ../src/wxMaximaFrame.cpp:111
+#: ../src/wxMaximaFrame.cpp:110
 #, fuzzy
 msgid "Maxima is ready for input."
 msgstr "Maxima 输入"
 
-#: ../src/wxMaxima.cpp:2945
+#: ../src/wxMaxima.cpp:2953
 msgid "Maxima package (*.mac)|*.mac"
 msgstr "Maxima 包 (*.mac)|*.mac"
 
-#: ../src/wxMaxima.cpp:2934
+#: ../src/wxMaxima.cpp:2942
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr "Maxima 包 (*.mac)|*.mac|Lisp 包 (*.lisp)|*.lisp|全部类型|*"
 
-#: ../src/wxMaxima.cpp:1014
+#: ../src/wxMaxima.cpp:1019
 msgid "Maxima process terminated."
 msgstr "Maxima 进程已中止。"
 
@@ -2672,7 +2675,7 @@ msgstr "Maxima 程序："
 msgid "Maxima questions"
 msgstr "Maxima 问题"
 
-#: ../src/wxMaxima.cpp:942
+#: ../src/wxMaxima.cpp:947
 msgid "Maxima started. Waiting for connection..."
 msgstr "Maxima 已启动。等待连接中..."
 
@@ -2695,7 +2698,7 @@ msgid ""
 msgstr ""
 "Maxima 使用”:“进行赋值（例如：”a : 3;“），使用”:=“定义函数（”f(x) := x^2“）。"
 
-#: ../src/wxMaxima.cpp:4597
+#: ../src/wxMaxima.cpp:4609
 msgid "Maxima version: "
 msgstr "Maxima 版本："
 
@@ -2732,40 +2735,40 @@ msgstr ""
 msgid "Maximum displayed number of digits:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1263
+#: ../src/wxMaximaFrame.cpp:1262
 msgid "Mean Difference Test..."
 msgstr "平均差检验..."
 
-#: ../src/wxMaximaFrame.cpp:1262
+#: ../src/wxMaximaFrame.cpp:1261
 msgid "Mean Test..."
 msgstr "平均值检验..."
 
-#: ../src/wxMaximaFrame.cpp:1255
+#: ../src/wxMaximaFrame.cpp:1254
 msgid "Mean..."
 msgstr "求平均值..."
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Mean:"
 msgstr "平均值："
 
-#: ../src/wxMaximaFrame.cpp:1256
+#: ../src/wxMaximaFrame.cpp:1255
 msgid "Median..."
 msgstr "中值..."
 
-#: ../src/MathCtrl.cpp:945
+#: ../src/MathCtrl.cpp:987
 msgid "Merge Cells"
 msgstr "合并单元"
 
-#: ../src/wxMaximaFrame.cpp:633
+#: ../src/wxMaximaFrame.cpp:632
 #, fuzzy
 msgid "Merge Cells\tCtrl-M"
 msgstr "合并单元"
 
-#: ../src/wxMaximaFrame.cpp:634
+#: ../src/wxMaximaFrame.cpp:633
 msgid "Merge the text from two input cells into one"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2668
+#: ../src/wxMaxima.cpp:2676
 msgid "Message from the stdout of Maxima: "
 msgstr ""
 
@@ -2773,20 +2776,20 @@ msgstr ""
 msgid "Method:"
 msgstr "方法："
 
-#: ../src/wxMaxima.cpp:5289
+#: ../src/wxMaxima.cpp:5301
 #, fuzzy
 msgid "Mismatched parenthesis"
 msgstr "在文本控件中输入时匹配括号"
 
-#: ../src/wxMaxima.cpp:3972
+#: ../src/wxMaxima.cpp:3984
 msgid "Modulus"
 msgstr "求模"
 
-#: ../src/wxMaximaFrame.cpp:1375
+#: ../src/wxMaximaFrame.cpp:1374
 msgid "Mu"
 msgstr ""
 
-#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Name:"
 msgstr "名："
 
@@ -2794,7 +2797,7 @@ msgstr "名："
 msgid "New"
 msgstr "新建"
 
-#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
+#: ../src/wxMaximaFrame.cpp:456 ../src/wxMaximaFrame.cpp:459
 msgid "New\tCtrl-N"
 msgstr "新建\tCtrl-N"
 
@@ -2810,11 +2813,11 @@ msgstr ""
 msgid "New value:"
 msgstr "新值："
 
-#: ../src/wxMaxima.cpp:3993 ../src/wxMaxima.cpp:4119 ../src/wxMaxima.cpp:4136
+#: ../src/wxMaxima.cpp:4005 ../src/wxMaxima.cpp:4131 ../src/wxMaxima.cpp:4148
 msgid "New variable:"
 msgstr "新变量："
 
-#: ../src/wxMaximaFrame.cpp:630
+#: ../src/wxMaximaFrame.cpp:629
 msgid "Next Command\tAlt-Down"
 msgstr "下一条命令\tAlt-Down"
 
@@ -2822,15 +2825,15 @@ msgstr "下一条命令\tAlt-Down"
 msgid "No"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5362
+#: ../src/wxMaxima.cpp:5378
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3249 ../src/wxMaxima.cpp:3271
+#: ../src/wxMaxima.cpp:3260 ../src/wxMaxima.cpp:3283
 msgid "No matches found!"
 msgstr "无法找到匹配项！"
 
-#: ../src/wxMaximaFrame.cpp:1264
+#: ../src/wxMaximaFrame.cpp:1263
 msgid "Normality Test..."
 msgstr "正态分布检验"
 
@@ -2853,34 +2856,34 @@ msgstr ""
 msgid "Norwegian"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:3740
 msgid "Not a valid matrix dimension!"
 msgstr "矩阵的大小无效！"
 
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629
 msgid "Not a valid number of equations!"
 msgstr "方程的个数不对！"
 
-#: ../src/wxMaximaFrame.cpp:197
+#: ../src/wxMaximaFrame.cpp:196
 #, fuzzy
 msgid "Not connected to maxima"
 msgstr ""
 "\n"
 "未连接到 Maxima！\n"
 
-#: ../src/wxMaxima.cpp:4599
+#: ../src/wxMaxima.cpp:4611
 msgid "Not connected."
 msgstr "未连接。"
 
-#: ../src/wxMaximaFrame.cpp:1376
+#: ../src/wxMaximaFrame.cpp:1375
 msgid "Nu"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Num. deg:"
 msgstr "分子次数："
 
-#: ../src/wxMaxima.cpp:3585 ../src/wxMaxima.cpp:3609
+#: ../src/wxMaxima.cpp:3597 ../src/wxMaxima.cpp:3621
 msgid "Number of equations:"
 msgstr "方程个数："
 
@@ -2907,15 +2910,15 @@ msgstr "确认"
 msgid "Old value:"
 msgstr "旧值："
 
-#: ../src/wxMaxima.cpp:3992 ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135
+#: ../src/wxMaxima.cpp:4004 ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147
 msgid "Old variable:"
 msgstr "旧变量："
 
-#: ../src/wxMaximaFrame.cpp:1387
+#: ../src/wxMaximaFrame.cpp:1386
 msgid "Omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1378
+#: ../src/wxMaximaFrame.cpp:1377
 msgid "Omicron"
 msgstr ""
 
@@ -2929,20 +2932,20 @@ msgid ""
 "stream for messages."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4763
+#: ../src/wxMaxima.cpp:4775
 msgid "One sample t-test"
 msgstr "单样本 t-检验"
 
-#: ../src/wxMaximaFrame.cpp:971
+#: ../src/wxMaximaFrame.cpp:970
 msgid "Online tutorials"
 msgstr "在线教程"
 
 #: ../src/ConfigDialogue.cpp:656 ../src/main.cpp:347 ../src/ToolBar.cpp:119
-#: ../src/wxMaxima.cpp:2797
+#: ../src/wxMaxima.cpp:2805
 msgid "Open"
 msgstr "打开"
 
-#: ../src/wxMaximaFrame.cpp:466
+#: ../src/wxMaximaFrame.cpp:465
 msgid "Open Recent"
 msgstr "打开最近的文件"
 
@@ -2950,11 +2953,11 @@ msgstr "打开最近的文件"
 msgid "Open a cell when Maxima expects input"
 msgstr "当 Maxima 期望输入时打开一个新单元"
 
-#: ../src/wxMaximaFrame.cpp:464
+#: ../src/wxMaximaFrame.cpp:463
 msgid "Open a document"
 msgstr "打开文档"
 
-#: ../src/wxMaximaFrame.cpp:458 ../src/wxMaximaFrame.cpp:461
+#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
 msgid "Open a new window"
 msgstr "打开新窗口"
 
@@ -2962,11 +2965,11 @@ msgstr "打开新窗口"
 msgid "Open document"
 msgstr "打开文档"
 
-#: ../src/wxMaxima.cpp:4824
+#: ../src/wxMaxima.cpp:4836
 msgid "Open matrix"
 msgstr "打开矩阵"
 
-#: ../src/wxMaxima.cpp:1446 ../src/wxMaxima.cpp:1518
+#: ../src/wxMaxima.cpp:1451 ../src/wxMaxima.cpp:1523
 msgid "Opening file"
 msgstr "正在打开文件"
 
@@ -2990,11 +2993,11 @@ msgstr "单元已过期"
 msgid "Output labels"
 msgstr "输出标签"
 
-#: ../src/wxMaximaFrame.cpp:796
+#: ../src/wxMaximaFrame.cpp:795
 msgid "P&ade Approximation..."
 msgstr "Pade 近似(&A)..."
 
-#: ../src/wxMaxima.cpp:3132 ../src/wxMaxima.cpp:5133
+#: ../src/wxMaxima.cpp:3141 ../src/wxMaxima.cpp:5145
 #, fuzzy
 msgid ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
@@ -3004,15 +3007,15 @@ msgstr ""
 "PNG 图片 (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows 位图 (*.bmp)|*.bmp|X "
 "位图 (*.xpm)|*.xpm"
 
-#: ../src/wxMaxima.cpp:4012
+#: ../src/wxMaxima.cpp:4024
 msgid "Pade approximation"
 msgstr "Pade 近似"
 
-#: ../src/wxMaximaFrame.cpp:797
+#: ../src/wxMaximaFrame.cpp:796
 msgid "Pade approximation of a Taylor series"
 msgstr "泰勒级数的 Pade 近似"
 
-#: ../src/wxMaximaFrame.cpp:1500
+#: ../src/wxMaximaFrame.cpp:1519
 msgid "Pagebreak"
 msgstr "换页"
 
@@ -3024,19 +3027,19 @@ msgstr ""
 msgid "Parametric plot"
 msgstr "参数式绘图"
 
-#: ../src/wxMaximaFrame.cpp:188
+#: ../src/wxMaximaFrame.cpp:187
 msgid "Parsing output"
 msgstr "解析输出"
 
-#: ../src/wxMaximaFrame.cpp:819
+#: ../src/wxMaximaFrame.cpp:818
 msgid "Partial &Fractions..."
 msgstr "部分分式(&F)..."
 
-#: ../src/wxMaxima.cpp:4076
+#: ../src/wxMaxima.cpp:4088
 msgid "Partial fractions"
 msgstr "部分分式"
 
-#: ../src/wxMaxima.cpp:1769
+#: ../src/wxMaxima.cpp:1774
 msgid "Parts of the document will not be loaded correctly!"
 msgstr "文档的某些部分无法正确载入！"
 
@@ -3047,11 +3050,11 @@ msgid ""
 "Found unknown XML Tag name "
 msgstr "文档的某些部分无法正确载入！"
 
-#: ../src/ToolBar.cpp:143 ../src/MathCtrl.cpp:1010 ../src/MathCtrl.cpp:1025
+#: ../src/MathCtrl.cpp:1052 ../src/MathCtrl.cpp:1067 ../src/ToolBar.cpp:143
 msgid "Paste"
 msgstr "粘贴"
 
-#: ../src/wxMaximaFrame.cpp:518
+#: ../src/wxMaximaFrame.cpp:517
 msgid "Paste\tCtrl-V"
 msgstr "粘贴\tCtrl-V"
 
@@ -3059,7 +3062,7 @@ msgstr "粘贴\tCtrl-V"
 msgid "Paste from clipboard"
 msgstr "粘贴自剪贴板"
 
-#: ../src/wxMaximaFrame.cpp:519
+#: ../src/wxMaximaFrame.cpp:518
 msgid "Paste text from clipboard"
 msgstr "粘贴文本自剪贴板"
 
@@ -3067,19 +3070,19 @@ msgstr "粘贴文本自剪贴板"
 msgid "Perpendicular to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1384
+#: ../src/wxMaximaFrame.cpp:1383
 msgid "Phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1379
+#: ../src/wxMaximaFrame.cpp:1378
 msgid "Pi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1273
+#: ../src/wxMaximaFrame.cpp:1272
 msgid "Piechart..."
 msgstr "饼图..."
 
-#: ../src/wxMaxima.cpp:1952
+#: ../src/wxMaxima.cpp:1957
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr "请用 “编辑->配置” 配置 wxMaxima。"
 
@@ -3087,52 +3090,52 @@ msgstr "请用 “编辑->配置” 配置 wxMaxima。"
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr "请重启 wxMaxima 以使变更生效。"
 
-#: ../src/wxMaximaFrame.cpp:923
+#: ../src/wxMaximaFrame.cpp:922
 msgid "Plot &2d..."
 msgstr "二维绘图(&2)..."
 
-#: ../src/wxMaximaFrame.cpp:925
+#: ../src/wxMaximaFrame.cpp:924
 msgid "Plot &3d..."
 msgstr "三维绘图(&3)..."
 
-#: ../src/wxMaximaFrame.cpp:927
+#: ../src/wxMaximaFrame.cpp:926
 msgid "Plot &Format..."
 msgstr "绘图格式(&F)..."
 
 #: ../src/Plot2dWiz.cpp:104 ../src/Plot2dWiz.cpp:450 ../src/Plot2dWiz.cpp:464
-#: ../src/wxMaxima.cpp:4283 ../src/wxMaxima.cpp:5102
+#: ../src/wxMaxima.cpp:4295 ../src/wxMaxima.cpp:5114
 msgid "Plot 2D"
 msgstr "二维绘图"
 
-#: ../src/wxMaximaFrame.cpp:1227
+#: ../src/wxMaximaFrame.cpp:1226
 msgid "Plot 2D..."
 msgstr "二维绘图..."
 
-#: ../src/MathCtrl.cpp:1003
+#: ../src/MathCtrl.cpp:1045
 msgid "Plot 2d..."
 msgstr "二维绘图..."
 
-#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4269 ../src/wxMaxima.cpp:5115
+#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4281 ../src/wxMaxima.cpp:5127
 msgid "Plot 3D"
 msgstr "三维绘图"
 
-#: ../src/wxMaximaFrame.cpp:1228
+#: ../src/wxMaximaFrame.cpp:1227
 msgid "Plot 3D..."
 msgstr "三维绘图..."
 
-#: ../src/MathCtrl.cpp:1004
+#: ../src/MathCtrl.cpp:1046
 msgid "Plot 3d..."
 msgstr "三维绘图..."
 
-#: ../src/wxMaxima.cpp:4296
+#: ../src/wxMaxima.cpp:4308
 msgid "Plot format"
 msgstr "绘图格式"
 
-#: ../src/wxMaximaFrame.cpp:924
+#: ../src/wxMaximaFrame.cpp:923
 msgid "Plot in 2 dimensions"
 msgstr "二维绘图"
 
-#: ../src/wxMaximaFrame.cpp:926
+#: ../src/wxMaximaFrame.cpp:925
 msgid "Plot in 3 dimensions"
 msgstr "三维绘图"
 
@@ -3141,8 +3144,8 @@ msgid "Plot to file:"
 msgstr "绘图至文件："
 
 #: ../src/BC2Wiz.cpp:30 ../src/BC2Wiz.cpp:36 ../src/LimitWiz.cpp:33
-#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
-#: ../src/wxMaxima.cpp:3648
+#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
+#: ../src/wxMaxima.cpp:3660
 msgid "Point:"
 msgstr "点："
 
@@ -3150,11 +3153,11 @@ msgstr "点："
 msgid "Polish"
 msgstr "波兰语"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 1:"
 msgstr "多项式1："
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 2:"
 msgstr "多项式2："
 
@@ -3166,11 +3169,11 @@ msgstr "葡萄牙语（巴西）"
 msgid "Postscript file (*.eps)|*.eps|All|*"
 msgstr "Postscript 文件 (*.eps)|*.eps|全部类型|*"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Precision"
 msgstr "精度"
 
-#: ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:536
 #, fuzzy
 msgid "Preferences...\tCtrl+,"
 msgstr "首选项...\tCtrl+,"
@@ -3183,7 +3186,7 @@ msgid ""
 "packages and from functions that are defined in the current file."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:628
+#: ../src/wxMaximaFrame.cpp:627
 msgid "Previous Command\tAlt-Up"
 msgstr "前一条命令\tAlt-Up"
 
@@ -3191,11 +3194,11 @@ msgstr "前一条命令\tAlt-Up"
 msgid "Print"
 msgstr "打印"
 
-#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:484
+#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:483
 msgid "Print document"
 msgstr "打印文档"
 
-#: ../src/wxMaxima.cpp:4242
+#: ../src/wxMaxima.cpp:4254
 msgid "Product"
 msgstr "乘积"
 
@@ -3204,36 +3207,36 @@ msgstr "乘积"
 msgid "Product sign"
 msgstr "乘积"
 
-#: ../src/wxMaximaFrame.cpp:1386
+#: ../src/wxMaximaFrame.cpp:1385
 msgid "Psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:331
+#: ../src/wxMaximaFrame.cpp:330
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:592
+#: ../src/wxMaximaFrame.cpp:591
 #, fuzzy
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr "对文档中所有单元求值"
 
-#: ../src/wxMaximaFrame.cpp:1278
+#: ../src/wxMaximaFrame.cpp:1277
 msgid "Read Matrix..."
 msgstr "读入矩阵..."
 
-#: ../src/wxMaximaFrame.cpp:177
+#: ../src/wxMaximaFrame.cpp:176
 msgid "Reading Maxima output"
 msgstr "正在读取 Maxima 输入"
 
-#: ../src/wxMaximaFrame.cpp:153
+#: ../src/wxMaximaFrame.cpp:152
 msgid "Ready for user input"
 msgstr "输入准备就绪"
 
-#: ../src/wxMaximaFrame.cpp:631
+#: ../src/wxMaximaFrame.cpp:630
 msgid "Recall next command from history"
 msgstr "重调历史中的下一条命令"
 
-#: ../src/wxMaximaFrame.cpp:629
+#: ../src/wxMaximaFrame.cpp:628
 msgid "Recall previous command from history"
 msgstr "重调历史中的前一条命令"
 
@@ -3241,36 +3244,36 @@ msgstr "重调历史中的前一条命令"
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1215
+#: ../src/wxMaximaFrame.cpp:1214
 msgid "Rectform"
 msgstr "直角坐标x形式"
 
-#: ../src/wxMaximaFrame.cpp:495
+#: ../src/wxMaximaFrame.cpp:494
 #, fuzzy
 msgid "Redo\tCtrl-Y"
 msgstr "撤销\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:496
+#: ../src/wxMaximaFrame.cpp:495
 msgid "Redo last change"
 msgstr "重做上次变更"
 
-#: ../src/wxMaximaFrame.cpp:1220
+#: ../src/wxMaximaFrame.cpp:1219
 msgid "Reduce (tr)"
 msgstr "化简（三角）"
 
-#: ../src/wxMaximaFrame.cpp:871
+#: ../src/wxMaximaFrame.cpp:870
 msgid "Reduce trigonometric expression"
 msgstr "对表达式进行三角函数化简"
 
-#: ../src/wxMaxima.cpp:622 ../src/wxMaxima.cpp:5495
+#: ../src/wxMaxima.cpp:627 ../src/wxMaxima.cpp:5511
 msgid "Refusing to send cell to maxima: "
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:594
+#: ../src/wxMaximaFrame.cpp:593
 msgid "Remove All Output"
 msgstr "移除所有输出"
 
-#: ../src/wxMaximaFrame.cpp:595
+#: ../src/wxMaximaFrame.cpp:594
 msgid "Remove output from input cells"
 msgstr "移除所有输入单元的输出"
 
@@ -3279,7 +3282,7 @@ msgstr "移除所有输入单元的输出"
 msgid "Replace All"
 msgstr "选择全部"
 
-#: ../src/wxMaxima.cpp:3282
+#: ../src/wxMaxima.cpp:3294
 #, c-format
 msgid "Replaced %d occurrences."
 msgstr "替换了 %d 次。"
@@ -3288,11 +3291,11 @@ msgstr "替换了 %d 次。"
 msgid "Replacement:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:976
+#: ../src/wxMaximaFrame.cpp:975
 msgid "Report bug"
 msgstr "报告错误"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "Restart Maxima"
 msgstr "重启 Maxima"
 
@@ -3301,7 +3304,7 @@ msgstr "重启 Maxima"
 msgid "Restart maxima"
 msgstr "重启 Maxima"
 
-#: ../src/MathCtrl.cpp:4442
+#: ../src/MathCtrl.cpp:4497
 msgid "Result"
 msgstr ""
 
@@ -3309,7 +3312,7 @@ msgstr ""
 msgid "Return to the cell that is currently being evaluated"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1380
+#: ../src/wxMaximaFrame.cpp:1379
 msgid "Rho"
 msgstr ""
 
@@ -3317,19 +3320,19 @@ msgstr ""
 msgid "Right arrow"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:779
+#: ../src/wxMaximaFrame.cpp:778
 msgid "Risch Integration..."
 msgstr "Risch 积分..."
 
-#: ../src/wxMaximaFrame.cpp:694
+#: ../src/wxMaximaFrame.cpp:693
 msgid "Roots of &Polynomial"
 msgstr "多项式求根(&P)"
 
-#: ../src/wxMaximaFrame.cpp:697
+#: ../src/wxMaximaFrame.cpp:696
 msgid "Roots of Polynomial (bfloat)"
 msgstr "多项式求根（长浮点数）"
 
-#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Rows:"
 msgstr "行："
 
@@ -3337,56 +3340,56 @@ msgstr "行："
 msgid "Russian"
 msgstr "俄语"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 1:"
 msgstr "样本1："
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 2:"
 msgstr "样本2："
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Sample:"
 msgstr "样本："
 
 #: ../src/ConfigDialogue.cpp:781 ../src/ToolBar.cpp:122
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Save"
 msgstr "保存"
 
-#: ../src/MathCtrl.cpp:921
+#: ../src/MathCtrl.cpp:963
 msgid "Save Animation..."
 msgstr "保存动画"
 
-#: ../src/wxMaxima.cpp:2565
+#: ../src/wxMaxima.cpp:2572
 msgid "Save As"
 msgstr "另存为"
 
-#: ../src/wxMaximaFrame.cpp:474
+#: ../src/wxMaximaFrame.cpp:473
 msgid "Save As...\tShift-Ctrl-S"
 msgstr "另存为...\tShift-Ctrl-S"
 
-#: ../src/MathCtrl.cpp:919
+#: ../src/MathCtrl.cpp:961
 msgid "Save Image..."
 msgstr "保存图片..."
 
-#: ../src/wxMaxima.cpp:3130
+#: ../src/wxMaxima.cpp:3139
 msgid "Save Selection to Image"
 msgstr "保存所选区域到图片"
 
-#: ../src/wxMaximaFrame.cpp:528
+#: ../src/wxMaximaFrame.cpp:527
 msgid "Save Selection to Image..."
 msgstr "保存所选区域到图片..."
 
-#: ../src/wxMaxima.cpp:5150
+#: ../src/wxMaxima.cpp:5162
 msgid "Save animation to file"
 msgstr "保存动画到文件"
 
-#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:473
+#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:472
 msgid "Save document"
 msgstr "保存文档"
 
-#: ../src/wxMaximaFrame.cpp:475
+#: ../src/wxMaximaFrame.cpp:474
 msgid "Save document as"
 msgstr "另存文档为"
 
@@ -3408,11 +3411,11 @@ msgstr "保存会话间的面板布局。"
 msgid "Save plot to file"
 msgstr "保存绘图到文件"
 
-#: ../src/wxMaximaFrame.cpp:529
+#: ../src/wxMaximaFrame.cpp:528
 msgid "Save selection from document to an image file"
 msgstr "保存文档中所选区域到图片文件"
 
-#: ../src/wxMaxima.cpp:5131
+#: ../src/wxMaxima.cpp:5143
 msgid "Save selection to file"
 msgstr "保存所选区域到文件"
 
@@ -3428,28 +3431,28 @@ msgstr "保存 wxMaxima 窗口大小和位置"
 msgid "Save wxMaxima window size/position between sessions."
 msgstr "保存会话间的 wxMaxima 窗口的大小和位置。"
 
-#: ../src/wxMaximaFrame.cpp:246
+#: ../src/wxMaximaFrame.cpp:245
 #, fuzzy
 msgid "Saving failed."
 msgstr "启动服务器失败"
 
-#: ../src/wxMaximaFrame.cpp:222
+#: ../src/wxMaximaFrame.cpp:221
 msgid "Saving successful."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:212
+#: ../src/wxMaximaFrame.cpp:211
 msgid "Saving..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4699
+#: ../src/wxMaxima.cpp:4711
 msgid "Scatterplot"
 msgstr "散布图"
 
-#: ../src/wxMaximaFrame.cpp:1271
+#: ../src/wxMaximaFrame.cpp:1270
 msgid "Scatterplot..."
 msgstr "散布图..."
 
-#: ../src/wxMaximaFrame.cpp:1498
+#: ../src/wxMaximaFrame.cpp:1517
 msgid "Section"
 msgstr "节"
 
@@ -3457,26 +3460,26 @@ msgstr "节"
 msgid "Section cell"
 msgstr "节单元"
 
-#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:292 ../src/TextCell.cpp:306
-#: ../src/TextCell.cpp:322 ../src/TextCell.cpp:334
+#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:290 ../src/TextCell.cpp:304
+#: ../src/TextCell.cpp:320 ../src/TextCell.cpp:332
 msgid ""
 "Seems like something is broken with a font. Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/TextCell.cpp:139
+#: ../src/TextCell.cpp:137
 msgid ""
 "Seems like something is broken with the maths font. Installing http://www."
 "math.union.edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use "
 "JSmath fonts\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1011 ../src/MathCtrl.cpp:1027
+#: ../src/MathCtrl.cpp:1053 ../src/MathCtrl.cpp:1069
 msgid "Select All"
 msgstr "选择全部"
 
-#: ../src/wxMaximaFrame.cpp:525
+#: ../src/wxMaximaFrame.cpp:524
 msgid "Select All\tCtrl-A"
 msgstr "选择全部\tCtrl-A"
 
@@ -3484,7 +3487,7 @@ msgstr "选择全部\tCtrl-A"
 msgid "Select Maxima program"
 msgstr "选择 Maxima 程序"
 
-#: ../src/wxMaxima.cpp:4860
+#: ../src/wxMaxima.cpp:4872
 msgid "Select Subsample"
 msgstr "选择子样本"
 
@@ -3493,11 +3496,11 @@ msgstr "选择子样本"
 msgid "Select a constant"
 msgstr "选择一个常量"
 
-#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:526
+#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:525
 msgid "Select all"
 msgstr "选择全部"
 
-#: ../src/wxMaxima.cpp:3319
+#: ../src/wxMaxima.cpp:3331
 msgid "Select math display algorithm"
 msgstr "选择数学式显示算法"
 
@@ -3514,23 +3517,23 @@ msgstr ""
 msgid "Selection"
 msgstr "选择"
 
-#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4178
+#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4190
 msgid "Series"
 msgstr "级数"
 
-#: ../src/wxMaximaFrame.cpp:1226
+#: ../src/wxMaximaFrame.cpp:1225
 msgid "Series..."
 msgstr "级数..."
 
-#: ../src/wxMaxima.cpp:863
+#: ../src/wxMaxima.cpp:868
 msgid "Server started"
 msgstr "服务器已启动"
 
-#: ../src/wxMaximaFrame.cpp:575
+#: ../src/wxMaximaFrame.cpp:574
 msgid "Set Zoom"
 msgstr "设定显示比例"
 
-#: ../src/wxMaximaFrame.cpp:944
+#: ../src/wxMaximaFrame.cpp:943
 #, fuzzy
 msgid "Set bigfloat &Precision..."
 msgstr "设定长浮点数精度"
@@ -3539,61 +3542,61 @@ msgstr "设定长浮点数精度"
 msgid "Set fixed font in text controls."
 msgstr "设定文本控件中使用等宽字体"
 
-#: ../src/wxMaximaFrame.cpp:928
+#: ../src/wxMaximaFrame.cpp:927
 msgid "Set plot format"
 msgstr "设定绘图格式"
 
-#: ../src/wxMaximaFrame.cpp:945
+#: ../src/wxMaximaFrame.cpp:944
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can "
 "be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:569
+#: ../src/wxMaximaFrame.cpp:568
 msgid "Set zoom to 100%"
 msgstr "设定显示比例为100%"
 
-#: ../src/wxMaximaFrame.cpp:570
+#: ../src/wxMaximaFrame.cpp:569
 msgid "Set zoom to 120%"
 msgstr "设定显示比例为120%"
 
-#: ../src/wxMaximaFrame.cpp:571
+#: ../src/wxMaximaFrame.cpp:570
 msgid "Set zoom to 150%"
 msgstr "设定显示比例为150%"
 
-#: ../src/wxMaximaFrame.cpp:572
+#: ../src/wxMaximaFrame.cpp:571
 msgid "Set zoom to 200%"
 msgstr "设定显示比例为200%"
 
-#: ../src/wxMaximaFrame.cpp:573
+#: ../src/wxMaximaFrame.cpp:572
 msgid "Set zoom to 300%"
 msgstr "设定显示比例为300%"
 
-#: ../src/wxMaximaFrame.cpp:568
+#: ../src/wxMaximaFrame.cpp:567
 msgid "Set zoom to 80%"
 msgstr "设定显示比例为80%"
 
-#: ../src/wxMaximaFrame.cpp:732
+#: ../src/wxMaximaFrame.cpp:731
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr "在使用 Laplace 变换解常微分方程前将定点设值"
 
-#: ../src/wxMaximaFrame.cpp:918
+#: ../src/wxMaximaFrame.cpp:917
 msgid "Setup modulus computation"
 msgstr "设定模运算"
 
-#: ../src/wxMaximaFrame.cpp:662
+#: ../src/wxMaximaFrame.cpp:661
 msgid "Show &Definition..."
 msgstr "显示函数定义(&D)..."
 
-#: ../src/wxMaximaFrame.cpp:660
+#: ../src/wxMaximaFrame.cpp:659
 msgid "Show &Functions"
 msgstr "显示函数(&F)"
 
-#: ../src/wxMaximaFrame.cpp:967
+#: ../src/wxMaximaFrame.cpp:966
 msgid "Show &Tips..."
 msgstr "显示提示(&T)..."
 
-#: ../src/wxMaximaFrame.cpp:665
+#: ../src/wxMaximaFrame.cpp:664
 msgid "Show &Variables"
 msgstr "显示变量(&V)"
 
@@ -3601,43 +3604,43 @@ msgstr "显示变量(&V)"
 msgid "Show Maxima help"
 msgstr "显示 Maxima 帮助"
 
-#: ../src/wxMaximaFrame.cpp:603
+#: ../src/wxMaximaFrame.cpp:602
 msgid "Show Template\tCtrl-Shift-K"
 msgstr "显示模板\tCtrl-Shift-K"
 
-#: ../src/wxMaximaFrame.cpp:968
+#: ../src/wxMaximaFrame.cpp:967
 msgid "Show a tip"
 msgstr "显示提示"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Show all commands similar to:"
 msgstr "显示所有与其相似的命令："
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Show an example for the command:"
 msgstr "显示以下命令的示例："
 
-#: ../src/wxMaximaFrame.cpp:962
+#: ../src/wxMaximaFrame.cpp:961
 msgid "Show an example of usage"
 msgstr "显示用法示例"
 
-#: ../src/wxMaximaFrame.cpp:965
+#: ../src/wxMaximaFrame.cpp:964
 msgid "Show commands similar to"
 msgstr "显示与其相似的命令"
 
-#: ../src/wxMaximaFrame.cpp:661
+#: ../src/wxMaximaFrame.cpp:660
 msgid "Show defined functions"
 msgstr "显示已定义函数"
 
-#: ../src/wxMaximaFrame.cpp:666
+#: ../src/wxMaximaFrame.cpp:665
 msgid "Show defined variables"
 msgstr "显示已定义变量"
 
-#: ../src/wxMaximaFrame.cpp:663
+#: ../src/wxMaximaFrame.cpp:662
 msgid "Show definition of a function"
 msgstr "显示函数的定义"
 
-#: ../src/wxMaximaFrame.cpp:604
+#: ../src/wxMaximaFrame.cpp:603
 msgid "Show function template"
 msgstr "显示函数模板"
 
@@ -3650,7 +3653,7 @@ msgstr "在 wxMaxima 文档中显示长表达式"
 msgid "Show long expressions:"
 msgstr "显示长表达式"
 
-#: ../src/wxMaxima.cpp:3341
+#: ../src/wxMaxima.cpp:3353
 msgid "Show the definition of function:"
 msgstr "显示函数的定义"
 
@@ -3659,44 +3662,44 @@ msgstr "显示函数的定义"
 msgid "Show user-defined labels instead of (%oxx)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:953 ../src/wxMaximaFrame.cpp:956
+#: ../src/wxMaximaFrame.cpp:952 ../src/wxMaximaFrame.cpp:955
 #, fuzzy
 msgid "Show wxMaxima help"
 msgstr "显示 Maxima 帮助"
 
-#: ../src/wxMaximaFrame.cpp:1381
+#: ../src/wxMaximaFrame.cpp:1380
 msgid "Sigma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1211
+#: ../src/wxMaximaFrame.cpp:1210
 msgid "Simplify"
 msgstr "化简"
 
-#: ../src/wxMaximaFrame.cpp:831
+#: ../src/wxMaximaFrame.cpp:830
 msgid "Simplify &Radicals"
 msgstr "化简根式(&R)"
 
-#: ../src/wxMaximaFrame.cpp:1212
+#: ../src/wxMaximaFrame.cpp:1211
 msgid "Simplify (r)"
 msgstr "化简根式"
 
-#: ../src/wxMaximaFrame.cpp:1218
+#: ../src/wxMaximaFrame.cpp:1217
 msgid "Simplify (tr)"
 msgstr "化简三角函数"
 
-#: ../src/MathCtrl.cpp:995
+#: ../src/MathCtrl.cpp:1037
 msgid "Simplify Expression"
 msgstr "化简表达式"
 
-#: ../src/wxMaximaFrame.cpp:857
+#: ../src/wxMaximaFrame.cpp:856
 msgid "Simplify an expression containing factorials"
 msgstr "化简含有阶乘的表达式"
 
-#: ../src/wxMaximaFrame.cpp:832
+#: ../src/wxMaximaFrame.cpp:831
 msgid "Simplify expression containing radicals"
 msgstr "化简含有根式的表达式"
 
-#: ../src/wxMaximaFrame.cpp:830
+#: ../src/wxMaximaFrame.cpp:829
 msgid "Simplify rational expression"
 msgstr "化简有理式"
 
@@ -3704,7 +3707,7 @@ msgstr "化简有理式"
 msgid "Simplify the sum"
 msgstr "化简求和表达式"
 
-#: ../src/wxMaximaFrame.cpp:868
+#: ../src/wxMaximaFrame.cpp:867
 msgid "Simplify trigonometric expression"
 msgstr "化简三角表达式"
 
@@ -3718,87 +3721,87 @@ msgstr ""
 "自 wxMaxima 0.8.0 起您可以使用菜单命令“单元->插入图片...“在文档中插入图片。注"
 "意：如果您想让图片随文档一起保存，您必须将文档保存为 “wxMaxima XML 文档”。"
 
-#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
+#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
 msgid "Solution:"
 msgstr "解："
 
-#: ../src/wxMaxima.cpp:3461 ../src/wxMaxima.cpp:3475 ../src/wxMaxima.cpp:5020
+#: ../src/wxMaxima.cpp:3473 ../src/wxMaxima.cpp:3487 ../src/wxMaxima.cpp:5032
 msgid "Solve"
 msgstr "求解"
 
-#: ../src/wxMaximaFrame.cpp:706
+#: ../src/wxMaximaFrame.cpp:705
 msgid "Solve &Algebraic System..."
 msgstr "求解代数系统(&A)..."
 
-#: ../src/wxMaximaFrame.cpp:703
+#: ../src/wxMaximaFrame.cpp:702
 msgid "Solve &Linear System..."
 msgstr "求解线性系统(&L)..."
 
-#: ../src/wxMaximaFrame.cpp:714
+#: ../src/wxMaximaFrame.cpp:713
 msgid "Solve &ODE..."
 msgstr "求解常微分方程(&O)..."
 
-#: ../src/wxMaximaFrame.cpp:690
+#: ../src/wxMaximaFrame.cpp:689
 msgid "Solve (to_poly)..."
 msgstr "求解 (to_poly)..."
 
-#: ../src/wxMaxima.cpp:3511 ../src/wxMaxima.cpp:3635
+#: ../src/wxMaxima.cpp:3523 ../src/wxMaxima.cpp:3647
 msgid "Solve ODE"
 msgstr "求解常微分方程"
 
-#: ../src/wxMaximaFrame.cpp:728
+#: ../src/wxMaximaFrame.cpp:727
 msgid "Solve ODE with Lapla&ce..."
 msgstr "利用 Laplace 变换求解常微分方程(&C)..."
 
-#: ../src/wxMaximaFrame.cpp:1222
+#: ../src/wxMaximaFrame.cpp:1221
 msgid "Solve ODE..."
 msgstr "求解常微分方程..."
 
-#: ../src/wxMaxima.cpp:3586 ../src/wxMaxima.cpp:3597
+#: ../src/wxMaxima.cpp:3598 ../src/wxMaxima.cpp:3609
 msgid "Solve algebraic system"
 msgstr "求解代数系统"
 
-#: ../src/wxMaximaFrame.cpp:707
+#: ../src/wxMaximaFrame.cpp:706
 msgid "Solve algebraic system of equations"
 msgstr "求解代数程组"
 
-#: ../src/wxMaximaFrame.cpp:725
+#: ../src/wxMaximaFrame.cpp:724
 msgid "Solve boundary value problem for second degree ODE"
 msgstr "求解二阶常微分方程的边界值问题"
 
-#: ../src/wxMaximaFrame.cpp:689
+#: ../src/wxMaximaFrame.cpp:688
 msgid "Solve equation(s)"
 msgstr "求解方程"
 
-#: ../src/wxMaximaFrame.cpp:691
+#: ../src/wxMaximaFrame.cpp:690
 msgid "Solve equation(s) with to_poly_solve"
 msgstr "使用 to_poly_solve 求解方程"
 
-#: ../src/wxMaximaFrame.cpp:719
+#: ../src/wxMaximaFrame.cpp:718
 msgid "Solve initial value problem for first degree ODE"
 msgstr "求解一阶常微分方程的初始值问题"
 
-#: ../src/wxMaximaFrame.cpp:722
+#: ../src/wxMaximaFrame.cpp:721
 msgid "Solve initial value problem for second degree ODE"
 msgstr "求解二阶常微分方程的初始值问题"
 
-#: ../src/wxMaxima.cpp:3610 ../src/wxMaxima.cpp:3621
+#: ../src/wxMaxima.cpp:3622 ../src/wxMaxima.cpp:3633
 msgid "Solve linear system"
 msgstr "求解线性系统"
 
-#: ../src/wxMaximaFrame.cpp:704
+#: ../src/wxMaximaFrame.cpp:703
 msgid "Solve linear system of equations"
 msgstr "求解线性方程组"
 
-#: ../src/wxMaximaFrame.cpp:715
+#: ../src/wxMaximaFrame.cpp:714
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr "求解常微分方程（最大2阶）"
 
-#: ../src/wxMaximaFrame.cpp:729
+#: ../src/wxMaximaFrame.cpp:728
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr "利用 Laplace 变换求解常微分方程"
 
-#: ../src/wxMaximaFrame.cpp:1221 ../src/MathCtrl.cpp:992
+#: ../src/MathCtrl.cpp:1034 ../src/wxMaximaFrame.cpp:1220
 msgid "Solve..."
 msgstr "求解..."
 
@@ -3822,7 +3825,7 @@ msgstr "特殊"
 msgid "Special constants"
 msgstr "特殊常量"
 
-#: ../src/MathCtrl.cpp:922
+#: ../src/MathCtrl.cpp:964
 msgid "Start Animation"
 msgstr "开始动画"
 
@@ -3841,28 +3844,28 @@ msgstr ""
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:294
+#: ../src/wxMaxima.cpp:295
 msgid "Starting Maxima process failed"
 msgstr "启动 Maxima 进程失败"
 
-#: ../src/wxMaxima.cpp:928
+#: ../src/wxMaxima.cpp:933
 msgid "Starting Maxima..."
 msgstr "正在启动 Maxima..."
 
-#: ../src/wxMaxima.cpp:292 ../src/wxMaxima.cpp:860
+#: ../src/wxMaxima.cpp:293 ../src/wxMaxima.cpp:865
 msgid "Starting server failed"
 msgstr "启动服务器失败"
 
-#: ../src/wxMaxima.cpp:841
+#: ../src/wxMaxima.cpp:846
 #, c-format
 msgid "Starting server on port %d"
 msgstr "正在启动服务器，端口为 %d"
 
-#: ../src/wxMaximaFrame.cpp:342
+#: ../src/wxMaximaFrame.cpp:341
 msgid "Statistics"
 msgstr "统计"
 
-#: ../src/wxMaximaFrame.cpp:550
+#: ../src/wxMaximaFrame.cpp:549
 msgid "Statistics\tAlt-Shift-S"
 msgstr "统计\tAlt-Shift-S"
 
@@ -3878,11 +3881,11 @@ msgstr "样式"
 msgid "Styles"
 msgstr "样式"
 
-#: ../src/wxMaximaFrame.cpp:1283
+#: ../src/wxMaximaFrame.cpp:1282
 msgid "Subsample..."
 msgstr "子样本"
 
-#: ../src/wxMaximaFrame.cpp:1496
+#: ../src/wxMaximaFrame.cpp:1515
 msgid "Subsection"
 msgstr "小节"
 
@@ -3890,20 +3893,20 @@ msgstr "小节"
 msgid "Subsection cell"
 msgstr "小节单元"
 
-#: ../src/wxMaximaFrame.cpp:1216
+#: ../src/wxMaximaFrame.cpp:1215
 msgid "Subst..."
 msgstr "代换"
 
-#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3423
-#: ../src/wxMaxima.cpp:5089
+#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3435
+#: ../src/wxMaxima.cpp:5101
 msgid "Substitute"
 msgstr "代换"
 
-#: ../src/wxMaximaFrame.cpp:906 ../src/MathCtrl.cpp:998
+#: ../src/MathCtrl.cpp:1040 ../src/wxMaximaFrame.cpp:905
 msgid "Substitute..."
 msgstr "代换"
 
-#: ../src/wxMaximaFrame.cpp:1497
+#: ../src/wxMaximaFrame.cpp:1516
 #, fuzzy
 msgid "Subsubsection"
 msgstr "小节"
@@ -3913,7 +3916,7 @@ msgstr "小节"
 msgid "Subsubsection cell"
 msgstr "小节单元"
 
-#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4226
+#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4238
 msgid "Sum"
 msgstr "求和"
 
@@ -3921,37 +3924,37 @@ msgstr "求和"
 msgid "Sum sign"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:553
+#: ../src/wxMaximaFrame.cpp:552
 #, fuzzy
 msgid "Symbols\tAlt-Shift-Y"
 msgstr "统计\tAlt-Shift-S"
 
-#: ../src/wxMaxima.cpp:4456
+#: ../src/wxMaxima.cpp:4468
 msgid "System info"
 msgstr "系统信息"
 
-#: ../src/wxMaximaFrame.cpp:320
+#: ../src/wxMaximaFrame.cpp:319
 msgid "Table of Contents"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:556
+#: ../src/wxMaximaFrame.cpp:555
 #, fuzzy
 msgid "Table of Contents\tAlt-Shift-T"
 msgstr "工具栏\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:1382
+#: ../src/wxMaximaFrame.cpp:1381
 msgid "Tau"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Taylor series:"
 msgstr "泰勒级数："
 
-#: ../src/wxMaxima.cpp:3963
+#: ../src/wxMaxima.cpp:3975
 msgid "Tellrat"
 msgstr "Tellrat 函数"
 
-#: ../src/wxMaximaFrame.cpp:1494
+#: ../src/wxMaximaFrame.cpp:1513
 msgid "Text"
 msgstr "文本"
 
@@ -3997,7 +4000,7 @@ msgstr ""
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr ""
 
-#: ../src/TextCell.cpp:136
+#: ../src/TextCell.cpp:134
 msgid ""
 "The letter \"X\" is of width zero. Installing http://www.math.union.edu/"
 "~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts\" in "
@@ -4014,7 +4017,7 @@ msgstr ""
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:959
+#: ../src/wxMaximaFrame.cpp:958
 msgid "The offline manual of maxima"
 msgstr ""
 
@@ -4052,7 +4055,7 @@ msgstr ""
 "sourceforge.net/wiki/index.php/Tutorials 获得更多关于 wxMaxima 和 Maxima 的信"
 "息。"
 
-#: ../src/SlideShowCell.cpp:332
+#: ../src/SlideShowCell.cpp:336
 msgid ""
 "There was an error during GIF export!\n"
 "\n"
@@ -4062,7 +4065,7 @@ msgstr ""
 "\n"
 "确认 ImageMagick 已安装且 wxMaxima 能够找到 convert 程序。"
 
-#: ../src/wxMaxima.cpp:442
+#: ../src/wxMaxima.cpp:447
 msgid ""
 "There was an error in generated XML!\n"
 "\n"
@@ -4072,7 +4075,7 @@ msgstr ""
 "\n"
 "请报告这一错误。"
 
-#: ../src/wxMaximaFrame.cpp:1371
+#: ../src/wxMaximaFrame.cpp:1370
 msgid "Theta"
 msgstr ""
 
@@ -4080,7 +4083,7 @@ msgstr ""
 msgid "Ticks:"
 msgstr "坐标刻度："
 
-#: ../src/wxMaxima.cpp:4153 ../src/wxMaxima.cpp:5065
+#: ../src/wxMaxima.cpp:4165 ../src/wxMaxima.cpp:5077
 msgid "Times:"
 msgstr "微分次数："
 
@@ -4088,7 +4091,7 @@ msgstr "微分次数："
 msgid "Tips not available, sorry!"
 msgstr "对不起，没有提示!"
 
-#: ../src/wxMaximaFrame.cpp:1495
+#: ../src/wxMaximaFrame.cpp:1514
 msgid "Title"
 msgstr "标题"
 
@@ -4105,19 +4108,19 @@ msgstr ""
 "标题，节和小节单元可以折叠以隐藏其内容。点击紧邻单元的小方块可以折叠或展开单"
 "元，如果同时按下 Shift 键，此单元的所有下级单元也跟着折叠和展开。"
 
-#: ../src/wxMaximaFrame.cpp:938
+#: ../src/wxMaximaFrame.cpp:937
 msgid "To &Bigfloat"
 msgstr "转换成长浮点数(&B)"
 
-#: ../src/wxMaximaFrame.cpp:935
+#: ../src/wxMaximaFrame.cpp:934
 msgid "To &Float"
 msgstr "转换成浮点数(&F)"
 
-#: ../src/MathCtrl.cpp:990
+#: ../src/MathCtrl.cpp:1032
 msgid "To Float"
 msgstr "转换成浮点数"
 
-#: ../src/wxMaximaFrame.cpp:941
+#: ../src/wxMaximaFrame.cpp:940
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr ""
 
@@ -4155,51 +4158,51 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:41 ../src/Plot2dWiz.cpp:40 ../src/Plot2dWiz.cpp:50
 #: ../src/Plot2dWiz.cpp:539 ../src/Plot3dWiz.cpp:39 ../src/Plot3dWiz.cpp:48
-#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4241
+#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4253
 msgid "To:"
 msgstr "到："
 
-#: ../src/wxMaximaFrame.cpp:912
+#: ../src/wxMaximaFrame.cpp:911
 msgid "Toggle &Algebraic Flag"
 msgstr "打开代数标志(&A)"
 
-#: ../src/wxMaximaFrame.cpp:933
+#: ../src/wxMaximaFrame.cpp:932
 msgid "Toggle &Numeric Output"
 msgstr "代开数值输出(&N)"
 
-#: ../src/wxMaximaFrame.cpp:673
+#: ../src/wxMaximaFrame.cpp:672
 msgid "Toggle &Time Display"
 msgstr "打开时间显示(&T)"
 
-#: ../src/wxMaximaFrame.cpp:913
+#: ../src/wxMaximaFrame.cpp:912
 msgid "Toggle algebraic flag"
 msgstr "打开代数标志"
 
-#: ../src/wxMaximaFrame.cpp:577
+#: ../src/wxMaximaFrame.cpp:576
 msgid "Toggle full screen editing"
 msgstr "打开全屏编辑"
 
-#: ../src/wxMaximaFrame.cpp:934
+#: ../src/wxMaximaFrame.cpp:933
 msgid "Toggle numeric output"
 msgstr "打开数值输出"
 
-#: ../src/wxMaxima.cpp:4464
+#: ../src/wxMaxima.cpp:4476
 msgid "Toolbar icons"
 msgstr "工具栏图标"
 
-#: ../src/wxMaxima.cpp:4465
+#: ../src/wxMaxima.cpp:4477
 msgid "Translated by"
 msgstr "翻译人员："
 
-#: ../src/wxMaximaFrame.cpp:763
+#: ../src/wxMaximaFrame.cpp:762
 msgid "Transpose a matrix"
 msgstr "转置矩阵"
 
-#: ../src/MathCtrl.cpp:5834
+#: ../src/MathCtrl.cpp:5886
 msgid "Trying to undo an action without starting cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5901
+#: ../src/MathCtrl.cpp:5953
 msgid "Trying to undo something but the undo action is empty."
 msgstr ""
 
@@ -4207,11 +4210,11 @@ msgstr ""
 msgid "Turkish"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:970
+#: ../src/wxMaximaFrame.cpp:969
 msgid "Tutorials"
 msgstr "教程"
 
-#: ../src/wxMaxima.cpp:4778
+#: ../src/wxMaxima.cpp:4790
 msgid "Two sample t-test"
 msgstr "双样本 t-检验"
 
@@ -4223,15 +4226,15 @@ msgstr "类型："
 msgid "Ukrainian"
 msgstr "乌克兰语"
 
-#: ../src/wxMaxima.cpp:5356
+#: ../src/wxMaxima.cpp:5372
 msgid "Un-closed parenthesis"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5323
+#: ../src/wxMaxima.cpp:5335
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5889
 msgid ""
 "Unable to interpret the version info I got from http://andrejv.github.io//"
 "wxmaxima/version.txt: "
@@ -4245,11 +4248,11 @@ msgstr "下划线"
 msgid "Underscore converts to subscripts:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:492
+#: ../src/wxMaximaFrame.cpp:491
 msgid "Undo\tCtrl-Z"
 msgstr "撤销\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:493
+#: ../src/wxMaximaFrame.cpp:492
 msgid "Undo last change"
 msgstr "撤销上一次更改"
 
@@ -4257,23 +4260,23 @@ msgstr "撤销上一次更改"
 msgid "Undo limit (0 for none):"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:625
+#: ../src/wxMaximaFrame.cpp:624
 msgid "Unfold All\tCtrl-Alt-]"
 msgstr "展开全部\tCtrl-Alt-]"
 
-#: ../src/wxMaximaFrame.cpp:626
+#: ../src/wxMaximaFrame.cpp:625
 msgid "Unfold all folded sections"
 msgstr "展开所有已折叠节单元"
 
-#: ../src/wxMaxima.cpp:4458
+#: ../src/wxMaxima.cpp:4470
 msgid "Unicode Support"
 msgstr "Unicode 支持"
 
-#: ../src/wxMaxima.cpp:5335
+#: ../src/wxMaxima.cpp:5347
 msgid "Unterminated comment."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5309
+#: ../src/wxMaxima.cpp:5321
 msgid "Unterminated string."
 msgstr ""
 
@@ -4281,15 +4284,15 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5859 ../src/wxMaxima.cpp:5866 ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5874 ../src/wxMaxima.cpp:5881 ../src/wxMaxima.cpp:5889
 msgid "Upgrade"
 msgstr "升级"
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Upper bound:"
 msgstr "上限："
 
-#: ../src/wxMaximaFrame.cpp:1383
+#: ../src/wxMaximaFrame.cpp:1382
 #, fuzzy
 msgid "Upsilon"
 msgstr "Epsilon："
@@ -4334,22 +4337,22 @@ msgstr ""
 msgid "User-defined labels"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3525
-#: ../src/wxMaxima.cpp:3541 ../src/wxMaxima.cpp:3649
+#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3537
+#: ../src/wxMaxima.cpp:3553 ../src/wxMaxima.cpp:3661
 msgid "Value:"
 msgstr "值："
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:5019 ../src/wxMaxima.cpp:5064
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:5031 ../src/wxMaxima.cpp:5076
 msgid "Variable(s):"
 msgstr "变量："
 
 #: ../src/IntegrateWiz.cpp:33 ../src/LimitWiz.cpp:30 ../src/Plot2dWiz.cpp:34
 #: ../src/Plot2dWiz.cpp:44 ../src/Plot2dWiz.cpp:533 ../src/Plot3dWiz.cpp:33
 #: ../src/Plot3dWiz.cpp:42 ../src/SeriesWiz.cpp:36 ../src/SumWiz.cpp:30
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3749
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3761
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5045
 msgid "Variable:"
 msgstr "变量："
 
@@ -4357,25 +4360,25 @@ msgstr "变量："
 msgid "Variables"
 msgstr "变量"
 
-#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3571 ../src/wxMaxima.cpp:4206
-#: ../src/wxMaxima.cpp:4807
+#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3583 ../src/wxMaxima.cpp:4218
+#: ../src/wxMaxima.cpp:4819
 msgid "Variables:"
 msgstr "变量："
 
-#: ../src/wxMaximaFrame.cpp:1257
+#: ../src/wxMaximaFrame.cpp:1256
 msgid "Variance..."
 msgstr "方差..."
 
-#: ../src/wxMaximaFrame.cpp:580
+#: ../src/wxMaximaFrame.cpp:579
 msgid "View"
 msgstr ""
 
-#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1674 ../src/wxMaxima.cpp:1769
-#: ../src/wxMaxima.cpp:1950
+#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1679 ../src/wxMaxima.cpp:1774
+#: ../src/wxMaxima.cpp:1955
 msgid "Warning"
 msgstr "警告"
 
-#: ../src/wxMaximaFrame.cpp:109 ../src/wxMaximaFrame.cpp:295
+#: ../src/wxMaximaFrame.cpp:108 ../src/wxMaximaFrame.cpp:294
 msgid "Welcome to wxMaxima"
 msgstr "欢迎使用 wxMaxima"
 
@@ -4397,7 +4400,7 @@ msgid ""
 "introducing an empty line."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2567
+#: ../src/wxMaxima.cpp:2574
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) "
 "(*.wxm)|*.wxm"
@@ -4413,7 +4416,7 @@ msgid ""
 "as equation markers"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6798
+#: ../src/MathCtrl.cpp:6856
 msgid "Wrapped search"
 msgstr ""
 
@@ -4421,15 +4424,15 @@ msgstr ""
 msgid "Write matching parenthesis in text controls."
 msgstr "在文本控件中输入时插入匹配的括号。"
 
-#: ../src/wxMaxima.cpp:4461
+#: ../src/wxMaxima.cpp:4473
 msgid "Written by"
 msgstr "作者："
 
-#: ../src/wxMaximaFrame.cpp:557
+#: ../src/wxMaximaFrame.cpp:556
 msgid "XML Inspector"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1377
+#: ../src/wxMaximaFrame.cpp:1376
 msgid "Xi"
 msgstr ""
 
@@ -4493,7 +4496,7 @@ msgstr ""
 "移动光标”）选择多个单元，然后对其进行操作。这在您想删除或对多个单元求值时很有"
 "用。"
 
-#: ../src/wxMaxima.cpp:5856
+#: ../src/wxMaxima.cpp:5871
 #, c-format
 msgid ""
 "You have version %s. Current version is %s.\n"
@@ -4504,41 +4507,41 @@ msgstr ""
 "\n"
 "按“确认”后，会访问 wxMaxima 网页。"
 
-#: ../src/wxMaxima.cpp:5921
+#: ../src/wxMaxima.cpp:5936
 msgid "Your changes will be lost if you don't save them."
 msgstr "如果您未保存，您的所有更改将会丢掉。"
 
-#: ../src/wxMaxima.cpp:5866
+#: ../src/wxMaxima.cpp:5881
 msgid "Your version of wxMaxima is up to date."
 msgstr "您的 wxMaxima 版本是最新版本。"
 
-#: ../src/wxMaximaFrame.cpp:1369
+#: ../src/wxMaximaFrame.cpp:1368
 msgid "Zeta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:562
+#: ../src/wxMaximaFrame.cpp:561
 #, fuzzy
 msgid "Zoom &In\tCtrl-+"
 msgstr "放大(&I)\tAlt-I"
 
-#: ../src/wxMaximaFrame.cpp:564
+#: ../src/wxMaximaFrame.cpp:563
 #, fuzzy
 msgid "Zoom Ou&t\tCtrl--"
 msgstr "缩小(&T)\tAlt-O"
 
-#: ../src/wxMaximaFrame.cpp:563
+#: ../src/wxMaximaFrame.cpp:562
 msgid "Zoom in 10%"
 msgstr "将显示比例放大10%"
 
-#: ../src/wxMaximaFrame.cpp:565
+#: ../src/wxMaximaFrame.cpp:564
 msgid "Zoom out 10%"
 msgstr "将显示比例缩小10%"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaximaFrame.cpp:287
 msgid "[ unsaved ]"
 msgstr "未保存"
 
-#: ../src/wxMaxima.cpp:5700
+#: ../src/wxMaxima.cpp:5715
 msgid "[ unsaved* ]"
 msgstr "未保存*"
 
@@ -4547,17 +4550,17 @@ msgstr "未保存*"
 msgid "[%i digits]"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4392
+#: ../src/MathCtrl.cpp:4447
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" style=\"max-width:90%%;\" >\n"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4517
+#: ../src/MathCtrl.cpp:4572
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" >"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1333
+#: ../src/wxMaximaFrame.cpp:1332
 msgid "alpha"
 msgstr ""
 
@@ -4570,7 +4573,7 @@ msgstr "展开"
 msgid "antisymmetric"
 msgstr "非对称"
 
-#: ../src/wxMaximaFrame.cpp:1334
+#: ../src/wxMaximaFrame.cpp:1333
 msgid "beta"
 msgstr ""
 
@@ -4614,7 +4617,7 @@ msgstr ""
 msgid "bug:Invalid sup tag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1354
+#: ../src/wxMaximaFrame.cpp:1353
 msgid "chi"
 msgstr ""
 
@@ -4627,7 +4630,7 @@ msgstr ""
 msgid "default"
 msgstr "默认"
 
-#: ../src/wxMaximaFrame.cpp:1336
+#: ../src/wxMaximaFrame.cpp:1335
 msgid "delta"
 msgstr ""
 
@@ -4639,7 +4642,7 @@ msgstr "对角"
 msgid "empty"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1337
+#: ../src/wxMaximaFrame.cpp:1336
 #, fuzzy
 msgid "epsilon"
 msgstr "Epsilon："
@@ -4648,7 +4651,7 @@ msgstr "Epsilon："
 msgid "equivalent"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1339
+#: ../src/wxMaximaFrame.cpp:1338
 msgid "eta"
 msgstr ""
 
@@ -4664,7 +4667,7 @@ msgid ""
 "all=_ marks subscripts."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1335
+#: ../src/wxMaximaFrame.cpp:1334
 msgid "gamma"
 msgstr ""
 
@@ -4693,15 +4696,15 @@ msgstr "inline"
 msgid "intersection"
 msgstr "方向："
 
-#: ../src/wxMaximaFrame.cpp:1341
+#: ../src/wxMaximaFrame.cpp:1340
 msgid "iota"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1342
+#: ../src/wxMaximaFrame.cpp:1341
 msgid "kappa"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1343
+#: ../src/wxMaximaFrame.cpp:1342
 msgid "lambda"
 msgstr ""
 
@@ -4718,7 +4721,7 @@ msgstr "小节单元"
 msgid "logscale"
 msgstr "对数尺度"
 
-#: ../src/wxMaxima.cpp:3783
+#: ../src/wxMaxima.cpp:3795
 msgid "matrix[i,j]:"
 msgstr "矩阵[i,j]："
 
@@ -4726,7 +4729,7 @@ msgstr "矩阵[i,j]："
 msgid "maxima's pwd is path to document"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1344
+#: ../src/wxMaximaFrame.cpp:1343
 msgid "mu"
 msgstr ""
 
@@ -4743,7 +4746,7 @@ msgstr ""
 msgid "nand"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4524
+#: ../src/wxMaxima.cpp:4536
 msgid "no"
 msgstr "否"
 
@@ -4769,15 +4772,15 @@ msgstr ""
 msgid "not subset or equal"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1345
+#: ../src/wxMaximaFrame.cpp:1344
 msgid "nu"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1356
+#: ../src/wxMaximaFrame.cpp:1355
 msgid "omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1347
+#: ../src/wxMaximaFrame.cpp:1346
 msgid "omicron"
 msgstr ""
 
@@ -4790,11 +4793,11 @@ msgstr ""
 msgid "partial sign"
 msgstr "部分分式"
 
-#: ../src/wxMaximaFrame.cpp:1353
+#: ../src/wxMaximaFrame.cpp:1352
 msgid "phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1348
+#: ../src/wxMaximaFrame.cpp:1347
 msgid "pi"
 msgstr ""
 
@@ -4806,11 +4809,11 @@ msgstr ""
 msgid "proportional to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1355
+#: ../src/wxMaximaFrame.cpp:1354
 msgid "psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1349
+#: ../src/wxMaximaFrame.cpp:1348
 msgid "rho"
 msgstr ""
 
@@ -4818,7 +4821,7 @@ msgstr ""
 msgid "right"
 msgstr "右"
 
-#: ../src/wxMaximaFrame.cpp:1350
+#: ../src/wxMaximaFrame.cpp:1349
 msgid "sigma"
 msgstr ""
 
@@ -4840,7 +4843,7 @@ msgstr "小节单元"
 msgid "symmetric"
 msgstr "对称"
 
-#: ../src/wxMaximaFrame.cpp:1351
+#: ../src/wxMaximaFrame.cpp:1350
 msgid "tau"
 msgstr ""
 
@@ -4852,7 +4855,7 @@ msgstr ""
 msgid "there is no"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1340
+#: ../src/wxMaximaFrame.cpp:1339
 msgid "theta"
 msgstr ""
 
@@ -4868,12 +4871,12 @@ msgstr ""
 msgid "union"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5903
+#: ../src/wxMaxima.cpp:5918
 msgid "unsaved"
 msgstr "未保存"
 
-#: ../src/wxMaximaFrame.cpp:290 ../src/wxMaxima.cpp:2559
-#: ../src/wxMaxima.cpp:2826
+#: ../src/wxMaxima.cpp:2566 ../src/wxMaxima.cpp:2834
+#: ../src/wxMaximaFrame.cpp:289
 msgid "untitled"
 msgstr "未命名"
 
@@ -4882,27 +4885,27 @@ msgstr "未命名"
 msgid "untitled %d"
 msgstr "未命名 %d"
 
-#: ../src/wxMaximaFrame.cpp:1352
+#: ../src/wxMaximaFrame.cpp:1351
 #, fuzzy
 msgid "upsilon"
 msgstr "Epsilon："
 
-#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4538
+#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4550
 msgid "wxMaxima"
 msgstr "wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
-#: ../src/wxMaxima.cpp:5700 ../src/wxMaxima.cpp:5709 ../src/wxMaxima.cpp:5712
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaxima.cpp:5715 ../src/wxMaxima.cpp:5724
+#: ../src/wxMaxima.cpp:5727 ../src/wxMaximaFrame.cpp:287
 #, c-format
 msgid "wxMaxima %s "
 msgstr "wxMaxima %s "
 
-#: ../src/wxMaximaFrame.cpp:952
+#: ../src/wxMaximaFrame.cpp:951
 #, fuzzy
 msgid "wxMaxima &Help\tCtrl+?"
 msgstr "Maxima 帮助(&H)\tCtrl+?"
 
-#: ../src/wxMaximaFrame.cpp:955
+#: ../src/wxMaximaFrame.cpp:954
 #, fuzzy
 msgid "wxMaxima &Help\tF1"
 msgstr "Maxima 帮助\tF1"
@@ -4914,11 +4917,11 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1619
+#: ../src/wxMaxima.cpp:1624
 msgid "wxMaxima cannot open content.xml in the .wxmx zip archive "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1633
+#: ../src/wxMaxima.cpp:1638
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
@@ -4926,7 +4929,7 @@ msgstr ""
 msgid "wxMaxima configuration"
 msgstr "wxMaxima 配置"
 
-#: ../src/wxMaxima.cpp:1947
+#: ../src/wxMaxima.cpp:1952
 msgid ""
 "wxMaxima could not find Maxima!\n"
 "\n"
@@ -4938,7 +4941,7 @@ msgstr ""
 "请通过“编辑->配置”来配置 wxMaxima。\n"
 "然后执行“Maxima->重启 Maxima”来启动 Maxima。"
 
-#: ../src/wxMaxima.cpp:2204
+#: ../src/wxMaxima.cpp:2209
 msgid ""
 "wxMaxima could not find help files.\n"
 "\n"
@@ -4948,7 +4951,7 @@ msgstr ""
 "\n"
 "请检查您的安装是否完整。"
 
-#: ../src/wxMaxima.cpp:2032
+#: ../src/wxMaxima.cpp:2037
 msgid ""
 "wxMaxima could not find tip files.\n"
 "\n"
@@ -4958,7 +4961,7 @@ msgstr ""
 "\n"
 "请检查您的安装是否完整。"
 
-#: ../src/wxMaxima.cpp:282
+#: ../src/wxMaxima.cpp:283
 msgid ""
 "wxMaxima could not start the server.\n"
 "\n"
@@ -4978,29 +4981,29 @@ msgstr ""
 "wxMaxima 对话框设定了其内各种输入框的默认值，其中一种是”%“。如果您在文档已有"
 "选中区域，所选内容将替代”%“。"
 
-#: ../src/wxMaxima.cpp:2330
+#: ../src/wxMaxima.cpp:2336
 msgid "wxMaxima document"
 msgstr "wxMaxima 文档"
 
-#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2799
+#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2807
 msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 msgstr "wxMaxima 文档 (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 
-#: ../src/wxMaxima.cpp:1455 ../src/wxMaxima.cpp:1469
+#: ../src/wxMaxima.cpp:1460 ../src/wxMaxima.cpp:1474
 msgid "wxMaxima encountered an error loading "
 msgstr "wxMaxima 在载入下列文件时出现错误："
 
-#: ../src/wxMaxima.cpp:4463
+#: ../src/wxMaxima.cpp:4475
 msgid "wxMaxima icon"
 msgstr "wxMaxima 图标"
 
-#: ../src/wxMaxima.cpp:4455
+#: ../src/wxMaxima.cpp:4467
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "MAXIMA based on wxWidgets."
 msgstr "wxMaxima 是计算机代数系统 Maxima 的图形用户界面，基于 wxWidgets。"
 
-#: ../src/wxMaxima.cpp:4516
+#: ../src/wxMaxima.cpp:4528
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "Maxima based on wxWidgets."
@@ -5018,11 +5021,11 @@ msgstr ""
 msgid "x"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1346
+#: ../src/wxMaximaFrame.cpp:1345
 msgid "xi"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1643
+#: ../src/wxMaxima.cpp:1648
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
@@ -5031,11 +5034,11 @@ msgstr ""
 msgid "xor"
 msgstr "导出"
 
-#: ../src/wxMaxima.cpp:4522
+#: ../src/wxMaxima.cpp:4534
 msgid "yes"
 msgstr "是"
 
-#: ../src/wxMaximaFrame.cpp:1338
+#: ../src/wxMaximaFrame.cpp:1337
 msgid "zeta"
 msgstr ""
 

--- a/locales/zh_TW.po
+++ b/locales/zh_TW.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wxMaxima 0.8.6\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-07 21:42+0200\n"
+"POT-Creation-Date: 2016-10-16 17:47+0900\n"
 "PO-Revision-Date: 2012-03-14 10:23+0800\n"
 "Last-Translator: cw.ahbong <cwahbong@users.sourceforge.net>\n"
 "Language-Team: American English <kde-i18n-doc@kde.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "X-Generator: Lokalize 1.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../src/wxMaxima.cpp:4519
+#: ../src/wxMaxima.cpp:4531
 #, c-format
 msgid ""
 "\n"
@@ -31,7 +31,7 @@ msgstr ""
 "wxWidgets 版本：%d.%d.%d\n"
 "支援 Unicode：%s"
 
-#: ../src/wxMaxima.cpp:4532
+#: ../src/wxMaxima.cpp:4544
 msgid ""
 "\n"
 "Lisp: "
@@ -39,7 +39,7 @@ msgstr ""
 "\n"
 "Lisp 版本："
 
-#: ../src/wxMaxima.cpp:4528
+#: ../src/wxMaxima.cpp:4540
 msgid ""
 "\n"
 "Maxima version: "
@@ -47,7 +47,7 @@ msgstr ""
 "\n"
 "Maxima 版本："
 
-#: ../src/wxMaxima.cpp:5381
+#: ../src/wxMaxima.cpp:5397
 msgid ""
 "\n"
 "Not connected to Maxima!\n"
@@ -55,7 +55,7 @@ msgstr ""
 "\n"
 "未連線到 Maxima！\n"
 
-#: ../src/wxMaxima.cpp:4530
+#: ../src/wxMaxima.cpp:4542
 msgid ""
 "\n"
 "Not connected."
@@ -75,7 +75,7 @@ msgstr ""
 msgid " (Graphics) "
 msgstr ""
 
-#: ../src/EditorCell.cpp:3045 ../src/EditorCell.cpp:3227
+#: ../src/EditorCell.cpp:3088 ../src/EditorCell.cpp:3270
 #, c-format
 msgid " ... + %i hidden lines"
 msgstr ""
@@ -84,14 +84,14 @@ msgstr ""
 msgid " << Expression longer than allowed by the configuration setting! >>"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1673
+#: ../src/wxMaxima.cpp:1678
 msgid ""
 " was saved using a newer version of wxMaxima so it may not load correctly. "
 "Please update your wxMaxima."
 msgstr ""
 " 是以新版的 wxMaxima 儲存，所以可能無法正確的讀取。請更新您的 wxMaxima。"
 
-#: ../src/wxMaxima.cpp:1665
+#: ../src/wxMaxima.cpp:1670
 msgid ""
 " was saved using a newer version of wxMaxima. Please update your wxMaxima."
 msgstr " 是以新版的 wxMaxima 儲存，請更新您的 wxMaxima 。"
@@ -104,64 +104,64 @@ msgstr ""
 msgid "\"implies\" symbol"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:101
+#: ../src/wxMaximaFrame.cpp:100
 #, c-format
 msgid "%i cells in evaluation queue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:773
+#: ../src/wxMaximaFrame.cpp:772
 msgid "&Algebra"
 msgstr "代數(&A)"
 
-#: ../src/wxMaximaFrame.cpp:767
+#: ../src/wxMaximaFrame.cpp:766
 msgid "&Apply to List..."
 msgstr "套用函數至串列(&A)..."
 
-#: ../src/wxMaximaFrame.cpp:964
+#: ../src/wxMaximaFrame.cpp:963
 msgid "&Apropos..."
 msgstr "Apropos 指令(&A)..."
 
-#: ../src/wxMaximaFrame.cpp:478
+#: ../src/wxMaximaFrame.cpp:477
 msgid "&Batch File...\tCtrl-B"
 msgstr "以批次檔載入(&B)...\tCtrl-B"
 
-#: ../src/wxMaximaFrame.cpp:724
+#: ../src/wxMaximaFrame.cpp:723
 msgid "&Boundary Value Problem..."
 msgstr "邊界值問題(&B)..."
 
-#: ../src/wxMaximaFrame.cpp:975
+#: ../src/wxMaximaFrame.cpp:974
 msgid "&Bug Report"
 msgstr "錯誤回報(&B)"
 
-#: ../src/wxMaximaFrame.cpp:825
+#: ../src/wxMaximaFrame.cpp:824
 msgid "&Calculus"
 msgstr "微積分(&C)"
 
-#: ../src/wxMaximaFrame.cpp:876
+#: ../src/wxMaximaFrame.cpp:875
 msgid "&Canonical Form"
 msgstr "標準形式(&C)"
 
-#: ../src/wxMaximaFrame.cpp:749
+#: ../src/wxMaximaFrame.cpp:748
 msgid "&Characteristic Polynomial..."
 msgstr "特徵多項式(&C)..."
 
-#: ../src/wxMaximaFrame.cpp:654
+#: ../src/wxMaximaFrame.cpp:653
 msgid "&Clear Memory"
 msgstr "清除記憶體(&C)"
 
-#: ../src/wxMaximaFrame.cpp:859
+#: ../src/wxMaximaFrame.cpp:858
 msgid "&Combine Factorials"
 msgstr "合併階乘(&C)"
 
-#: ../src/wxMaximaFrame.cpp:902
+#: ../src/wxMaximaFrame.cpp:901
 msgid "&Complex Simplification"
 msgstr "複數化簡(&C)"
 
-#: ../src/wxMaximaFrame.cpp:822
+#: ../src/wxMaximaFrame.cpp:821
 msgid "&Continued Fraction"
 msgstr "連分數(&C)"
 
-#: ../src/wxMaximaFrame.cpp:502
+#: ../src/wxMaximaFrame.cpp:501
 msgid "&Copy\tCtrl-C"
 msgstr "複製(&C)\tCtrl-C"
 
@@ -169,109 +169,109 @@ msgstr "複製(&C)\tCtrl-C"
 msgid "&Definite integration"
 msgstr "定積分(&D)"
 
-#: ../src/wxMaximaFrame.cpp:896
+#: ../src/wxMaximaFrame.cpp:895
 msgid "&Demoivre"
 msgstr "Demoivre(&D)"
 
-#: ../src/wxMaximaFrame.cpp:752
+#: ../src/wxMaximaFrame.cpp:751
 msgid "&Determinant"
 msgstr "行列式(&D)"
 
-#: ../src/wxMaximaFrame.cpp:785
+#: ../src/wxMaximaFrame.cpp:784
 msgid "&Differentiate..."
 msgstr "微分(&D)..."
 
-#: ../src/wxMaximaFrame.cpp:543
+#: ../src/wxMaximaFrame.cpp:542
 msgid "&Edit"
 msgstr "編輯(&E)"
 
-#: ../src/wxMaximaFrame.cpp:709
+#: ../src/wxMaximaFrame.cpp:708
 msgid "&Eliminate Variable..."
 msgstr "消去變數(&E)..."
 
-#: ../src/wxMaximaFrame.cpp:744
+#: ../src/wxMaximaFrame.cpp:743
 msgid "&Enter Matrix..."
 msgstr "輸入矩陣(&E)..."
 
-#: ../src/wxMaximaFrame.cpp:961
+#: ../src/wxMaximaFrame.cpp:960
 msgid "&Example..."
 msgstr "範例(&E)..."
 
-#: ../src/wxMaximaFrame.cpp:839
+#: ../src/wxMaximaFrame.cpp:838
 msgid "&Expand Expression"
 msgstr "展開數式(&E)"
 
-#: ../src/wxMaximaFrame.cpp:873
+#: ../src/wxMaximaFrame.cpp:872
 msgid "&Expand Trigonometric"
 msgstr "展開三角函數(&E)"
 
-#: ../src/wxMaximaFrame.cpp:899
+#: ../src/wxMaximaFrame.cpp:898
 msgid "&Exponentialize"
 msgstr "指數化(&E)"
 
-#: ../src/wxMaximaFrame.cpp:480
+#: ../src/wxMaximaFrame.cpp:479
 msgid "&Export..."
 msgstr "匯出(&E)..."
 
-#: ../src/wxMaximaFrame.cpp:834
+#: ../src/wxMaximaFrame.cpp:833
 msgid "&Factor Expression"
 msgstr "因式分解數式(&F)"
 
-#: ../src/wxMaximaFrame.cpp:489
+#: ../src/wxMaximaFrame.cpp:488
 msgid "&File"
 msgstr "檔案(&F)"
 
-#: ../src/wxMaximaFrame.cpp:692
+#: ../src/wxMaximaFrame.cpp:691
 msgid "&Find Root..."
 msgstr "找根(&F)..."
 
-#: ../src/wxMaximaFrame.cpp:738
+#: ../src/wxMaximaFrame.cpp:737
 msgid "&Generate Matrix..."
 msgstr "產生矩陣(&G)..."
 
-#: ../src/wxMaximaFrame.cpp:809
+#: ../src/wxMaximaFrame.cpp:808
 msgid "&Greatest Common Divisor..."
 msgstr "最大公因式(&G)..."
 
-#: ../src/wxMaximaFrame.cpp:994
+#: ../src/wxMaximaFrame.cpp:993
 msgid "&Help"
 msgstr "說明(&H)"
 
-#: ../src/wxMaximaFrame.cpp:777
+#: ../src/wxMaximaFrame.cpp:776
 msgid "&Integrate..."
 msgstr "積分(&I)..."
 
-#: ../src/wxMaximaFrame.cpp:645
+#: ../src/wxMaximaFrame.cpp:644
 msgid "&Interrupt\tCtrl-."
 msgstr "中斷(&I)\tCtrl-."
 
-#: ../src/wxMaximaFrame.cpp:649
+#: ../src/wxMaximaFrame.cpp:648
 msgid "&Interrupt\tCtrl-G"
 msgstr "中斷(&I)\tCtrl-G"
 
-#: ../src/wxMaximaFrame.cpp:746
+#: ../src/wxMaximaFrame.cpp:745
 msgid "&Invert Matrix"
 msgstr "反矩陣(&I)"
 
-#: ../src/wxMaximaFrame.cpp:476
+#: ../src/wxMaximaFrame.cpp:475
 msgid "&Load Package...\tCtrl-L"
 msgstr "載入 Package(&L)...\tCtrl-L"
 
-#: ../src/wxMaximaFrame.cpp:769
+#: ../src/wxMaximaFrame.cpp:768
 #, fuzzy
 msgid "&Map to List(s)..."
 msgstr "映射至整個串列(&M)..."
 
-#: ../src/wxMaximaFrame.cpp:684
+#: ../src/wxMaximaFrame.cpp:683
 msgid "&Maxima"
 msgstr "Maxima(&M)"
 
-#: ../src/wxMaximaFrame.cpp:958
+#: ../src/wxMaximaFrame.cpp:957
 #, fuzzy
 msgid "&Maxima help"
 msgstr "顯示 Maxima 說明"
 
-#: ../src/wxMaximaFrame.cpp:917
+#: ../src/wxMaximaFrame.cpp:916
 msgid "&Modulus Computation..."
 msgstr "設定模運算(&M)..."
 
@@ -279,7 +279,7 @@ msgstr "設定模運算(&M)..."
 msgid "&New\tCtrl-N"
 msgstr "新增(&N)\tCtrl-N"
 
-#: ../src/wxMaximaFrame.cpp:947
+#: ../src/wxMaximaFrame.cpp:946
 msgid "&Numeric"
 msgstr "數值(&N)"
 
@@ -295,11 +295,11 @@ msgstr "使用 Nusum(&N)"
 msgid "&Open\tCtrl-O"
 msgstr "開啟(&O)\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:463
+#: ../src/wxMaximaFrame.cpp:462
 msgid "&Open...\tCtrl-O"
 msgstr "開啟(&O)...\tCtrl-O"
 
-#: ../src/wxMaximaFrame.cpp:929
+#: ../src/wxMaximaFrame.cpp:928
 msgid "&Plot"
 msgstr "繪圖(&P)"
 
@@ -307,7 +307,7 @@ msgstr "繪圖(&P)"
 msgid "&Power series"
 msgstr "冪級數(&P)"
 
-#: ../src/wxMaximaFrame.cpp:483
+#: ../src/wxMaximaFrame.cpp:482
 msgid "&Print...\tCtrl-P"
 msgstr "列印(&P)...\tCtrl-P"
 
@@ -315,39 +315,39 @@ msgstr "列印(&P)...\tCtrl-P"
 msgid "&Rational"
 msgstr "有理式(&R)"
 
-#: ../src/wxMaximaFrame.cpp:870
+#: ../src/wxMaximaFrame.cpp:869
 msgid "&Reduce Trigonometric"
 msgstr "縮併三角函數(&R)"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "&Restart Maxima"
 msgstr "重新啟動 Maxima(&R)"
 
-#: ../src/wxMaximaFrame.cpp:700
+#: ../src/wxMaximaFrame.cpp:699
 msgid "&Roots of Polynomial (Real)"
 msgstr "找多項式所有的根(實數) (&R)"
 
-#: ../src/wxMaximaFrame.cpp:472
+#: ../src/wxMaximaFrame.cpp:471
 msgid "&Save\tCtrl-S"
 msgstr "儲存(&S)\tCtrl-S"
 
-#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:919
+#: ../src/SumWiz.cpp:39 ../src/wxMaximaFrame.cpp:918
 msgid "&Simplify"
 msgstr "化簡(&S)"
 
-#: ../src/wxMaximaFrame.cpp:829
+#: ../src/wxMaximaFrame.cpp:828
 msgid "&Simplify Expression"
 msgstr "化簡數式(&S)"
 
-#: ../src/wxMaximaFrame.cpp:856
+#: ../src/wxMaximaFrame.cpp:855
 msgid "&Simplify Factorials"
 msgstr "化簡階乘(&S)"
 
-#: ../src/wxMaximaFrame.cpp:867
+#: ../src/wxMaximaFrame.cpp:866
 msgid "&Simplify Trigonometric"
 msgstr "化簡三角函數(&S)"
 
-#: ../src/wxMaximaFrame.cpp:688
+#: ../src/wxMaximaFrame.cpp:687
 msgid "&Solve..."
 msgstr "求解(&S)..."
 
@@ -359,11 +359,11 @@ msgstr "特殊(&S)"
 msgid "&Taylor series"
 msgstr "Taylor 級數(&T)"
 
-#: ../src/wxMaximaFrame.cpp:762
+#: ../src/wxMaximaFrame.cpp:761
 msgid "&Transpose Matrix"
 msgstr "轉置矩陣(&T)"
 
-#: ../src/wxMaximaFrame.cpp:879
+#: ../src/wxMaximaFrame.cpp:878
 msgid "&Trigonometric Simplification"
 msgstr "三角化簡(&T)"
 
@@ -381,7 +381,7 @@ msgstr "( 使用預設語言 )"
 msgid "- Infinity"
 msgstr "負無限大"
 
-#: ../src/wxMaxima.cpp:351
+#: ../src/wxMaxima.cpp:356
 msgid ""
 "... [suppressed additional lines since the output is longer than allowed in "
 "the configuration] "
@@ -391,16 +391,16 @@ msgstr ""
 msgid "1/2"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:103
+#: ../src/wxMaximaFrame.cpp:102
 #, c-format
 msgid "; %i commands left in the current cell"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4601
+#: ../src/wxMaxima.cpp:4613
 msgid "<br>Lisp: "
 msgstr "<br>Lisp 版本："
 
-#: ../src/wxMaxima.cpp:5487
+#: ../src/wxMaxima.cpp:5503
 msgid ""
 "A \":lisp\" as the first command might fail to send a \"finished\" signal."
 msgstr ""
@@ -430,11 +430,11 @@ msgid ""
 "\". \"draw\" can be replaced by \"wxdraw\", plot by \"wxplot\" etc."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1472
+#: ../src/wxMaximaFrame.cpp:1495
 msgid "A symbol from the configuration dialogue"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:731
+#: ../src/wxMaximaFrame.cpp:730
 msgid "A&t Value..."
 msgstr "定點設值(T)..."
 
@@ -442,12 +442,12 @@ msgstr "定點設值(T)..."
 msgid "Abort evaluation on error"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaxima.cpp:4603
+#: ../src/wxMaxima.cpp:4615 ../src/wxMaximaFrame.cpp:985
 msgid "About"
 msgstr "關於"
 
-#: ../src/wxMaximaFrame.cpp:987 ../src/wxMaximaFrame.cpp:990
-#: ../src/wxMaximaFrame.cpp:991
+#: ../src/wxMaximaFrame.cpp:986 ../src/wxMaximaFrame.cpp:989
+#: ../src/wxMaximaFrame.cpp:990
 msgid "About wxMaxima"
 msgstr "關於 wxMaxima"
 
@@ -455,23 +455,23 @@ msgstr "關於 wxMaxima"
 msgid "Active cell bracket"
 msgstr "作用中的單元框"
 
-#: ../src/wxMaximaFrame.cpp:760
+#: ../src/wxMaximaFrame.cpp:759
 msgid "Ad&joint Matrix"
 msgstr "伴隨矩陣(&J)"
 
-#: ../src/wxMaximaFrame.cpp:914
+#: ../src/wxMaximaFrame.cpp:913
 msgid "Add Algebraic E&quality..."
 msgstr "新增代數"
 
-#: ../src/wxMaximaFrame.cpp:657
+#: ../src/wxMaximaFrame.cpp:656
 msgid "Add a directory to search path"
 msgstr "將目錄加入搜尋路徑"
 
-#: ../src/wxMaxima.cpp:3353
+#: ../src/wxMaxima.cpp:3365
 msgid "Add dir to path:"
 msgstr "將目錄加入搜尋路徑："
 
-#: ../src/wxMaximaFrame.cpp:915
+#: ../src/wxMaximaFrame.cpp:914
 msgid "Add equality to the rational simplifier"
 msgstr "新增有理數式化簡所使用的等式"
 
@@ -479,7 +479,7 @@ msgstr "新增有理數式化簡所使用的等式"
 msgid "Add the .wxmx file to the HTML export"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:656
+#: ../src/wxMaximaFrame.cpp:655
 msgid "Add to &Path..."
 msgstr "加入搜尋路徑(&P)..."
 
@@ -520,27 +520,27 @@ msgstr "舊變數："
 msgid "All|*"
 msgstr "所有類型|*"
 
-#: ../src/wxMaximaFrame.cpp:1364
+#: ../src/wxMaximaFrame.cpp:1363
 msgid "Alpha"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3838
+#: ../src/wxMaxima.cpp:3850
 msgid "Apply"
 msgstr "套用"
 
-#: ../src/wxMaximaFrame.cpp:768
+#: ../src/wxMaximaFrame.cpp:767
 msgid "Apply function to a list"
 msgstr "套用函數至串列"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Apropos"
 msgstr "Apropos 指令"
 
-#: ../src/wxMaxima.cpp:3764
+#: ../src/wxMaxima.cpp:3776
 msgid "Array:"
 msgstr "陣列："
 
-#: ../src/wxMaxima.cpp:4462
+#: ../src/wxMaxima.cpp:4474
 msgid "Artwork by"
 msgstr "美工"
 
@@ -548,7 +548,7 @@ msgstr "美工"
 msgid "Ask to save untitled documents"
 msgstr "詢問是否儲存未命名文件"
 
-#: ../src/wxMaxima.cpp:3650
+#: ../src/wxMaxima.cpp:3662
 msgid "At value"
 msgstr "定點設值"
 
@@ -569,11 +569,11 @@ msgstr ""
 msgid "Autosave interval (minutes, 0 means: off):"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3557
+#: ../src/BC2Wiz.cpp:58 ../src/wxMaxima.cpp:3569
 msgid "BC2"
 msgstr "邊界條件(二階)"
 
-#: ../src/wxMaximaFrame.cpp:1272
+#: ../src/wxMaximaFrame.cpp:1271
 msgid "Barsplot..."
 msgstr "長條圖..."
 
@@ -581,7 +581,7 @@ msgstr "長條圖..."
 msgid "Bat files (*.bat)|*.bat|All|*"
 msgstr "批次檔 (*.bat)|*.bat|所有類型|*"
 
-#: ../src/wxMaxima.cpp:2943
+#: ../src/wxMaxima.cpp:2951
 msgid "Batch File"
 msgstr "以批次檔載入"
 
@@ -594,7 +594,7 @@ msgid ""
 "cells."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1365
+#: ../src/wxMaximaFrame.cpp:1364
 msgid "Beta"
 msgstr ""
 
@@ -606,11 +606,11 @@ msgstr ""
 msgid "Bold"
 msgstr "粗體"
 
-#: ../src/wxMaxima.cpp:2359
+#: ../src/wxMaxima.cpp:2366
 msgid "Both horizontal and vertical cursor active at the same time"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1274
+#: ../src/wxMaximaFrame.cpp:1273
 msgid "Boxplot..."
 msgstr "箱形圖..."
 
@@ -622,15 +622,15 @@ msgstr "瀏覽"
 msgid "Bug: Autocompletion requested for unknown type of item."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2080
+#: ../src/MathCtrl.cpp:2127
 msgid "Bug: Cell left but not entered."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1178
+#: ../src/wxMaxima.cpp:1183
 msgid "Bug: Found a math end marker without any start marker."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1222
+#: ../src/wxMaxima.cpp:1227
 msgid "Bug: Found the end of autocompletion symbols but no beginning"
 msgstr ""
 
@@ -642,22 +642,22 @@ msgstr ""
 msgid "Bug: Fraction without enumerator"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2312
+#: ../src/MathCtrl.cpp:2359
 msgid "Bug: Got a question but no cell to answer it in"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5839
+#: ../src/MathCtrl.cpp:5891
 msgid ""
 "Bug: Got a request to change the contents of the cell above the beginning of "
 "the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5913
+#: ../src/MathCtrl.cpp:5965
 msgid ""
 "Bug: Got a request to delete the cell above the beginning of the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5882
+#: ../src/MathCtrl.cpp:5934
 msgid ""
 "Bug: Got a request to first change the contents of a cell and to then "
 "undelete it."
@@ -667,49 +667,49 @@ msgstr ""
 msgid "Bug: Math Cell that claims to have no group Cell it belongs to"
 msgstr ""
 
-#: ../src/GroupCell.cpp:780 ../src/GroupCell.cpp:951
+#: ../src/GroupCell.cpp:781 ../src/GroupCell.cpp:952
 msgid "Bug: No image counter to write to!"
 msgstr ""
 
-#: ../src/AbsCell.cpp:193
+#: ../src/AbsCell.cpp:199
 msgid "Bug: No last cell in an absCell!"
 msgstr ""
 
-#: ../src/ConjugateCell.cpp:185
+#: ../src/ConjugateCell.cpp:194
 msgid "Bug: No last cell in an conjugateCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:471
+#: ../src/FracCell.cpp:472
 msgid "Bug: No last cell in an denominator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:267
+#: ../src/ExptCell.cpp:270
 msgid "Bug: No last cell in an exponent of an exptCell!"
 msgstr ""
 
-#: ../src/FracCell.cpp:459
+#: ../src/FracCell.cpp:460
 msgid "Bug: No last cell in an numerator!"
 msgstr ""
 
-#: ../src/ExptCell.cpp:257
+#: ../src/ExptCell.cpp:260
 msgid "Bug: No last cell in the base of an exptCell!"
 msgstr ""
 
-#: ../src/ParenCell.cpp:534
+#: ../src/ParenCell.cpp:535
 msgid "Bug: No last cell inside a parenthesis!"
 msgstr ""
 
-#: ../src/SqrtCell.cpp:312
+#: ../src/SqrtCell.cpp:317
 msgid "Bug: No last cell inside a square root!"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2123
+#: ../src/MathCtrl.cpp:2170
 msgid ""
 "Bug: Start or end of merging of subsequent editing actions was requested two "
 "times in a row."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2090
+#: ../src/MathCtrl.cpp:2137
 msgid "Bug: Text changed, but no active cell."
 msgstr ""
 
@@ -717,39 +717,39 @@ msgstr ""
 msgid "Bug: Trying to append NULL to a group cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:555
+#: ../src/MathCtrl.cpp:600
 msgid "Bug: Trying to append maxima's output to a cell outside the worksheet."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2014
+#: ../src/MathCtrl.cpp:2061
 msgid ""
 "Bug: Trying to merge individual cell adds to a region in the undo buffer but "
 "there are other cells between them."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6522
+#: ../src/MathCtrl.cpp:6577
 msgid ""
 "Bug: Trying to move the horizontally-drawn cursor to a place inside a "
 "GroupCell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:2092
+#: ../src/MathCtrl.cpp:2139
 msgid "Bug: Trying to record a cell contents change without a cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1495
+#: ../src/MathCtrl.cpp:1540
 msgid "Bug: Trying to select inside a cell without having a current cell"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5883
+#: ../src/MathCtrl.cpp:5935
 msgid "Bug: Undo action with both cell contents change and cell addition."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5844 ../src/MathCtrl.cpp:5918 ../src/MathCtrl.cpp:5952
+#: ../src/MathCtrl.cpp:5896 ../src/MathCtrl.cpp:5970 ../src/MathCtrl.cpp:6004
 msgid "Bug: Undo request for cell outside worksheet."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:973
+#: ../src/wxMaximaFrame.cpp:972
 msgid "Build &Info"
 msgstr "建置資訊(&I)"
 
@@ -765,52 +765,52 @@ msgstr ""
 "過「編輯(E)」->「設定(O)」對話框中勾選「按 Enter 鍵評算單元」變更。這會交換這"
 "兩組按鍵的功能。"
 
-#: ../src/wxMaximaFrame.cpp:782
+#: ../src/wxMaximaFrame.cpp:781
 msgid "C&hange Variable..."
 msgstr "變數變換(&H)..."
 
-#: ../src/wxMaximaFrame.cpp:540
+#: ../src/wxMaximaFrame.cpp:539
 msgid "C&onfigure"
 msgstr "設定(&O)"
 
-#: ../src/wxMaximaFrame.cpp:801
+#: ../src/wxMaximaFrame.cpp:800
 msgid "Calculate &Product..."
 msgstr "計算乘積(&P)..."
 
-#: ../src/wxMaximaFrame.cpp:799
+#: ../src/wxMaximaFrame.cpp:798
 msgid "Calculate Su&m..."
 msgstr "計算加總(&M)..."
 
-#: ../src/wxMaximaFrame.cpp:939
+#: ../src/wxMaximaFrame.cpp:938
 msgid "Calculate bigfloat value of the last result"
 msgstr "將最後的計算結果以長浮點數 (bigfloat) 表示"
 
-#: ../src/wxMaximaFrame.cpp:936
+#: ../src/wxMaximaFrame.cpp:935
 msgid "Calculate float value of the last result"
 msgstr "將最後的計算結果以浮點數 (float) 表示"
 
-#: ../src/wxMaxima.cpp:3971
+#: ../src/wxMaxima.cpp:3983
 msgid "Calculate modulus:"
 msgstr "模運算："
 
-#: ../src/wxMaximaFrame.cpp:942
+#: ../src/wxMaximaFrame.cpp:941
 #, fuzzy
 msgid "Calculate numeric value of the last result"
 msgstr "將最後的計算結果以浮點數 (float) 表示"
 
-#: ../src/wxMaximaFrame.cpp:802
+#: ../src/wxMaximaFrame.cpp:801
 msgid "Calculate products"
 msgstr "計算乘積"
 
-#: ../src/wxMaximaFrame.cpp:800
+#: ../src/wxMaximaFrame.cpp:799
 msgid "Calculate sums"
 msgstr "計算加總"
 
-#: ../src/wxMaxima.cpp:5830
+#: ../src/wxMaxima.cpp:5845
 msgid "Can not connect to the web server."
 msgstr "無法連線至網路伺服器。"
 
-#: ../src/wxMaxima.cpp:5881
+#: ../src/wxMaxima.cpp:5896
 msgid "Can not download version info."
 msgstr "無法下載版本資訊。"
 
@@ -826,15 +826,15 @@ msgstr "無法下載版本資訊。"
 #: ../src/PlotFormatWiz.cpp:48 ../src/SeriesWiz.cpp:49 ../src/SeriesWiz.cpp:51
 #: ../src/SubstituteWiz.cpp:41 ../src/SubstituteWiz.cpp:43 ../src/SumWiz.cpp:44
 #: ../src/SumWiz.cpp:46 ../src/SystemWiz.cpp:38 ../src/SystemWiz.cpp:40
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Cancel"
 msgstr "取消"
 
-#: ../src/wxMaximaFrame.cpp:126 ../src/wxMaxima.cpp:932
+#: ../src/wxMaxima.cpp:937 ../src/wxMaximaFrame.cpp:125
 msgid "Cannot start the maxima binary"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1217
+#: ../src/wxMaximaFrame.cpp:1216
 msgid "Canonical (tr)"
 msgstr "標準型式 (三角)"
 
@@ -842,7 +842,7 @@ msgstr "標準型式 (三角)"
 msgid "Catalan"
 msgstr "Catalan"
 
-#: ../src/wxMaximaFrame.cpp:638
+#: ../src/wxMaximaFrame.cpp:637
 msgid "Ce&ll"
 msgstr "單元(&L)"
 
@@ -850,39 +850,39 @@ msgstr "單元(&L)"
 msgid "Cell bracket"
 msgstr "單元框"
 
-#: ../src/wxMaxima.cpp:5261
+#: ../src/wxMaxima.cpp:5273
 msgid "Cell ends in a backslash"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:676
+#: ../src/wxMaximaFrame.cpp:675
 msgid "Change &2d Display"
 msgstr "變更顯示方式(&2)"
 
-#: ../src/wxMaximaFrame.cpp:677
+#: ../src/wxMaximaFrame.cpp:676
 msgid "Change the 2d display algorithm used to display math output"
 msgstr "變更顯示數學輸出的演算法"
 
-#: ../src/wxMaxima.cpp:3995
+#: ../src/wxMaxima.cpp:4007
 msgid "Change variable"
 msgstr "變數變換"
 
-#: ../src/wxMaximaFrame.cpp:783
+#: ../src/wxMaximaFrame.cpp:782
 msgid "Change variable in integral or sum"
 msgstr "對積分數式或加總數式作變數變換"
 
-#: ../src/wxMaxima.cpp:3751
+#: ../src/wxMaxima.cpp:3763
 msgid "Char poly"
 msgstr "特徵多項式"
 
-#: ../src/wxMaximaFrame.cpp:978
+#: ../src/wxMaximaFrame.cpp:977
 msgid "Check for Updates"
 msgstr "檢查更新"
 
-#: ../src/wxMaximaFrame.cpp:979
+#: ../src/wxMaximaFrame.cpp:978
 msgid "Check if a newer version of wxMaxima/Maxima exist."
 msgstr "檢查是否存在新版的 wxMaxima 或 Maxima"
 
-#: ../src/wxMaximaFrame.cpp:1385
+#: ../src/wxMaximaFrame.cpp:1384
 msgid "Chi"
 msgstr ""
 
@@ -903,15 +903,15 @@ msgstr "選擇字型"
 msgid "Choose new plot format:"
 msgstr "選擇新的繪圖格式："
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710
 msgid "Classes:"
 msgstr "種類數："
 
-#: ../src/wxMaximaFrame.cpp:469
+#: ../src/wxMaximaFrame.cpp:468
 msgid "Close\tCtrl-W"
 msgstr "關閉\tCtrl-W"
 
-#: ../src/wxMaximaFrame.cpp:470
+#: ../src/wxMaximaFrame.cpp:469
 msgid "Close window"
 msgstr "關閉視窗"
 
@@ -943,19 +943,19 @@ msgstr ""
 msgid "Code highlighting: Variables"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4806
+#: ../src/wxMaxima.cpp:4818
 msgid "Col. names:"
 msgstr "欄位名："
 
-#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:168 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Columns:"
 msgstr "欄："
 
-#: ../src/wxMaximaFrame.cpp:860
+#: ../src/wxMaximaFrame.cpp:859
 msgid "Combine factorials in an expression"
 msgstr "合併數式中的階乘"
 
-#: ../src/wxMaxima.cpp:5293
+#: ../src/wxMaxima.cpp:5305
 msgid "Comma directly followed by a closing parenthesis"
 msgstr ""
 
@@ -967,24 +967,24 @@ msgstr "x 座標，以逗號分隔"
 msgid "Comma separated y coordinates"
 msgstr "y 座標，以逗號分隔"
 
-#: ../src/MathCtrl.cpp:1030
+#: ../src/MathCtrl.cpp:1072
 msgid "Comment Selection"
 msgstr "將所選區域變成註解"
 
-#: ../src/wxMaximaFrame.cpp:533
+#: ../src/wxMaximaFrame.cpp:532
 msgid "Comment out the currently selected text"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:532
+#: ../src/wxMaximaFrame.cpp:531
 #, fuzzy
 msgid "Comment selection\tCtrl-/"
 msgstr "將所選區域變成註解"
 
-#: ../src/wxMaximaFrame.cpp:601
+#: ../src/wxMaximaFrame.cpp:600
 msgid "Complete Word\tCtrl-K"
 msgstr "自動完成\tCtrl-K"
 
-#: ../src/wxMaximaFrame.cpp:602
+#: ../src/wxMaximaFrame.cpp:601
 msgid "Complete word"
 msgstr "自動完成"
 
@@ -992,35 +992,35 @@ msgstr "自動完成"
 msgid "Completely stop maxima and restart it"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:823
+#: ../src/wxMaximaFrame.cpp:822
 msgid "Compute continued fraction of a value"
 msgstr "計算數值的連分數表示"
 
-#: ../src/wxMaximaFrame.cpp:761
+#: ../src/wxMaximaFrame.cpp:760
 msgid "Compute the adjoint matrix"
 msgstr "計算伴隨矩陣"
 
-#: ../src/wxMaximaFrame.cpp:750
+#: ../src/wxMaximaFrame.cpp:749
 msgid "Compute the characteristic polynomial of a matrix"
 msgstr "計算矩陣的特徵多項式"
 
-#: ../src/wxMaximaFrame.cpp:753
+#: ../src/wxMaximaFrame.cpp:752
 msgid "Compute the determinant of a matrix"
 msgstr "計算矩陣的行列式的值"
 
-#: ../src/wxMaximaFrame.cpp:810
+#: ../src/wxMaximaFrame.cpp:809
 msgid "Compute the greatest common divisor"
 msgstr "計算最大公因式"
 
-#: ../src/wxMaximaFrame.cpp:747
+#: ../src/wxMaximaFrame.cpp:746
 msgid "Compute the inverse of a matrix"
 msgstr "計算矩陣的反矩陣"
 
-#: ../src/wxMaximaFrame.cpp:813
+#: ../src/wxMaximaFrame.cpp:812
 msgid "Compute the least common multiple (do load(functs) before using)"
 msgstr "計算最小公倍式 (在使用前會先執行 load(functs) )"
 
-#: ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4868
 msgid "Condition:"
 msgstr "條件："
 
@@ -1032,8 +1032,8 @@ msgstr "設定檔 (*.ini)|*.ini"
 msgid "Configuration warning"
 msgstr "設定值警告"
 
-#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:538
-#: ../src/wxMaximaFrame.cpp:541
+#: ../src/ToolBar.cpp:133 ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:540
 msgid "Configure wxMaxima"
 msgstr "設定 wxMaxima"
 
@@ -1042,130 +1042,132 @@ msgstr "設定 wxMaxima"
 msgid "Constant"
 msgstr "常數"
 
-#: ../src/wxMaximaFrame.cpp:844
+#: ../src/wxMaximaFrame.cpp:843
 msgid "Contract Logarithms"
 msgstr "合併對數數式"
 
-#: ../src/wxMaximaFrame.cpp:851
+#: ../src/wxMaximaFrame.cpp:850
 msgid "Convert binomials, beta and gamma function to factorials"
 msgstr "轉換二項式、beta、及 gamma 函數為階乘數式"
 
-#: ../src/wxMaximaFrame.cpp:854
+#: ../src/wxMaximaFrame.cpp:853
 msgid "Convert binomials, factorials and beta function to gamma function"
 msgstr "轉換二項式、階乘和 beta 函數為 gamma 函數"
 
-#: ../src/wxMaximaFrame.cpp:888
+#: ../src/wxMaximaFrame.cpp:887
 msgid "Convert complex expression to polar form"
 msgstr "轉換複數數式為極座標形式"
 
-#: ../src/wxMaximaFrame.cpp:885
+#: ../src/wxMaximaFrame.cpp:884
 msgid "Convert complex expression to rect form"
 msgstr "轉換複數數式為直角座標形式"
 
-#: ../src/wxMaximaFrame.cpp:897
+#: ../src/wxMaximaFrame.cpp:896
 msgid ""
 "Convert exponential function of imaginary argument to trigonometric form"
 msgstr "轉換虛數的指數函數為三角函數形式"
 
-#: ../src/wxMaximaFrame.cpp:842
+#: ../src/wxMaximaFrame.cpp:841
 msgid "Convert logarithm of product to sum of logarithms"
 msgstr "將對數內的乘積轉換為數項相加的對數"
 
-#: ../src/wxMaximaFrame.cpp:845
+#: ../src/wxMaximaFrame.cpp:844
 msgid "Convert sum of logarithms to logarithm of product"
 msgstr "將數項相加的對數轉換為對數內的乘積"
 
-#: ../src/wxMaximaFrame.cpp:850
+#: ../src/wxMaximaFrame.cpp:849
 msgid "Convert to &Factorials"
 msgstr "轉換為階乘(&F)"
 
-#: ../src/wxMaximaFrame.cpp:853
+#: ../src/wxMaximaFrame.cpp:852
 msgid "Convert to &Gamma"
 msgstr "轉換為 Gamma 函數(&G)"
 
-#: ../src/wxMaximaFrame.cpp:887
+#: ../src/wxMaximaFrame.cpp:886
 msgid "Convert to &Polarform"
 msgstr "轉換為極座標形式(&P)"
 
-#: ../src/wxMaximaFrame.cpp:884
+#: ../src/wxMaximaFrame.cpp:883
 msgid "Convert to &Rectform"
 msgstr "轉換為直角座標形式(&R)"
 
-#: ../src/wxMaximaFrame.cpp:877
+#: ../src/wxMaximaFrame.cpp:876
 msgid "Convert trigonometric expression to canonical quasilinear form"
 msgstr "轉換三角函數數式為標準準線性形式"
 
-#: ../src/wxMaximaFrame.cpp:900
+#: ../src/wxMaximaFrame.cpp:899
 msgid "Convert trigonometric functions to exponential form"
 msgstr "轉換三角函數數式為指數形式"
 
-#: ../src/ToolBar.cpp:140 ../src/MathCtrl.cpp:918 ../src/MathCtrl.cpp:931
-#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1024
+#: ../src/MathCtrl.cpp:960 ../src/MathCtrl.cpp:973 ../src/MathCtrl.cpp:1019
+#: ../src/MathCtrl.cpp:1066 ../src/ToolBar.cpp:140
 msgid "Copy"
 msgstr "複製"
 
-#: ../src/wxMaximaFrame.cpp:597
+#: ../src/wxMaximaFrame.cpp:596
 msgid "Copy Previous Input\tCtrl-I"
 msgstr "複製上一個輸入\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:599
+#: ../src/wxMaximaFrame.cpp:598
 #, fuzzy
 msgid "Copy Previous Output\tCtrl-U"
 msgstr "複製上一個輸入\tCtrl-I"
 
-#: ../src/wxMaximaFrame.cpp:514 ../src/MathCtrl.cpp:936 ../src/MathCtrl.cpp:982
+#: ../src/MathCtrl.cpp:978 ../src/MathCtrl.cpp:1024
+#: ../src/wxMaximaFrame.cpp:513
 msgid "Copy as Image"
 msgstr "複製為圖片"
 
-#: ../src/wxMaximaFrame.cpp:507 ../src/MathCtrl.cpp:932 ../src/MathCtrl.cpp:978
+#: ../src/MathCtrl.cpp:974 ../src/MathCtrl.cpp:1020
+#: ../src/wxMaximaFrame.cpp:506
 msgid "Copy as LaTeX"
 msgstr "複製為 LaTeX 格式"
 
-#: ../src/wxMaximaFrame.cpp:510
+#: ../src/wxMaximaFrame.cpp:509
 #, fuzzy
 msgid "Copy as MathML"
 msgstr "複製為圖片"
 
-#: ../src/MathCtrl.cpp:935 ../src/MathCtrl.cpp:980
+#: ../src/MathCtrl.cpp:977 ../src/MathCtrl.cpp:1022
 msgid "Copy as MathML (e.g. to word processor)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:504
+#: ../src/wxMaximaFrame.cpp:503
 msgid "Copy as Text\tCtrl-Shift-C"
 msgstr "複製為純文字\tCtrl-Shift-C"
 
-#: ../src/MathCtrl.cpp:933 ../src/MathCtrl.cpp:979
+#: ../src/MathCtrl.cpp:975 ../src/MathCtrl.cpp:1021
 #, fuzzy
 msgid "Copy as plain text"
 msgstr "複製為圖片"
 
-#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:503
+#: ../src/ToolBar.cpp:142 ../src/wxMaximaFrame.cpp:502
 msgid "Copy selection"
 msgstr "複製所選區域"
 
-#: ../src/wxMaximaFrame.cpp:515
+#: ../src/wxMaximaFrame.cpp:514
 msgid "Copy selection from document as an image"
 msgstr "複製所選區域為圖片"
 
-#: ../src/wxMaximaFrame.cpp:505
+#: ../src/wxMaximaFrame.cpp:504
 msgid "Copy selection from document as text"
 msgstr "複製所選區域為純文字"
 
-#: ../src/wxMaximaFrame.cpp:508
+#: ../src/wxMaximaFrame.cpp:507
 msgid "Copy selection from document in LaTeX format"
 msgstr "複製所選區域為 LaTeX 格式"
 
-#: ../src/wxMaximaFrame.cpp:511
+#: ../src/wxMaximaFrame.cpp:510
 msgid ""
 "Copy selection from document in a MathML format many word processors can "
 "display as 2d equation"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:598
+#: ../src/wxMaximaFrame.cpp:597
 msgid "Create a new cell with previous input"
 msgstr "以上一個輸入建立一個新的單元"
 
-#: ../src/wxMaximaFrame.cpp:600
+#: ../src/wxMaximaFrame.cpp:599
 #, fuzzy
 msgid "Create a new cell with previous output"
 msgstr "以上一個輸入建立一個新的單元"
@@ -1174,15 +1176,15 @@ msgstr "以上一個輸入建立一個新的單元"
 msgid "Cursor"
 msgstr "游標"
 
-#: ../src/ToolBar.cpp:137 ../src/MathCtrl.cpp:1023
+#: ../src/MathCtrl.cpp:1065 ../src/ToolBar.cpp:137
 msgid "Cut"
 msgstr "剪下"
 
-#: ../src/wxMaximaFrame.cpp:499
+#: ../src/wxMaximaFrame.cpp:498
 msgid "Cut\tCtrl-X"
 msgstr "剪下\tCtrl-X"
 
-#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:500
+#: ../src/ToolBar.cpp:139 ../src/wxMaximaFrame.cpp:499
 msgid "Cut selection"
 msgstr "剪下所選區域"
 
@@ -1194,18 +1196,18 @@ msgstr "Czech"
 msgid "Danish"
 msgstr "Danish"
 
-#: ../src/wxMaxima.cpp:4799 ../src/wxMaxima.cpp:4806 ../src/wxMaxima.cpp:4856
+#: ../src/wxMaxima.cpp:4811 ../src/wxMaxima.cpp:4818 ../src/wxMaxima.cpp:4868
 msgid "Data Matrix:"
 msgstr "資料矩陣："
 
-#: ../src/wxMaxima.cpp:4826
+#: ../src/wxMaxima.cpp:4838
 msgid "Data file (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 msgstr "資料檔 (*.csv, *.tab, *.txt)|*.csv;*.tab;*.txt"
 
-#: ../src/wxMaxima.cpp:4684 ../src/wxMaxima.cpp:4698 ../src/wxMaxima.cpp:4712
-#: ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726 ../src/wxMaxima.cpp:4734
-#: ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748 ../src/wxMaxima.cpp:4755
-#: ../src/wxMaxima.cpp:4791
+#: ../src/wxMaxima.cpp:4696 ../src/wxMaxima.cpp:4710 ../src/wxMaxima.cpp:4724
+#: ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738 ../src/wxMaxima.cpp:4746
+#: ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760 ../src/wxMaxima.cpp:4767
+#: ../src/wxMaxima.cpp:4803
 msgid "Data:"
 msgstr "資料："
 
@@ -1213,7 +1215,7 @@ msgstr "資料："
 msgid "Debug: watch maxima's stdout stream"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:820
+#: ../src/wxMaximaFrame.cpp:819
 msgid "Decompose rational function to partial fractions"
 msgstr "將有理函數分解為部分分式"
 
@@ -1244,47 +1246,47 @@ msgid ""
 "with."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3403 ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3415 ../src/wxMaxima.cpp:3424
 msgid "Delete"
 msgstr "刪除"
 
-#: ../src/wxMaximaFrame.cpp:667
+#: ../src/wxMaximaFrame.cpp:666
 msgid "Delete F&unction..."
 msgstr "刪除函數(&U)..."
 
-#: ../src/MathCtrl.cpp:939 ../src/MathCtrl.cpp:985
+#: ../src/MathCtrl.cpp:981 ../src/MathCtrl.cpp:1027
 msgid "Delete Selection"
 msgstr "刪除所選區域"
 
-#: ../src/wxMaximaFrame.cpp:669
+#: ../src/wxMaximaFrame.cpp:668
 msgid "Delete V&ariable..."
 msgstr "刪除變數(&A)..."
 
-#: ../src/wxMaximaFrame.cpp:668
+#: ../src/wxMaximaFrame.cpp:667
 msgid "Delete a function"
 msgstr "刪除函數"
 
-#: ../src/wxMaximaFrame.cpp:670
+#: ../src/wxMaximaFrame.cpp:669
 msgid "Delete a variable"
 msgstr "刪除變數"
 
-#: ../src/wxMaximaFrame.cpp:655
+#: ../src/wxMaximaFrame.cpp:654
 msgid "Delete all values from memory"
 msgstr "刪除記憶體中全部的值"
 
-#: ../src/wxMaxima.cpp:3412
+#: ../src/wxMaxima.cpp:3424
 msgid "Delete function(s):"
 msgstr "刪除該函數："
 
-#: ../src/wxMaxima.cpp:3403
+#: ../src/wxMaxima.cpp:3415
 msgid "Delete variable(s):"
 msgstr "刪除該變數："
 
-#: ../src/wxMaximaFrame.cpp:1367
+#: ../src/wxMaximaFrame.cpp:1366
 msgid "Delta"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4011
+#: ../src/wxMaxima.cpp:4023
 msgid "Denom. deg:"
 msgstr "分母 degree："
 
@@ -1292,35 +1294,35 @@ msgstr "分母 degree："
 msgid "Depth:"
 msgstr "深度："
 
-#: ../src/wxMaxima.cpp:3541
+#: ../src/wxMaxima.cpp:3553
 msgid "Derivative:"
 msgstr "導函數："
 
-#: ../src/wxMaximaFrame.cpp:1258
+#: ../src/wxMaximaFrame.cpp:1257
 msgid "Deviation..."
 msgstr "偏差..."
 
-#: ../src/wxMaximaFrame.cpp:816
+#: ../src/wxMaximaFrame.cpp:815
 msgid "Di&vide Polynomials..."
 msgstr "多項式相除(&V)..."
 
-#: ../src/wxMaximaFrame.cpp:1223
+#: ../src/wxMaximaFrame.cpp:1222
 msgid "Diff..."
 msgstr "微分..."
 
-#: ../src/wxMaxima.cpp:4154 ../src/wxMaxima.cpp:5066
+#: ../src/wxMaxima.cpp:4166 ../src/wxMaxima.cpp:5078
 msgid "Differentiate"
 msgstr "微分"
 
-#: ../src/wxMaximaFrame.cpp:786
+#: ../src/wxMaximaFrame.cpp:785
 msgid "Differentiate expression"
 msgstr "對數式微分"
 
-#: ../src/MathCtrl.cpp:1001
+#: ../src/MathCtrl.cpp:1043
 msgid "Differentiate..."
 msgstr "微分..."
 
-#: ../src/LimitWiz.cpp:37 ../src/FindReplacePane.cpp:76
+#: ../src/FindReplacePane.cpp:76 ../src/LimitWiz.cpp:37
 msgid "Direction:"
 msgstr "方向："
 
@@ -1328,48 +1330,49 @@ msgstr "方向："
 msgid "Discrete plot"
 msgstr "離散繪圖"
 
-#: ../src/wxMaximaFrame.cpp:679
+#: ../src/wxMaximaFrame.cpp:678
 msgid "Display Te&X Form"
 msgstr "以 TeX 格式顯示(&X)"
 
-#: ../src/wxMaxima.cpp:3320
+#: ../src/wxMaxima.cpp:3332
 msgid "Display algorithm"
 msgstr "用於顯示的演算法"
 
-#: ../src/wxMaximaFrame.cpp:680
+#: ../src/wxMaximaFrame.cpp:679
 msgid "Display last result in TeX form"
 msgstr "將最後的結果以 TeX 格式顯示"
 
-#: ../src/wxMaximaFrame.cpp:674
+#: ../src/wxMaximaFrame.cpp:673
 msgid "Display time used for evaluation"
 msgstr "顯示評算所花費的時間"
 
-#: ../src/wxMaxima.cpp:4061
+#: ../src/wxMaxima.cpp:4073
 msgid "Divide"
 msgstr "數字／多項式相除"
 
-#: ../src/MathCtrl.cpp:1032
+#: ../src/MathCtrl.cpp:1074
 msgid "Divide Cell"
 msgstr "分割單元"
 
-#: ../src/wxMaximaFrame.cpp:635
+#: ../src/wxMaximaFrame.cpp:634
 #, fuzzy
 msgid "Divide Cell\tCtrl-D"
 msgstr "分割單元"
 
-#: ../src/wxMaximaFrame.cpp:817
+#: ../src/wxMaximaFrame.cpp:816
 msgid "Divide numbers or polynomials"
 msgstr "將數字或多項式相除"
 
-#: ../src/wxMaximaFrame.cpp:636
+#: ../src/wxMaximaFrame.cpp:635
 msgid "Divide this input cell into two cells"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5917
-msgid "Do you want to save the changes you made in the document \""
+#: ../src/wxMaxima.cpp:5932
+#, fuzzy, c-format
+msgid "Do you want to save the changes you made in the document \"%s\"?"
 msgstr "您是否想儲存於此文件中的變更： \""
 
-#: ../src/wxMaxima.cpp:1664 ../src/wxMaxima.cpp:1672
+#: ../src/wxMaxima.cpp:1669 ../src/wxMaxima.cpp:1677
 msgid "Document "
 msgstr "文件"
 
@@ -1388,7 +1391,7 @@ msgid ""
 "differences."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Don't save"
 msgstr "不要儲存"
 
@@ -1396,27 +1399,27 @@ msgstr "不要儲存"
 msgid "Down"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:734
+#: ../src/wxMaximaFrame.cpp:733
 msgid "E&quations"
 msgstr "方程式(&Q)"
 
-#: ../src/wxMaximaFrame.cpp:487
+#: ../src/wxMaximaFrame.cpp:486
 msgid "E&xit\tCtrl-Q"
 msgstr "結束(&X)\tCtrl-Q"
 
-#: ../src/wxMaximaFrame.cpp:757
+#: ../src/wxMaximaFrame.cpp:756
 msgid "Eige&nvectors"
 msgstr "特徵向量(&N)"
 
-#: ../src/wxMaximaFrame.cpp:755
+#: ../src/wxMaximaFrame.cpp:754
 msgid "Eigen&values"
 msgstr "特徵值(&V)"
 
-#: ../src/wxMaxima.cpp:3572
+#: ../src/wxMaxima.cpp:3584
 msgid "Eliminate"
 msgstr "消去"
 
-#: ../src/wxMaximaFrame.cpp:710
+#: ../src/wxMaximaFrame.cpp:709
 msgid "Eliminate a variable from a system of equations"
 msgstr "自方程組中消去變數"
 
@@ -1428,21 +1431,21 @@ msgstr ""
 msgid "English"
 msgstr "English"
 
-#: ../src/wxMaxima.cpp:4712 ../src/wxMaxima.cpp:4719 ../src/wxMaxima.cpp:4726
-#: ../src/wxMaxima.cpp:4734 ../src/wxMaxima.cpp:4741 ../src/wxMaxima.cpp:4748
-#: ../src/wxMaxima.cpp:4755 ../src/wxMaxima.cpp:4791 ../src/wxMaxima.cpp:4799
+#: ../src/wxMaxima.cpp:4724 ../src/wxMaxima.cpp:4731 ../src/wxMaxima.cpp:4738
+#: ../src/wxMaxima.cpp:4746 ../src/wxMaxima.cpp:4753 ../src/wxMaxima.cpp:4760
+#: ../src/wxMaxima.cpp:4767 ../src/wxMaxima.cpp:4803 ../src/wxMaxima.cpp:4811
 msgid "Enter Data"
 msgstr "輸入資料"
 
-#: ../src/wxMaximaFrame.cpp:1279
+#: ../src/wxMaximaFrame.cpp:1278
 msgid "Enter Matrix..."
 msgstr "輸入矩陣..."
 
-#: ../src/wxMaximaFrame.cpp:745
+#: ../src/wxMaximaFrame.cpp:744
 msgid "Enter a matrix"
 msgstr "輸入一個矩陣"
 
-#: ../src/wxMaxima.cpp:3962
+#: ../src/wxMaxima.cpp:3974
 msgid "Enter an equation for rational simplification:"
 msgstr "輸入供化簡有理數式的方程式："
 
@@ -1454,11 +1457,11 @@ msgstr "輸入以逗號分隔的所有變數"
 msgid "Enter evaluates cells"
 msgstr "按 Enter 評算單元"
 
-#: ../src/wxMaxima.cpp:3734
+#: ../src/wxMaxima.cpp:3746
 msgid "Enter matrix"
 msgstr "輸入矩陣"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 #, fuzzy
 msgid "Enter new precision for bigfloats:"
 msgstr "輸入新的精確度："
@@ -1467,12 +1470,12 @@ msgstr "輸入新的精確度："
 msgid "Enter the path to the Maxima executable."
 msgstr "輸入可執行 Maxima 的路徑"
 
-#: ../src/wxMaximaFrame.cpp:1368
+#: ../src/wxMaximaFrame.cpp:1367
 #, fuzzy
 msgid "Epsilon"
 msgstr "Epsilon:"
 
-#: ../src/wxMaxima.cpp:4208
+#: ../src/wxMaxima.cpp:4220
 msgid "Epsilon:"
 msgstr "Epsilon:"
 
@@ -1481,13 +1484,13 @@ msgstr "Epsilon:"
 msgid "Equation %d:"
 msgstr "方程式 %d："
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:3633
-#: ../src/wxMaxima.cpp:5019
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:3645
+#: ../src/wxMaxima.cpp:5031
 msgid "Equation(s):"
 msgstr "方程式："
 
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3993
-#: ../src/wxMaxima.cpp:4807 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:4005
+#: ../src/wxMaxima.cpp:4819 ../src/wxMaxima.cpp:5045
 msgid "Equation:"
 msgstr "方程式："
 
@@ -1498,79 +1501,79 @@ msgid ""
 "be introduced one into another. Also they are always printed out as 2D maths."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3570
+#: ../src/wxMaxima.cpp:3582
 msgid "Equations:"
 msgstr "方程式："
 
-#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1455
-#: ../src/wxMaxima.cpp:1469 ../src/wxMaxima.cpp:1620 ../src/wxMaxima.cpp:1633
-#: ../src/wxMaxima.cpp:1643 ../src/wxMaxima.cpp:1666 ../src/wxMaxima.cpp:2034
-#: ../src/wxMaxima.cpp:2206 ../src/wxMaxima.cpp:5381 ../src/wxMaxima.cpp:5830
-#: ../src/wxMaxima.cpp:5881
+#: ../src/ConfigDialogue.cpp:919 ../src/Image.cpp:184 ../src/wxMaxima.cpp:1460
+#: ../src/wxMaxima.cpp:1474 ../src/wxMaxima.cpp:1625 ../src/wxMaxima.cpp:1638
+#: ../src/wxMaxima.cpp:1648 ../src/wxMaxima.cpp:1671 ../src/wxMaxima.cpp:2039
+#: ../src/wxMaxima.cpp:2211 ../src/wxMaxima.cpp:5397 ../src/wxMaxima.cpp:5845
+#: ../src/wxMaxima.cpp:5896
 msgid "Error"
 msgstr "錯誤"
 
-#: ../src/wxMaxima.cpp:2886 ../src/wxMaxima.cpp:2900 ../src/wxMaxima.cpp:2913
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617 ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:2894 ../src/wxMaxima.cpp:2908 ../src/wxMaxima.cpp:2921
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629 ../src/wxMaxima.cpp:3740
 msgid "Error!"
 msgstr "錯誤！"
 
-#: ../src/wxMaximaFrame.cpp:1370
+#: ../src/wxMaximaFrame.cpp:1369
 msgid "Eta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:909
+#: ../src/wxMaximaFrame.cpp:908
 msgid "Evaluate &Noun Forms"
 msgstr "評算名詞形式(&N)"
 
-#: ../src/wxMaximaFrame.cpp:589
+#: ../src/wxMaximaFrame.cpp:588
 #, fuzzy
 msgid "Evaluate All Cells\tCtrl-Shift-R"
 msgstr "評算所有單元\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:587
+#: ../src/wxMaximaFrame.cpp:586
 #, fuzzy
 msgid "Evaluate All Visible Cells\tCtrl-R"
 msgstr "評算所有單元\tCtrl-R"
 
-#: ../src/wxMaximaFrame.cpp:585 ../src/MathCtrl.cpp:942
+#: ../src/MathCtrl.cpp:984 ../src/wxMaximaFrame.cpp:584
 msgid "Evaluate Cell(s)"
 msgstr "評算單元"
 
-#: ../src/wxMaximaFrame.cpp:591
+#: ../src/wxMaximaFrame.cpp:590
 #, fuzzy
 msgid "Evaluate Cells Above\tCtrl-Shift-P"
 msgstr "評算所有單元\tCtrl-R"
 
-#: ../src/MathCtrl.cpp:956 ../src/MathCtrl.cpp:1051
+#: ../src/MathCtrl.cpp:998 ../src/MathCtrl.cpp:1093
 msgid "Evaluate Part\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:961 ../src/MathCtrl.cpp:1053
+#: ../src/MathCtrl.cpp:1003 ../src/MathCtrl.cpp:1095
 msgid "Evaluate Section\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:971 ../src/MathCtrl.cpp:1057
+#: ../src/MathCtrl.cpp:1013 ../src/MathCtrl.cpp:1099
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:966 ../src/MathCtrl.cpp:1055
+#: ../src/MathCtrl.cpp:1008 ../src/MathCtrl.cpp:1097
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:586
+#: ../src/wxMaximaFrame.cpp:585
 msgid "Evaluate active or selected cell(s)"
 msgstr "評算正在活動中或所選擇的單元"
 
-#: ../src/wxMaximaFrame.cpp:590
+#: ../src/wxMaximaFrame.cpp:589
 msgid "Evaluate all cells in the document"
 msgstr "評算這份文件中的所有單元"
 
-#: ../src/wxMaximaFrame.cpp:910
+#: ../src/wxMaximaFrame.cpp:909
 msgid "Evaluate all noun forms in expression"
 msgstr "評算數式中所有的名詞形式"
 
-#: ../src/wxMaximaFrame.cpp:588
+#: ../src/wxMaximaFrame.cpp:587
 #, fuzzy
 msgid "Evaluate all visible cells in the document"
 msgstr "評算這份文件中的所有單元"
@@ -1584,7 +1587,7 @@ msgstr ""
 msgid "Evaluate to point"
 msgstr "評算名詞形式(&N)"
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Example"
 msgstr "範例"
 
@@ -1597,31 +1600,31 @@ msgstr "Example text 範例文字"
 msgid "Examples:"
 msgstr "範例"
 
-#: ../src/wxMaximaFrame.cpp:488
+#: ../src/wxMaximaFrame.cpp:487
 msgid "Exit wxMaxima"
 msgstr "離開 wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:1214
+#: ../src/wxMaximaFrame.cpp:1213
 msgid "Expand"
 msgstr "展開"
 
-#: ../src/wxMaximaFrame.cpp:1219
+#: ../src/wxMaximaFrame.cpp:1218
 msgid "Expand (tr)"
 msgstr "展開 (三角)"
 
-#: ../src/MathCtrl.cpp:997
+#: ../src/MathCtrl.cpp:1039
 msgid "Expand Expression"
 msgstr "展開數式"
 
-#: ../src/wxMaximaFrame.cpp:841
+#: ../src/wxMaximaFrame.cpp:840
 msgid "Expand Logarithms"
 msgstr "展開對數數式"
 
-#: ../src/wxMaximaFrame.cpp:840
+#: ../src/wxMaximaFrame.cpp:839
 msgid "Expand an expression"
 msgstr "展開數式"
 
-#: ../src/wxMaximaFrame.cpp:874
+#: ../src/wxMaximaFrame.cpp:873
 msgid "Expand trigonometric expression"
 msgstr "展開三角函數數式"
 
@@ -1629,7 +1632,7 @@ msgstr "展開三角函數數式"
 msgid "Expected the icon files to be found at"
 msgstr ""
 
-#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2834
+#: ../src/ConfigDialogue.cpp:146 ../src/wxMaxima.cpp:2842
 msgid "Export"
 msgstr "匯出"
 
@@ -1638,33 +1641,33 @@ msgid ""
 "Export animations to TeX (Images only move if the PDF viewer supports this)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:481
+#: ../src/wxMaximaFrame.cpp:480
 msgid "Export document to a HTML or pdfLaTeX file"
 msgstr "將文件匯出為 HTML 或 pdfLaTeX 檔案"
 
-#: ../src/wxMaximaFrame.cpp:253
+#: ../src/wxMaximaFrame.cpp:252
 #, fuzzy
 msgid "Export failed."
 msgstr "匯出為 TeX 失敗！"
 
-#: ../src/wxMaximaFrame.cpp:239
+#: ../src/wxMaximaFrame.cpp:238
 msgid "Export successful."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2913
+#: ../src/wxMaxima.cpp:2921
 msgid "Exporting to HTML failed!"
 msgstr "匯出為 HTML 失敗！"
 
-#: ../src/wxMaxima.cpp:2886
+#: ../src/wxMaxima.cpp:2894
 msgid "Exporting to TeX failed!"
 msgstr "匯出為 TeX 失敗！"
 
-#: ../src/wxMaxima.cpp:2900
+#: ../src/wxMaxima.cpp:2908
 #, fuzzy
 msgid "Exporting to maxima batch file failed!"
 msgstr "匯出為 TeX 失敗！"
 
-#: ../src/wxMaximaFrame.cpp:229
+#: ../src/wxMaximaFrame.cpp:228
 #, fuzzy
 msgid "Exporting..."
 msgstr "匯出(&E)..."
@@ -1678,42 +1681,42 @@ msgid "Expression(s):"
 msgstr "數式："
 
 #: ../src/IntegrateWiz.cpp:30 ../src/LimitWiz.cpp:27 ../src/SeriesWiz.cpp:33
-#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3648
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:4205 ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5064
+#: ../src/SubstituteWiz.cpp:28 ../src/SumWiz.cpp:27 ../src/wxMaxima.cpp:3660
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:4217 ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5076
 msgid "Expression:"
 msgstr "數式："
 
-#: ../src/wxMaximaFrame.cpp:1213
+#: ../src/wxMaximaFrame.cpp:1212
 msgid "Factor"
 msgstr "因式分解"
 
-#: ../src/wxMaximaFrame.cpp:836
+#: ../src/wxMaximaFrame.cpp:835
 msgid "Factor Complex"
 msgstr "複數因式分解"
 
-#: ../src/MathCtrl.cpp:996
+#: ../src/MathCtrl.cpp:1038
 msgid "Factor Expression"
 msgstr "因式分解數式"
 
-#: ../src/wxMaximaFrame.cpp:835
+#: ../src/wxMaximaFrame.cpp:834
 msgid "Factor an expression"
 msgstr "因式分解數式"
 
-#: ../src/wxMaximaFrame.cpp:837
+#: ../src/wxMaximaFrame.cpp:836
 msgid "Factor an expression in Gaussian numbers"
 msgstr "因式分解含 Gaussian 數的數式"
 
-#: ../src/wxMaximaFrame.cpp:862
+#: ../src/wxMaximaFrame.cpp:861
 msgid "Factorials and &Gamma"
 msgstr "階乘與 Gamma 函數(&G)"
 
-#: ../src/wxMaxima.cpp:285
+#: ../src/wxMaxima.cpp:286
 msgid "Fatal error"
 msgstr "嚴重錯誤"
 
-#: ../src/GroupCell.cpp:1571
+#: ../src/GroupCell.cpp:1572
 #, c-format
 msgid "Figure %d:"
 msgstr "圖 %d:"
@@ -1722,22 +1725,22 @@ msgstr "圖 %d:"
 msgid "File"
 msgstr "檔案"
 
-#: ../src/wxMaxima.cpp:1457 ../src/wxMaxima.cpp:1623 ../src/wxMaxima.cpp:1636
-#: ../src/wxMaxima.cpp:1646 ../src/wxMaxima.cpp:1668
+#: ../src/wxMaxima.cpp:1462 ../src/wxMaxima.cpp:1628 ../src/wxMaxima.cpp:1641
+#: ../src/wxMaxima.cpp:1651 ../src/wxMaxima.cpp:1673
 #, fuzzy
 msgid "File could not be opened"
 msgstr "找不到檔案"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File not found"
 msgstr "找不到檔案"
 
-#: ../src/wxMaxima.cpp:1511 ../src/wxMaxima.cpp:1729
+#: ../src/wxMaxima.cpp:1516 ../src/wxMaxima.cpp:1734
 #, fuzzy
 msgid "File opened"
 msgstr "找不到檔案"
 
-#: ../src/wxMaxima.cpp:5187
+#: ../src/wxMaxima.cpp:5199
 msgid "File you tried to open does not exist."
 msgstr "找不到您想開啟的檔案。"
 
@@ -1749,67 +1752,67 @@ msgstr "檔案："
 msgid "Find"
 msgstr "尋找"
 
-#: ../src/wxMaximaFrame.cpp:523
+#: ../src/wxMaximaFrame.cpp:522
 msgid "Find\tCtrl-F"
 msgstr "尋找\tCtrl-F"
 
-#: ../src/wxMaximaFrame.cpp:787
+#: ../src/wxMaximaFrame.cpp:786
 msgid "Find &Limit..."
 msgstr "求極限(&L)..."
 
-#: ../src/wxMaximaFrame.cpp:790
+#: ../src/wxMaximaFrame.cpp:789
 msgid "Find Minimum..."
 msgstr "求極小值..."
 
-#: ../src/MathCtrl.cpp:993
+#: ../src/MathCtrl.cpp:1035
 msgid "Find Root..."
 msgstr "找根..."
 
-#: ../src/wxMaximaFrame.cpp:791
+#: ../src/wxMaximaFrame.cpp:790
 msgid "Find a (unconstrained) minimum of an expression"
 msgstr "找數式的極小值(無區間限制)"
 
-#: ../src/wxMaximaFrame.cpp:788
+#: ../src/wxMaximaFrame.cpp:787
 msgid "Find a limit of an expression"
 msgstr "求數式的極限"
 
-#: ../src/wxMaximaFrame.cpp:693
+#: ../src/wxMaximaFrame.cpp:692
 msgid "Find a root of an equation on an interval"
 msgstr "在區間中找方程式的根"
 
-#: ../src/wxMaximaFrame.cpp:695
+#: ../src/wxMaximaFrame.cpp:694
 msgid "Find all roots of a polynomial"
 msgstr "找多項式所有的根"
 
-#: ../src/wxMaximaFrame.cpp:698
+#: ../src/wxMaximaFrame.cpp:697
 msgid "Find all roots of a polynomial (bfloat)"
 msgstr "找多項式所有的根(以長浮點數表示)"
 
-#: ../src/wxMaxima.cpp:3220
+#: ../src/wxMaxima.cpp:3215
 msgid "Find and Replace"
 msgstr "尋找及取代"
 
-#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:523
+#: ../src/ToolBar.cpp:154 ../src/wxMaximaFrame.cpp:522
 msgid "Find and replace"
 msgstr "尋找及取代"
 
-#: ../src/wxMaximaFrame.cpp:756
+#: ../src/wxMaximaFrame.cpp:755
 msgid "Find eigenvalues of a matrix"
 msgstr "尋找矩陣的特徵值"
 
-#: ../src/wxMaximaFrame.cpp:758
+#: ../src/wxMaximaFrame.cpp:757
 msgid "Find eigenvectors of a matrix"
 msgstr "尋找矩陣的特徵向量"
 
-#: ../src/wxMaxima.cpp:4210
+#: ../src/wxMaxima.cpp:4222
 msgid "Find minimum"
 msgstr "求極小值"
 
-#: ../src/wxMaximaFrame.cpp:701
+#: ../src/wxMaximaFrame.cpp:700
 msgid "Find real roots of a polynomial"
 msgstr "找多項式所有的實根"
 
-#: ../src/wxMaxima.cpp:3493 ../src/wxMaxima.cpp:5036
+#: ../src/wxMaxima.cpp:3505 ../src/wxMaxima.cpp:5048
 msgid "Find root"
 msgstr "找根"
 
@@ -1832,12 +1835,12 @@ msgstr ""
 msgid "Fixed font in text controls"
 msgstr "文字控制項使用等寬字型"
 
-#: ../src/wxMaximaFrame.cpp:623
+#: ../src/wxMaximaFrame.cpp:622
 #, fuzzy
 msgid "Fold All\tCtrl-Alt-["
 msgstr "全部選取\tCtrl-A"
 
-#: ../src/wxMaximaFrame.cpp:624
+#: ../src/wxMaximaFrame.cpp:623
 msgid "Fold all sections"
 msgstr ""
 
@@ -1845,25 +1848,25 @@ msgstr ""
 msgid "Follow"
 msgstr ""
 
-#: ../src/ParenCell.cpp:319
+#: ../src/ParenCell.cpp:320
 msgid "Font issue: The Parenthesis sign is too small!"
 msgstr ""
 
-#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:381
+#: ../src/IntCell.cpp:286 ../src/ParenCell.cpp:382
 msgid ""
 "Font issue: The char height is too small! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:199
+#: ../src/SqrtCell.cpp:202
 msgid ""
 "Font issue: The sqrt() sign has the size 0! Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should be a workaround."
 msgstr ""
 
-#: ../src/SqrtCell.cpp:198
+#: ../src/SqrtCell.cpp:201
 msgid "Font issue? The contents of a sqrt() has the size 0."
 msgstr ""
 
@@ -1894,15 +1897,15 @@ msgstr "French"
 
 #: ../src/IntegrateWiz.cpp:37 ../src/Plot2dWiz.cpp:37 ../src/Plot2dWiz.cpp:47
 #: ../src/Plot2dWiz.cpp:536 ../src/Plot3dWiz.cpp:36 ../src/Plot3dWiz.cpp:45
-#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4240
+#: ../src/SumWiz.cpp:33 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4252
 msgid "From:"
 msgstr "從："
 
-#: ../src/wxMaximaFrame.cpp:576
+#: ../src/wxMaximaFrame.cpp:575
 msgid "Full Screen\tAlt-Enter"
 msgstr "全螢幕\tAlt-Enter"
 
-#: ../src/wxMaxima.cpp:3342
+#: ../src/wxMaxima.cpp:3354
 msgid "Function"
 msgstr "函數"
 
@@ -1910,32 +1913,32 @@ msgstr "函數"
 msgid "Function names"
 msgstr "函數名"
 
-#: ../src/wxMaxima.cpp:3633
+#: ../src/wxMaxima.cpp:3645
 msgid "Function(s):"
 msgstr "函數："
 
-#: ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3803
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3815
+#: ../src/wxMaxima.cpp:3848
 msgid "Function:"
 msgstr "函數："
 
-#: ../src/wxMaximaFrame.cpp:904
+#: ../src/wxMaximaFrame.cpp:903
 msgid "Functions for complex simplification"
 msgstr "用以化簡複數數式的函數"
 
-#: ../src/wxMaximaFrame.cpp:864
+#: ../src/wxMaximaFrame.cpp:863
 msgid "Functions for simplifying factorials and gamma function"
 msgstr "用以化簡階乘及 gamma 函數的函數"
 
-#: ../src/wxMaximaFrame.cpp:881
+#: ../src/wxMaximaFrame.cpp:880
 msgid "Functions for simplifying trigonometric expressions"
 msgstr "用以化簡三角函數數式的函數"
 
-#: ../src/wxMaxima.cpp:4046
+#: ../src/wxMaxima.cpp:4058
 msgid "GCD"
 msgstr "最大公因式"
 
-#: ../src/wxMaxima.cpp:5152
+#: ../src/wxMaxima.cpp:5164
 msgid "GIF image (*.gif)|*.gif"
 msgstr "GIF (*.gif)|*.gif"
 
@@ -1943,31 +1946,31 @@ msgstr "GIF (*.gif)|*.gif"
 msgid "Galician"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1366
+#: ../src/wxMaximaFrame.cpp:1365
 msgid "Gamma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:391
+#: ../src/wxMaximaFrame.cpp:390
 msgid "General Math"
 msgstr "常用數學"
 
-#: ../src/wxMaximaFrame.cpp:549
+#: ../src/wxMaximaFrame.cpp:548
 msgid "General Math\tAlt-Shift-M"
 msgstr "常用數學\tAlt-Shift-M"
 
-#: ../src/wxMaxima.cpp:3766 ../src/wxMaxima.cpp:3785
+#: ../src/wxMaxima.cpp:3778 ../src/wxMaxima.cpp:3797
 msgid "Generate Matrix"
 msgstr "產生矩陣"
 
-#: ../src/wxMaximaFrame.cpp:741
+#: ../src/wxMaximaFrame.cpp:740
 msgid "Generate Matrix from Expression..."
 msgstr "以數式產生矩陣..."
 
-#: ../src/wxMaximaFrame.cpp:739
+#: ../src/wxMaximaFrame.cpp:738
 msgid "Generate a matrix from a 2-dimensional array"
 msgstr "以二維陣列產生一個矩陣"
 
-#: ../src/wxMaximaFrame.cpp:742
+#: ../src/wxMaximaFrame.cpp:741
 msgid "Generate a matrix from a lambda expression"
 msgstr "以 lambda 數式產生矩陣"
 
@@ -1975,39 +1978,39 @@ msgstr "以 lambda 數式產生矩陣"
 msgid "German"
 msgstr "German"
 
-#: ../src/wxMaximaFrame.cpp:893
+#: ../src/wxMaximaFrame.cpp:892
 msgid "Get &Imaginary Part"
 msgstr "取虛部(&I)"
 
-#: ../src/wxMaximaFrame.cpp:793
+#: ../src/wxMaximaFrame.cpp:792
 msgid "Get &Series..."
 msgstr "取級數(&S)..."
 
-#: ../src/wxMaximaFrame.cpp:804
+#: ../src/wxMaximaFrame.cpp:803
 msgid "Get Laplace transformation of an expression"
 msgstr "計算數式的 Laplace 變換"
 
-#: ../src/wxMaximaFrame.cpp:890
+#: ../src/wxMaximaFrame.cpp:889
 msgid "Get Real P&art"
 msgstr "取實部(&A)"
 
-#: ../src/wxMaximaFrame.cpp:807
+#: ../src/wxMaximaFrame.cpp:806
 msgid "Get inverse Laplace transformation of an expression"
 msgstr "計算數式的 Laplace 逆變換"
 
-#: ../src/wxMaximaFrame.cpp:794
+#: ../src/wxMaximaFrame.cpp:793
 msgid "Get the Taylor or power series of expression"
 msgstr "取數式的 Taylor 級數或冪級數"
 
-#: ../src/wxMaximaFrame.cpp:894
+#: ../src/wxMaximaFrame.cpp:893
 msgid "Get the imaginary part of complex expression"
 msgstr "取得複數數式的虛部"
 
-#: ../src/wxMaximaFrame.cpp:891
+#: ../src/wxMaximaFrame.cpp:890
 msgid "Get the real part of complex expression"
 msgstr "取得複數數式的實部"
 
-#: ../src/MathCtrl.cpp:5932
+#: ../src/MathCtrl.cpp:5984
 msgid ""
 "Got a request to undo an action that involves an delete which isn't possible "
 "at this moment."
@@ -2017,12 +2020,12 @@ msgstr ""
 msgid "Greek"
 msgstr "Greek"
 
-#: ../src/wxMaximaFrame.cpp:356
+#: ../src/wxMaximaFrame.cpp:355
 #, fuzzy
 msgid "Greek Letters"
 msgstr "希臘字母"
 
-#: ../src/wxMaximaFrame.cpp:552
+#: ../src/wxMaximaFrame.cpp:551
 #, fuzzy
 msgid "Greek Letters\tAlt-Shift-G"
 msgstr "常用數學\tAlt-Shift-M"
@@ -2035,7 +2038,7 @@ msgstr "希臘字母"
 msgid "Grid:"
 msgstr "格線："
 
-#: ../src/wxMaxima.cpp:2836
+#: ../src/wxMaxima.cpp:2844
 #, fuzzy
 msgid ""
 "HTML file (*.html)|*.html|maxima batch file (*.mac)|*.mac|pdfLaTeX file (*."
@@ -2050,12 +2053,12 @@ msgstr ""
 msgid "Help"
 msgstr "說明"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 #, fuzzy
 msgid "Hide All Toolbars\tAlt-Shift--"
 msgstr "全部隱藏\tAlt-Shift--"
 
-#: ../src/wxMaximaFrame.cpp:560
+#: ../src/wxMaximaFrame.cpp:559
 msgid "Hide all panes"
 msgstr "隱藏所有窗格"
 
@@ -2063,19 +2066,19 @@ msgstr "隱藏所有窗格"
 msgid "Highlight (dpart)"
 msgstr "高亮度標記(於dpart函數中)"
 
-#: ../src/wxMaxima.cpp:4685
+#: ../src/wxMaxima.cpp:4697
 msgid "Histogram"
 msgstr "直方圖"
 
-#: ../src/wxMaximaFrame.cpp:1270
+#: ../src/wxMaximaFrame.cpp:1269
 msgid "Histogram..."
 msgstr "直方圖..."
 
-#: ../src/wxMaximaFrame.cpp:309
+#: ../src/wxMaximaFrame.cpp:308
 msgid "History"
 msgstr "歷史記錄"
 
-#: ../src/wxMaximaFrame.cpp:555
+#: ../src/wxMaximaFrame.cpp:554
 #, fuzzy
 msgid "History\tAlt-Shift-I"
 msgstr "歷史記錄\tAlt-Shift-H"
@@ -2095,11 +2098,11 @@ msgstr ""
 msgid "Hungarian"
 msgstr "Hungarian"
 
-#: ../src/wxMaxima.cpp:3527
+#: ../src/wxMaxima.cpp:3539
 msgid "IC1"
 msgstr "初始條件(一階)"
 
-#: ../src/wxMaxima.cpp:3543
+#: ../src/wxMaxima.cpp:3555
 msgid "IC2"
 msgstr "初始條件(二階)"
 
@@ -2115,7 +2118,7 @@ msgid ""
 "same output cell."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:683
+#: ../src/wxMaximaFrame.cpp:682
 msgid ""
 "If maxima ever finishes evaluating without wxMaxima realizing this this menu "
 "item can force wxMaxima to try to send commands to maxima again."
@@ -2177,11 +2180,11 @@ msgstr ""
 "若您的計算花費過長的時間，您可以嘗試「Maxima(M)」->「中斷(I)」或"
 "「Maxima(M)」->「重新啟動 Maxima(R)」這兩個功能表命令。"
 
-#: ../src/wxMaximaFrame.cpp:1499
+#: ../src/wxMaximaFrame.cpp:1518
 msgid "Image"
 msgstr "圖片"
 
-#: ../src/wxMaxima.cpp:5644
+#: ../src/wxMaxima.cpp:5659
 msgid "Image files (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 msgstr "圖片檔 (*.png, *.jpg, *.bmp, *.xpm)|*.png;*.jpg;*.bmp;*.xpm"
 
@@ -2208,7 +2211,7 @@ msgid ""
 "above it. Might increase readability for some fonts and short subscripts."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Include columns:"
 msgstr "包含欄位："
 
@@ -2227,19 +2230,19 @@ msgstr ""
 msgid "Infinity"
 msgstr "無限大"
 
-#: ../src/wxMaximaFrame.cpp:974
+#: ../src/wxMaximaFrame.cpp:973
 msgid "Info about Maxima build"
 msgstr "關於 Maxima 建置的資訊"
 
-#: ../src/wxMaxima.cpp:4207
+#: ../src/wxMaxima.cpp:4219
 msgid "Initial Estimates:"
 msgstr "起始預估："
 
-#: ../src/wxMaximaFrame.cpp:718
+#: ../src/wxMaximaFrame.cpp:717
 msgid "Initial Value Problem (&1)..."
 msgstr "一階常微方初始值問題(&1)..."
 
-#: ../src/wxMaximaFrame.cpp:721
+#: ../src/wxMaximaFrame.cpp:720
 msgid "Initial Value Problem (&2)..."
 msgstr "二階常微方初始值問題(&2)..."
 
@@ -2247,7 +2250,7 @@ msgstr "二階常微方初始值問題(&2)..."
 msgid "Input labels"
 msgstr "輸入標籤"
 
-#: ../src/wxMaximaFrame.cpp:403
+#: ../src/wxMaximaFrame.cpp:402
 msgid "Insert"
 msgstr "插入"
 
@@ -2255,98 +2258,98 @@ msgstr "插入"
 msgid "Insert % before an operator at the beginning of a cell"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:612
+#: ../src/wxMaximaFrame.cpp:611
 msgid "Insert &Section Cell\tCtrl-3"
 msgstr "插入章節單元(&S)\tCtrl-3"
 
-#: ../src/wxMaximaFrame.cpp:608
+#: ../src/wxMaximaFrame.cpp:607
 msgid "Insert &Text Cell\tCtrl-1"
 msgstr "插入文字單元(&T)\tCtrl-1"
 
-#: ../src/wxMaximaFrame.cpp:558
+#: ../src/wxMaximaFrame.cpp:557
 msgid "Insert Cell\tAlt-Shift-C"
 msgstr "插入(單元)\tAlt-Shift-C"
 
-#: ../src/wxMaxima.cpp:5642
+#: ../src/wxMaxima.cpp:5657
 msgid "Insert Image"
 msgstr "插入圖片"
 
-#: ../src/wxMaximaFrame.cpp:620
+#: ../src/wxMaximaFrame.cpp:619
 msgid "Insert Image..."
 msgstr "插入圖片..."
 
-#: ../src/wxMaximaFrame.cpp:606
+#: ../src/wxMaximaFrame.cpp:605
 msgid "Insert Input &Cell"
 msgstr "插入輸入單元(&C)"
 
-#: ../src/wxMaximaFrame.cpp:618
+#: ../src/wxMaximaFrame.cpp:617
 msgid "Insert Page Break"
 msgstr "插入換頁符號"
 
-#: ../src/wxMaximaFrame.cpp:614
+#: ../src/wxMaximaFrame.cpp:613
 msgid "Insert S&ubsection Cell\tCtrl-4"
 msgstr "插入子章節單元(&U)\tCtrl-4"
 
-#: ../src/wxMaximaFrame.cpp:616
+#: ../src/wxMaximaFrame.cpp:615
 #, fuzzy
 msgid "Insert S&ubsubsection Cell\tCtrl-5"
 msgstr "插入子章節單元(&U)\tCtrl-4"
 
-#: ../src/MathCtrl.cpp:1015
+#: ../src/MathCtrl.cpp:1057
 msgid "Insert Section Cell"
 msgstr "插入章節單元"
 
-#: ../src/MathCtrl.cpp:1016
+#: ../src/MathCtrl.cpp:1058
 msgid "Insert Subsection Cell"
 msgstr "插入子章節單元"
 
-#: ../src/MathCtrl.cpp:1017
+#: ../src/MathCtrl.cpp:1059
 #, fuzzy
 msgid "Insert Subsubsection Cell"
 msgstr "插入子章節單元"
 
-#: ../src/wxMaximaFrame.cpp:610
+#: ../src/wxMaximaFrame.cpp:609
 msgid "Insert T&itle Cell\tCtrl-2"
 msgstr "插入標題單元(&I)\tCtrl-2"
 
-#: ../src/MathCtrl.cpp:1013
+#: ../src/MathCtrl.cpp:1055
 msgid "Insert Text Cell"
 msgstr "插入文字單元"
 
-#: ../src/MathCtrl.cpp:1014
+#: ../src/MathCtrl.cpp:1056
 msgid "Insert Title Cell"
 msgstr "插入標題單元"
 
-#: ../src/wxMaximaFrame.cpp:607
+#: ../src/wxMaximaFrame.cpp:606
 msgid "Insert a new input cell"
 msgstr "插入新的輸入單元"
 
-#: ../src/wxMaximaFrame.cpp:613
+#: ../src/wxMaximaFrame.cpp:612
 msgid "Insert a new section cell"
 msgstr "插入新的章節單元"
 
-#: ../src/wxMaximaFrame.cpp:615
+#: ../src/wxMaximaFrame.cpp:614
 msgid "Insert a new subsection cell"
 msgstr "插入新的子章節單元"
 
-#: ../src/wxMaximaFrame.cpp:617
+#: ../src/wxMaximaFrame.cpp:616
 #, fuzzy
 msgid "Insert a new subsubsection cell"
 msgstr "插入新的子章節單元"
 
-#: ../src/wxMaximaFrame.cpp:609
+#: ../src/wxMaximaFrame.cpp:608
 msgid "Insert a new text cell"
 msgstr "插入新的文字單元"
 
-#: ../src/wxMaximaFrame.cpp:611
+#: ../src/wxMaximaFrame.cpp:610
 msgid "Insert a new title cell"
 msgstr "插入新的標題單元"
 
-#: ../src/wxMaximaFrame.cpp:619
+#: ../src/wxMaximaFrame.cpp:618
 msgid "Insert a page break"
 msgstr "插入一個換頁符號"
 
-#: ../src/wxMaximaFrame.cpp:621
+#: ../src/wxMaximaFrame.cpp:620
 msgid "Insert image"
 msgstr "插入圖片"
 
@@ -2359,27 +2362,27 @@ msgstr ""
 msgid "Integral sign"
 msgstr "對數式積分"
 
-#: ../src/wxMaxima.cpp:3992
+#: ../src/wxMaxima.cpp:4004
 msgid "Integral/Sum:"
 msgstr "積分／加總："
 
-#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4105 ../src/wxMaxima.cpp:5051
+#: ../src/IntegrateWiz.cpp:66 ../src/wxMaxima.cpp:4117 ../src/wxMaxima.cpp:5063
 msgid "Integrate"
 msgstr "積分"
 
-#: ../src/wxMaxima.cpp:4091
+#: ../src/wxMaxima.cpp:4103
 msgid "Integrate (risch)"
 msgstr "Risch 積分"
 
-#: ../src/wxMaximaFrame.cpp:778
+#: ../src/wxMaximaFrame.cpp:777
 msgid "Integrate expression"
 msgstr "對數式積分"
 
-#: ../src/wxMaximaFrame.cpp:780
+#: ../src/wxMaximaFrame.cpp:779
 msgid "Integrate expression with Risch algorithm"
 msgstr "使用 Risch 演算法積分數式"
 
-#: ../src/wxMaximaFrame.cpp:1224 ../src/MathCtrl.cpp:1000
+#: ../src/MathCtrl.cpp:1042 ../src/wxMaximaFrame.cpp:1223
 msgid "Integrate..."
 msgstr "積分..."
 
@@ -2387,7 +2390,7 @@ msgstr "積分..."
 msgid "Interrupt"
 msgstr "中斷"
 
-#: ../src/wxMaximaFrame.cpp:646 ../src/wxMaximaFrame.cpp:650
+#: ../src/wxMaximaFrame.cpp:645 ../src/wxMaximaFrame.cpp:649
 msgid "Interrupt current computation"
 msgstr "中斷目前的計算"
 
@@ -2407,15 +2410,15 @@ msgstr ""
 "\n"
 "請再次輸入 Maxima 程式的所在路徑。"
 
-#: ../src/wxMaxima.cpp:4137
+#: ../src/wxMaxima.cpp:4149
 msgid "Inverse Laplace"
 msgstr "Laplace 逆變換"
 
-#: ../src/wxMaximaFrame.cpp:806
+#: ../src/wxMaximaFrame.cpp:805
 msgid "Inverse Laplace T&ransform..."
 msgstr "反 Laplace 變換(&R)..."
 
-#: ../src/wxMaximaFrame.cpp:1372
+#: ../src/wxMaximaFrame.cpp:1371
 msgid "Iota"
 msgstr ""
 
@@ -2449,7 +2452,7 @@ msgstr "Japanese"
 msgid "Kabyle"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1373
+#: ../src/wxMaximaFrame.cpp:1372
 msgid "Kappa"
 msgstr ""
 
@@ -2458,7 +2461,7 @@ msgstr ""
 msgid "Keep percent sign with special symbols: %e, %i, etc."
 msgstr "保留特殊符號前的百分比號，像是「%e」、「%i」等..."
 
-#: ../src/wxMaxima.cpp:4031
+#: ../src/wxMaxima.cpp:4043
 msgid "LCM"
 msgstr "最小公倍式"
 
@@ -2474,7 +2477,7 @@ msgstr ""
 msgid "Label width:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1374
+#: ../src/wxMaximaFrame.cpp:1373
 msgid "Lambda"
 msgstr ""
 
@@ -2486,11 +2489,11 @@ msgstr "wxMaxima 圖形介面的語言"
 msgid "Language:"
 msgstr "語言："
 
-#: ../src/wxMaxima.cpp:4120
+#: ../src/wxMaxima.cpp:4132
 msgid "Laplace"
 msgstr "Laplace 變換"
 
-#: ../src/wxMaximaFrame.cpp:803
+#: ../src/wxMaximaFrame.cpp:802
 msgid "Laplace &Transform..."
 msgstr "Laplace 變換(&T)..."
 
@@ -2498,15 +2501,15 @@ msgstr "Laplace 變換(&T)..."
 msgid "Leads to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:812
+#: ../src/wxMaximaFrame.cpp:811
 msgid "Least Common Multiple..."
 msgstr "最小公倍式..."
 
-#: ../src/wxMaxima.cpp:4809
+#: ../src/wxMaxima.cpp:4821
 msgid "Least Squares Fit"
 msgstr "最小平方法"
 
-#: ../src/wxMaximaFrame.cpp:1266
+#: ../src/wxMaximaFrame.cpp:1265
 msgid "Least Squares Fit..."
 msgstr "最小平方法..."
 
@@ -2517,24 +2520,24 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4192
+#: ../src/LimitWiz.cpp:66 ../src/wxMaxima.cpp:4204
 msgid "Limit"
 msgstr "極限"
 
-#: ../src/wxMaximaFrame.cpp:1225
+#: ../src/wxMaximaFrame.cpp:1224
 msgid "Limit..."
 msgstr "極限..."
 
-#: ../src/wxMaximaFrame.cpp:1265
+#: ../src/wxMaximaFrame.cpp:1264
 msgid "Linear Regression..."
 msgstr "線性迴歸..."
 
-#: ../src/wxMaxima.cpp:3803
+#: ../src/wxMaxima.cpp:3815
 #, fuzzy
 msgid "List(s):"
 msgstr "串列："
 
-#: ../src/wxMaxima.cpp:3836
+#: ../src/wxMaxima.cpp:3848
 msgid "List:"
 msgstr "串列："
 
@@ -2542,15 +2545,15 @@ msgstr "串列："
 msgid "Load"
 msgstr "載入"
 
-#: ../src/wxMaxima.cpp:2932
+#: ../src/wxMaxima.cpp:2940
 msgid "Load Package"
 msgstr "載入 Package"
 
-#: ../src/wxMaximaFrame.cpp:479
+#: ../src/wxMaximaFrame.cpp:478
 msgid "Load a Maxima file using the batch command"
 msgstr "以批次命令的方式載入 Maxima 檔"
 
-#: ../src/wxMaximaFrame.cpp:477
+#: ../src/wxMaximaFrame.cpp:476
 msgid "Load a Maxima package file"
 msgstr "讀取 Maxima package 檔"
 
@@ -2562,49 +2565,49 @@ msgstr "自檔案載入樣式"
 msgid "Long Right arrow"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Lower bound:"
 msgstr "下界："
 
-#: ../src/wxMaximaFrame.cpp:771
+#: ../src/wxMaximaFrame.cpp:770
 msgid "Ma&p to Matrix..."
 msgstr "映射至整個矩陣(&P)..."
 
-#: ../src/wxMaximaFrame.cpp:547
+#: ../src/wxMaximaFrame.cpp:546
 #, fuzzy
 msgid "Main Toolbar\tAlt-Shift-B"
 msgstr "工具列\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:765
+#: ../src/wxMaximaFrame.cpp:764
 msgid "Make &List..."
 msgstr "產生串列(&L)..."
 
-#: ../src/wxMaxima.cpp:3821
+#: ../src/wxMaxima.cpp:3833
 msgid "Make list"
 msgstr "產生串列"
 
-#: ../src/wxMaximaFrame.cpp:766
+#: ../src/wxMaximaFrame.cpp:765
 msgid "Make list from expression"
 msgstr "從數式產生串列"
 
-#: ../src/wxMaximaFrame.cpp:907
+#: ../src/wxMaximaFrame.cpp:906
 msgid "Make substitution in expression"
 msgstr "在數式中作代換"
 
-#: ../src/wxMaximaFrame.cpp:682
+#: ../src/wxMaximaFrame.cpp:681
 #, fuzzy
 msgid "Manually Trigger Evaluation"
 msgstr "顯示評算所花費的時間"
 
-#: ../src/wxMaxima.cpp:3805
+#: ../src/wxMaxima.cpp:3817
 msgid "Map"
 msgstr "映射"
 
-#: ../src/wxMaximaFrame.cpp:770
+#: ../src/wxMaximaFrame.cpp:769
 msgid "Map function to a list"
 msgstr "映射函數至串列"
 
-#: ../src/wxMaximaFrame.cpp:772
+#: ../src/wxMaximaFrame.cpp:771
 msgid "Map function to a matrix"
 msgstr "映射函數至矩陣"
 
@@ -2621,23 +2624,23 @@ msgstr "在文字控制項中輸入時匹配括弧"
 msgid "Math font:"
 msgstr "數學字型："
 
-#: ../src/wxMaximaFrame.cpp:374
+#: ../src/wxMaximaFrame.cpp:373
 msgid "Mathematical Symbols"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3716
+#: ../src/wxMaxima.cpp:3728
 msgid "Matrix"
 msgstr "矩陣"
 
-#: ../src/wxMaxima.cpp:3702
+#: ../src/wxMaxima.cpp:3714
 msgid "Matrix map"
 msgstr "矩陣映射"
 
-#: ../src/wxMaxima.cpp:4857
+#: ../src/wxMaxima.cpp:4869
 msgid "Matrix name:"
 msgstr "矩陣名："
 
-#: ../src/wxMaxima.cpp:3700 ../src/wxMaxima.cpp:3749
+#: ../src/wxMaxima.cpp:3712 ../src/wxMaxima.cpp:3761
 msgid "Matrix:"
 msgstr "矩陣："
 
@@ -2645,7 +2648,7 @@ msgstr "矩陣："
 msgid "Maxima"
 msgstr "Maxima"
 
-#: ../src/wxMaximaFrame.cpp:137
+#: ../src/wxMaximaFrame.cpp:136
 #, fuzzy
 msgid "Maxima has a question"
 msgstr "Maxima 詢問"
@@ -2654,24 +2657,24 @@ msgstr "Maxima 詢問"
 msgid "Maxima input"
 msgstr "Maxima 輸入"
 
-#: ../src/wxMaximaFrame.cpp:166
+#: ../src/wxMaximaFrame.cpp:165
 msgid "Maxima is calculating"
 msgstr "Maxima 計算中"
 
-#: ../src/wxMaximaFrame.cpp:111
+#: ../src/wxMaximaFrame.cpp:110
 #, fuzzy
 msgid "Maxima is ready for input."
 msgstr "Maxima 輸入"
 
-#: ../src/wxMaxima.cpp:2945
+#: ../src/wxMaxima.cpp:2953
 msgid "Maxima package (*.mac)|*.mac"
 msgstr "Maxima package (*.mac)|*.mac"
 
-#: ../src/wxMaxima.cpp:2934
+#: ../src/wxMaxima.cpp:2942
 msgid "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|All|*"
 msgstr "Maxima package (*.mac)|*.mac|Lisp package (*.lisp)|*.lisp|所有類型|*"
 
-#: ../src/wxMaxima.cpp:1014
+#: ../src/wxMaxima.cpp:1019
 msgid "Maxima process terminated."
 msgstr "Maxima 程序已結束"
 
@@ -2683,7 +2686,7 @@ msgstr "Maxima 程式："
 msgid "Maxima questions"
 msgstr "Maxima 詢問"
 
-#: ../src/wxMaxima.cpp:942
+#: ../src/wxMaxima.cpp:947
 msgid "Maxima started. Waiting for connection..."
 msgstr "Maxima 已啟動，等待連線中..."
 
@@ -2707,7 +2710,7 @@ msgstr ""
 "Maxima 使用 \":\" 來設定數值 (例：\"a : 3;\")，使用 \":=\" 來定義函數 (例："
 "\"f(x) := x^2\")。"
 
-#: ../src/wxMaxima.cpp:4597
+#: ../src/wxMaxima.cpp:4609
 msgid "Maxima version: "
 msgstr "Maxima 版本："
 
@@ -2744,40 +2747,40 @@ msgstr ""
 msgid "Maximum displayed number of digits:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1263
+#: ../src/wxMaximaFrame.cpp:1262
 msgid "Mean Difference Test..."
 msgstr "平均差檢驗..."
 
-#: ../src/wxMaximaFrame.cpp:1262
+#: ../src/wxMaximaFrame.cpp:1261
 msgid "Mean Test..."
 msgstr "平均值檢驗..."
 
-#: ../src/wxMaximaFrame.cpp:1255
+#: ../src/wxMaximaFrame.cpp:1254
 msgid "Mean..."
 msgstr "平均..."
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Mean:"
 msgstr "平均值："
 
-#: ../src/wxMaximaFrame.cpp:1256
+#: ../src/wxMaximaFrame.cpp:1255
 msgid "Median..."
 msgstr "中位數..."
 
-#: ../src/MathCtrl.cpp:945
+#: ../src/MathCtrl.cpp:987
 msgid "Merge Cells"
 msgstr "合併單元"
 
-#: ../src/wxMaximaFrame.cpp:633
+#: ../src/wxMaximaFrame.cpp:632
 #, fuzzy
 msgid "Merge Cells\tCtrl-M"
 msgstr "合併單元"
 
-#: ../src/wxMaximaFrame.cpp:634
+#: ../src/wxMaximaFrame.cpp:633
 msgid "Merge the text from two input cells into one"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2668
+#: ../src/wxMaxima.cpp:2676
 msgid "Message from the stdout of Maxima: "
 msgstr ""
 
@@ -2785,20 +2788,20 @@ msgstr ""
 msgid "Method:"
 msgstr "方法："
 
-#: ../src/wxMaxima.cpp:5289
+#: ../src/wxMaxima.cpp:5301
 #, fuzzy
 msgid "Mismatched parenthesis"
 msgstr "在文字控制項中輸入時匹配括弧"
 
-#: ../src/wxMaxima.cpp:3972
+#: ../src/wxMaxima.cpp:3984
 msgid "Modulus"
 msgstr "模運算"
 
-#: ../src/wxMaximaFrame.cpp:1375
+#: ../src/wxMaximaFrame.cpp:1374
 msgid "Mu"
 msgstr ""
 
-#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:181 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Name:"
 msgstr "命名："
 
@@ -2806,7 +2809,7 @@ msgstr "命名："
 msgid "New"
 msgstr "新增"
 
-#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
+#: ../src/wxMaximaFrame.cpp:456 ../src/wxMaximaFrame.cpp:459
 msgid "New\tCtrl-N"
 msgstr "新增\tCtrl-N"
 
@@ -2822,11 +2825,11 @@ msgstr ""
 msgid "New value:"
 msgstr "新值："
 
-#: ../src/wxMaxima.cpp:3993 ../src/wxMaxima.cpp:4119 ../src/wxMaxima.cpp:4136
+#: ../src/wxMaxima.cpp:4005 ../src/wxMaxima.cpp:4131 ../src/wxMaxima.cpp:4148
 msgid "New variable:"
 msgstr "新變數："
 
-#: ../src/wxMaximaFrame.cpp:630
+#: ../src/wxMaximaFrame.cpp:629
 msgid "Next Command\tAlt-Down"
 msgstr "下一個命令\tAlt-Down"
 
@@ -2834,15 +2837,15 @@ msgstr "下一個命令\tAlt-Down"
 msgid "No"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5362
+#: ../src/wxMaxima.cpp:5378
 msgid "No dollar ($) or semicolon (;) at the end of command"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3249 ../src/wxMaxima.cpp:3271
+#: ../src/wxMaxima.cpp:3260 ../src/wxMaxima.cpp:3283
 msgid "No matches found!"
 msgstr "找不到匹配的項目！"
 
-#: ../src/wxMaximaFrame.cpp:1264
+#: ../src/wxMaximaFrame.cpp:1263
 msgid "Normality Test..."
 msgstr "常態分布檢驗..."
 
@@ -2865,34 +2868,34 @@ msgstr ""
 msgid "Norwegian"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:3728
+#: ../src/wxMaxima.cpp:3740
 msgid "Not a valid matrix dimension!"
 msgstr "這不是有效的矩陣大小！"
 
-#: ../src/wxMaxima.cpp:3593 ../src/wxMaxima.cpp:3617
+#: ../src/wxMaxima.cpp:3605 ../src/wxMaxima.cpp:3629
 msgid "Not a valid number of equations!"
 msgstr "這不是有效的數字或方程式！"
 
-#: ../src/wxMaximaFrame.cpp:197
+#: ../src/wxMaximaFrame.cpp:196
 #, fuzzy
 msgid "Not connected to maxima"
 msgstr ""
 "\n"
 "未連線到 Maxima！\n"
 
-#: ../src/wxMaxima.cpp:4599
+#: ../src/wxMaxima.cpp:4611
 msgid "Not connected."
 msgstr "未連線"
 
-#: ../src/wxMaximaFrame.cpp:1376
+#: ../src/wxMaximaFrame.cpp:1375
 msgid "Nu"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Num. deg:"
 msgstr "分子 degree："
 
-#: ../src/wxMaxima.cpp:3585 ../src/wxMaxima.cpp:3609
+#: ../src/wxMaxima.cpp:3597 ../src/wxMaxima.cpp:3621
 msgid "Number of equations:"
 msgstr "方程式數量："
 
@@ -2919,15 +2922,15 @@ msgstr "確認"
 msgid "Old value:"
 msgstr "舊值："
 
-#: ../src/wxMaxima.cpp:3992 ../src/wxMaxima.cpp:4118 ../src/wxMaxima.cpp:4135
+#: ../src/wxMaxima.cpp:4004 ../src/wxMaxima.cpp:4130 ../src/wxMaxima.cpp:4147
 msgid "Old variable:"
 msgstr "舊變數："
 
-#: ../src/wxMaximaFrame.cpp:1387
+#: ../src/wxMaximaFrame.cpp:1386
 msgid "Omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1378
+#: ../src/wxMaximaFrame.cpp:1377
 msgid "Omicron"
 msgstr ""
 
@@ -2941,20 +2944,20 @@ msgid ""
 "stream for messages."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4763
+#: ../src/wxMaxima.cpp:4775
 msgid "One sample t-test"
 msgstr "單樣本 t-檢驗"
 
-#: ../src/wxMaximaFrame.cpp:971
+#: ../src/wxMaximaFrame.cpp:970
 msgid "Online tutorials"
 msgstr "線上教材"
 
 #: ../src/ConfigDialogue.cpp:656 ../src/main.cpp:347 ../src/ToolBar.cpp:119
-#: ../src/wxMaxima.cpp:2797
+#: ../src/wxMaxima.cpp:2805
 msgid "Open"
 msgstr "開啟"
 
-#: ../src/wxMaximaFrame.cpp:466
+#: ../src/wxMaximaFrame.cpp:465
 msgid "Open Recent"
 msgstr "最近開啟的文件"
 
@@ -2962,11 +2965,11 @@ msgstr "最近開啟的文件"
 msgid "Open a cell when Maxima expects input"
 msgstr "當 Maxima 期望輸入時新增單元"
 
-#: ../src/wxMaximaFrame.cpp:464
+#: ../src/wxMaximaFrame.cpp:463
 msgid "Open a document"
 msgstr "開啟文件"
 
-#: ../src/wxMaximaFrame.cpp:458 ../src/wxMaximaFrame.cpp:461
+#: ../src/wxMaximaFrame.cpp:457 ../src/wxMaximaFrame.cpp:460
 msgid "Open a new window"
 msgstr "開新視窗"
 
@@ -2974,11 +2977,11 @@ msgstr "開新視窗"
 msgid "Open document"
 msgstr "開啟文件"
 
-#: ../src/wxMaxima.cpp:4824
+#: ../src/wxMaxima.cpp:4836
 msgid "Open matrix"
 msgstr "開啟矩陣"
 
-#: ../src/wxMaxima.cpp:1446 ../src/wxMaxima.cpp:1518
+#: ../src/wxMaxima.cpp:1451 ../src/wxMaxima.cpp:1523
 msgid "Opening file"
 msgstr "正在開啟檔案"
 
@@ -3002,11 +3005,11 @@ msgstr "過時的單元"
 msgid "Output labels"
 msgstr "輸出標籤"
 
-#: ../src/wxMaximaFrame.cpp:796
+#: ../src/wxMaximaFrame.cpp:795
 msgid "P&ade Approximation..."
 msgstr "Pade 近似(&A)..."
 
-#: ../src/wxMaxima.cpp:3132 ../src/wxMaxima.cpp:5133
+#: ../src/wxMaxima.cpp:3141 ../src/wxMaxima.cpp:5145
 #, fuzzy
 msgid ""
 "PNG image (*.png)|*.png|JPEG image (*.jpg)|*.jpg|Windows bitmap (*.bmp)|*."
@@ -3016,15 +3019,15 @@ msgstr ""
 "PNG (*.png)|*.png|JPEG (*.jpg)|*.jpg|Windows 點陣圖 (*.bmp)|*.bmp|X pixmap "
 "(*.xpm)|*.xpm"
 
-#: ../src/wxMaxima.cpp:4012
+#: ../src/wxMaxima.cpp:4024
 msgid "Pade approximation"
 msgstr "Pade 近似"
 
-#: ../src/wxMaximaFrame.cpp:797
+#: ../src/wxMaximaFrame.cpp:796
 msgid "Pade approximation of a Taylor series"
 msgstr "計算 Taylor 級數的 Pade 近似"
 
-#: ../src/wxMaximaFrame.cpp:1500
+#: ../src/wxMaximaFrame.cpp:1519
 msgid "Pagebreak"
 msgstr "換頁符號"
 
@@ -3036,19 +3039,19 @@ msgstr ""
 msgid "Parametric plot"
 msgstr "參數式繪圖"
 
-#: ../src/wxMaximaFrame.cpp:188
+#: ../src/wxMaximaFrame.cpp:187
 msgid "Parsing output"
 msgstr "解析輸出中"
 
-#: ../src/wxMaximaFrame.cpp:819
+#: ../src/wxMaximaFrame.cpp:818
 msgid "Partial &Fractions..."
 msgstr "部分分式(&F)..."
 
-#: ../src/wxMaxima.cpp:4076
+#: ../src/wxMaxima.cpp:4088
 msgid "Partial fractions"
 msgstr "部分分式"
 
-#: ../src/wxMaxima.cpp:1769
+#: ../src/wxMaxima.cpp:1774
 msgid "Parts of the document will not be loaded correctly!"
 msgstr "文件的某部分將無法被正確的讀取！"
 
@@ -3059,11 +3062,11 @@ msgid ""
 "Found unknown XML Tag name "
 msgstr "文件的某部分將無法被正確的讀取！"
 
-#: ../src/ToolBar.cpp:143 ../src/MathCtrl.cpp:1010 ../src/MathCtrl.cpp:1025
+#: ../src/MathCtrl.cpp:1052 ../src/MathCtrl.cpp:1067 ../src/ToolBar.cpp:143
 msgid "Paste"
 msgstr "貼上"
 
-#: ../src/wxMaximaFrame.cpp:518
+#: ../src/wxMaximaFrame.cpp:517
 msgid "Paste\tCtrl-V"
 msgstr "貼上\tCtrl-V"
 
@@ -3071,7 +3074,7 @@ msgstr "貼上\tCtrl-V"
 msgid "Paste from clipboard"
 msgstr "從剪貼簿貼上"
 
-#: ../src/wxMaximaFrame.cpp:519
+#: ../src/wxMaximaFrame.cpp:518
 msgid "Paste text from clipboard"
 msgstr "從剪貼簿貼上文字"
 
@@ -3079,19 +3082,19 @@ msgstr "從剪貼簿貼上文字"
 msgid "Perpendicular to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1384
+#: ../src/wxMaximaFrame.cpp:1383
 msgid "Phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1379
+#: ../src/wxMaximaFrame.cpp:1378
 msgid "Pi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1273
+#: ../src/wxMaximaFrame.cpp:1272
 msgid "Piechart..."
 msgstr "圓餅圖..."
 
-#: ../src/wxMaxima.cpp:1952
+#: ../src/wxMaxima.cpp:1957
 msgid "Please configure wxMaxima with 'Edit->Configure'."
 msgstr "請從「編輯(E)」->「設定(O)」設定 wxMaxima"
 
@@ -3099,52 +3102,52 @@ msgstr "請從「編輯(E)」->「設定(O)」設定 wxMaxima"
 msgid "Please restart wxMaxima for changes to take effect!"
 msgstr "請重新啟動 wxMaxima 使變更生效！"
 
-#: ../src/wxMaximaFrame.cpp:923
+#: ../src/wxMaximaFrame.cpp:922
 msgid "Plot &2d..."
 msgstr "二維繪圖(&2)..."
 
-#: ../src/wxMaximaFrame.cpp:925
+#: ../src/wxMaximaFrame.cpp:924
 msgid "Plot &3d..."
 msgstr "三維繪圖(&3)..."
 
-#: ../src/wxMaximaFrame.cpp:927
+#: ../src/wxMaximaFrame.cpp:926
 msgid "Plot &Format..."
 msgstr "繪圖格式(&F)..."
 
 #: ../src/Plot2dWiz.cpp:104 ../src/Plot2dWiz.cpp:450 ../src/Plot2dWiz.cpp:464
-#: ../src/wxMaxima.cpp:4283 ../src/wxMaxima.cpp:5102
+#: ../src/wxMaxima.cpp:4295 ../src/wxMaxima.cpp:5114
 msgid "Plot 2D"
 msgstr "二維繪圖"
 
-#: ../src/wxMaximaFrame.cpp:1227
+#: ../src/wxMaximaFrame.cpp:1226
 msgid "Plot 2D..."
 msgstr "二維繪圖..."
 
-#: ../src/MathCtrl.cpp:1003
+#: ../src/MathCtrl.cpp:1045
 msgid "Plot 2d..."
 msgstr "二維繪圖..."
 
-#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4269 ../src/wxMaxima.cpp:5115
+#: ../src/Plot3dWiz.cpp:108 ../src/wxMaxima.cpp:4281 ../src/wxMaxima.cpp:5127
 msgid "Plot 3D"
 msgstr "三維繪圖"
 
-#: ../src/wxMaximaFrame.cpp:1228
+#: ../src/wxMaximaFrame.cpp:1227
 msgid "Plot 3D..."
 msgstr "三維繪圖..."
 
-#: ../src/MathCtrl.cpp:1004
+#: ../src/MathCtrl.cpp:1046
 msgid "Plot 3d..."
 msgstr "三維繪圖..."
 
-#: ../src/wxMaxima.cpp:4296
+#: ../src/wxMaxima.cpp:4308
 msgid "Plot format"
 msgstr "繪圖格式"
 
-#: ../src/wxMaximaFrame.cpp:924
+#: ../src/wxMaximaFrame.cpp:923
 msgid "Plot in 2 dimensions"
 msgstr "二維繪圖"
 
-#: ../src/wxMaximaFrame.cpp:926
+#: ../src/wxMaximaFrame.cpp:925
 msgid "Plot in 3 dimensions"
 msgstr "三維繪圖"
 
@@ -3153,8 +3156,8 @@ msgid "Plot to file:"
 msgstr "繪圖存檔："
 
 #: ../src/BC2Wiz.cpp:30 ../src/BC2Wiz.cpp:36 ../src/LimitWiz.cpp:33
-#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
-#: ../src/wxMaxima.cpp:3648
+#: ../src/SeriesWiz.cpp:39 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
+#: ../src/wxMaxima.cpp:3660
 msgid "Point:"
 msgstr "點："
 
@@ -3162,11 +3165,11 @@ msgstr "點："
 msgid "Polish"
 msgstr "Polish"
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 1:"
 msgstr "多項式 1："
 
-#: ../src/wxMaxima.cpp:4029 ../src/wxMaxima.cpp:4044 ../src/wxMaxima.cpp:4059
+#: ../src/wxMaxima.cpp:4041 ../src/wxMaxima.cpp:4056 ../src/wxMaxima.cpp:4071
 msgid "Polynomial 2:"
 msgstr "多項式 2："
 
@@ -3178,11 +3181,11 @@ msgstr "Portuguese (Brazilian)"
 msgid "Postscript file (*.eps)|*.eps|All|*"
 msgstr "Postscript 檔 (*.eps)|*.eps|所有類型|*"
 
-#: ../src/wxMaxima.cpp:4340
+#: ../src/wxMaxima.cpp:4352
 msgid "Precision"
 msgstr "精確度"
 
-#: ../src/wxMaximaFrame.cpp:537
+#: ../src/wxMaximaFrame.cpp:536
 #, fuzzy
 msgid "Preferences...\tCtrl+,"
 msgstr "偏好設定...\tCTRL+,"
@@ -3195,7 +3198,7 @@ msgid ""
 "packages and from functions that are defined in the current file."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:628
+#: ../src/wxMaximaFrame.cpp:627
 msgid "Previous Command\tAlt-Up"
 msgstr "上一個命令\tAlt-Up"
 
@@ -3203,11 +3206,11 @@ msgstr "上一個命令\tAlt-Up"
 msgid "Print"
 msgstr "列印"
 
-#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:484
+#: ../src/ToolBar.cpp:130 ../src/wxMaximaFrame.cpp:483
 msgid "Print document"
 msgstr "列印文件"
 
-#: ../src/wxMaxima.cpp:4242
+#: ../src/wxMaxima.cpp:4254
 msgid "Product"
 msgstr "乘積"
 
@@ -3216,36 +3219,36 @@ msgstr "乘積"
 msgid "Product sign"
 msgstr "乘積"
 
-#: ../src/wxMaximaFrame.cpp:1386
+#: ../src/wxMaximaFrame.cpp:1385
 msgid "Psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:331
+#: ../src/wxMaximaFrame.cpp:330
 msgid "Raw XML monitor"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:592
+#: ../src/wxMaximaFrame.cpp:591
 #, fuzzy
 msgid "Re-evaluate all cells above the one the cursor is in"
 msgstr "評算這份文件中的所有單元"
 
-#: ../src/wxMaximaFrame.cpp:1278
+#: ../src/wxMaximaFrame.cpp:1277
 msgid "Read Matrix..."
 msgstr "讀取矩陣..."
 
-#: ../src/wxMaximaFrame.cpp:177
+#: ../src/wxMaximaFrame.cpp:176
 msgid "Reading Maxima output"
 msgstr "正在讀取 Maxima 的輸出"
 
-#: ../src/wxMaximaFrame.cpp:153
+#: ../src/wxMaximaFrame.cpp:152
 msgid "Ready for user input"
 msgstr "準備就緒"
 
-#: ../src/wxMaximaFrame.cpp:631
+#: ../src/wxMaximaFrame.cpp:630
 msgid "Recall next command from history"
 msgstr "呼叫歷史記錄中的下一個命令"
 
-#: ../src/wxMaximaFrame.cpp:629
+#: ../src/wxMaximaFrame.cpp:628
 msgid "Recall previous command from history"
 msgstr "呼叫歷史紀錄中的上一個命令"
 
@@ -3253,36 +3256,36 @@ msgstr "呼叫歷史紀錄中的上一個命令"
 msgid "Recent files list length:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1215
+#: ../src/wxMaximaFrame.cpp:1214
 msgid "Rectform"
 msgstr "直角坐標形式"
 
-#: ../src/wxMaximaFrame.cpp:495
+#: ../src/wxMaximaFrame.cpp:494
 #, fuzzy
 msgid "Redo\tCtrl-Y"
 msgstr "復原\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:496
+#: ../src/wxMaximaFrame.cpp:495
 msgid "Redo last change"
 msgstr "重作上次的變更"
 
-#: ../src/wxMaximaFrame.cpp:1220
+#: ../src/wxMaximaFrame.cpp:1219
 msgid "Reduce (tr)"
 msgstr "縮併 (三角)"
 
-#: ../src/wxMaximaFrame.cpp:871
+#: ../src/wxMaximaFrame.cpp:870
 msgid "Reduce trigonometric expression"
 msgstr "縮併三角函數數式"
 
-#: ../src/wxMaxima.cpp:622 ../src/wxMaxima.cpp:5495
+#: ../src/wxMaxima.cpp:627 ../src/wxMaxima.cpp:5511
 msgid "Refusing to send cell to maxima: "
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:594
+#: ../src/wxMaximaFrame.cpp:593
 msgid "Remove All Output"
 msgstr "移除所有輸出"
 
-#: ../src/wxMaximaFrame.cpp:595
+#: ../src/wxMaximaFrame.cpp:594
 msgid "Remove output from input cells"
 msgstr "移除所有輸入單元的輸出"
 
@@ -3291,7 +3294,7 @@ msgstr "移除所有輸入單元的輸出"
 msgid "Replace All"
 msgstr "全部選取"
 
-#: ../src/wxMaxima.cpp:3282
+#: ../src/wxMaxima.cpp:3294
 #, c-format
 msgid "Replaced %d occurrences."
 msgstr "找到 %d 個並取代。"
@@ -3300,11 +3303,11 @@ msgstr "找到 %d 個並取代。"
 msgid "Replacement:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:976
+#: ../src/wxMaximaFrame.cpp:975
 msgid "Report bug"
 msgstr "回報發現的錯誤"
 
-#: ../src/wxMaximaFrame.cpp:653
+#: ../src/wxMaximaFrame.cpp:652
 msgid "Restart Maxima"
 msgstr "重新啟動 Maxima"
 
@@ -3313,7 +3316,7 @@ msgstr "重新啟動 Maxima"
 msgid "Restart maxima"
 msgstr "重新啟動 Maxima"
 
-#: ../src/MathCtrl.cpp:4442
+#: ../src/MathCtrl.cpp:4497
 msgid "Result"
 msgstr ""
 
@@ -3321,7 +3324,7 @@ msgstr ""
 msgid "Return to the cell that is currently being evaluated"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1380
+#: ../src/wxMaximaFrame.cpp:1379
 msgid "Rho"
 msgstr ""
 
@@ -3329,19 +3332,19 @@ msgstr ""
 msgid "Right arrow"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:779
+#: ../src/wxMaximaFrame.cpp:778
 msgid "Risch Integration..."
 msgstr "Risch 積分..."
 
-#: ../src/wxMaximaFrame.cpp:694
+#: ../src/wxMaximaFrame.cpp:693
 msgid "Roots of &Polynomial"
 msgstr "找多項式所有的根(&P)"
 
-#: ../src/wxMaximaFrame.cpp:697
+#: ../src/wxMaximaFrame.cpp:696
 msgid "Roots of Polynomial (bfloat)"
 msgstr "找多項式所有的根(長浮點數)"
 
-#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3764 ../src/wxMaxima.cpp:3783
+#: ../src/MatWiz.cpp:165 ../src/wxMaxima.cpp:3776 ../src/wxMaxima.cpp:3795
 msgid "Rows:"
 msgstr "列："
 
@@ -3349,56 +3352,56 @@ msgstr "列："
 msgid "Russian"
 msgstr "Russian"
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 1:"
 msgstr "樣本 1："
 
-#: ../src/wxMaxima.cpp:4776
+#: ../src/wxMaxima.cpp:4788
 msgid "Sample 2:"
 msgstr "樣本 2："
 
-#: ../src/wxMaxima.cpp:4762
+#: ../src/wxMaxima.cpp:4774
 msgid "Sample:"
 msgstr "樣本："
 
 #: ../src/ConfigDialogue.cpp:781 ../src/ToolBar.cpp:122
-#: ../src/wxMaxima.cpp:5922
+#: ../src/wxMaxima.cpp:5937
 msgid "Save"
 msgstr "儲存"
 
-#: ../src/MathCtrl.cpp:921
+#: ../src/MathCtrl.cpp:963
 msgid "Save Animation..."
 msgstr "儲存動畫..."
 
-#: ../src/wxMaxima.cpp:2565
+#: ../src/wxMaxima.cpp:2572
 msgid "Save As"
 msgstr "另存新檔"
 
-#: ../src/wxMaximaFrame.cpp:474
+#: ../src/wxMaximaFrame.cpp:473
 msgid "Save As...\tShift-Ctrl-S"
 msgstr "另存新檔...\tShift-Ctrl-S"
 
-#: ../src/MathCtrl.cpp:919
+#: ../src/MathCtrl.cpp:961
 msgid "Save Image..."
 msgstr "儲存圖片..."
 
-#: ../src/wxMaxima.cpp:3130
+#: ../src/wxMaxima.cpp:3139
 msgid "Save Selection to Image"
 msgstr "儲存所選區域為圖片"
 
-#: ../src/wxMaximaFrame.cpp:528
+#: ../src/wxMaximaFrame.cpp:527
 msgid "Save Selection to Image..."
 msgstr "儲存為圖片..."
 
-#: ../src/wxMaxima.cpp:5150
+#: ../src/wxMaxima.cpp:5162
 msgid "Save animation to file"
 msgstr "儲存動畫至檔案"
 
-#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:473
+#: ../src/ToolBar.cpp:124 ../src/wxMaximaFrame.cpp:472
 msgid "Save document"
 msgstr "儲存文件"
 
-#: ../src/wxMaximaFrame.cpp:475
+#: ../src/wxMaximaFrame.cpp:474
 msgid "Save document as"
 msgstr "將文件另存新檔"
 
@@ -3420,11 +3423,11 @@ msgstr "儲存工作階段間的窗格配置"
 msgid "Save plot to file"
 msgstr "儲存繪圖至檔案"
 
-#: ../src/wxMaximaFrame.cpp:529
+#: ../src/wxMaximaFrame.cpp:528
 msgid "Save selection from document to an image file"
 msgstr "儲存所選區域為圖片檔"
 
-#: ../src/wxMaxima.cpp:5131
+#: ../src/wxMaxima.cpp:5143
 msgid "Save selection to file"
 msgstr "儲存選取區域至檔案"
 
@@ -3440,28 +3443,28 @@ msgstr "儲存 wxMaxima 視窗的大小及位置"
 msgid "Save wxMaxima window size/position between sessions."
 msgstr "儲存工作階段間 wxMaxima 視窗的大小及位置"
 
-#: ../src/wxMaximaFrame.cpp:246
+#: ../src/wxMaximaFrame.cpp:245
 #, fuzzy
 msgid "Saving failed."
 msgstr "伺服器啟動失敗"
 
-#: ../src/wxMaximaFrame.cpp:222
+#: ../src/wxMaximaFrame.cpp:221
 msgid "Saving successful."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:212
+#: ../src/wxMaximaFrame.cpp:211
 msgid "Saving..."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4699
+#: ../src/wxMaxima.cpp:4711
 msgid "Scatterplot"
 msgstr "散布圖"
 
-#: ../src/wxMaximaFrame.cpp:1271
+#: ../src/wxMaximaFrame.cpp:1270
 msgid "Scatterplot..."
 msgstr "散布圖..."
 
-#: ../src/wxMaximaFrame.cpp:1498
+#: ../src/wxMaximaFrame.cpp:1517
 msgid "Section"
 msgstr "章節"
 
@@ -3469,26 +3472,26 @@ msgstr "章節"
 msgid "Section cell"
 msgstr "章節單元"
 
-#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:292 ../src/TextCell.cpp:306
-#: ../src/TextCell.cpp:322 ../src/TextCell.cpp:334
+#: ../src/BTextCtrl.cpp:48 ../src/TextCell.cpp:290 ../src/TextCell.cpp:304
+#: ../src/TextCell.cpp:320 ../src/TextCell.cpp:332
 msgid ""
 "Seems like something is broken with a font. Installing http://www.math.union."
 "edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts"
 "\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/TextCell.cpp:139
+#: ../src/TextCell.cpp:137
 msgid ""
 "Seems like something is broken with the maths font. Installing http://www."
 "math.union.edu/~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use "
 "JSmath fonts\" in the configuration dialogue should fix it."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:1011 ../src/MathCtrl.cpp:1027
+#: ../src/MathCtrl.cpp:1053 ../src/MathCtrl.cpp:1069
 msgid "Select All"
 msgstr "全部選取"
 
-#: ../src/wxMaximaFrame.cpp:525
+#: ../src/wxMaximaFrame.cpp:524
 msgid "Select All\tCtrl-A"
 msgstr "全部選取\tCtrl-A"
 
@@ -3496,7 +3499,7 @@ msgstr "全部選取\tCtrl-A"
 msgid "Select Maxima program"
 msgstr "選擇 Maxima 程式"
 
-#: ../src/wxMaxima.cpp:4860
+#: ../src/wxMaxima.cpp:4872
 msgid "Select Subsample"
 msgstr "選取子樣本"
 
@@ -3505,11 +3508,11 @@ msgstr "選取子樣本"
 msgid "Select a constant"
 msgstr "選擇常數"
 
-#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:526
+#: ../src/ToolBar.cpp:146 ../src/ToolBar.cpp:148 ../src/wxMaximaFrame.cpp:525
 msgid "Select all"
 msgstr "全部選取"
 
-#: ../src/wxMaxima.cpp:3319
+#: ../src/wxMaxima.cpp:3331
 msgid "Select math display algorithm"
 msgstr "選擇用於顯示數學的演算法"
 
@@ -3525,23 +3528,23 @@ msgstr ""
 msgid "Selection"
 msgstr "所選區域"
 
-#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4178
+#: ../src/SeriesWiz.cpp:62 ../src/wxMaxima.cpp:4190
 msgid "Series"
 msgstr "級數"
 
-#: ../src/wxMaximaFrame.cpp:1226
+#: ../src/wxMaximaFrame.cpp:1225
 msgid "Series..."
 msgstr "級數..."
 
-#: ../src/wxMaxima.cpp:863
+#: ../src/wxMaxima.cpp:868
 msgid "Server started"
 msgstr "伺服器已啟動"
 
-#: ../src/wxMaximaFrame.cpp:575
+#: ../src/wxMaximaFrame.cpp:574
 msgid "Set Zoom"
 msgstr "顯示比例"
 
-#: ../src/wxMaximaFrame.cpp:944
+#: ../src/wxMaximaFrame.cpp:943
 #, fuzzy
 msgid "Set bigfloat &Precision..."
 msgstr "設定 bigfloat 的精確度"
@@ -3550,61 +3553,61 @@ msgstr "設定 bigfloat 的精確度"
 msgid "Set fixed font in text controls."
 msgstr "在文字控制項中使用等寬字型"
 
-#: ../src/wxMaximaFrame.cpp:928
+#: ../src/wxMaximaFrame.cpp:927
 msgid "Set plot format"
 msgstr "設定繪圖格式"
 
-#: ../src/wxMaximaFrame.cpp:945
+#: ../src/wxMaximaFrame.cpp:944
 msgid ""
 "Set the precision for numbers that are defined as bigfloat. Such numbers can "
 "be generated by entering 1.5b12 or as bfloat(1.234)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:569
+#: ../src/wxMaximaFrame.cpp:568
 msgid "Set zoom to 100%"
 msgstr "將顯示比例設定為 100%"
 
-#: ../src/wxMaximaFrame.cpp:570
+#: ../src/wxMaximaFrame.cpp:569
 msgid "Set zoom to 120%"
 msgstr "將顯示比例設定為 120%"
 
-#: ../src/wxMaximaFrame.cpp:571
+#: ../src/wxMaximaFrame.cpp:570
 msgid "Set zoom to 150%"
 msgstr "將顯示比例設定為 150%"
 
-#: ../src/wxMaximaFrame.cpp:572
+#: ../src/wxMaximaFrame.cpp:571
 msgid "Set zoom to 200%"
 msgstr "將顯示比例設定為 200%"
 
-#: ../src/wxMaximaFrame.cpp:573
+#: ../src/wxMaximaFrame.cpp:572
 msgid "Set zoom to 300%"
 msgstr "將顯示比例設定為 300%"
 
-#: ../src/wxMaximaFrame.cpp:568
+#: ../src/wxMaximaFrame.cpp:567
 msgid "Set zoom to 80%"
 msgstr "將顯示比例設定為 80%"
 
-#: ../src/wxMaximaFrame.cpp:732
+#: ../src/wxMaximaFrame.cpp:731
 msgid "Setup atvalues for solving ODE with Laplace transformation"
 msgstr "在使用 Laplace 變換解常微分方程前將定點設值"
 
-#: ../src/wxMaximaFrame.cpp:918
+#: ../src/wxMaximaFrame.cpp:917
 msgid "Setup modulus computation"
 msgstr "設定模運算"
 
-#: ../src/wxMaximaFrame.cpp:662
+#: ../src/wxMaximaFrame.cpp:661
 msgid "Show &Definition..."
 msgstr "顯示函數定義(&D)..."
 
-#: ../src/wxMaximaFrame.cpp:660
+#: ../src/wxMaximaFrame.cpp:659
 msgid "Show &Functions"
 msgstr "顯示函數(&F)"
 
-#: ../src/wxMaximaFrame.cpp:967
+#: ../src/wxMaximaFrame.cpp:966
 msgid "Show &Tips..."
 msgstr "顯示小秘訣(&T)..."
 
-#: ../src/wxMaximaFrame.cpp:665
+#: ../src/wxMaximaFrame.cpp:664
 msgid "Show &Variables"
 msgstr "顯示變數(&V)"
 
@@ -3612,43 +3615,43 @@ msgstr "顯示變數(&V)"
 msgid "Show Maxima help"
 msgstr "顯示 Maxima 說明"
 
-#: ../src/wxMaximaFrame.cpp:603
+#: ../src/wxMaximaFrame.cpp:602
 msgid "Show Template\tCtrl-Shift-K"
 msgstr "顯示範本\tCtrl-Shift-K"
 
-#: ../src/wxMaximaFrame.cpp:968
+#: ../src/wxMaximaFrame.cpp:967
 msgid "Show a tip"
 msgstr "顯示小秘訣"
 
-#: ../src/wxMaxima.cpp:4640
+#: ../src/wxMaxima.cpp:4652
 msgid "Show all commands similar to:"
 msgstr "顯示全部與此指令相似的指令："
 
-#: ../src/wxMaxima.cpp:4627
+#: ../src/wxMaxima.cpp:4639
 msgid "Show an example for the command:"
 msgstr "顯示這個指令的使用範例："
 
-#: ../src/wxMaximaFrame.cpp:962
+#: ../src/wxMaximaFrame.cpp:961
 msgid "Show an example of usage"
 msgstr "顯示一個使用範例"
 
-#: ../src/wxMaximaFrame.cpp:965
+#: ../src/wxMaximaFrame.cpp:964
 msgid "Show commands similar to"
 msgstr "顯示相似的指令"
 
-#: ../src/wxMaximaFrame.cpp:661
+#: ../src/wxMaximaFrame.cpp:660
 msgid "Show defined functions"
 msgstr "顯示已定義的函數"
 
-#: ../src/wxMaximaFrame.cpp:666
+#: ../src/wxMaximaFrame.cpp:665
 msgid "Show defined variables"
 msgstr "顯示已定義的變數"
 
-#: ../src/wxMaximaFrame.cpp:663
+#: ../src/wxMaximaFrame.cpp:662
 msgid "Show definition of a function"
 msgstr "顯示函數的定義"
 
-#: ../src/wxMaximaFrame.cpp:604
+#: ../src/wxMaximaFrame.cpp:603
 msgid "Show function template"
 msgstr "顯示函數範本"
 
@@ -3661,7 +3664,7 @@ msgstr "在 wxMaxima 文件中顯示長的數式"
 msgid "Show long expressions:"
 msgstr "顯示長的數式"
 
-#: ../src/wxMaxima.cpp:3341
+#: ../src/wxMaxima.cpp:3353
 msgid "Show the definition of function:"
 msgstr "顯示該函數的定義："
 
@@ -3670,44 +3673,44 @@ msgstr "顯示該函數的定義："
 msgid "Show user-defined labels instead of (%oxx)"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:953 ../src/wxMaximaFrame.cpp:956
+#: ../src/wxMaximaFrame.cpp:952 ../src/wxMaximaFrame.cpp:955
 #, fuzzy
 msgid "Show wxMaxima help"
 msgstr "顯示 Maxima 說明"
 
-#: ../src/wxMaximaFrame.cpp:1381
+#: ../src/wxMaximaFrame.cpp:1380
 msgid "Sigma"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1211
+#: ../src/wxMaximaFrame.cpp:1210
 msgid "Simplify"
 msgstr "化簡"
 
-#: ../src/wxMaximaFrame.cpp:831
+#: ../src/wxMaximaFrame.cpp:830
 msgid "Simplify &Radicals"
 msgstr "化簡根式(&R)"
 
-#: ../src/wxMaximaFrame.cpp:1212
+#: ../src/wxMaximaFrame.cpp:1211
 msgid "Simplify (r)"
 msgstr "化簡根式"
 
-#: ../src/wxMaximaFrame.cpp:1218
+#: ../src/wxMaximaFrame.cpp:1217
 msgid "Simplify (tr)"
 msgstr "化簡 (三角)"
 
-#: ../src/MathCtrl.cpp:995
+#: ../src/MathCtrl.cpp:1037
 msgid "Simplify Expression"
 msgstr "化簡數式"
 
-#: ../src/wxMaximaFrame.cpp:857
+#: ../src/wxMaximaFrame.cpp:856
 msgid "Simplify an expression containing factorials"
 msgstr "化簡包含階乘的數式"
 
-#: ../src/wxMaximaFrame.cpp:832
+#: ../src/wxMaximaFrame.cpp:831
 msgid "Simplify expression containing radicals"
 msgstr "化簡包含根號的數式"
 
-#: ../src/wxMaximaFrame.cpp:830
+#: ../src/wxMaximaFrame.cpp:829
 msgid "Simplify rational expression"
 msgstr "化簡有理數式"
 
@@ -3715,7 +3718,7 @@ msgstr "化簡有理數式"
 msgid "Simplify the sum"
 msgstr "化簡此加總"
 
-#: ../src/wxMaximaFrame.cpp:868
+#: ../src/wxMaximaFrame.cpp:867
 msgid "Simplify trigonometric expression"
 msgstr "化簡三角函數數式"
 
@@ -3730,87 +3733,87 @@ msgstr ""
 "插入圖片。請注意：若您希望將圖片與文件一起儲存，您必須將您的文件儲存為 "
 "「wxMaxima XML 文件」。"
 
-#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3525 ../src/wxMaxima.cpp:3540
+#: ../src/BC2Wiz.cpp:27 ../src/wxMaxima.cpp:3537 ../src/wxMaxima.cpp:3552
 msgid "Solution:"
 msgstr "一般解："
 
-#: ../src/wxMaxima.cpp:3461 ../src/wxMaxima.cpp:3475 ../src/wxMaxima.cpp:5020
+#: ../src/wxMaxima.cpp:3473 ../src/wxMaxima.cpp:3487 ../src/wxMaxima.cpp:5032
 msgid "Solve"
 msgstr "求解"
 
-#: ../src/wxMaximaFrame.cpp:706
+#: ../src/wxMaximaFrame.cpp:705
 msgid "Solve &Algebraic System..."
 msgstr "解代數系統(&A)..."
 
-#: ../src/wxMaximaFrame.cpp:703
+#: ../src/wxMaximaFrame.cpp:702
 msgid "Solve &Linear System..."
 msgstr "解線性系統(&L)..."
 
-#: ../src/wxMaximaFrame.cpp:714
+#: ../src/wxMaximaFrame.cpp:713
 msgid "Solve &ODE..."
 msgstr "解常微分方程(&O)..."
 
-#: ../src/wxMaximaFrame.cpp:690
+#: ../src/wxMaximaFrame.cpp:689
 msgid "Solve (to_poly)..."
 msgstr "求解 (to_poly)..."
 
-#: ../src/wxMaxima.cpp:3511 ../src/wxMaxima.cpp:3635
+#: ../src/wxMaxima.cpp:3523 ../src/wxMaxima.cpp:3647
 msgid "Solve ODE"
 msgstr "解常微分方程"
 
-#: ../src/wxMaximaFrame.cpp:728
+#: ../src/wxMaximaFrame.cpp:727
 msgid "Solve ODE with Lapla&ce..."
 msgstr "以 Laplace 變換解常微分方程(&C)..."
 
-#: ../src/wxMaximaFrame.cpp:1222
+#: ../src/wxMaximaFrame.cpp:1221
 msgid "Solve ODE..."
 msgstr "解常微分方程..."
 
-#: ../src/wxMaxima.cpp:3586 ../src/wxMaxima.cpp:3597
+#: ../src/wxMaxima.cpp:3598 ../src/wxMaxima.cpp:3609
 msgid "Solve algebraic system"
 msgstr "解代數系統"
 
-#: ../src/wxMaximaFrame.cpp:707
+#: ../src/wxMaximaFrame.cpp:706
 msgid "Solve algebraic system of equations"
 msgstr "解代數方程組"
 
-#: ../src/wxMaximaFrame.cpp:725
+#: ../src/wxMaximaFrame.cpp:724
 msgid "Solve boundary value problem for second degree ODE"
 msgstr "解 2 階常微分方程的邊界值問題"
 
-#: ../src/wxMaximaFrame.cpp:689
+#: ../src/wxMaximaFrame.cpp:688
 msgid "Solve equation(s)"
 msgstr "解方程式"
 
-#: ../src/wxMaximaFrame.cpp:691
+#: ../src/wxMaximaFrame.cpp:690
 msgid "Solve equation(s) with to_poly_solve"
 msgstr "使用 to_poly_solve 解方程式"
 
-#: ../src/wxMaximaFrame.cpp:719
+#: ../src/wxMaximaFrame.cpp:718
 msgid "Solve initial value problem for first degree ODE"
 msgstr "解 1 階常微分方程的初始值問題"
 
-#: ../src/wxMaximaFrame.cpp:722
+#: ../src/wxMaximaFrame.cpp:721
 msgid "Solve initial value problem for second degree ODE"
 msgstr "解 2 階常微分方程的初始值問題"
 
-#: ../src/wxMaxima.cpp:3610 ../src/wxMaxima.cpp:3621
+#: ../src/wxMaxima.cpp:3622 ../src/wxMaxima.cpp:3633
 msgid "Solve linear system"
 msgstr "解線性系統"
 
-#: ../src/wxMaximaFrame.cpp:704
+#: ../src/wxMaximaFrame.cpp:703
 msgid "Solve linear system of equations"
 msgstr "解線性方程組"
 
-#: ../src/wxMaximaFrame.cpp:715
+#: ../src/wxMaximaFrame.cpp:714
 msgid "Solve ordinary differential equation of maximum degree 2"
 msgstr "解常微分方程式 (最大 2 階)"
 
-#: ../src/wxMaximaFrame.cpp:729
+#: ../src/wxMaximaFrame.cpp:728
 msgid "Solve ordinary differential equations with Laplace transformation"
 msgstr "以 Laplace 變換解常微分方程式"
 
-#: ../src/wxMaximaFrame.cpp:1221 ../src/MathCtrl.cpp:992
+#: ../src/MathCtrl.cpp:1034 ../src/wxMaximaFrame.cpp:1220
 msgid "Solve..."
 msgstr "求解..."
 
@@ -3834,7 +3837,7 @@ msgstr "特殊"
 msgid "Special constants"
 msgstr "特殊常數"
 
-#: ../src/MathCtrl.cpp:922
+#: ../src/MathCtrl.cpp:964
 msgid "Start Animation"
 msgstr "開始動畫"
 
@@ -3853,28 +3856,28 @@ msgstr ""
 msgid "Start searching while the phrase to search for is still being typed."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:294
+#: ../src/wxMaxima.cpp:295
 msgid "Starting Maxima process failed"
 msgstr "Maxima 程序啟動失敗"
 
-#: ../src/wxMaxima.cpp:928
+#: ../src/wxMaxima.cpp:933
 msgid "Starting Maxima..."
 msgstr "Maxima 啟動中..."
 
-#: ../src/wxMaxima.cpp:292 ../src/wxMaxima.cpp:860
+#: ../src/wxMaxima.cpp:293 ../src/wxMaxima.cpp:865
 msgid "Starting server failed"
 msgstr "伺服器啟動失敗"
 
-#: ../src/wxMaxima.cpp:841
+#: ../src/wxMaxima.cpp:846
 #, c-format
 msgid "Starting server on port %d"
 msgstr "於 %d埠啟動伺服器"
 
-#: ../src/wxMaximaFrame.cpp:342
+#: ../src/wxMaximaFrame.cpp:341
 msgid "Statistics"
 msgstr "統計"
 
-#: ../src/wxMaximaFrame.cpp:550
+#: ../src/wxMaximaFrame.cpp:549
 msgid "Statistics\tAlt-Shift-S"
 msgstr "統計\tAlt-Shift-S"
 
@@ -3890,11 +3893,11 @@ msgstr "樣式"
 msgid "Styles"
 msgstr "樣式"
 
-#: ../src/wxMaximaFrame.cpp:1283
+#: ../src/wxMaximaFrame.cpp:1282
 msgid "Subsample..."
 msgstr "子樣本..."
 
-#: ../src/wxMaximaFrame.cpp:1496
+#: ../src/wxMaximaFrame.cpp:1515
 msgid "Subsection"
 msgstr "子章節"
 
@@ -3902,20 +3905,20 @@ msgstr "子章節"
 msgid "Subsection cell"
 msgstr "子章節單元"
 
-#: ../src/wxMaximaFrame.cpp:1216
+#: ../src/wxMaximaFrame.cpp:1215
 msgid "Subst..."
 msgstr "代換"
 
-#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3423
-#: ../src/wxMaxima.cpp:5089
+#: ../src/SubstituteWiz.cpp:54 ../src/wxMaxima.cpp:3435
+#: ../src/wxMaxima.cpp:5101
 msgid "Substitute"
 msgstr "代換"
 
-#: ../src/wxMaximaFrame.cpp:906 ../src/MathCtrl.cpp:998
+#: ../src/MathCtrl.cpp:1040 ../src/wxMaximaFrame.cpp:905
 msgid "Substitute..."
 msgstr "代換..."
 
-#: ../src/wxMaximaFrame.cpp:1497
+#: ../src/wxMaximaFrame.cpp:1516
 #, fuzzy
 msgid "Subsubsection"
 msgstr "子章節"
@@ -3925,7 +3928,7 @@ msgstr "子章節"
 msgid "Subsubsection cell"
 msgstr "子章節單元"
 
-#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4226
+#: ../src/SumWiz.cpp:58 ../src/wxMaxima.cpp:4238
 msgid "Sum"
 msgstr "加總"
 
@@ -3933,37 +3936,37 @@ msgstr "加總"
 msgid "Sum sign"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:553
+#: ../src/wxMaximaFrame.cpp:552
 #, fuzzy
 msgid "Symbols\tAlt-Shift-Y"
 msgstr "統計\tAlt-Shift-S"
 
-#: ../src/wxMaxima.cpp:4456
+#: ../src/wxMaxima.cpp:4468
 msgid "System info"
 msgstr "系統資訊"
 
-#: ../src/wxMaximaFrame.cpp:320
+#: ../src/wxMaximaFrame.cpp:319
 msgid "Table of Contents"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:556
+#: ../src/wxMaximaFrame.cpp:555
 #, fuzzy
 msgid "Table of Contents\tAlt-Shift-T"
 msgstr "工具列\tAlt-Shift-T"
 
-#: ../src/wxMaximaFrame.cpp:1382
+#: ../src/wxMaximaFrame.cpp:1381
 msgid "Tau"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4010
+#: ../src/wxMaxima.cpp:4022
 msgid "Taylor series:"
 msgstr "Taylor 級數："
 
-#: ../src/wxMaxima.cpp:3963
+#: ../src/wxMaxima.cpp:3975
 msgid "Tellrat"
 msgstr "Tellrat 函數"
 
-#: ../src/wxMaximaFrame.cpp:1494
+#: ../src/wxMaximaFrame.cpp:1513
 msgid "Text"
 msgstr "文字"
 
@@ -4009,7 +4012,7 @@ msgstr ""
 msgid "The document class LaTeX is instructed to use for our documents."
 msgstr ""
 
-#: ../src/TextCell.cpp:136
+#: ../src/TextCell.cpp:134
 msgid ""
 "The letter \"X\" is of width zero. Installing http://www.math.union.edu/"
 "~dpvc/jsmath/download/jsMath-fonts.html and checking \"Use JSmath fonts\" in "
@@ -4026,7 +4029,7 @@ msgstr ""
 msgid "The number of recently opened files that is to be remembered."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:959
+#: ../src/wxMaximaFrame.cpp:958
 msgid "The offline manual of maxima"
 msgstr ""
 
@@ -4064,7 +4067,7 @@ msgstr ""
 "sourceforge.net/wiki/index.php/Tutorials 以獲得更多 wxMaxima 與 Maxima 的相關"
 "資訊。"
 
-#: ../src/SlideShowCell.cpp:332
+#: ../src/SlideShowCell.cpp:336
 msgid ""
 "There was an error during GIF export!\n"
 "\n"
@@ -4074,7 +4077,7 @@ msgstr ""
 "\n"
 "請確認您已安裝 ImageMagick 且 wxMaxima 可找到該程式。"
 
-#: ../src/wxMaxima.cpp:442
+#: ../src/wxMaxima.cpp:447
 msgid ""
 "There was an error in generated XML!\n"
 "\n"
@@ -4084,7 +4087,7 @@ msgstr ""
 "\n"
 "請回報此錯誤。"
 
-#: ../src/wxMaximaFrame.cpp:1371
+#: ../src/wxMaximaFrame.cpp:1370
 msgid "Theta"
 msgstr ""
 
@@ -4092,7 +4095,7 @@ msgstr ""
 msgid "Ticks:"
 msgstr "描繪密度："
 
-#: ../src/wxMaxima.cpp:4153 ../src/wxMaxima.cpp:5065
+#: ../src/wxMaxima.cpp:4165 ../src/wxMaxima.cpp:5077
 msgid "Times:"
 msgstr "次數："
 
@@ -4100,7 +4103,7 @@ msgstr "次數："
 msgid "Tips not available, sorry!"
 msgstr "抱歉，小秘訣無法顯示！"
 
-#: ../src/wxMaximaFrame.cpp:1495
+#: ../src/wxMaximaFrame.cpp:1514
 msgid "Title"
 msgstr "標題"
 
@@ -4118,19 +4121,19 @@ msgstr ""
 "擊該單元左側的小正方形。如果您按住 Shift 鍵並點擊小正方形，所有該單元中的子單"
 "元也會跟著折疊或取消折疊。"
 
-#: ../src/wxMaximaFrame.cpp:938
+#: ../src/wxMaximaFrame.cpp:937
 msgid "To &Bigfloat"
 msgstr "計算長浮點數(&B)"
 
-#: ../src/wxMaximaFrame.cpp:935
+#: ../src/wxMaximaFrame.cpp:934
 msgid "To &Float"
 msgstr "計算浮點數(&F)"
 
-#: ../src/MathCtrl.cpp:990
+#: ../src/MathCtrl.cpp:1032
 msgid "To Float"
 msgstr "計算浮點數"
 
-#: ../src/wxMaximaFrame.cpp:941
+#: ../src/wxMaximaFrame.cpp:940
 msgid "To Numeri&c\tCtrl+Shift+N"
 msgstr ""
 
@@ -4169,51 +4172,51 @@ msgstr ""
 
 #: ../src/IntegrateWiz.cpp:41 ../src/Plot2dWiz.cpp:40 ../src/Plot2dWiz.cpp:50
 #: ../src/Plot2dWiz.cpp:539 ../src/Plot3dWiz.cpp:39 ../src/Plot3dWiz.cpp:48
-#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3819 ../src/wxMaxima.cpp:4241
+#: ../src/SumWiz.cpp:36 ../src/wxMaxima.cpp:3831 ../src/wxMaxima.cpp:4253
 msgid "To:"
 msgstr "到："
 
-#: ../src/wxMaximaFrame.cpp:912
+#: ../src/wxMaximaFrame.cpp:911
 msgid "Toggle &Algebraic Flag"
 msgstr "切換代數旗標(&A)"
 
-#: ../src/wxMaximaFrame.cpp:933
+#: ../src/wxMaximaFrame.cpp:932
 msgid "Toggle &Numeric Output"
 msgstr "切換數值輸出(&N)"
 
-#: ../src/wxMaximaFrame.cpp:673
+#: ../src/wxMaximaFrame.cpp:672
 msgid "Toggle &Time Display"
 msgstr "切換計算時間顯示(&T)"
 
-#: ../src/wxMaximaFrame.cpp:913
+#: ../src/wxMaximaFrame.cpp:912
 msgid "Toggle algebraic flag"
 msgstr "切換代數旗標"
 
-#: ../src/wxMaximaFrame.cpp:577
+#: ../src/wxMaximaFrame.cpp:576
 msgid "Toggle full screen editing"
 msgstr "切換全螢幕編輯模式"
 
-#: ../src/wxMaximaFrame.cpp:934
+#: ../src/wxMaximaFrame.cpp:933
 msgid "Toggle numeric output"
 msgstr "切換數值輸出／數式輸出"
 
-#: ../src/wxMaxima.cpp:4464
+#: ../src/wxMaxima.cpp:4476
 msgid "Toolbar icons"
 msgstr "工具列圖示"
 
-#: ../src/wxMaxima.cpp:4465
+#: ../src/wxMaxima.cpp:4477
 msgid "Translated by"
 msgstr "翻譯者"
 
-#: ../src/wxMaximaFrame.cpp:763
+#: ../src/wxMaximaFrame.cpp:762
 msgid "Transpose a matrix"
 msgstr "計算轉置矩陣"
 
-#: ../src/MathCtrl.cpp:5834
+#: ../src/MathCtrl.cpp:5886
 msgid "Trying to undo an action without starting cell."
 msgstr ""
 
-#: ../src/MathCtrl.cpp:5901
+#: ../src/MathCtrl.cpp:5953
 msgid "Trying to undo something but the undo action is empty."
 msgstr ""
 
@@ -4221,11 +4224,11 @@ msgstr ""
 msgid "Turkish"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:970
+#: ../src/wxMaximaFrame.cpp:969
 msgid "Tutorials"
 msgstr "教材"
 
-#: ../src/wxMaxima.cpp:4778
+#: ../src/wxMaxima.cpp:4790
 msgid "Two sample t-test"
 msgstr "雙樣本 t-檢驗"
 
@@ -4237,15 +4240,15 @@ msgstr "類型："
 msgid "Ukrainian"
 msgstr "Ukrainian"
 
-#: ../src/wxMaxima.cpp:5356
+#: ../src/wxMaxima.cpp:5372
 msgid "Un-closed parenthesis"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5323
+#: ../src/wxMaxima.cpp:5335
 msgid "Un-closed parenthesis on encountering ; or $"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5889
 msgid ""
 "Unable to interpret the version info I got from http://andrejv.github.io//"
 "wxmaxima/version.txt: "
@@ -4259,11 +4262,11 @@ msgstr "底線"
 msgid "Underscore converts to subscripts:"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:492
+#: ../src/wxMaximaFrame.cpp:491
 msgid "Undo\tCtrl-Z"
 msgstr "復原\tCtrl-Z"
 
-#: ../src/wxMaximaFrame.cpp:493
+#: ../src/wxMaximaFrame.cpp:492
 msgid "Undo last change"
 msgstr "復原上次的變更"
 
@@ -4271,24 +4274,24 @@ msgstr "復原上次的變更"
 msgid "Undo limit (0 for none):"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:625
+#: ../src/wxMaximaFrame.cpp:624
 #, fuzzy
 msgid "Unfold All\tCtrl-Alt-]"
 msgstr "全部選取\tCtrl-A"
 
-#: ../src/wxMaximaFrame.cpp:626
+#: ../src/wxMaximaFrame.cpp:625
 msgid "Unfold all folded sections"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4458
+#: ../src/wxMaxima.cpp:4470
 msgid "Unicode Support"
 msgstr "支援 Unicode"
 
-#: ../src/wxMaxima.cpp:5335
+#: ../src/wxMaxima.cpp:5347
 msgid "Unterminated comment."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5309
+#: ../src/wxMaxima.cpp:5321
 msgid "Unterminated string."
 msgstr ""
 
@@ -4296,15 +4299,15 @@ msgstr ""
 msgid "Up"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5859 ../src/wxMaxima.cpp:5866 ../src/wxMaxima.cpp:5874
+#: ../src/wxMaxima.cpp:5874 ../src/wxMaxima.cpp:5881 ../src/wxMaxima.cpp:5889
 msgid "Upgrade"
 msgstr "升級"
 
-#: ../src/wxMaxima.cpp:3491 ../src/wxMaxima.cpp:5034
+#: ../src/wxMaxima.cpp:3503 ../src/wxMaxima.cpp:5046
 msgid "Upper bound:"
 msgstr "上界："
 
-#: ../src/wxMaximaFrame.cpp:1383
+#: ../src/wxMaximaFrame.cpp:1382
 #, fuzzy
 msgid "Upsilon"
 msgstr "Epsilon:"
@@ -4349,22 +4352,22 @@ msgstr ""
 msgid "User-defined labels"
 msgstr ""
 
-#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3525
-#: ../src/wxMaxima.cpp:3541 ../src/wxMaxima.cpp:3649
+#: ../src/BC2Wiz.cpp:33 ../src/BC2Wiz.cpp:39 ../src/wxMaxima.cpp:3537
+#: ../src/wxMaxima.cpp:3553 ../src/wxMaxima.cpp:3661
 msgid "Value:"
 msgstr "值："
 
-#: ../src/wxMaxima.cpp:3460 ../src/wxMaxima.cpp:3474 ../src/wxMaxima.cpp:4152
-#: ../src/wxMaxima.cpp:5019 ../src/wxMaxima.cpp:5064
+#: ../src/wxMaxima.cpp:3472 ../src/wxMaxima.cpp:3486 ../src/wxMaxima.cpp:4164
+#: ../src/wxMaxima.cpp:5031 ../src/wxMaxima.cpp:5076
 msgid "Variable(s):"
 msgstr "變數："
 
 #: ../src/IntegrateWiz.cpp:33 ../src/LimitWiz.cpp:30 ../src/Plot2dWiz.cpp:34
 #: ../src/Plot2dWiz.cpp:44 ../src/Plot2dWiz.cpp:533 ../src/Plot3dWiz.cpp:33
 #: ../src/Plot3dWiz.cpp:42 ../src/SeriesWiz.cpp:36 ../src/SumWiz.cpp:30
-#: ../src/wxMaxima.cpp:3490 ../src/wxMaxima.cpp:3509 ../src/wxMaxima.cpp:3749
-#: ../src/wxMaxima.cpp:3818 ../src/wxMaxima.cpp:4074 ../src/wxMaxima.cpp:4089
-#: ../src/wxMaxima.cpp:4240 ../src/wxMaxima.cpp:5033
+#: ../src/wxMaxima.cpp:3502 ../src/wxMaxima.cpp:3521 ../src/wxMaxima.cpp:3761
+#: ../src/wxMaxima.cpp:3830 ../src/wxMaxima.cpp:4086 ../src/wxMaxima.cpp:4101
+#: ../src/wxMaxima.cpp:4252 ../src/wxMaxima.cpp:5045
 msgid "Variable:"
 msgstr "變數："
 
@@ -4372,25 +4375,25 @@ msgstr "變數："
 msgid "Variables"
 msgstr "變數"
 
-#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3571 ../src/wxMaxima.cpp:4206
-#: ../src/wxMaxima.cpp:4807
+#: ../src/SystemWiz.cpp:73 ../src/wxMaxima.cpp:3583 ../src/wxMaxima.cpp:4218
+#: ../src/wxMaxima.cpp:4819
 msgid "Variables:"
 msgstr "變數："
 
-#: ../src/wxMaximaFrame.cpp:1257
+#: ../src/wxMaximaFrame.cpp:1256
 msgid "Variance..."
 msgstr "變異數..."
 
-#: ../src/wxMaximaFrame.cpp:580
+#: ../src/wxMaximaFrame.cpp:579
 msgid "View"
 msgstr ""
 
-#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1674 ../src/wxMaxima.cpp:1769
-#: ../src/wxMaxima.cpp:1950
+#: ../src/MathParser.cpp:1028 ../src/wxMaxima.cpp:1679 ../src/wxMaxima.cpp:1774
+#: ../src/wxMaxima.cpp:1955
 msgid "Warning"
 msgstr "警告"
 
-#: ../src/wxMaximaFrame.cpp:109 ../src/wxMaximaFrame.cpp:295
+#: ../src/wxMaximaFrame.cpp:108 ../src/wxMaximaFrame.cpp:294
 msgid "Welcome to wxMaxima"
 msgstr "歡迎使用 wxMaxima"
 
@@ -4412,7 +4415,7 @@ msgid ""
 "introducing an empty line."
 msgstr ""
 
-#: ../src/wxMaxima.cpp:2567
+#: ../src/wxMaxima.cpp:2574
 msgid ""
 "Whole document (*.wxmx)|*.wxmx|The input, readable by load() (maxima > 5.38) "
 "(*.wxm)|*.wxm"
@@ -4428,7 +4431,7 @@ msgid ""
 "as equation markers"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:6798
+#: ../src/MathCtrl.cpp:6856
 msgid "Wrapped search"
 msgstr ""
 
@@ -4436,15 +4439,15 @@ msgstr ""
 msgid "Write matching parenthesis in text controls."
 msgstr "在文字控制項輸入時插入匹配的括弧"
 
-#: ../src/wxMaxima.cpp:4461
+#: ../src/wxMaxima.cpp:4473
 msgid "Written by"
 msgstr "作者"
 
-#: ../src/wxMaximaFrame.cpp:557
+#: ../src/wxMaximaFrame.cpp:556
 msgid "XML Inspector"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1377
+#: ../src/wxMaximaFrame.cpp:1376
 msgid "Xi"
 msgstr ""
 
@@ -4510,7 +4513,7 @@ msgstr ""
 "您可以透過滑鼠(在單元之間或左側的單元框拖曳)或鍵盤(在移動水平游標時按住Shift"
 "鍵)選取多個單元，然後對所選區域操作。這在您想要刪除或評算多個單元時很有用。"
 
-#: ../src/wxMaxima.cpp:5856
+#: ../src/wxMaxima.cpp:5871
 #, c-format
 msgid ""
 "You have version %s. Current version is %s.\n"
@@ -4521,41 +4524,41 @@ msgstr ""
 "\n"
 "按「確認」至 wxMaxima 首頁。"
 
-#: ../src/wxMaxima.cpp:5921
+#: ../src/wxMaxima.cpp:5936
 msgid "Your changes will be lost if you don't save them."
 msgstr "如果您未儲存，您所做的所有修改將遺失。"
 
-#: ../src/wxMaxima.cpp:5866
+#: ../src/wxMaxima.cpp:5881
 msgid "Your version of wxMaxima is up to date."
 msgstr "您的 wxMaxima 是最新版本"
 
-#: ../src/wxMaximaFrame.cpp:1369
+#: ../src/wxMaximaFrame.cpp:1368
 msgid "Zeta"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:562
+#: ../src/wxMaximaFrame.cpp:561
 #, fuzzy
 msgid "Zoom &In\tCtrl-+"
 msgstr "放大(&I)\tAlt-I"
 
-#: ../src/wxMaximaFrame.cpp:564
+#: ../src/wxMaximaFrame.cpp:563
 #, fuzzy
 msgid "Zoom Ou&t\tCtrl--"
 msgstr "縮小(&T)\tAlt-O"
 
-#: ../src/wxMaximaFrame.cpp:563
+#: ../src/wxMaximaFrame.cpp:562
 msgid "Zoom in 10%"
 msgstr "將顯示比例放大 10%"
 
-#: ../src/wxMaximaFrame.cpp:565
+#: ../src/wxMaximaFrame.cpp:564
 msgid "Zoom out 10%"
 msgstr "將顯示比例縮小 10%"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaximaFrame.cpp:287
 msgid "[ unsaved ]"
 msgstr "[ 未儲存 ]"
 
-#: ../src/wxMaxima.cpp:5700
+#: ../src/wxMaxima.cpp:5715
 msgid "[ unsaved* ]"
 msgstr "[ 未儲存* ]"
 
@@ -4564,17 +4567,17 @@ msgstr "[ 未儲存* ]"
 msgid "[%i digits]"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4392
+#: ../src/MathCtrl.cpp:4447
 #, c-format
 msgid "_%d.gif\"  alt=\"Animated Diagram\" style=\"max-width:90%%;\" >\n"
 msgstr ""
 
-#: ../src/MathCtrl.cpp:4517
+#: ../src/MathCtrl.cpp:4572
 #, c-format
 msgid "_%d.gif\" alt=\"Animated Diagram\" style=\"max-width:90%%;\" >"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1333
+#: ../src/wxMaximaFrame.cpp:1332
 msgid "alpha"
 msgstr ""
 
@@ -4587,7 +4590,7 @@ msgstr "展開"
 msgid "antisymmetric"
 msgstr "反對稱"
 
-#: ../src/wxMaximaFrame.cpp:1334
+#: ../src/wxMaximaFrame.cpp:1333
 msgid "beta"
 msgstr ""
 
@@ -4631,7 +4634,7 @@ msgstr ""
 msgid "bug:Invalid sup tag"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1354
+#: ../src/wxMaximaFrame.cpp:1353
 msgid "chi"
 msgstr ""
 
@@ -4644,7 +4647,7 @@ msgstr ""
 msgid "default"
 msgstr "預設值"
 
-#: ../src/wxMaximaFrame.cpp:1336
+#: ../src/wxMaximaFrame.cpp:1335
 msgid "delta"
 msgstr ""
 
@@ -4656,7 +4659,7 @@ msgstr "對角"
 msgid "empty"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1337
+#: ../src/wxMaximaFrame.cpp:1336
 #, fuzzy
 msgid "epsilon"
 msgstr "Epsilon:"
@@ -4665,7 +4668,7 @@ msgstr "Epsilon:"
 msgid "equivalent"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1339
+#: ../src/wxMaximaFrame.cpp:1338
 msgid "eta"
 msgstr ""
 
@@ -4681,7 +4684,7 @@ msgid ""
 "all=_ marks subscripts."
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1335
+#: ../src/wxMaximaFrame.cpp:1334
 msgid "gamma"
 msgstr ""
 
@@ -4710,15 +4713,15 @@ msgstr "隨文字顯示"
 msgid "intersection"
 msgstr "方向："
 
-#: ../src/wxMaximaFrame.cpp:1341
+#: ../src/wxMaximaFrame.cpp:1340
 msgid "iota"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1342
+#: ../src/wxMaximaFrame.cpp:1341
 msgid "kappa"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1343
+#: ../src/wxMaximaFrame.cpp:1342
 msgid "lambda"
 msgstr ""
 
@@ -4735,7 +4738,7 @@ msgstr "子章節單元"
 msgid "logscale"
 msgstr "對數尺度"
 
-#: ../src/wxMaxima.cpp:3783
+#: ../src/wxMaxima.cpp:3795
 msgid "matrix[i,j]:"
 msgstr "矩陣[i,j]："
 
@@ -4743,7 +4746,7 @@ msgstr "矩陣[i,j]："
 msgid "maxima's pwd is path to document"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1344
+#: ../src/wxMaximaFrame.cpp:1343
 msgid "mu"
 msgstr ""
 
@@ -4760,7 +4763,7 @@ msgstr ""
 msgid "nand"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:4524
+#: ../src/wxMaxima.cpp:4536
 msgid "no"
 msgstr "否"
 
@@ -4786,15 +4789,15 @@ msgstr ""
 msgid "not subset or equal"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1345
+#: ../src/wxMaximaFrame.cpp:1344
 msgid "nu"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1356
+#: ../src/wxMaximaFrame.cpp:1355
 msgid "omega"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1347
+#: ../src/wxMaximaFrame.cpp:1346
 msgid "omicron"
 msgstr ""
 
@@ -4807,11 +4810,11 @@ msgstr ""
 msgid "partial sign"
 msgstr "部分分式"
 
-#: ../src/wxMaximaFrame.cpp:1353
+#: ../src/wxMaximaFrame.cpp:1352
 msgid "phi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1348
+#: ../src/wxMaximaFrame.cpp:1347
 msgid "pi"
 msgstr ""
 
@@ -4823,11 +4826,11 @@ msgstr ""
 msgid "proportional to"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1355
+#: ../src/wxMaximaFrame.cpp:1354
 msgid "psi"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1349
+#: ../src/wxMaximaFrame.cpp:1348
 msgid "rho"
 msgstr ""
 
@@ -4835,7 +4838,7 @@ msgstr ""
 msgid "right"
 msgstr "右"
 
-#: ../src/wxMaximaFrame.cpp:1350
+#: ../src/wxMaximaFrame.cpp:1349
 msgid "sigma"
 msgstr ""
 
@@ -4857,7 +4860,7 @@ msgstr "子章節單元"
 msgid "symmetric"
 msgstr "對稱"
 
-#: ../src/wxMaximaFrame.cpp:1351
+#: ../src/wxMaximaFrame.cpp:1350
 msgid "tau"
 msgstr ""
 
@@ -4869,7 +4872,7 @@ msgstr ""
 msgid "there is no"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1340
+#: ../src/wxMaximaFrame.cpp:1339
 msgid "theta"
 msgstr ""
 
@@ -4885,12 +4888,12 @@ msgstr ""
 msgid "union"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:5903
+#: ../src/wxMaxima.cpp:5918
 msgid "unsaved"
 msgstr "未儲存"
 
-#: ../src/wxMaximaFrame.cpp:290 ../src/wxMaxima.cpp:2559
-#: ../src/wxMaxima.cpp:2826
+#: ../src/wxMaxima.cpp:2566 ../src/wxMaxima.cpp:2834
+#: ../src/wxMaximaFrame.cpp:289
 msgid "untitled"
 msgstr "未命名"
 
@@ -4899,27 +4902,27 @@ msgstr "未命名"
 msgid "untitled %d"
 msgstr "未命名 %d"
 
-#: ../src/wxMaximaFrame.cpp:1352
+#: ../src/wxMaximaFrame.cpp:1351
 #, fuzzy
 msgid "upsilon"
 msgstr "Epsilon:"
 
-#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4538
+#: ../src/main.cpp:311 ../src/wxMaxima.cpp:4550
 msgid "wxMaxima"
 msgstr "wxMaxima"
 
-#: ../src/wxMaximaFrame.cpp:288 ../src/wxMaxima.cpp:5698
-#: ../src/wxMaxima.cpp:5700 ../src/wxMaxima.cpp:5709 ../src/wxMaxima.cpp:5712
+#: ../src/wxMaxima.cpp:5713 ../src/wxMaxima.cpp:5715 ../src/wxMaxima.cpp:5724
+#: ../src/wxMaxima.cpp:5727 ../src/wxMaximaFrame.cpp:287
 #, c-format
 msgid "wxMaxima %s "
 msgstr "wxMaxima %s "
 
-#: ../src/wxMaximaFrame.cpp:952
+#: ../src/wxMaximaFrame.cpp:951
 #, fuzzy
 msgid "wxMaxima &Help\tCtrl+?"
 msgstr "Maxima 說明(H)\tCTRL+?"
 
-#: ../src/wxMaximaFrame.cpp:955
+#: ../src/wxMaximaFrame.cpp:954
 #, fuzzy
 msgid "wxMaxima &Help\tF1"
 msgstr "Maxima 說明(H)\tF1"
@@ -4931,11 +4934,11 @@ msgid ""
 "directory can be found by typing maxima_userdir"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1619
+#: ../src/wxMaxima.cpp:1624
 msgid "wxMaxima cannot open content.xml in the .wxmx zip archive "
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1633
+#: ../src/wxMaxima.cpp:1638
 msgid "wxMaxima cannot read the xml contents of "
 msgstr ""
 
@@ -4943,7 +4946,7 @@ msgstr ""
 msgid "wxMaxima configuration"
 msgstr "wxMaxima 設定"
 
-#: ../src/wxMaxima.cpp:1947
+#: ../src/wxMaxima.cpp:1952
 msgid ""
 "wxMaxima could not find Maxima!\n"
 "\n"
@@ -4955,7 +4958,7 @@ msgstr ""
 "請從「編輯(E)」->「設定(O)」設定 wxMaxima\n"
 "然後從「Maxima(M)」->「重新啟動 Maxima(R)」啟動 Maxima"
 
-#: ../src/wxMaxima.cpp:2204
+#: ../src/wxMaxima.cpp:2209
 msgid ""
 "wxMaxima could not find help files.\n"
 "\n"
@@ -4965,7 +4968,7 @@ msgstr ""
 "\n"
 "請檢查您的安裝"
 
-#: ../src/wxMaxima.cpp:2032
+#: ../src/wxMaxima.cpp:2037
 msgid ""
 "wxMaxima could not find tip files.\n"
 "\n"
@@ -4975,7 +4978,7 @@ msgstr ""
 "\n"
 "請檢查您的安裝"
 
-#: ../src/wxMaxima.cpp:282
+#: ../src/wxMaxima.cpp:283
 msgid ""
 "wxMaxima could not start the server.\n"
 "\n"
@@ -4996,29 +4999,29 @@ msgstr ""
 "wxMaxima 對話框會設定輸入內容為預設值，其中一種是 \"%\"。如果您已經在您的文件"
 "中作選取，則這個選取內容將會取代 \"%\"。"
 
-#: ../src/wxMaxima.cpp:2330
+#: ../src/wxMaxima.cpp:2336
 msgid "wxMaxima document"
 msgstr "wxMaxima 文件"
 
-#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2799
+#: ../src/main.cpp:349 ../src/wxMaxima.cpp:2807
 msgid "wxMaxima document (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 msgstr "wxMaxima 文件 (*.wxm, *.wxmx)|*.wxm;*.wxmx"
 
-#: ../src/wxMaxima.cpp:1455 ../src/wxMaxima.cpp:1469
+#: ../src/wxMaxima.cpp:1460 ../src/wxMaxima.cpp:1474
 msgid "wxMaxima encountered an error loading "
 msgstr "wxMaxima 發生讀取錯誤"
 
-#: ../src/wxMaxima.cpp:4463
+#: ../src/wxMaxima.cpp:4475
 msgid "wxMaxima icon"
 msgstr "wxMaxima 圖示"
 
-#: ../src/wxMaxima.cpp:4455
+#: ../src/wxMaxima.cpp:4467
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "MAXIMA based on wxWidgets."
 msgstr "wxMaxima 是基於 wxWidgets ，為電腦代數系統 MAXIMA 的圖形使用界面。"
 
-#: ../src/wxMaxima.cpp:4516
+#: ../src/wxMaxima.cpp:4528
 msgid ""
 "wxMaxima is a graphical user interface for the computer algebra system "
 "Maxima based on wxWidgets."
@@ -5036,11 +5039,11 @@ msgstr ""
 msgid "x"
 msgstr ""
 
-#: ../src/wxMaximaFrame.cpp:1346
+#: ../src/wxMaximaFrame.cpp:1345
 msgid "xi"
 msgstr ""
 
-#: ../src/wxMaxima.cpp:1643
+#: ../src/wxMaxima.cpp:1648
 msgid "xml contained in the file claims not to be a wxMaxima worksheet. "
 msgstr ""
 
@@ -5049,11 +5052,11 @@ msgstr ""
 msgid "xor"
 msgstr "匯出"
 
-#: ../src/wxMaxima.cpp:4522
+#: ../src/wxMaxima.cpp:4534
 msgid "yes"
 msgstr "是"
 
-#: ../src/wxMaximaFrame.cpp:1338
+#: ../src/wxMaximaFrame.cpp:1337
 msgid "zeta"
 msgstr ""
 

--- a/src/wxMaxima.cpp
+++ b/src/wxMaxima.cpp
@@ -5929,8 +5929,8 @@ int wxMaxima::SaveDocumentP()
   }
 
   wxMessageDialog dialog(this,
-                         _("Do you want to save the changes you made in the document \"") +
-                         file + wxT("\"?"),
+                         wxString::Format(_("Do you want to save the changes you made in the document \"%s\"?"),
+                                          file),
 			 wxEmptyString, wxCENTER | wxYES_NO | wxCANCEL);
 
   dialog.SetExtendedMessage(_("Your changes will be lost if you don't save them."));


### PR DESCRIPTION
Use formatting function to include the file name in the message, instead of string concatenation.