### PR TITLE
Updated Italian translation unstranslating untranslatable accel key names

### DIFF
--- a/locales/it.po
+++ b/locales/it.po
@@ -1191,7 +1191,7 @@ msgstr "Copia come MathML (per es. per un programma di videoscrittura)"
 
 #: ../src/wxMaximaFrame.cpp:463
 msgid "Copy as Text\tCtrl+Shift+C"
-msgstr "Copia come testo\tCtrl+Maiusc+C"
+msgstr "Copia come testo\tCtrl+Shift+C"
 
 #: ../src/MathCtrl.cpp:943 ../src/MathCtrl.cpp:989
 msgid "Copy as plain text"
@@ -1607,7 +1607,7 @@ msgstr "Elabora le forme &nominali"
 
 #: ../src/wxMaximaFrame.cpp:550
 msgid "Evaluate All Cells\tCtrl+Shift+R"
-msgstr "Elabora tutte le celle\tCtrl+Maiusc-R"
+msgstr "Elabora tutte le celle\tCtrl+Shift-R"
 
 #: ../src/wxMaximaFrame.cpp:548
 msgid "Evaluate All Visible Cells\tCtrl+R"
@@ -1619,23 +1619,23 @@ msgstr "Elabora le celle"
 
 #: ../src/wxMaximaFrame.cpp:552
 msgid "Evaluate Cells Above\tCtrl+Shift+P"
-msgstr "Elabora le celle sopra\tCtrl+Maiusc-P"
+msgstr "Elabora le celle sopra\tCtrl+Shift+P"
 
 #: ../src/MathCtrl.cpp:966 ../src/MathCtrl.cpp:1063
 msgid "Evaluate Part\tShift+Ctrl+Enter"
-msgstr "Elabora parte\tMaiusc+Ctrl+Invio"
+msgstr "Elabora parte\tShift+Ctrl+Enter"
 
 #: ../src/MathCtrl.cpp:971 ../src/MathCtrl.cpp:1066
 msgid "Evaluate Section\tShift+Ctrl+Enter"
-msgstr "Elabora sezione\tMaiusc+Ctrl+Invio"
+msgstr "Elabora sezione\tShift+Ctrl+Enter"
 
 #: ../src/MathCtrl.cpp:981 ../src/MathCtrl.cpp:1071 ../src/MathCtrl.cpp:1102
 msgid "Evaluate Sub-Subsection\tShift+Ctrl+Enter"
-msgstr "Elabora sotto-sottosezione\tMaiusc+Ctrl+Invio"
+msgstr "Elabora sotto-sottosezione\tShift+Ctrl+Enter"
 
 #: ../src/MathCtrl.cpp:976 ../src/MathCtrl.cpp:1069 ../src/MathCtrl.cpp:1093
 msgid "Evaluate Subsection\tShift+Ctrl+Enter"
-msgstr "Elabora sottosezione\tMaiusc+Ctrl+Invio"
+msgstr "Elabora sottosezione\tShift+Ctrl+Enter"
 
 #: ../src/wxMaximaFrame.cpp:547
 msgid "Evaluate active or selected cell(s)"
@@ -1994,7 +1994,7 @@ msgstr "Da:"
 
 #: ../src/wxMaximaFrame.cpp:537
 msgid "Full Screen\tAlt+Enter"
-msgstr "Pieno schermo\tAlt+Invio"
+msgstr "Pieno schermo\tAlt+Enter"
 
 #: ../src/wxMaxima.cpp:3510
 msgid "Function"
@@ -2047,7 +2047,7 @@ msgstr "Matematica generale"
 
 #: ../src/wxMaximaFrame.cpp:508
 msgid "General Math\tAlt+Shift+M"
-msgstr "Matematica generale\tAlt+Maiusc+M"
+msgstr "Matematica generale\tAlt+Shift+M"
 
 #: ../src/wxMaxima.cpp:3958 ../src/wxMaxima.cpp:3978
 msgid "Generate Matrix"
@@ -2119,7 +2119,7 @@ msgstr "Lettere greche"
 
 #: ../src/wxMaximaFrame.cpp:511
 msgid "Greek Letters\tAlt+Shift+G"
-msgstr "Lettere greche\tAlt+Maiusc+G"
+msgstr "Lettere greche\tAlt+Shift+G"
 
 #: ../src/ConfigDialogue.cpp:774
 msgid "Greek constants"
@@ -2147,7 +2147,7 @@ msgstr "Nascondi"
 
 #: ../src/wxMaximaFrame.cpp:521
 msgid "Hide All Toolbars\tAlt+Shift+-"
-msgstr "Nascondi tutte le barre\tAlt+Maiusc+-"
+msgstr "Nascondi tutte le barre\tAlt+Shift+-"
 
 #: ../src/ToolBar.cpp:207
 msgid "Hide Code"
@@ -2209,7 +2209,7 @@ msgstr "Cronologia"
 
 #: ../src/wxMaximaFrame.cpp:514
 msgid "History\tAlt+Shift+I"
-msgstr "Cronologia\tAlt+Maiusc+I"
+msgstr "Cronologia\tAlt+Shift+I"
 
 #: ../data/tips.txt:14
 msgid ""
@@ -2433,7 +2433,7 @@ msgstr "Inserisci cella &testo\tCtrl+1"
 
 #: ../src/wxMaximaFrame.cpp:517
 msgid "Insert Cell\tAlt+Shift+C"
-msgstr "Inserisci cella\tAlt+Maiusc+C"
+msgstr "Inserisci cella\tAlt+Shift+C"
 
 #: ../src/wxMaxima.cpp:5984
 msgid "Insert Image"
@@ -2754,7 +2754,7 @@ msgstr "Map&pa su matrice..."
 
 #: ../src/wxMaximaFrame.cpp:506
 msgid "Main Toolbar\tAlt+Shift+B"
-msgstr "Barra strumenti principale\tAlt+Maiusc+B"
+msgstr "Barra strumenti principale\tAlt+Shift+B"
 
 #: ../src/wxMaximaFrame.cpp:726
 msgid "Make &List..."
@@ -3161,7 +3161,7 @@ msgstr "Nuova variabile:"
 
 #: ../src/wxMaximaFrame.cpp:591
 msgid "Next Command\tAlt+Down"
-msgstr "Comando successivo\tAlt+Giù"
+msgstr "Comando successivo\tAlt+Down"
 
 #: ../src/ConfigDialogue.cpp:433 ../src/ConfigDialogue.cpp:443
 #: ../src/ConfigDialogue.cpp:452
@@ -3542,7 +3542,7 @@ msgstr ""
 
 #: ../src/wxMaximaFrame.cpp:589
 msgid "Previous Command\tAlt+Up"
-msgstr "Comando precedente\tAlt+Su"
+msgstr "Comando precedente\tAlt+Up"
 
 #: ../src/ToolBar.cpp:125
 msgid "Print"
@@ -3720,7 +3720,7 @@ msgstr "Salva come"
 
 #: ../src/wxMaximaFrame.cpp:433
 msgid "Save As...\tShift+Ctrl+S"
-msgstr "Salva come...\tMaiusc+Ctrl+S"
+msgstr "Salva come...\tShift+Ctrl+S"
 
 #: ../src/MathCtrl.cpp:929
 msgid "Save Image..."
@@ -3973,7 +3973,7 @@ msgstr "Mostra la guida di maxima"
 
 #: ../src/wxMaximaFrame.cpp:564
 msgid "Show Template\tCtrl+Shift+K"
-msgstr "Mostra il modello\tCtrl+Maiusc+K"
+msgstr "Mostra il modello\tCtrl+Shift+K"
 
 #: ../src/wxMaximaFrame.cpp:929
 msgid "Show a tip"
@@ -4243,7 +4243,7 @@ msgstr "Statistiche"
 
 #: ../src/wxMaximaFrame.cpp:509
 msgid "Statistics\tAlt+Shift+S"
-msgstr "Statistiche\tAlt+Maiusc+S"
+msgstr "Statistiche\tAlt+Shift+S"
 
 #: ../src/ConfigDialogue.cpp:775
 msgid "Strings"
@@ -4300,7 +4300,7 @@ msgstr "Segno somma"
 
 #: ../src/wxMaximaFrame.cpp:512
 msgid "Symbols\tAlt+Shift+Y"
-msgstr "Simboli\tAlt+Maiusc+Y"
+msgstr "Simboli\tAlt+Shift+Y"
 
 #: ../src/ConfigDialogue.cpp:223
 msgid ""
@@ -4320,7 +4320,7 @@ msgstr "Sommario"
 
 #: ../src/wxMaximaFrame.cpp:515
 msgid "Table of Contents\tAlt+Shift+T"
-msgstr "Sommario\tAlt+Maiusc+T"
+msgstr "Sommario\tAlt+Shift+T"
 
 #: ../src/wxMaximaFrame.cpp:1343
 msgid "Tau"
@@ -4564,7 +4564,7 @@ msgstr "In virgola mobile"
 
 #: ../src/wxMaximaFrame.cpp:902
 msgid "To Numeri&c\tCtrl+Shift+N"
-msgstr "In forma numeri&ca\tCtrl+Maiusc+N"
+msgstr "In forma numeri&ca\tCtrl+Shift+N"
 
 #: ../data/tips.txt:19
 msgid ""


### PR DESCRIPTION
Accel key names seems to be untranslatable since when I start wxMaxima it complains with a series of:

13:31:39: Debug: Unknown accel modifier: 'maiusc'

Probably we should open a bug report for making translatable the accel key names...