### PR TITLE
Changed the Maxima path escaping stuff to work properly.

### DIFF
--- a/src/wxMaxima.h
+++ b/src/wxMaxima.h
@@ -1,4 +1,4 @@
-﻿// -*- mode: c++; c-file-style: "linux"; c-basic-offset: 2; indent-tabs-mode: nil -*-
+// -*- mode: c++; c-file-style: "linux"; c-basic-offset: 2; indent-tabs-mode: nil -*-
 //  Copyright (C) 2004-2015 Andrej Vodopivec <andrej.vodopivec@gmail.com>
 //            (C) 2013 Doug Ilijev <doug.ilijev@gmail.com>
 //            (C) 2014-2017 Gunter Königsmann <wxMaxima@physikbuch.de>


### PR DESCRIPTION
Instead of escaping spaces, I rewrote the code to escape quotation marks and to enclose the path itself by quotation marks. Now everything seems to work properly on Windows and Linux.